### PR TITLE
Make case expression constructors infallible

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -10,10 +10,11 @@ use self::runtime::RuntimePlan;
 use ecow::EcoString;
 use std::fmt;
 
-pub use expression::{BoolExpr, CallArg, Expr, FunctionExpr, IntExpr, NilExpr, StringExpr};
 pub(crate) use expression::{
-    BoolExprKind, CallArgKind, ExprKind, FunctionExprKind, IntExprKind, NilExprKind, StringExprKind,
+    BoolCaseBranches, BoolExprKind, CallArgKind, ExprKind, FunctionExprKind, IntCaseBranches,
+    IntExprKind, NilExprKind, StringExprKind,
 };
+pub use expression::{BoolExpr, CallArg, Expr, FunctionExpr, IntExpr, NilExpr, StringExpr};
 pub(crate) use frame::FrameLayout;
 pub use function::{FunctionPlan, Param, ReturnExpr};
 pub(crate) use function::{ReturnExprKind, RuntimeFunction};

--- a/src/plan/expression.rs
+++ b/src/plan/expression.rs
@@ -1,4 +1,5 @@
 mod bool;
+mod case;
 mod function;
 mod int;
 mod nil;
@@ -6,8 +7,8 @@ mod string;
 
 use super::id::{BoolLocalId, IntLocalId, LocalId, NilLocalId, StringLocalId};
 use super::value::{Value, ValueType};
-use num_bigint::BigInt;
 
+pub(crate) use self::case::{BoolCaseBranches, IntCaseBranches};
 pub use self::{
     bool::BoolExpr, function::FunctionExpr, int::IntExpr, nil::NilExpr, string::StringExpr,
 };
@@ -86,115 +87,42 @@ impl Expr {
         }
     }
 
-    pub(crate) fn bool_case(
-        subject: BoolExpr,
-        true_: Expr,
-        false_: Expr,
-    ) -> Result<Self, Box<(Self, Self)>> {
-        match (true_.kind, false_.kind) {
-            (ExprKind::Int(true_), ExprKind::Int(false_)) => {
-                Ok(Self::int(IntExpr::bool_case(subject, true_, false_)))
+    pub(crate) fn bool_case(subject: BoolExpr, branches: BoolCaseBranches) -> Self {
+        match branches {
+            BoolCaseBranches::Int { true_, false_ } => {
+                Self::int(IntExpr::bool_case(subject, true_, false_))
             }
-            (ExprKind::String(true_), ExprKind::String(false_)) => {
-                Ok(Self::string(StringExpr::bool_case(subject, true_, false_)))
+            BoolCaseBranches::String { true_, false_ } => {
+                Self::string(StringExpr::bool_case(subject, true_, false_))
             }
-            (ExprKind::Bool(true_), ExprKind::Bool(false_)) => {
-                Ok(Self::bool(BoolExpr::bool_case(subject, true_, false_)))
+            BoolCaseBranches::Bool { true_, false_ } => {
+                Self::bool(BoolExpr::bool_case(subject, true_, false_))
             }
-            (ExprKind::Nil(true_), ExprKind::Nil(false_)) => {
-                Ok(Self::nil(NilExpr::bool_case(subject, true_, false_)))
+            BoolCaseBranches::Nil { true_, false_ } => {
+                Self::nil(NilExpr::bool_case(subject, true_, false_))
             }
-            (ExprKind::Function(true_), ExprKind::Function(false_)) => {
-                if true_.type_() == false_.type_() {
-                    Ok(Self::function(FunctionExpr::bool_case(
-                        subject, true_, false_,
-                    )))
-                } else {
-                    Err(Box::new((Self::function(true_), Self::function(false_))))
-                }
+            BoolCaseBranches::Function { true_, false_ } => {
+                Self::function(FunctionExpr::bool_case(subject, true_, false_))
             }
-            (true_, false_) => Err(Box::new((Self { kind: true_ }, Self { kind: false_ }))),
         }
     }
 
-    pub(crate) fn int_case(
-        subject: IntExpr,
-        clauses: Vec<(BigInt, Expr)>,
-        fallback: Expr,
-    ) -> Result<Self, ()> {
-        match fallback.kind {
-            ExprKind::Int(fallback) => {
-                let mut typed_clauses = Vec::with_capacity(clauses.len());
-                for (value, clause) in clauses {
-                    let ExprKind::Int(clause) = clause.kind else {
-                        return Err(());
-                    };
-                    typed_clauses.push((value, clause));
-                }
-                Ok(Self::int(IntExpr::int_case(
-                    subject,
-                    typed_clauses,
-                    fallback,
-                )))
+    pub(crate) fn int_case(subject: IntExpr, branches: IntCaseBranches) -> Self {
+        match branches {
+            IntCaseBranches::Int { clauses, fallback } => {
+                Self::int(IntExpr::int_case(subject, clauses, fallback))
             }
-            ExprKind::String(fallback) => {
-                let mut typed_clauses = Vec::with_capacity(clauses.len());
-                for (value, clause) in clauses {
-                    let ExprKind::String(clause) = clause.kind else {
-                        return Err(());
-                    };
-                    typed_clauses.push((value, clause));
-                }
-                Ok(Self::string(StringExpr::int_case(
-                    subject,
-                    typed_clauses,
-                    fallback,
-                )))
+            IntCaseBranches::String { clauses, fallback } => {
+                Self::string(StringExpr::int_case(subject, clauses, fallback))
             }
-            ExprKind::Bool(fallback) => {
-                let mut typed_clauses = Vec::with_capacity(clauses.len());
-                for (value, clause) in clauses {
-                    let ExprKind::Bool(clause) = clause.kind else {
-                        return Err(());
-                    };
-                    typed_clauses.push((value, clause));
-                }
-                Ok(Self::bool(BoolExpr::int_case(
-                    subject,
-                    typed_clauses,
-                    fallback,
-                )))
+            IntCaseBranches::Bool { clauses, fallback } => {
+                Self::bool(BoolExpr::int_case(subject, clauses, fallback))
             }
-            ExprKind::Nil(fallback) => {
-                let mut typed_clauses = Vec::with_capacity(clauses.len());
-                for (value, clause) in clauses {
-                    let ExprKind::Nil(clause) = clause.kind else {
-                        return Err(());
-                    };
-                    typed_clauses.push((value, clause));
-                }
-                Ok(Self::nil(NilExpr::int_case(
-                    subject,
-                    typed_clauses,
-                    fallback,
-                )))
+            IntCaseBranches::Nil { clauses, fallback } => {
+                Self::nil(NilExpr::int_case(subject, clauses, fallback))
             }
-            ExprKind::Function(fallback) => {
-                let mut typed_clauses = Vec::with_capacity(clauses.len());
-                for (value, clause) in clauses {
-                    let ExprKind::Function(clause) = clause.kind else {
-                        return Err(());
-                    };
-                    if clause.type_() != fallback.type_() {
-                        return Err(());
-                    }
-                    typed_clauses.push((value, clause));
-                }
-                Ok(Self::function(FunctionExpr::int_case(
-                    subject,
-                    typed_clauses,
-                    fallback,
-                )))
+            IntCaseBranches::Function { clauses, fallback } => {
+                Self::function(FunctionExpr::int_case(subject, clauses, fallback))
             }
         }
     }
@@ -310,10 +238,13 @@ impl From<Value> for Expr {
 
 #[cfg(test)]
 mod tests {
-    use super::{BoolExpr, CallArgKind, Expr, FunctionExpr, IntExpr, NilExpr, StringExpr};
+    use super::{
+        BoolCaseBranches, BoolExpr, CallArgKind, Expr, FunctionExpr, IntCaseBranches, IntExpr,
+        NilExpr, StringExpr,
+    };
     use crate::plan::{
         BoolLocalId, FunctionType, FunctionValue, IntFunctionId, IntLocalId, LocalId, NilLocalId,
-        RuntimeFunctionId, StringFunctionId, StringLocalId, Value, ValueType,
+        RuntimeFunctionId, StringLocalId, Value, ValueType,
     };
     use num_bigint::BigInt;
 
@@ -343,84 +274,72 @@ mod tests {
         assert_eq!(
             Expr::bool_case(
                 BoolExpr::value(true),
-                Expr::int(IntExpr::value(BigInt::from(1))),
-                Expr::int(IntExpr::value(BigInt::from(0))),
+                BoolCaseBranches::Int {
+                    true_: IntExpr::value(BigInt::from(1)),
+                    false_: IntExpr::value(BigInt::from(0)),
+                },
             ),
-            Ok(Expr::int(IntExpr::bool_case(
+            Expr::int(IntExpr::bool_case(
                 BoolExpr::value(true),
                 IntExpr::value(BigInt::from(1)),
                 IntExpr::value(BigInt::from(0)),
-            ))),
+            )),
         );
         assert_eq!(
             Expr::bool_case(
                 BoolExpr::value(true),
-                Expr::string(StringExpr::value("yes".into())),
-                Expr::string(StringExpr::value("no".into())),
+                BoolCaseBranches::String {
+                    true_: StringExpr::value("yes".into()),
+                    false_: StringExpr::value("no".into()),
+                },
             ),
-            Ok(Expr::string(StringExpr::bool_case(
+            Expr::string(StringExpr::bool_case(
                 BoolExpr::value(true),
                 StringExpr::value("yes".into()),
                 StringExpr::value("no".into()),
-            ))),
+            )),
         );
         assert_eq!(
             Expr::bool_case(
                 BoolExpr::value(true),
-                Expr::bool(BoolExpr::value(true)),
-                Expr::bool(BoolExpr::value(false)),
+                BoolCaseBranches::Bool {
+                    true_: BoolExpr::value(true),
+                    false_: BoolExpr::value(false),
+                },
             ),
-            Ok(Expr::bool(BoolExpr::bool_case(
+            Expr::bool(BoolExpr::bool_case(
                 BoolExpr::value(true),
                 BoolExpr::value(true),
                 BoolExpr::value(false),
-            ))),
+            )),
         );
         assert_eq!(
             Expr::bool_case(
                 BoolExpr::value(true),
-                Expr::nil(NilExpr::value()),
-                Expr::nil(NilExpr::value()),
+                BoolCaseBranches::Nil {
+                    true_: NilExpr::value(),
+                    false_: NilExpr::value(),
+                },
             ),
-            Ok(Expr::nil(NilExpr::bool_case(
+            Expr::nil(NilExpr::bool_case(
                 BoolExpr::value(true),
                 NilExpr::value(),
                 NilExpr::value(),
-            ))),
+            )),
         );
         assert_eq!(
             Expr::bool_case(
                 BoolExpr::value(true),
-                Expr::function(FunctionExpr::value(function_value())),
-                Expr::function(FunctionExpr::value(function_value())),
+                BoolCaseBranches::Function {
+                    true_: FunctionExpr::value(function_value()),
+                    false_: FunctionExpr::value(function_value()),
+                },
             ),
-            Ok(Expr::function(FunctionExpr::bool_case(
+            Expr::function(FunctionExpr::bool_case(
                 BoolExpr::value(true),
                 FunctionExpr::value(function_value()),
                 FunctionExpr::value(function_value()),
-            ))),
-        );
-        assert_eq!(
-            Expr::bool_case(
-                BoolExpr::value(true),
-                Expr::int(IntExpr::value(BigInt::from(1))),
-                Expr::bool(BoolExpr::value(false)),
-            ),
-            Err(Box::new((
-                Expr::int(IntExpr::value(BigInt::from(1))),
-                Expr::bool(BoolExpr::value(false)),
-            ))),
-        );
-        assert_eq!(
-            Expr::bool_case(
-                BoolExpr::value(true),
-                Expr::function(FunctionExpr::value(function_value())),
-                Expr::function(FunctionExpr::value(string_function_value())),
-            ),
-            Err(Box::new((
-                Expr::function(FunctionExpr::value(function_value())),
-                Expr::function(FunctionExpr::value(string_function_value())),
-            ))),
+            )),
         );
     }
 
@@ -429,119 +348,72 @@ mod tests {
         assert_eq!(
             Expr::int_case(
                 IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), Expr::int(IntExpr::value(BigInt::from(10))))],
-                Expr::int(IntExpr::value(BigInt::from(0))),
+                IntCaseBranches::Int {
+                    clauses: vec![(BigInt::from(1), IntExpr::value(BigInt::from(10)))],
+                    fallback: IntExpr::value(BigInt::from(0)),
+                },
             ),
-            Ok(Expr::int(IntExpr::int_case(
+            Expr::int(IntExpr::int_case(
                 IntExpr::value(BigInt::from(1)),
                 vec![(BigInt::from(1), IntExpr::value(BigInt::from(10)))],
                 IntExpr::value(BigInt::from(0)),
-            ))),
+            )),
         );
         assert_eq!(
             Expr::int_case(
                 IntExpr::value(BigInt::from(1)),
-                vec![(
-                    BigInt::from(1),
-                    Expr::string(StringExpr::value("one".into()))
-                )],
-                Expr::string(StringExpr::value("other".into())),
+                IntCaseBranches::String {
+                    clauses: vec![(BigInt::from(1), StringExpr::value("one".into()))],
+                    fallback: StringExpr::value("other".into()),
+                },
             ),
-            Ok(Expr::string(StringExpr::int_case(
+            Expr::string(StringExpr::int_case(
                 IntExpr::value(BigInt::from(1)),
                 vec![(BigInt::from(1), StringExpr::value("one".into()))],
                 StringExpr::value("other".into()),
-            ))),
+            )),
         );
         assert_eq!(
             Expr::int_case(
                 IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), Expr::bool(BoolExpr::value(true)))],
-                Expr::bool(BoolExpr::value(false)),
+                IntCaseBranches::Bool {
+                    clauses: vec![(BigInt::from(1), BoolExpr::value(true))],
+                    fallback: BoolExpr::value(false),
+                },
             ),
-            Ok(Expr::bool(BoolExpr::int_case(
+            Expr::bool(BoolExpr::int_case(
                 IntExpr::value(BigInt::from(1)),
                 vec![(BigInt::from(1), BoolExpr::value(true))],
                 BoolExpr::value(false),
-            ))),
+            )),
         );
         assert_eq!(
             Expr::int_case(
                 IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), Expr::nil(NilExpr::value()))],
-                Expr::nil(NilExpr::value()),
+                IntCaseBranches::Nil {
+                    clauses: vec![(BigInt::from(1), NilExpr::value())],
+                    fallback: NilExpr::value(),
+                },
             ),
-            Ok(Expr::nil(NilExpr::int_case(
+            Expr::nil(NilExpr::int_case(
                 IntExpr::value(BigInt::from(1)),
                 vec![(BigInt::from(1), NilExpr::value())],
                 NilExpr::value(),
-            ))),
+            )),
         );
         assert_eq!(
             Expr::int_case(
                 IntExpr::value(BigInt::from(1)),
-                vec![(
-                    BigInt::from(1),
-                    Expr::function(FunctionExpr::value(function_value()))
-                )],
-                Expr::function(FunctionExpr::value(function_value())),
+                IntCaseBranches::Function {
+                    clauses: vec![(BigInt::from(1), FunctionExpr::value(function_value()))],
+                    fallback: FunctionExpr::value(function_value()),
+                },
             ),
-            Ok(Expr::function(FunctionExpr::int_case(
+            Expr::function(FunctionExpr::int_case(
                 IntExpr::value(BigInt::from(1)),
                 vec![(BigInt::from(1), FunctionExpr::value(function_value()))],
                 FunctionExpr::value(function_value()),
-            ))),
-        );
-        assert_eq!(
-            Expr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), Expr::bool(BoolExpr::value(true)))],
-                Expr::int(IntExpr::value(BigInt::from(0))),
-            ),
-            Err(()),
-        );
-        assert_eq!(
-            Expr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), Expr::int(IntExpr::value(BigInt::from(1))))],
-                Expr::string(StringExpr::value("other".into())),
-            ),
-            Err(()),
-        );
-        assert_eq!(
-            Expr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(
-                    BigInt::from(1),
-                    Expr::function(FunctionExpr::value(string_function_value()))
-                )],
-                Expr::function(FunctionExpr::value(function_value())),
-            ),
-            Err(()),
-        );
-        assert_eq!(
-            Expr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), Expr::int(IntExpr::value(BigInt::from(1))))],
-                Expr::function(FunctionExpr::value(function_value())),
-            ),
-            Err(()),
-        );
-        assert_eq!(
-            Expr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), Expr::int(IntExpr::value(BigInt::from(1))))],
-                Expr::bool(BoolExpr::value(false)),
-            ),
-            Err(()),
-        );
-        assert_eq!(
-            Expr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), Expr::int(IntExpr::value(BigInt::from(1))))],
-                Expr::nil(NilExpr::value()),
-            ),
-            Err(()),
+            )),
         );
     }
 
@@ -652,13 +524,6 @@ mod tests {
     fn function_value() -> FunctionValue {
         FunctionValue::new(
             RuntimeFunctionId::Int(IntFunctionId(0)),
-            vec![LocalId::Int(IntLocalId(0))],
-        )
-    }
-
-    fn string_function_value() -> FunctionValue {
-        FunctionValue::new(
-            RuntimeFunctionId::String(StringFunctionId(0)),
             vec![LocalId::Int(IntLocalId(0))],
         )
     }

--- a/src/plan/expression/case.rs
+++ b/src/plan/expression/case.rs
@@ -1,0 +1,48 @@
+use super::{BoolExpr, FunctionExpr, IntExpr, NilExpr, StringExpr};
+use num_bigint::BigInt;
+
+pub(crate) enum BoolCaseBranches {
+    Int {
+        true_: IntExpr,
+        false_: IntExpr,
+    },
+    String {
+        true_: StringExpr,
+        false_: StringExpr,
+    },
+    Bool {
+        true_: BoolExpr,
+        false_: BoolExpr,
+    },
+    Nil {
+        true_: NilExpr,
+        false_: NilExpr,
+    },
+    Function {
+        true_: FunctionExpr,
+        false_: FunctionExpr,
+    },
+}
+
+pub(crate) enum IntCaseBranches {
+    Int {
+        clauses: Vec<(BigInt, IntExpr)>,
+        fallback: IntExpr,
+    },
+    String {
+        clauses: Vec<(BigInt, StringExpr)>,
+        fallback: StringExpr,
+    },
+    Bool {
+        clauses: Vec<(BigInt, BoolExpr)>,
+        fallback: BoolExpr,
+    },
+    Nil {
+        clauses: Vec<(BigInt, NilExpr)>,
+        fallback: NilExpr,
+    },
+    Function {
+        clauses: Vec<(BigInt, FunctionExpr)>,
+        fallback: FunctionExpr,
+    },
+}

--- a/src/planner/expression/case/bool_subject.rs
+++ b/src/planner/expression/case/bool_subject.rs
@@ -2,7 +2,7 @@ use super::{
     invalid_case_shape, single_case_pattern, unsupported_case, validate_case_branch_type,
     validate_clause_shape,
 };
-use crate::plan::{BoolExpr, Expr};
+use crate::plan::{BoolCaseBranches, BoolExpr, Expr, ExprKind};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
@@ -128,8 +128,26 @@ fn set_case_branch(branch: &mut Option<Expr>, value: Expr) {
 }
 
 fn bool_case_expr(subject: BoolExpr, true_: Expr, false_: Expr) -> Result<Expr, PlanError> {
-    Expr::bool_case(subject, true_, false_)
-        .map_err(|_| invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch))
+    let branches = match (true_.into_kind(), false_.into_kind()) {
+        (ExprKind::Int(true_), ExprKind::Int(false_)) => BoolCaseBranches::Int { true_, false_ },
+        (ExprKind::String(true_), ExprKind::String(false_)) => {
+            BoolCaseBranches::String { true_, false_ }
+        }
+        (ExprKind::Bool(true_), ExprKind::Bool(false_)) => BoolCaseBranches::Bool { true_, false_ },
+        (ExprKind::Nil(true_), ExprKind::Nil(false_)) => BoolCaseBranches::Nil { true_, false_ },
+        (ExprKind::Function(true_), ExprKind::Function(false_))
+            if true_.type_() == false_.type_() =>
+        {
+            BoolCaseBranches::Function { true_, false_ }
+        }
+        _ => {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        }
+    };
+
+    Ok(Expr::bool_case(subject, branches))
 }
 
 #[cfg(test)]

--- a/src/planner/expression/case/int_subject.rs
+++ b/src/planner/expression/case/int_subject.rs
@@ -2,7 +2,7 @@ use super::{
     invalid_case_shape, single_case_pattern, unsupported_case, validate_case_branch_type,
     validate_clause_shape,
 };
-use crate::plan::{Expr, IntExpr};
+use crate::plan::{Expr, ExprKind, FunctionType, IntCaseBranches, IntExpr};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
@@ -106,15 +106,113 @@ fn int_case_expr(
     clauses: Vec<(BigInt, Expr)>,
     fallback: Expr,
 ) -> Result<Expr, PlanError> {
-    Expr::int_case(subject, clauses, fallback)
-        .map_err(|()| invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch))
+    let branches = match fallback.into_kind() {
+        ExprKind::Int(fallback) => IntCaseBranches::Int {
+            clauses: int_case_clauses(clauses)?,
+            fallback,
+        },
+        ExprKind::String(fallback) => IntCaseBranches::String {
+            clauses: string_case_clauses(clauses)?,
+            fallback,
+        },
+        ExprKind::Bool(fallback) => IntCaseBranches::Bool {
+            clauses: bool_case_clauses(clauses)?,
+            fallback,
+        },
+        ExprKind::Nil(fallback) => IntCaseBranches::Nil {
+            clauses: nil_case_clauses(clauses)?,
+            fallback,
+        },
+        ExprKind::Function(fallback) => IntCaseBranches::Function {
+            clauses: function_case_clauses(clauses, fallback.type_())?,
+            fallback,
+        },
+    };
+
+    Ok(Expr::int_case(subject, branches))
+}
+
+fn int_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::IntExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Int(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn string_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::StringExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::String(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn bool_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::BoolExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Bool(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn nil_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::NilExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Nil(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn function_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+    expected: &FunctionType,
+) -> Result<Vec<(BigInt, crate::plan::FunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        if clause.type_() != expected {
+            return Err(branch_return_type_mismatch());
+        }
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn branch_return_type_mismatch() -> PlanError {
+    invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch)
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::plan::{
+        FunctionExpr, IntFunctionId, IntLocalId, LocalId, RuntimeFunctionId, StringFunctionId,
+    };
     use crate::planner::dsl::{
-        bool_, function, int, int_case_bool, int_case_int, int_case_nil, int_case_string,
-        local_int, module, nil, string,
+        bool_, function, function_ref, int, int_case_bool, int_case_int, int_case_nil,
+        int_case_string, local_int, module, nil, string,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -234,6 +332,32 @@ fn duplicate_literal(value: Int) {
                 .param_int(0, "value"),
             ],
         );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_int_case_function_expr_shape() {
+        let actual = super::int_case_expr(
+            int(1).into(),
+            vec![(BigInt::from(1), int_function_ref_expr(0))],
+            int_function_ref_expr(0),
+        );
+        let branch: FunctionExpr = function_ref(
+            RuntimeFunctionId::Int(IntFunctionId(0)),
+            [LocalId::Int(IntLocalId(0))],
+        )
+        .into();
+        let fallback: FunctionExpr = function_ref(
+            RuntimeFunctionId::Int(IntFunctionId(0)),
+            [LocalId::Int(IntLocalId(0))],
+        )
+        .into();
+        let expected = Ok(crate::plan::Expr::function(FunctionExpr::int_case(
+            int(1).into(),
+            vec![(BigInt::from(1), branch)],
+            fallback,
+        )));
 
         assert_eq!(actual, expected);
     }
@@ -421,15 +545,78 @@ pub fn main() {
         assert_eq!(
             super::int_case_expr(
                 int(1).into(),
+                vec![(BigInt::from(1), bool_(true).into())],
+                int(0).into(),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+
+        assert_eq!(
+            super::int_case_expr(
+                int(1).into(),
+                vec![(BigInt::from(1), int(10).into())],
+                string("other").into(),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+
+        assert_eq!(
+            super::int_case_expr(
+                int(1).into(),
                 vec![(BigInt::from(1), int(10).into())],
                 bool_(false).into(),
             ),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CaseShape {
-                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
-                },
-            }),
+            Err(case_branch_return_type_mismatch()),
         );
+
+        assert_eq!(
+            super::int_case_expr(
+                int(1).into(),
+                vec![(BigInt::from(1), int(10).into())],
+                nil().into(),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+
+        assert_eq!(
+            super::int_case_expr(
+                int(1).into(),
+                vec![(BigInt::from(1), int(10).into())],
+                int_function_ref_expr(0),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+
+        let string_function: crate::plan::Expr = function_ref(
+            RuntimeFunctionId::String(StringFunctionId(0)),
+            [LocalId::Int(IntLocalId(0))],
+        )
+        .into();
+
+        assert_eq!(
+            super::int_case_expr(
+                int(1).into(),
+                vec![(BigInt::from(1), string_function)],
+                int_function_ref_expr(0),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+    }
+
+    fn int_function_ref_expr(id: usize) -> crate::plan::Expr {
+        function_ref(
+            RuntimeFunctionId::Int(IntFunctionId(id)),
+            [LocalId::Int(IntLocalId(0))],
+        )
+        .into()
+    }
+
+    fn case_branch_return_type_mismatch() -> PlanError {
+        PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CaseShape {
+                reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            },
+        }
     }
 
     #[test]


### PR DESCRIPTION
- Move case branch shape validation into planner lowering.
- Add typed bool and int case branch wrapper shapes for accepted plan data.
- Keep plan case constructors focused on already-validated execution shapes.
- Move case branch wrapper types into a dedicated expression case module.

Closes #1
