### PR TITLE
Support function value locals

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -11,21 +11,29 @@ use ecow::EcoString;
 use std::fmt;
 
 pub(crate) use expression::{
-    BoolCaseBranches, BoolExprKind, CallArgKind, ExprKind, FunctionExprKind, IntCaseBranches,
-    IntExprKind, NilExprKind, StringExprKind,
+    BoolCaseBranches, BoolExprKind, BoolFunctionExprKind, CallArgKind, ExprKind, FunctionExprKind,
+    IntCaseBranches, IntExprKind, IntFunctionExprKind, NilExprKind, NilFunctionExprKind,
+    StringExprKind, StringFunctionExprKind,
 };
-pub use expression::{BoolExpr, CallArg, Expr, FunctionExpr, IntExpr, NilExpr, StringExpr};
+pub use expression::{
+    BoolExpr, BoolFunctionExpr, CallArg, Expr, FunctionExpr, IntExpr, IntFunctionExpr, NilExpr,
+    NilFunctionExpr, StringExpr, StringFunctionExpr,
+};
 pub(crate) use frame::FrameLayout;
 pub use function::{FunctionPlan, Param, ReturnExpr};
 pub(crate) use function::{ReturnExprKind, RuntimeFunction};
 pub(crate) use id::RuntimeFunctionId;
 pub use id::{
-    BoolFunctionId, BoolLocalId, FunctionId, IntFunctionId, IntLocalId, LocalId, NilFunctionId,
-    NilLocalId, StringFunctionId, StringLocalId,
+    BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FunctionId, IntFunctionId,
+    IntFunctionLocalId, IntLocalId, LocalId, NilFunctionId, NilFunctionLocalId, NilLocalId,
+    StringFunctionId, StringFunctionLocalId, StringLocalId,
 };
 pub use step::Step;
 pub(crate) use step::StepKind;
-pub(crate) use value::FunctionArgumentType;
+pub(crate) use value::{
+    BoolFunctionValue, FunctionArgumentType, FunctionValueKind, IntFunctionValue, NilFunctionValue,
+    StringFunctionValue,
+};
 pub use value::{FunctionType, FunctionValue, Value, ValueType};
 
 pub struct ExecutionPlan {

--- a/src/plan/expression.rs
+++ b/src/plan/expression.rs
@@ -10,10 +10,22 @@ use super::value::{Value, ValueType};
 
 pub(crate) use self::case::{BoolCaseBranches, IntCaseBranches};
 pub use self::{
-    bool::BoolExpr, function::FunctionExpr, int::IntExpr, nil::NilExpr, string::StringExpr,
+    bool::BoolExpr,
+    function::{
+        BoolFunctionExpr, FunctionExpr, IntFunctionExpr, NilFunctionExpr, StringFunctionExpr,
+    },
+    int::IntExpr,
+    nil::NilExpr,
+    string::StringExpr,
 };
 pub(crate) use self::{
-    bool::BoolExprKind, function::FunctionExprKind, int::IntExprKind, nil::NilExprKind,
+    bool::BoolExprKind,
+    function::{
+        BoolFunctionExprKind, FunctionExprKind, IntFunctionExprKind, NilFunctionExprKind,
+        StringFunctionExprKind,
+    },
+    int::IntExprKind,
+    nil::NilExprKind,
     string::StringExprKind,
 };
 
@@ -101,9 +113,18 @@ impl Expr {
             BoolCaseBranches::Nil { true_, false_ } => {
                 Self::nil(NilExpr::bool_case(subject, true_, false_))
             }
-            BoolCaseBranches::Function { true_, false_ } => {
-                Self::function(FunctionExpr::bool_case(subject, true_, false_))
-            }
+            BoolCaseBranches::IntFunction { true_, false_ } => Self::function(FunctionExpr::int(
+                IntFunctionExpr::bool_case(subject, true_, false_),
+            )),
+            BoolCaseBranches::StringFunction { true_, false_ } => Self::function(
+                FunctionExpr::string(StringFunctionExpr::bool_case(subject, true_, false_)),
+            ),
+            BoolCaseBranches::BoolFunction { true_, false_ } => Self::function(FunctionExpr::bool(
+                BoolFunctionExpr::bool_case(subject, true_, false_),
+            )),
+            BoolCaseBranches::NilFunction { true_, false_ } => Self::function(FunctionExpr::nil(
+                NilFunctionExpr::bool_case(subject, true_, false_),
+            )),
         }
     }
 
@@ -121,9 +142,18 @@ impl Expr {
             IntCaseBranches::Nil { clauses, fallback } => {
                 Self::nil(NilExpr::int_case(subject, clauses, fallback))
             }
-            IntCaseBranches::Function { clauses, fallback } => {
-                Self::function(FunctionExpr::int_case(subject, clauses, fallback))
-            }
+            IntCaseBranches::IntFunction { clauses, fallback } => Self::function(
+                FunctionExpr::int(IntFunctionExpr::int_case(subject, clauses, fallback)),
+            ),
+            IntCaseBranches::StringFunction { clauses, fallback } => Self::function(
+                FunctionExpr::string(StringFunctionExpr::int_case(subject, clauses, fallback)),
+            ),
+            IntCaseBranches::BoolFunction { clauses, fallback } => Self::function(
+                FunctionExpr::bool(BoolFunctionExpr::int_case(subject, clauses, fallback)),
+            ),
+            IntCaseBranches::NilFunction { clauses, fallback } => Self::function(
+                FunctionExpr::nil(NilFunctionExpr::int_case(subject, clauses, fallback)),
+            ),
         }
     }
 
@@ -239,12 +269,15 @@ impl From<Value> for Expr {
 #[cfg(test)]
 mod tests {
     use super::{
-        BoolCaseBranches, BoolExpr, CallArgKind, Expr, FunctionExpr, IntCaseBranches, IntExpr,
-        NilExpr, StringExpr,
+        BoolCaseBranches, BoolExpr, BoolFunctionExpr, CallArgKind, Expr, FunctionExpr,
+        IntCaseBranches, IntExpr, IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr,
+        StringFunctionExpr,
     };
     use crate::plan::{
-        BoolLocalId, FunctionArgumentType, FunctionType, FunctionValue, IntFunctionId, IntLocalId,
-        LocalId, NilLocalId, RuntimeFunctionId, StringLocalId, Value, ValueType,
+        BoolFunctionId, BoolFunctionValue, BoolLocalId, FunctionArgumentType, FunctionType,
+        FunctionValue, IntFunctionId, IntFunctionValue, IntLocalId, LocalId, NilFunctionId,
+        NilFunctionValue, NilLocalId, RuntimeFunctionId, StringFunctionId, StringFunctionValue,
+        StringLocalId, Value, ValueType,
     };
     use num_bigint::BigInt;
 
@@ -330,16 +363,58 @@ mod tests {
         assert_eq!(
             Expr::bool_case(
                 BoolExpr::value(true),
-                BoolCaseBranches::Function {
-                    true_: FunctionExpr::value(function_value()),
-                    false_: FunctionExpr::value(function_value()),
+                BoolCaseBranches::IntFunction {
+                    true_: int_function_expr(),
+                    false_: int_function_expr(),
                 },
             ),
-            Expr::function(FunctionExpr::bool_case(
+            Expr::function(FunctionExpr::int(IntFunctionExpr::bool_case(
                 BoolExpr::value(true),
-                FunctionExpr::value(function_value()),
-                FunctionExpr::value(function_value()),
-            )),
+                int_function_expr(),
+                int_function_expr(),
+            ))),
+        );
+        assert_eq!(
+            Expr::bool_case(
+                BoolExpr::value(true),
+                BoolCaseBranches::StringFunction {
+                    true_: string_function_expr(),
+                    false_: string_function_expr(),
+                },
+            ),
+            Expr::function(FunctionExpr::string(StringFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                string_function_expr(),
+                string_function_expr(),
+            ))),
+        );
+        assert_eq!(
+            Expr::bool_case(
+                BoolExpr::value(true),
+                BoolCaseBranches::BoolFunction {
+                    true_: bool_function_expr(),
+                    false_: bool_function_expr(),
+                },
+            ),
+            Expr::function(FunctionExpr::bool(BoolFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                bool_function_expr(),
+                bool_function_expr(),
+            ))),
+        );
+        assert_eq!(
+            Expr::bool_case(
+                BoolExpr::value(true),
+                BoolCaseBranches::NilFunction {
+                    true_: nil_function_expr(),
+                    false_: nil_function_expr(),
+                },
+            ),
+            Expr::function(FunctionExpr::nil(NilFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                nil_function_expr(),
+                nil_function_expr(),
+            ))),
         );
     }
 
@@ -404,16 +479,58 @@ mod tests {
         assert_eq!(
             Expr::int_case(
                 IntExpr::value(BigInt::from(1)),
-                IntCaseBranches::Function {
-                    clauses: vec![(BigInt::from(1), FunctionExpr::value(function_value()))],
-                    fallback: FunctionExpr::value(function_value()),
+                IntCaseBranches::IntFunction {
+                    clauses: vec![(BigInt::from(1), int_function_expr())],
+                    fallback: int_function_expr(),
                 },
             ),
-            Expr::function(FunctionExpr::int_case(
+            Expr::function(FunctionExpr::int(IntFunctionExpr::int_case(
                 IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), FunctionExpr::value(function_value()))],
-                FunctionExpr::value(function_value()),
-            )),
+                vec![(BigInt::from(1), int_function_expr())],
+                int_function_expr(),
+            ))),
+        );
+        assert_eq!(
+            Expr::int_case(
+                IntExpr::value(BigInt::from(1)),
+                IntCaseBranches::StringFunction {
+                    clauses: vec![(BigInt::from(1), string_function_expr())],
+                    fallback: string_function_expr(),
+                },
+            ),
+            Expr::function(FunctionExpr::string(StringFunctionExpr::int_case(
+                IntExpr::value(BigInt::from(1)),
+                vec![(BigInt::from(1), string_function_expr())],
+                string_function_expr(),
+            ))),
+        );
+        assert_eq!(
+            Expr::int_case(
+                IntExpr::value(BigInt::from(1)),
+                IntCaseBranches::BoolFunction {
+                    clauses: vec![(BigInt::from(1), bool_function_expr())],
+                    fallback: bool_function_expr(),
+                },
+            ),
+            Expr::function(FunctionExpr::bool(BoolFunctionExpr::int_case(
+                IntExpr::value(BigInt::from(1)),
+                vec![(BigInt::from(1), bool_function_expr())],
+                bool_function_expr(),
+            ))),
+        );
+        assert_eq!(
+            Expr::int_case(
+                IntExpr::value(BigInt::from(1)),
+                IntCaseBranches::NilFunction {
+                    clauses: vec![(BigInt::from(1), nil_function_expr())],
+                    fallback: nil_function_expr(),
+                },
+            ),
+            Expr::function(FunctionExpr::nil(NilFunctionExpr::int_case(
+                IntExpr::value(BigInt::from(1)),
+                vec![(BigInt::from(1), nil_function_expr())],
+                nil_function_expr(),
+            ))),
         );
     }
 
@@ -526,6 +643,34 @@ mod tests {
             RuntimeFunctionId::Int(IntFunctionId(0)),
             vec![LocalId::Int(IntLocalId(0))],
         )
+    }
+
+    fn int_function_expr() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(0),
+            vec![LocalId::Int(IntLocalId(0))],
+        ))
+    }
+
+    fn string_function_expr() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(
+            StringFunctionId(0),
+            vec![LocalId::String(StringLocalId(0))],
+        ))
+    }
+
+    fn bool_function_expr() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(
+            BoolFunctionId(0),
+            vec![LocalId::Bool(BoolLocalId(0))],
+        ))
+    }
+
+    fn nil_function_expr() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(
+            NilFunctionId(0),
+            vec![LocalId::Nil(NilLocalId(0))],
+        ))
     }
 
     fn function_type() -> FunctionType {

--- a/src/plan/expression/bool.rs
+++ b/src/plan/expression/bool.rs
@@ -1,4 +1,4 @@
-use super::{CallArg, Expr, IntExpr};
+use super::{BoolFunctionExpr, CallArg, Expr, IntExpr};
 use crate::plan::{BoolFunctionId, BoolLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -17,6 +17,10 @@ pub(crate) enum BoolExprKind {
     },
     Call {
         function: BoolFunctionId,
+        args: Vec<CallArg>,
+    },
+    FunctionCall {
+        function: Box<BoolFunctionExpr>,
         args: Vec<CallArg>,
     },
     Not(Box<BoolExpr>),
@@ -84,6 +88,15 @@ impl BoolExpr {
     pub(crate) fn call(function: BoolFunctionId, args: Vec<CallArg>) -> Self {
         Self {
             kind: BoolExprKind::Call { function, args },
+        }
+    }
+
+    pub(crate) fn function_call(function: BoolFunctionExpr, args: Vec<CallArg>) -> Self {
+        Self {
+            kind: BoolExprKind::FunctionCall {
+                function: Box::new(function),
+                args,
+            },
         }
     }
 
@@ -206,7 +219,9 @@ impl BoolExpr {
 #[cfg(test)]
 mod tests {
     use super::{BoolExpr, BoolExprKind};
-    use crate::plan::{Expr, IntExpr, Step};
+    use crate::plan::{
+        BoolFunctionId, BoolFunctionValue, BoolLocalId, Expr, IntExpr, LocalId, Step,
+    };
 
     #[test]
     fn bool_expr_kind_accessors() {
@@ -222,6 +237,10 @@ mod tests {
             )
             .kind(),
             BoolExprKind::BoolCase { .. }
+        ));
+        assert!(matches!(
+            BoolExpr::function_call(function_expr(), Vec::new()).kind(),
+            BoolExprKind::FunctionCall { .. }
         ));
         assert!(matches!(
             BoolExpr::int_case(
@@ -248,5 +267,12 @@ mod tests {
             .kind(),
             BoolExprKind::Block { .. }
         ));
+    }
+
+    fn function_expr() -> crate::plan::BoolFunctionExpr {
+        crate::plan::BoolFunctionExpr::value(BoolFunctionValue::new(
+            BoolFunctionId(0),
+            vec![LocalId::Bool(BoolLocalId(0))],
+        ))
     }
 }

--- a/src/plan/expression/case.rs
+++ b/src/plan/expression/case.rs
@@ -1,4 +1,7 @@
-use super::{BoolExpr, FunctionExpr, IntExpr, NilExpr, StringExpr};
+use super::{
+    BoolExpr, BoolFunctionExpr, IntExpr, IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr,
+    StringFunctionExpr,
+};
 use num_bigint::BigInt;
 
 pub(crate) enum BoolCaseBranches {
@@ -18,9 +21,21 @@ pub(crate) enum BoolCaseBranches {
         true_: NilExpr,
         false_: NilExpr,
     },
-    Function {
-        true_: FunctionExpr,
-        false_: FunctionExpr,
+    IntFunction {
+        true_: IntFunctionExpr,
+        false_: IntFunctionExpr,
+    },
+    StringFunction {
+        true_: StringFunctionExpr,
+        false_: StringFunctionExpr,
+    },
+    BoolFunction {
+        true_: BoolFunctionExpr,
+        false_: BoolFunctionExpr,
+    },
+    NilFunction {
+        true_: NilFunctionExpr,
+        false_: NilFunctionExpr,
     },
 }
 
@@ -41,8 +56,20 @@ pub(crate) enum IntCaseBranches {
         clauses: Vec<(BigInt, NilExpr)>,
         fallback: NilExpr,
     },
-    Function {
-        clauses: Vec<(BigInt, FunctionExpr)>,
-        fallback: FunctionExpr,
+    IntFunction {
+        clauses: Vec<(BigInt, IntFunctionExpr)>,
+        fallback: IntFunctionExpr,
+    },
+    StringFunction {
+        clauses: Vec<(BigInt, StringFunctionExpr)>,
+        fallback: StringFunctionExpr,
+    },
+    BoolFunction {
+        clauses: Vec<(BigInt, BoolFunctionExpr)>,
+        fallback: BoolFunctionExpr,
+    },
+    NilFunction {
+        clauses: Vec<(BigInt, NilFunctionExpr)>,
+        fallback: NilFunctionExpr,
     },
 }

--- a/src/plan/expression/function.rs
+++ b/src/plan/expression/function.rs
@@ -1,44 +1,250 @@
 use super::{BoolExpr, IntExpr};
-use crate::plan::{FunctionType, FunctionValue, Step};
+use crate::plan::{
+    BoolFunctionLocalId, BoolFunctionValue, FunctionType, FunctionValue, FunctionValueKind,
+    IntFunctionLocalId, IntFunctionValue, NilFunctionLocalId, NilFunctionValue, Step,
+    StringFunctionLocalId, StringFunctionValue,
+};
+use ecow::EcoString;
 use num_bigint::BigInt;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionExpr {
-    type_: FunctionType,
     kind: FunctionExprKind,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct IntFunctionExpr {
+    type_: FunctionType,
+    kind: IntFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StringFunctionExpr {
+    type_: FunctionType,
+    kind: StringFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BoolFunctionExpr {
+    type_: FunctionType,
+    kind: BoolFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NilFunctionExpr {
+    type_: FunctionType,
+    kind: NilFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum FunctionExprKind {
-    Value(FunctionValue),
+    Int(IntFunctionExpr),
+    String(StringFunctionExpr),
+    Bool(BoolFunctionExpr),
+    Nil(NilFunctionExpr),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum IntFunctionExprKind {
+    Value(IntFunctionValue),
+    LocalGet {
+        local: IntFunctionLocalId,
+        name: EcoString,
+    },
     BoolCase {
         subject: Box<BoolExpr>,
-        true_: Box<FunctionExpr>,
-        false_: Box<FunctionExpr>,
+        true_: Box<IntFunctionExpr>,
+        false_: Box<IntFunctionExpr>,
     },
     IntCase {
         subject: Box<IntExpr>,
-        clauses: Vec<(BigInt, FunctionExpr)>,
-        fallback: Box<FunctionExpr>,
+        clauses: Vec<(BigInt, IntFunctionExpr)>,
+        fallback: Box<IntFunctionExpr>,
     },
     Block {
         steps: Vec<Step>,
-        return_: Box<FunctionExpr>,
+        return_: Box<IntFunctionExpr>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum StringFunctionExprKind {
+    Value(StringFunctionValue),
+    LocalGet {
+        local: StringFunctionLocalId,
+        name: EcoString,
+    },
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<StringFunctionExpr>,
+        false_: Box<StringFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, StringFunctionExpr)>,
+        fallback: Box<StringFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<StringFunctionExpr>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum BoolFunctionExprKind {
+    Value(BoolFunctionValue),
+    LocalGet {
+        local: BoolFunctionLocalId,
+        name: EcoString,
+    },
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<BoolFunctionExpr>,
+        false_: Box<BoolFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, BoolFunctionExpr)>,
+        fallback: Box<BoolFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<BoolFunctionExpr>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum NilFunctionExprKind {
+    Value(NilFunctionValue),
+    LocalGet {
+        local: NilFunctionLocalId,
+        name: EcoString,
+    },
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<NilFunctionExpr>,
+        false_: Box<NilFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, NilFunctionExpr)>,
+        fallback: Box<NilFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<NilFunctionExpr>,
     },
 }
 
 impl FunctionExpr {
     pub(crate) fn value(value: FunctionValue) -> Self {
-        Self {
-            type_: value.type_(),
-            kind: FunctionExprKind::Value(value),
+        match value.kind() {
+            FunctionValueKind::Int(value) => Self::int(IntFunctionExpr::value(value.clone())),
+            FunctionValueKind::String(value) => {
+                Self::string(StringFunctionExpr::value(value.clone()))
+            }
+            FunctionValueKind::Bool(value) => Self::bool(BoolFunctionExpr::value(value.clone())),
+            FunctionValueKind::Nil(value) => Self::nil(NilFunctionExpr::value(value.clone())),
         }
     }
 
-    pub(crate) fn bool_case(subject: BoolExpr, true_: FunctionExpr, false_: FunctionExpr) -> Self {
+    pub(crate) fn int(expression: IntFunctionExpr) -> Self {
+        Self {
+            kind: FunctionExprKind::Int(expression),
+        }
+    }
+
+    pub(crate) fn string(expression: StringFunctionExpr) -> Self {
+        Self {
+            kind: FunctionExprKind::String(expression),
+        }
+    }
+
+    pub(crate) fn bool(expression: BoolFunctionExpr) -> Self {
+        Self {
+            kind: FunctionExprKind::Bool(expression),
+        }
+    }
+
+    pub(crate) fn nil(expression: NilFunctionExpr) -> Self {
+        Self {
+            kind: FunctionExprKind::Nil(expression),
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        match &self.kind {
+            FunctionExprKind::Int(expression) => expression.type_(),
+            FunctionExprKind::String(expression) => expression.type_(),
+            FunctionExprKind::Bool(expression) => expression.type_(),
+            FunctionExprKind::Nil(expression) => expression.type_(),
+        }
+    }
+
+    pub(crate) fn kind(&self) -> &FunctionExprKind {
+        &self.kind
+    }
+
+    pub(crate) fn into_kind(self) -> FunctionExprKind {
+        self.kind
+    }
+
+    pub(crate) fn into_int(self) -> Result<IntFunctionExpr, Self> {
+        match self.kind {
+            FunctionExprKind::Int(expression) => Ok(expression),
+            kind => Err(Self { kind }),
+        }
+    }
+
+    pub(crate) fn into_string(self) -> Result<StringFunctionExpr, Self> {
+        match self.kind {
+            FunctionExprKind::String(expression) => Ok(expression),
+            kind => Err(Self { kind }),
+        }
+    }
+
+    pub(crate) fn into_bool(self) -> Result<BoolFunctionExpr, Self> {
+        match self.kind {
+            FunctionExprKind::Bool(expression) => Ok(expression),
+            kind => Err(Self { kind }),
+        }
+    }
+
+    pub(crate) fn into_nil(self) -> Result<NilFunctionExpr, Self> {
+        match self.kind {
+            FunctionExprKind::Nil(expression) => Ok(expression),
+            kind => Err(Self { kind }),
+        }
+    }
+}
+
+impl IntFunctionExpr {
+    pub(crate) fn value(value: IntFunctionValue) -> Self {
+        Self {
+            type_: value.type_(),
+            kind: IntFunctionExprKind::Value(value),
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: IntFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: IntFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: IntFunctionExpr,
+        false_: IntFunctionExpr,
+    ) -> Self {
         Self {
             type_: true_.type_.clone(),
-            kind: FunctionExprKind::BoolCase {
+            kind: IntFunctionExprKind::BoolCase {
                 subject: Box::new(subject),
                 true_: Box::new(true_),
                 false_: Box::new(false_),
@@ -48,12 +254,12 @@ impl FunctionExpr {
 
     pub(crate) fn int_case(
         subject: IntExpr,
-        clauses: Vec<(BigInt, FunctionExpr)>,
-        fallback: FunctionExpr,
+        clauses: Vec<(BigInt, IntFunctionExpr)>,
+        fallback: IntFunctionExpr,
     ) -> Self {
         Self {
             type_: fallback.type_.clone(),
-            kind: FunctionExprKind::IntCase {
+            kind: IntFunctionExprKind::IntCase {
                 subject: Box::new(subject),
                 clauses,
                 fallback: Box::new(fallback),
@@ -61,10 +267,10 @@ impl FunctionExpr {
         }
     }
 
-    pub(crate) fn block(steps: Vec<Step>, return_: FunctionExpr) -> Self {
+    pub(crate) fn block(steps: Vec<Step>, return_: IntFunctionExpr) -> Self {
         Self {
             type_: return_.type_.clone(),
-            kind: FunctionExprKind::Block {
+            kind: IntFunctionExprKind::Block {
                 steps,
                 return_: Box::new(return_),
             },
@@ -75,50 +281,451 @@ impl FunctionExpr {
         &self.type_
     }
 
-    pub(crate) fn kind(&self) -> &FunctionExprKind {
+    pub(crate) fn kind(&self) -> &IntFunctionExprKind {
         &self.kind
+    }
+}
+
+impl StringFunctionExpr {
+    pub(crate) fn value(value: StringFunctionValue) -> Self {
+        Self {
+            type_: value.type_(),
+            kind: StringFunctionExprKind::Value(value),
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: StringFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: StringFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: StringFunctionExpr,
+        false_: StringFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: StringFunctionExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, StringFunctionExpr)>,
+        fallback: StringFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: StringFunctionExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: StringFunctionExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: StringFunctionExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &StringFunctionExprKind {
+        &self.kind
+    }
+}
+
+impl BoolFunctionExpr {
+    pub(crate) fn value(value: BoolFunctionValue) -> Self {
+        Self {
+            type_: value.type_(),
+            kind: BoolFunctionExprKind::Value(value),
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: BoolFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: BoolFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: BoolFunctionExpr,
+        false_: BoolFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: BoolFunctionExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, BoolFunctionExpr)>,
+        fallback: BoolFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: BoolFunctionExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: BoolFunctionExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: BoolFunctionExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &BoolFunctionExprKind {
+        &self.kind
+    }
+}
+
+impl NilFunctionExpr {
+    pub(crate) fn value(value: NilFunctionValue) -> Self {
+        Self {
+            type_: value.type_(),
+            kind: NilFunctionExprKind::Value(value),
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: NilFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: NilFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: NilFunctionExpr,
+        false_: NilFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: NilFunctionExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, NilFunctionExpr)>,
+        fallback: NilFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: NilFunctionExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: NilFunctionExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: NilFunctionExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &NilFunctionExprKind {
+        &self.kind
+    }
+}
+
+impl From<IntFunctionExpr> for FunctionExpr {
+    fn from(expression: IntFunctionExpr) -> Self {
+        Self::int(expression)
+    }
+}
+
+impl From<StringFunctionExpr> for FunctionExpr {
+    fn from(expression: StringFunctionExpr) -> Self {
+        Self::string(expression)
+    }
+}
+
+impl From<BoolFunctionExpr> for FunctionExpr {
+    fn from(expression: BoolFunctionExpr) -> Self {
+        Self::bool(expression)
+    }
+}
+
+impl From<NilFunctionExpr> for FunctionExpr {
+    fn from(expression: NilFunctionExpr) -> Self {
+        Self::nil(expression)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{FunctionExpr, FunctionExprKind};
+    use super::{
+        BoolFunctionExpr, BoolFunctionExprKind, FunctionExpr, FunctionExprKind, IntFunctionExpr,
+        IntFunctionExprKind, NilFunctionExpr, NilFunctionExprKind, StringFunctionExpr,
+        StringFunctionExprKind,
+    };
     use crate::plan::{
-        BoolExpr, Expr, FunctionValue, IntExpr, IntFunctionId, IntLocalId, LocalId,
-        RuntimeFunctionId, Step,
+        BoolExpr, BoolFunctionLocalId, BoolFunctionValue, BoolLocalId, Expr, FunctionType,
+        FunctionValue, IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId,
+        LocalId, NilFunctionLocalId, NilFunctionValue, RuntimeFunctionId, Step,
+        StringFunctionLocalId, StringFunctionValue, ValueType,
     };
 
     #[test]
     fn function_expr_kind_accessors() {
         assert!(matches!(
             FunctionExpr::value(function_value()).kind(),
-            FunctionExprKind::Value(_)
+            FunctionExprKind::Int(_)
         ));
         assert!(matches!(
-            FunctionExpr::int_case(
+            FunctionExpr::int(int_function_value()).kind(),
+            FunctionExprKind::Int(_)
+        ));
+        assert!(matches!(
+            FunctionExpr::string(string_function_value()).kind(),
+            FunctionExprKind::String(_)
+        ));
+        assert!(matches!(
+            FunctionExpr::bool(bool_function_value()).kind(),
+            FunctionExprKind::Bool(_)
+        ));
+        assert!(matches!(
+            FunctionExpr::nil(nil_function_value()).kind(),
+            FunctionExprKind::Nil(_)
+        ));
+    }
+
+    #[test]
+    fn function_expr_typed_conversions() {
+        assert!(FunctionExpr::int(int_function_value()).into_int().is_ok());
+        assert!(
+            FunctionExpr::string(string_function_value())
+                .into_string()
+                .is_ok()
+        );
+        assert!(
+            FunctionExpr::bool(bool_function_value())
+                .into_bool()
+                .is_ok()
+        );
+        assert!(FunctionExpr::nil(nil_function_value()).into_nil().is_ok());
+
+        assert!(
+            FunctionExpr::int(int_function_value())
+                .into_string()
+                .is_err()
+        );
+        assert!(FunctionExpr::int(int_function_value()).into_bool().is_err());
+        assert!(FunctionExpr::int(int_function_value()).into_nil().is_err());
+
+        assert!(matches!(
+            FunctionExpr::from(int_function_value()).kind(),
+            FunctionExprKind::Int(_),
+        ));
+        assert!(matches!(
+            FunctionExpr::from(string_function_value()).kind(),
+            FunctionExprKind::String(_),
+        ));
+        assert!(matches!(
+            FunctionExpr::from(bool_function_value()).kind(),
+            FunctionExprKind::Bool(_),
+        ));
+        assert!(matches!(
+            FunctionExpr::from(nil_function_value()).kind(),
+            FunctionExprKind::Nil(_),
+        ));
+    }
+
+    #[test]
+    fn int_function_expr_kind_accessors() {
+        assert_eq!(
+            int_function_type(),
+            FunctionType::new(vec![crate::plan::FunctionArgumentType::Int], ValueType::Int),
+        );
+        assert!(matches!(
+            IntFunctionExpr::local_get(IntFunctionLocalId(0), "f".into(), int_function_type(),)
+                .kind(),
+            IntFunctionExprKind::LocalGet { .. }
+        ));
+        assert!(matches!(
+            IntFunctionExpr::int_case(
                 IntExpr::value(1.into()),
-                vec![(1.into(), FunctionExpr::value(function_value()))],
-                FunctionExpr::value(function_value()),
+                vec![(1.into(), int_function_value())],
+                int_function_value(),
             )
             .kind(),
-            FunctionExprKind::IntCase { .. }
+            IntFunctionExprKind::IntCase { .. }
         ));
         assert!(matches!(
-            FunctionExpr::block(
+            IntFunctionExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
-                FunctionExpr::value(function_value()),
+                int_function_value(),
             )
             .kind(),
-            FunctionExprKind::Block { .. }
+            IntFunctionExprKind::Block { .. }
         ));
         assert!(matches!(
-            FunctionExpr::bool_case(
+            IntFunctionExpr::bool_case(
                 BoolExpr::value(true),
-                FunctionExpr::value(function_value()),
-                FunctionExpr::value(function_value()),
+                int_function_value(),
+                int_function_value(),
             )
             .kind(),
-            FunctionExprKind::BoolCase { .. }
+            IntFunctionExprKind::BoolCase { .. }
+        ));
+    }
+
+    #[test]
+    fn string_bool_nil_function_expr_kind_accessors() {
+        assert!(matches!(
+            StringFunctionExpr::local_get(
+                StringFunctionLocalId(0),
+                "f".into(),
+                string_function_value().type_().clone(),
+            )
+            .kind(),
+            StringFunctionExprKind::LocalGet { .. }
+        ));
+        assert!(matches!(
+            StringFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                string_function_value(),
+                string_function_value(),
+            )
+            .kind(),
+            StringFunctionExprKind::BoolCase { .. }
+        ));
+        assert!(matches!(
+            StringFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), string_function_value())],
+                string_function_value(),
+            )
+            .kind(),
+            StringFunctionExprKind::IntCase { .. }
+        ));
+        assert!(matches!(
+            StringFunctionExpr::block(Vec::new(), string_function_value()).kind(),
+            StringFunctionExprKind::Block { .. }
+        ));
+        assert!(matches!(
+            BoolFunctionExpr::local_get(
+                BoolFunctionLocalId(0),
+                "f".into(),
+                bool_function_value().type_().clone(),
+            )
+            .kind(),
+            BoolFunctionExprKind::LocalGet { .. }
+        ));
+        assert!(matches!(
+            BoolFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                bool_function_value(),
+                bool_function_value(),
+            )
+            .kind(),
+            BoolFunctionExprKind::BoolCase { .. }
+        ));
+        assert!(matches!(
+            BoolFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), bool_function_value())],
+                bool_function_value(),
+            )
+            .kind(),
+            BoolFunctionExprKind::IntCase { .. }
+        ));
+        assert!(matches!(
+            BoolFunctionExpr::block(Vec::new(), bool_function_value()).kind(),
+            BoolFunctionExprKind::Block { .. }
+        ));
+        assert!(matches!(
+            NilFunctionExpr::local_get(
+                NilFunctionLocalId(0),
+                "f".into(),
+                nil_function_value().type_().clone(),
+            )
+            .kind(),
+            NilFunctionExprKind::LocalGet { .. }
+        ));
+        assert!(matches!(
+            NilFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                nil_function_value(),
+                nil_function_value(),
+            )
+            .kind(),
+            NilFunctionExprKind::BoolCase { .. }
+        ));
+        assert!(matches!(
+            NilFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), nil_function_value())],
+                nil_function_value(),
+            )
+            .kind(),
+            NilFunctionExprKind::IntCase { .. }
+        ));
+        assert!(matches!(
+            NilFunctionExpr::block(Vec::new(), nil_function_value()).kind(),
+            NilFunctionExprKind::Block { .. }
         ));
     }
 
@@ -127,5 +734,37 @@ mod tests {
             RuntimeFunctionId::Int(IntFunctionId(0)),
             vec![LocalId::Int(IntLocalId(0))],
         )
+    }
+
+    fn int_function_value() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(0),
+            vec![LocalId::Int(IntLocalId(0))],
+        ))
+    }
+
+    fn string_function_value() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(
+            crate::plan::StringFunctionId(0),
+            vec![LocalId::String(crate::plan::StringLocalId(0))],
+        ))
+    }
+
+    fn bool_function_value() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(
+            crate::plan::BoolFunctionId(0),
+            vec![LocalId::Bool(BoolLocalId(0))],
+        ))
+    }
+
+    fn nil_function_value() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(
+            crate::plan::NilFunctionId(0),
+            vec![LocalId::Nil(crate::plan::NilLocalId(0))],
+        ))
+    }
+
+    fn int_function_type() -> FunctionType {
+        FunctionType::new(vec![crate::plan::FunctionArgumentType::Int], ValueType::Int)
     }
 }

--- a/src/plan/expression/int.rs
+++ b/src/plan/expression/int.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg};
+use super::{BoolExpr, CallArg, IntFunctionExpr};
 use crate::plan::{IntFunctionId, IntLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -17,6 +17,10 @@ pub(crate) enum IntExprKind {
     },
     Call {
         function: IntFunctionId,
+        args: Vec<CallArg>,
+    },
+    FunctionCall {
+        function: Box<IntFunctionExpr>,
         args: Vec<CallArg>,
     },
     Add {
@@ -72,6 +76,15 @@ impl IntExpr {
     pub(crate) fn call(function: IntFunctionId, args: Vec<CallArg>) -> Self {
         Self {
             kind: IntExprKind::Call { function, args },
+        }
+    }
+
+    pub(crate) fn function_call(function: IntFunctionExpr, args: Vec<CallArg>) -> Self {
+        Self {
+            kind: IntExprKind::FunctionCall {
+                function: Box::new(function),
+                args,
+            },
         }
     }
 
@@ -167,7 +180,7 @@ impl IntExpr {
 #[cfg(test)]
 mod tests {
     use super::{IntExpr, IntExprKind};
-    use crate::plan::{BoolExpr, Expr, Step};
+    use crate::plan::{BoolExpr, Expr, IntFunctionId, IntFunctionValue, IntLocalId, LocalId, Step};
 
     #[test]
     fn int_expr_kind_accessors() {
@@ -183,6 +196,10 @@ mod tests {
             )
             .kind(),
             IntExprKind::BoolCase { .. }
+        ));
+        assert!(matches!(
+            IntExpr::function_call(function_expr(), Vec::new()).kind(),
+            IntExprKind::FunctionCall { .. }
         ));
         assert!(matches!(
             IntExpr::int_case(
@@ -201,5 +218,12 @@ mod tests {
             .kind(),
             IntExprKind::Block { .. }
         ));
+    }
+
+    fn function_expr() -> crate::plan::IntFunctionExpr {
+        crate::plan::IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(0),
+            vec![LocalId::Int(IntLocalId(0))],
+        ))
     }
 }

--- a/src/plan/expression/nil.rs
+++ b/src/plan/expression/nil.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg, IntExpr};
+use super::{BoolExpr, CallArg, IntExpr, NilFunctionExpr};
 use crate::plan::{NilFunctionId, NilLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -17,6 +17,10 @@ pub(crate) enum NilExprKind {
     },
     Call {
         function: NilFunctionId,
+        args: Vec<CallArg>,
+    },
+    FunctionCall {
+        function: Box<NilFunctionExpr>,
         args: Vec<CallArg>,
     },
     BoolCase {
@@ -51,6 +55,15 @@ impl NilExpr {
     pub(crate) fn call(function: NilFunctionId, args: Vec<CallArg>) -> Self {
         Self {
             kind: NilExprKind::Call { function, args },
+        }
+    }
+
+    pub(crate) fn function_call(function: NilFunctionExpr, args: Vec<CallArg>) -> Self {
+        Self {
+            kind: NilExprKind::FunctionCall {
+                function: Box::new(function),
+                args,
+            },
         }
     }
 
@@ -95,11 +108,17 @@ impl NilExpr {
 #[cfg(test)]
 mod tests {
     use super::{NilExpr, NilExprKind};
-    use crate::plan::{BoolExpr, Expr, IntExpr, Step};
+    use crate::plan::{
+        BoolExpr, Expr, IntExpr, LocalId, NilFunctionId, NilFunctionValue, NilLocalId, Step,
+    };
 
     #[test]
     fn nil_expr_kind_accessors() {
         assert!(matches!(NilExpr::value().kind(), NilExprKind::Value));
+        assert!(matches!(
+            NilExpr::function_call(function_expr(), Vec::new()).kind(),
+            NilExprKind::FunctionCall { .. }
+        ));
         assert!(matches!(
             NilExpr::bool_case(BoolExpr::value(true), NilExpr::value(), NilExpr::value()).kind(),
             NilExprKind::BoolCase { .. }
@@ -121,5 +140,12 @@ mod tests {
             .kind(),
             NilExprKind::Block { .. }
         ));
+    }
+
+    fn function_expr() -> crate::plan::NilFunctionExpr {
+        crate::plan::NilFunctionExpr::value(NilFunctionValue::new(
+            NilFunctionId(0),
+            vec![LocalId::Nil(NilLocalId(0))],
+        ))
     }
 }

--- a/src/plan/expression/string.rs
+++ b/src/plan/expression/string.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg, IntExpr};
+use super::{BoolExpr, CallArg, IntExpr, StringFunctionExpr};
 use crate::plan::{Step, StringFunctionId, StringLocalId};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -17,6 +17,10 @@ pub(crate) enum StringExprKind {
     },
     Call {
         function: StringFunctionId,
+        args: Vec<CallArg>,
+    },
+    FunctionCall {
+        function: Box<StringFunctionExpr>,
         args: Vec<CallArg>,
     },
     Concatenate {
@@ -55,6 +59,15 @@ impl StringExpr {
     pub(crate) fn call(function: StringFunctionId, args: Vec<CallArg>) -> Self {
         Self {
             kind: StringExprKind::Call { function, args },
+        }
+    }
+
+    pub(crate) fn function_call(function: StringFunctionExpr, args: Vec<CallArg>) -> Self {
+        Self {
+            kind: StringExprKind::FunctionCall {
+                function: Box::new(function),
+                args,
+            },
         }
     }
 
@@ -108,7 +121,10 @@ impl StringExpr {
 #[cfg(test)]
 mod tests {
     use super::{StringExpr, StringExprKind};
-    use crate::plan::{BoolExpr, Expr, IntExpr, Step};
+    use crate::plan::{
+        BoolExpr, Expr, IntExpr, LocalId, Step, StringFunctionId, StringFunctionValue,
+        StringLocalId,
+    };
 
     #[test]
     fn string_expr_kind_accessors() {
@@ -124,6 +140,10 @@ mod tests {
             )
             .kind(),
             StringExprKind::BoolCase { .. }
+        ));
+        assert!(matches!(
+            StringExpr::function_call(function_expr(), Vec::new()).kind(),
+            StringExprKind::FunctionCall { .. }
         ));
         assert!(matches!(
             StringExpr::int_case(
@@ -142,5 +162,12 @@ mod tests {
             .kind(),
             StringExprKind::Block { .. }
         ));
+    }
+
+    fn function_expr() -> crate::plan::StringFunctionExpr {
+        crate::plan::StringFunctionExpr::value(StringFunctionValue::new(
+            StringFunctionId(0),
+            vec![LocalId::String(StringLocalId(0))],
+        ))
     }
 }

--- a/src/plan/frame.rs
+++ b/src/plan/frame.rs
@@ -1,10 +1,17 @@
-use super::expression::{BoolExpr, CallArg, Expr, FunctionExpr, IntExpr, NilExpr, StringExpr};
+use super::expression::{
+    BoolExpr, BoolFunctionExpr, CallArg, Expr, FunctionExpr, IntExpr, IntFunctionExpr, NilExpr,
+    NilFunctionExpr, StringExpr, StringFunctionExpr,
+};
 use super::function::{Param, ReturnExpr};
-use super::id::{BoolLocalId, IntLocalId, LocalId, NilLocalId, StringLocalId};
+use super::id::{
+    BoolFunctionLocalId, BoolLocalId, IntFunctionLocalId, IntLocalId, LocalId, NilFunctionLocalId,
+    NilLocalId, StringFunctionLocalId, StringLocalId,
+};
 use super::step::Step;
 use super::{
-    BoolExprKind, CallArgKind, ExprKind, FunctionExprKind, IntExprKind, NilExprKind,
-    ReturnExprKind, StepKind, StringExprKind,
+    BoolExprKind, BoolFunctionExprKind, CallArgKind, ExprKind, FunctionExprKind, IntExprKind,
+    IntFunctionExprKind, NilExprKind, NilFunctionExprKind, ReturnExprKind, StepKind,
+    StringExprKind, StringFunctionExprKind,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -13,6 +20,10 @@ pub(crate) struct FrameLayout {
     strings: usize,
     bools: usize,
     nils: usize,
+    int_functions: usize,
+    string_functions: usize,
+    bool_functions: usize,
+    nil_functions: usize,
 }
 
 impl FrameLayout {
@@ -57,6 +68,22 @@ impl FrameLayout {
         self.nils = self.nils.max(local.0 + 1);
     }
 
+    pub(crate) fn include_int_function(&mut self, local: IntFunctionLocalId) {
+        self.int_functions = self.int_functions.max(local.0 + 1);
+    }
+
+    pub(crate) fn include_string_function(&mut self, local: StringFunctionLocalId) {
+        self.string_functions = self.string_functions.max(local.0 + 1);
+    }
+
+    pub(crate) fn include_bool_function(&mut self, local: BoolFunctionLocalId) {
+        self.bool_functions = self.bool_functions.max(local.0 + 1);
+    }
+
+    pub(crate) fn include_nil_function(&mut self, local: NilFunctionLocalId) {
+        self.nil_functions = self.nil_functions.max(local.0 + 1);
+    }
+
     pub(crate) fn ints(self) -> usize {
         self.ints
     }
@@ -72,6 +99,22 @@ impl FrameLayout {
     #[cfg(test)]
     pub(crate) fn nils(self) -> usize {
         self.nils
+    }
+
+    pub(crate) fn int_functions(self) -> usize {
+        self.int_functions
+    }
+
+    pub(crate) fn string_functions(self) -> usize {
+        self.string_functions
+    }
+
+    pub(crate) fn bool_functions(self) -> usize {
+        self.bool_functions
+    }
+
+    pub(crate) fn nil_functions(self) -> usize {
+        self.nil_functions
     }
 
     fn include_steps(&mut self, steps: &[Step]) {
@@ -97,6 +140,22 @@ impl FrameLayout {
             StepKind::LetNil { local, value, .. } => {
                 self.include_nil_expr(value);
                 self.include_nil(*local);
+            }
+            StepKind::LetIntFunction { local, value, .. } => {
+                self.include_int_function_expr(value);
+                self.include_int_function(*local);
+            }
+            StepKind::LetStringFunction { local, value, .. } => {
+                self.include_string_function_expr(value);
+                self.include_string_function(*local);
+            }
+            StepKind::LetBoolFunction { local, value, .. } => {
+                self.include_bool_function_expr(value);
+                self.include_bool_function(*local);
+            }
+            StepKind::LetNilFunction { local, value, .. } => {
+                self.include_nil_function_expr(value);
+                self.include_nil_function(*local);
             }
             StepKind::Evaluate(value) => self.include_expr(value),
         }
@@ -137,6 +196,10 @@ impl FrameLayout {
             IntExprKind::Value(_) => {}
             IntExprKind::LocalGet { local, .. } => self.include_int(*local),
             IntExprKind::Call { args, .. } => self.include_call_args(args),
+            IntExprKind::FunctionCall { function, args } => {
+                self.include_int_function_expr(function);
+                self.include_call_args(args);
+            }
             IntExprKind::Add { left, right }
             | IntExprKind::Sub { left, right }
             | IntExprKind::Mult { left, right }
@@ -178,6 +241,10 @@ impl FrameLayout {
             StringExprKind::Value(_) => {}
             StringExprKind::LocalGet { local, .. } => self.include_string(*local),
             StringExprKind::Call { args, .. } => self.include_call_args(args),
+            StringExprKind::FunctionCall { function, args } => {
+                self.include_string_function_expr(function);
+                self.include_call_args(args);
+            }
             StringExprKind::Concatenate { left, right } => {
                 self.include_string_expr(left);
                 self.include_string_expr(right);
@@ -214,6 +281,10 @@ impl FrameLayout {
             BoolExprKind::Value(_) => {}
             BoolExprKind::LocalGet { local, .. } => self.include_bool(*local),
             BoolExprKind::Call { args, .. } => self.include_call_args(args),
+            BoolExprKind::FunctionCall { function, args } => {
+                self.include_bool_function_expr(function);
+                self.include_call_args(args);
+            }
             BoolExprKind::Not(value) => self.include_bool_expr(value),
             BoolExprKind::LtInt { left, right }
             | BoolExprKind::LtEqInt { left, right }
@@ -262,6 +333,10 @@ impl FrameLayout {
             NilExprKind::Value => {}
             NilExprKind::LocalGet { local, .. } => self.include_nil(*local),
             NilExprKind::Call { args, .. } => self.include_call_args(args),
+            NilExprKind::FunctionCall { function, args } => {
+                self.include_nil_function_expr(function);
+                self.include_call_args(args);
+            }
             NilExprKind::BoolCase {
                 subject,
                 true_,
@@ -291,30 +366,135 @@ impl FrameLayout {
 
     fn include_function_expr(&mut self, expression: &FunctionExpr) {
         match expression.kind() {
-            FunctionExprKind::Value(_) => {}
-            FunctionExprKind::BoolCase {
+            FunctionExprKind::Int(expression) => self.include_int_function_expr(expression),
+            FunctionExprKind::String(expression) => self.include_string_function_expr(expression),
+            FunctionExprKind::Bool(expression) => self.include_bool_function_expr(expression),
+            FunctionExprKind::Nil(expression) => self.include_nil_function_expr(expression),
+        }
+    }
+
+    fn include_int_function_expr(&mut self, expression: &IntFunctionExpr) {
+        match expression.kind() {
+            IntFunctionExprKind::Value(_) => {}
+            IntFunctionExprKind::LocalGet { local, .. } => self.include_int_function(*local),
+            IntFunctionExprKind::BoolCase {
                 subject,
                 true_,
                 false_,
             } => {
                 self.include_bool_expr(subject);
-                self.include_function_expr(true_);
-                self.include_function_expr(false_);
+                self.include_int_function_expr(true_);
+                self.include_int_function_expr(false_);
             }
-            FunctionExprKind::IntCase {
+            IntFunctionExprKind::IntCase {
                 subject,
                 clauses,
                 fallback,
             } => {
                 self.include_int_expr(subject);
                 for (_, branch) in clauses {
-                    self.include_function_expr(branch);
+                    self.include_int_function_expr(branch);
                 }
-                self.include_function_expr(fallback);
+                self.include_int_function_expr(fallback);
             }
-            FunctionExprKind::Block { steps, return_ } => {
+            IntFunctionExprKind::Block { steps, return_ } => {
                 self.include_steps(steps);
-                self.include_function_expr(return_);
+                self.include_int_function_expr(return_);
+            }
+        }
+    }
+
+    fn include_string_function_expr(&mut self, expression: &StringFunctionExpr) {
+        match expression.kind() {
+            StringFunctionExprKind::Value(_) => {}
+            StringFunctionExprKind::LocalGet { local, .. } => {
+                self.include_string_function(*local);
+            }
+            StringFunctionExprKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_string_function_expr(true_);
+                self.include_string_function_expr(false_);
+            }
+            StringFunctionExprKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_string_function_expr(branch);
+                }
+                self.include_string_function_expr(fallback);
+            }
+            StringFunctionExprKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_string_function_expr(return_);
+            }
+        }
+    }
+
+    fn include_bool_function_expr(&mut self, expression: &BoolFunctionExpr) {
+        match expression.kind() {
+            BoolFunctionExprKind::Value(_) => {}
+            BoolFunctionExprKind::LocalGet { local, .. } => self.include_bool_function(*local),
+            BoolFunctionExprKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_bool_function_expr(true_);
+                self.include_bool_function_expr(false_);
+            }
+            BoolFunctionExprKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_bool_function_expr(branch);
+                }
+                self.include_bool_function_expr(fallback);
+            }
+            BoolFunctionExprKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_bool_function_expr(return_);
+            }
+        }
+    }
+
+    fn include_nil_function_expr(&mut self, expression: &NilFunctionExpr) {
+        match expression.kind() {
+            NilFunctionExprKind::Value(_) => {}
+            NilFunctionExprKind::LocalGet { local, .. } => self.include_nil_function(*local),
+            NilFunctionExprKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_nil_function_expr(true_);
+                self.include_nil_function_expr(false_);
+            }
+            NilFunctionExprKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_nil_function_expr(branch);
+                }
+                self.include_nil_function_expr(fallback);
+            }
+            NilFunctionExprKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_nil_function_expr(return_);
             }
         }
     }
@@ -324,8 +504,11 @@ impl FrameLayout {
 mod tests {
     use super::FrameLayout;
     use crate::plan::{
-        BoolExpr, BoolLocalId, Expr, FunctionExpr, FunctionValue, IntExpr, IntFunctionId,
-        IntLocalId, LocalId, NilLocalId, ReturnExpr, RuntimeFunctionId, Step, StringLocalId,
+        BoolExpr, BoolFunctionExpr, BoolFunctionLocalId, BoolFunctionValue, BoolLocalId, Expr,
+        FunctionExpr, IntExpr, IntFunctionExpr, IntFunctionId, IntFunctionLocalId,
+        IntFunctionValue, IntLocalId, LocalId, NilExpr, NilFunctionExpr, NilFunctionLocalId,
+        NilFunctionValue, NilLocalId, ReturnExpr, Step, StringExpr, StringFunctionExpr,
+        StringFunctionLocalId, StringFunctionValue, StringLocalId,
     };
 
     #[test]
@@ -336,35 +519,43 @@ mod tests {
         layout.include_local(LocalId::String(StringLocalId(2)));
         layout.include_local(LocalId::Bool(BoolLocalId(3)));
         layout.include_local(LocalId::Nil(NilLocalId(4)));
+        layout.include_int_function(IntFunctionLocalId(5));
+        layout.include_nil_function(NilFunctionLocalId(6));
 
         assert_eq!(layout.ints(), 2);
         assert_eq!(layout.strings(), 3);
         assert_eq!(layout.bools(), 4);
         assert_eq!(layout.nils(), 5);
+        assert_eq!(layout.int_functions(), 6);
+        assert_eq!(layout.nil_functions(), 7);
     }
 
     #[test]
     fn frame_layout_includes_function_expression_nested_locals() {
-        let steps = vec![Step::evaluate(Expr::function(FunctionExpr::block(
-            vec![Step::evaluate(Expr::function(FunctionExpr::bool_case(
-                BoolExpr::local_get(BoolLocalId(2), "flag".into()),
-                FunctionExpr::value(function_value()),
-                FunctionExpr::int_case(
-                    IntExpr::local_get(IntLocalId(3), "subject".into()),
-                    vec![(
-                        1.into(),
-                        FunctionExpr::block(
-                            vec![Step::evaluate(Expr::int(IntExpr::local_get(
-                                IntLocalId(4),
-                                "value".into(),
-                            )))],
-                            FunctionExpr::value(function_value()),
-                        ),
-                    )],
-                    FunctionExpr::value(function_value()),
-                ),
+        let nested_block = IntFunctionExpr::block(
+            vec![Step::evaluate(Expr::int(IntExpr::local_get(
+                IntLocalId(4),
+                "value".into(),
             )))],
-            FunctionExpr::value(function_value()),
+            int_function_expr(),
+        );
+        let nested_case = IntFunctionExpr::int_case(
+            IntExpr::local_get(IntLocalId(3), "subject".into()),
+            vec![(1.into(), nested_block)],
+            int_function_expr(),
+        );
+        let function_case = IntFunctionExpr::bool_case(
+            BoolExpr::local_get(BoolLocalId(2), "flag".into()),
+            int_function_expr(),
+            nested_case,
+        );
+        let steps = vec![Step::evaluate(Expr::function(FunctionExpr::int(
+            IntFunctionExpr::block(
+                vec![Step::evaluate(Expr::function(FunctionExpr::int(
+                    function_case,
+                )))],
+                int_function_expr(),
+            ),
         )))];
         let return_ = ReturnExpr::int(IntExpr::value(0.into()));
 
@@ -374,10 +565,197 @@ mod tests {
         assert_eq!(layout.bools(), 3);
     }
 
-    fn function_value() -> FunctionValue {
-        FunctionValue::new(
-            RuntimeFunctionId::Int(IntFunctionId(0)),
+    #[test]
+    fn frame_layout_includes_function_local_storage() {
+        let steps = vec![Step::let_int_function(
+            IntFunctionLocalId(1),
+            "f".into(),
+            IntFunctionExpr::local_get(
+                IntFunctionLocalId(2),
+                "g".into(),
+                int_function_expr().type_().clone(),
+            ),
+        )];
+        let return_ = ReturnExpr::int(IntExpr::function_call(
+            IntFunctionExpr::local_get(
+                IntFunctionLocalId(3),
+                "h".into(),
+                int_function_expr().type_().clone(),
+            ),
+            Vec::new(),
+        ));
+
+        let layout = FrameLayout::from_function_parts(&[], &steps, &return_);
+
+        assert_eq!(layout.int_functions(), 4);
+    }
+
+    #[test]
+    fn frame_layout_includes_function_expression_return_families() {
+        let steps = vec![
+            Step::evaluate(Expr::function(FunctionExpr::string(
+                StringFunctionExpr::local_get(
+                    StringFunctionLocalId(1),
+                    "string".into(),
+                    string_function_expr().type_().clone(),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::bool(
+                BoolFunctionExpr::local_get(
+                    BoolFunctionLocalId(2),
+                    "bool".into(),
+                    bool_function_expr().type_().clone(),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::nil(
+                NilFunctionExpr::local_get(
+                    NilFunctionLocalId(3),
+                    "nil".into(),
+                    nil_function_expr().type_().clone(),
+                ),
+            ))),
+        ];
+        let return_ = ReturnExpr::int(IntExpr::value(0.into()));
+
+        let layout = FrameLayout::from_function_parts(&[], &steps, &return_);
+
+        assert_eq!(layout.string_functions(), 2);
+        assert_eq!(layout.bool_functions(), 3);
+        assert_eq!(layout.nil_functions(), 4);
+    }
+
+    #[test]
+    fn frame_layout_includes_step_and_function_expression_families() {
+        let steps = vec![
+            Step::let_string(
+                StringLocalId(1),
+                "text".into(),
+                StringExpr::block(
+                    Vec::new(),
+                    StringExpr::call(crate::plan::StringFunctionId(0), Vec::new()),
+                ),
+            ),
+            Step::let_bool(
+                BoolLocalId(1),
+                "flag".into(),
+                BoolExpr::block(
+                    Vec::new(),
+                    BoolExpr::equal(
+                        Expr::int(IntExpr::value(1.into())),
+                        Expr::int(IntExpr::value(1.into())),
+                    ),
+                ),
+            ),
+            Step::let_nil(
+                NilLocalId(1),
+                "none".into(),
+                NilExpr::block(
+                    Vec::new(),
+                    NilExpr::call(crate::plan::NilFunctionId(0), Vec::new()),
+                ),
+            ),
+            Step::let_string_function(
+                StringFunctionLocalId(2),
+                "string_fn".into(),
+                StringFunctionExpr::bool_case(
+                    BoolExpr::value(true),
+                    StringFunctionExpr::int_case(
+                        IntExpr::value(1.into()),
+                        vec![(1.into(), string_function_expr())],
+                        string_function_expr(),
+                    ),
+                    StringFunctionExpr::block(Vec::new(), string_function_expr()),
+                ),
+            ),
+            Step::let_bool_function(
+                BoolFunctionLocalId(2),
+                "bool_fn".into(),
+                BoolFunctionExpr::bool_case(
+                    BoolExpr::value(true),
+                    BoolFunctionExpr::int_case(
+                        IntExpr::value(1.into()),
+                        vec![(1.into(), bool_function_expr())],
+                        bool_function_expr(),
+                    ),
+                    BoolFunctionExpr::block(Vec::new(), bool_function_expr()),
+                ),
+            ),
+            Step::let_nil_function(
+                NilFunctionLocalId(2),
+                "nil_fn".into(),
+                NilFunctionExpr::bool_case(
+                    BoolExpr::value(true),
+                    NilFunctionExpr::int_case(
+                        IntExpr::value(1.into()),
+                        vec![(1.into(), nil_function_expr())],
+                        nil_function_expr(),
+                    ),
+                    NilFunctionExpr::block(Vec::new(), nil_function_expr()),
+                ),
+            ),
+            Step::evaluate(Expr::string(StringExpr::function_call(
+                StringFunctionExpr::local_get(
+                    StringFunctionLocalId(3),
+                    "string_fn".into(),
+                    string_function_expr().type_().clone(),
+                ),
+                Vec::new(),
+            ))),
+            Step::evaluate(Expr::bool(BoolExpr::function_call(
+                BoolFunctionExpr::local_get(
+                    BoolFunctionLocalId(3),
+                    "bool_fn".into(),
+                    bool_function_expr().type_().clone(),
+                ),
+                Vec::new(),
+            ))),
+            Step::evaluate(Expr::nil(NilExpr::function_call(
+                NilFunctionExpr::local_get(
+                    NilFunctionLocalId(3),
+                    "nil_fn".into(),
+                    nil_function_expr().type_().clone(),
+                ),
+                Vec::new(),
+            ))),
+            Step::evaluate(Expr::int(IntExpr::negate(IntExpr::value(1.into())))),
+        ];
+        let return_ = ReturnExpr::int(IntExpr::value(0.into()));
+
+        let layout = FrameLayout::from_function_parts(&[], &steps, &return_);
+
+        assert_eq!(layout.strings(), 2);
+        assert_eq!(layout.bools(), 2);
+        assert_eq!(layout.nils(), 2);
+        assert_eq!(layout.string_functions(), 4);
+        assert_eq!(layout.bool_functions(), 4);
+        assert_eq!(layout.nil_functions(), 4);
+    }
+
+    fn int_function_expr() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(0),
             vec![crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
-        )
+        ))
+    }
+
+    fn string_function_expr() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(
+            crate::plan::StringFunctionId(0),
+            vec![crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+        ))
+    }
+
+    fn bool_function_expr() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(
+            crate::plan::BoolFunctionId(0),
+            vec![crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))],
+        ))
+    }
+
+    fn nil_function_expr() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(
+            crate::plan::NilFunctionId(0),
+            vec![crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))],
+        ))
     }
 }

--- a/src/plan/id.rs
+++ b/src/plan/id.rs
@@ -18,6 +18,18 @@ pub struct BoolLocalId(pub(crate) usize);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NilLocalId(pub(crate) usize);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IntFunctionLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StringFunctionLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BoolFunctionLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NilFunctionLocalId(pub(crate) usize);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FunctionId(usize);
 
@@ -77,8 +89,9 @@ impl RuntimeFunctionId {
 #[cfg(test)]
 mod tests {
     use super::{
-        BoolFunctionId, BoolLocalId, FunctionId, IntFunctionId, IntLocalId, LocalId, NilFunctionId,
-        NilLocalId, RuntimeFunctionId, StringFunctionId, StringLocalId,
+        BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FunctionId, IntFunctionId,
+        IntFunctionLocalId, IntLocalId, LocalId, NilFunctionId, NilFunctionLocalId, NilLocalId,
+        RuntimeFunctionId, StringFunctionId, StringFunctionLocalId, StringLocalId,
     };
     use crate::plan::ValueType;
 
@@ -115,6 +128,26 @@ mod tests {
         assert_eq!(
             RuntimeFunctionId::Nil(NilFunctionId(0)).value_type(),
             ValueType::Nil
+        );
+    }
+
+    #[test]
+    fn function_local_id_debug_surface() {
+        assert_eq!(
+            format!("{:?}", IntFunctionLocalId(3)),
+            "IntFunctionLocalId(3)"
+        );
+        assert_eq!(
+            format!("{:?}", StringFunctionLocalId(3)),
+            "StringFunctionLocalId(3)"
+        );
+        assert_eq!(
+            format!("{:?}", BoolFunctionLocalId(3)),
+            "BoolFunctionLocalId(3)"
+        );
+        assert_eq!(
+            format!("{:?}", NilFunctionLocalId(3)),
+            "NilFunctionLocalId(3)"
         );
     }
 }

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -1,5 +1,11 @@
-use super::expression::{BoolExpr, Expr, IntExpr, NilExpr, StringExpr};
-use super::id::{BoolLocalId, IntLocalId, NilLocalId, StringLocalId};
+use super::expression::{
+    BoolExpr, BoolFunctionExpr, Expr, IntExpr, IntFunctionExpr, NilExpr, NilFunctionExpr,
+    StringExpr, StringFunctionExpr,
+};
+use super::id::{
+    BoolFunctionLocalId, BoolLocalId, IntFunctionLocalId, IntLocalId, NilFunctionLocalId,
+    NilLocalId, StringFunctionLocalId, StringLocalId,
+};
 use ecow::EcoString;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -29,6 +35,26 @@ pub(crate) enum StepKind {
         name: EcoString,
         value: NilExpr,
     },
+    LetIntFunction {
+        local: IntFunctionLocalId,
+        name: EcoString,
+        value: IntFunctionExpr,
+    },
+    LetStringFunction {
+        local: StringFunctionLocalId,
+        name: EcoString,
+        value: StringFunctionExpr,
+    },
+    LetBoolFunction {
+        local: BoolFunctionLocalId,
+        name: EcoString,
+        value: BoolFunctionExpr,
+    },
+    LetNilFunction {
+        local: NilFunctionLocalId,
+        name: EcoString,
+        value: NilFunctionExpr,
+    },
     Evaluate(Expr),
 }
 
@@ -57,6 +83,46 @@ impl Step {
         }
     }
 
+    pub(crate) fn let_int_function(
+        local: IntFunctionLocalId,
+        name: EcoString,
+        value: IntFunctionExpr,
+    ) -> Self {
+        Self {
+            kind: StepKind::LetIntFunction { local, name, value },
+        }
+    }
+
+    pub(crate) fn let_string_function(
+        local: StringFunctionLocalId,
+        name: EcoString,
+        value: StringFunctionExpr,
+    ) -> Self {
+        Self {
+            kind: StepKind::LetStringFunction { local, name, value },
+        }
+    }
+
+    pub(crate) fn let_bool_function(
+        local: BoolFunctionLocalId,
+        name: EcoString,
+        value: BoolFunctionExpr,
+    ) -> Self {
+        Self {
+            kind: StepKind::LetBoolFunction { local, name, value },
+        }
+    }
+
+    pub(crate) fn let_nil_function(
+        local: NilFunctionLocalId,
+        name: EcoString,
+        value: NilFunctionExpr,
+    ) -> Self {
+        Self {
+            kind: StepKind::LetNilFunction { local, name, value },
+        }
+    }
+
     pub(crate) fn evaluate(value: Expr) -> Self {
         Self {
             kind: StepKind::Evaluate(value),
@@ -71,7 +137,9 @@ impl Step {
 #[cfg(test)]
 mod tests {
     use super::{Step, StepKind};
-    use crate::plan::{Expr, IntExpr, IntLocalId};
+    use crate::plan::{
+        Expr, IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId, LocalId,
+    };
     use num_bigint::BigInt;
 
     #[test]
@@ -81,8 +149,19 @@ mod tests {
             StepKind::LetInt { .. },
         ));
         assert!(matches!(
+            Step::let_int_function(IntFunctionLocalId(0), "f".into(), function_expr()).kind(),
+            StepKind::LetIntFunction { .. },
+        ));
+        assert!(matches!(
             Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1)))).kind(),
             StepKind::Evaluate(_),
         ));
+    }
+
+    fn function_expr() -> crate::plan::IntFunctionExpr {
+        crate::plan::IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(0),
+            vec![LocalId::Int(IntLocalId(0))],
+        ))
     }
 }

--- a/src/plan/value.rs
+++ b/src/plan/value.rs
@@ -1,7 +1,9 @@
 use ecow::EcoString;
 use num_bigint::BigInt;
 
-use super::{LocalId, RuntimeFunctionId};
+use super::{
+    BoolFunctionId, IntFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringFunctionId,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValueType {
@@ -28,7 +30,38 @@ pub(crate) enum FunctionArgumentType {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionValue {
-    runtime_id: RuntimeFunctionId,
+    kind: FunctionValueKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FunctionValueKind {
+    Int(IntFunctionValue),
+    String(StringFunctionValue),
+    Bool(BoolFunctionValue),
+    Nil(NilFunctionValue),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IntFunctionValue {
+    runtime_id: IntFunctionId,
+    params: Vec<LocalId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StringFunctionValue {
+    runtime_id: StringFunctionId,
+    params: Vec<LocalId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoolFunctionValue {
+    runtime_id: BoolFunctionId,
+    params: Vec<LocalId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NilFunctionValue {
+    runtime_id: NilFunctionId,
     params: Vec<LocalId>,
 }
 
@@ -81,29 +114,144 @@ impl FunctionArgumentType {
 
 impl FunctionValue {
     pub(crate) fn new(runtime_id: RuntimeFunctionId, params: Vec<LocalId>) -> Self {
-        Self { runtime_id, params }
+        let kind = match runtime_id {
+            RuntimeFunctionId::Int(runtime_id) => {
+                FunctionValueKind::Int(IntFunctionValue::new(runtime_id, params))
+            }
+            RuntimeFunctionId::String(runtime_id) => {
+                FunctionValueKind::String(StringFunctionValue::new(runtime_id, params))
+            }
+            RuntimeFunctionId::Bool(runtime_id) => {
+                FunctionValueKind::Bool(BoolFunctionValue::new(runtime_id, params))
+            }
+            RuntimeFunctionId::Nil(runtime_id) => {
+                FunctionValueKind::Nil(NilFunctionValue::new(runtime_id, params))
+            }
+        };
+
+        Self { kind }
     }
 
     pub fn type_(&self) -> FunctionType {
-        FunctionType::new(
-            self.params
-                .iter()
-                .map(FunctionArgumentType::from_local)
-                .collect(),
-            self.runtime_id.value_type(),
-        )
+        match &self.kind {
+            FunctionValueKind::Int(value) => value.type_(),
+            FunctionValueKind::String(value) => value.type_(),
+            FunctionValueKind::Bool(value) => value.type_(),
+            FunctionValueKind::Nil(value) => value.type_(),
+        }
     }
 
-    pub(crate) fn runtime_id(&self) -> RuntimeFunctionId {
+    pub(crate) fn kind(&self) -> &FunctionValueKind {
+        &self.kind
+    }
+}
+
+impl IntFunctionValue {
+    pub(crate) fn new(runtime_id: IntFunctionId, params: Vec<LocalId>) -> Self {
+        Self { runtime_id, params }
+    }
+
+    pub(crate) fn type_(&self) -> FunctionType {
+        function_type(&self.params, ValueType::Int)
+    }
+
+    pub(crate) fn runtime_id(&self) -> IntFunctionId {
         self.runtime_id
+    }
+}
+
+impl StringFunctionValue {
+    pub(crate) fn new(runtime_id: StringFunctionId, params: Vec<LocalId>) -> Self {
+        Self { runtime_id, params }
+    }
+
+    pub(crate) fn type_(&self) -> FunctionType {
+        function_type(&self.params, ValueType::String)
+    }
+
+    pub(crate) fn runtime_id(&self) -> StringFunctionId {
+        self.runtime_id
+    }
+}
+
+impl BoolFunctionValue {
+    pub(crate) fn new(runtime_id: BoolFunctionId, params: Vec<LocalId>) -> Self {
+        Self { runtime_id, params }
+    }
+
+    pub(crate) fn type_(&self) -> FunctionType {
+        function_type(&self.params, ValueType::Bool)
+    }
+
+    pub(crate) fn runtime_id(&self) -> BoolFunctionId {
+        self.runtime_id
+    }
+}
+
+impl NilFunctionValue {
+    pub(crate) fn new(runtime_id: NilFunctionId, params: Vec<LocalId>) -> Self {
+        Self { runtime_id, params }
+    }
+
+    pub(crate) fn type_(&self) -> FunctionType {
+        function_type(&self.params, ValueType::Nil)
+    }
+
+    pub(crate) fn runtime_id(&self) -> NilFunctionId {
+        self.runtime_id
+    }
+}
+
+fn function_type(params: &[LocalId], return_: ValueType) -> FunctionType {
+    FunctionType::new(
+        params
+            .iter()
+            .map(FunctionArgumentType::from_local)
+            .collect(),
+        return_,
+    )
+}
+
+impl From<IntFunctionValue> for FunctionValue {
+    fn from(value: IntFunctionValue) -> Self {
+        Self {
+            kind: FunctionValueKind::Int(value),
+        }
+    }
+}
+
+impl From<StringFunctionValue> for FunctionValue {
+    fn from(value: StringFunctionValue) -> Self {
+        Self {
+            kind: FunctionValueKind::String(value),
+        }
+    }
+}
+
+impl From<BoolFunctionValue> for FunctionValue {
+    fn from(value: BoolFunctionValue) -> Self {
+        Self {
+            kind: FunctionValueKind::Bool(value),
+        }
+    }
+}
+
+impl From<NilFunctionValue> for FunctionValue {
+    fn from(value: NilFunctionValue) -> Self {
+        Self {
+            kind: FunctionValueKind::Nil(value),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{FunctionArgumentType, FunctionType, FunctionValue, ValueType};
+    use super::{
+        BoolFunctionValue, FunctionArgumentType, FunctionType, FunctionValue, IntFunctionValue,
+        NilFunctionValue, StringFunctionValue, ValueType,
+    };
     use crate::plan::{
-        BoolLocalId, IntFunctionId, IntLocalId, LocalId, NilFunctionId, NilLocalId,
+        BoolFunctionId, BoolLocalId, IntFunctionId, IntLocalId, LocalId, NilFunctionId, NilLocalId,
         RuntimeFunctionId, StringFunctionId, StringLocalId,
     };
 
@@ -120,10 +268,6 @@ mod tests {
             FunctionType::new(vec![FunctionArgumentType::Int], ValueType::String),
         );
         assert_eq!(type_.return_(), &ValueType::String);
-        assert_eq!(
-            value.runtime_id(),
-            RuntimeFunctionId::String(StringFunctionId(0))
-        );
     }
 
     #[test]
@@ -131,6 +275,20 @@ mod tests {
         let value = FunctionValue::new(RuntimeFunctionId::Nil(NilFunctionId(0)), Vec::new());
 
         assert_eq!(value.type_(), FunctionType::new(Vec::new(), ValueType::Nil));
+    }
+
+    #[test]
+    fn function_value_conversions_preserve_return_family() {
+        let int: FunctionValue = IntFunctionValue::new(IntFunctionId(0), Vec::new()).into();
+        let string: FunctionValue =
+            StringFunctionValue::new(StringFunctionId(0), Vec::new()).into();
+        let bool: FunctionValue = BoolFunctionValue::new(BoolFunctionId(0), Vec::new()).into();
+        let nil: FunctionValue = NilFunctionValue::new(NilFunctionId(0), Vec::new()).into();
+
+        assert_eq!(int.type_().return_(), &ValueType::Int);
+        assert_eq!(string.type_().return_(), &ValueType::String);
+        assert_eq!(bool.type_().return_(), &ValueType::Bool);
+        assert_eq!(nil.type_().return_(), &ValueType::Nil);
     }
 
     #[test]

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -1,7 +1,8 @@
 use crate::plan::{
-    BoolFunctionId, BoolLocalId, FunctionArgumentType, FunctionId, FunctionType, FunctionValue,
-    IntFunctionId, IntLocalId, LocalId, NilFunctionId, NilLocalId, RuntimeFunctionId,
-    StringFunctionId, StringLocalId, ValueType,
+    BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FunctionArgumentType, FunctionId,
+    FunctionType, FunctionValue, IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId,
+    NilFunctionId, NilFunctionLocalId, NilLocalId, RuntimeFunctionId, StringFunctionId,
+    StringFunctionLocalId, StringLocalId, ValueType,
 };
 use ecow::EcoString;
 use gleam_core::type_::Type;
@@ -28,12 +29,36 @@ pub(super) struct PlanContext<'a> {
     next_string_local: usize,
     next_bool_local: usize,
     next_nil_local: usize,
+    next_int_function_local: usize,
+    next_string_function_local: usize,
+    next_bool_function_local: usize,
+    next_nil_function_local: usize,
 }
 
 #[derive(Clone)]
 enum LocalBinding {
     Primitive { local: LocalId, type_: ValueType },
-    Function(FunctionValue),
+    Function(FunctionLocalBinding),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum FunctionLocalBinding {
+    Int {
+        local: IntFunctionLocalId,
+        type_: FunctionType,
+    },
+    String {
+        local: StringFunctionLocalId,
+        type_: FunctionType,
+    },
+    Bool {
+        local: BoolFunctionLocalId,
+        type_: FunctionType,
+    },
+    Nil {
+        local: NilFunctionLocalId,
+        type_: FunctionType,
+    },
 }
 
 impl<'a> PlanContext<'a> {
@@ -49,6 +74,10 @@ impl<'a> PlanContext<'a> {
             next_string_local: 0,
             next_bool_local: 0,
             next_nil_local: 0,
+            next_int_function_local: 0,
+            next_string_function_local: 0,
+            next_bool_function_local: 0,
+            next_nil_function_local: 0,
         }
     }
 
@@ -76,8 +105,60 @@ impl<'a> PlanContext<'a> {
             .insert(name, LocalBinding::Primitive { local, type_ });
     }
 
-    pub(super) fn define_function_alias(&mut self, name: EcoString, value: FunctionValue) {
-        self.bindings.insert(name, LocalBinding::Function(value));
+    pub(super) fn define_int_function_local(
+        &mut self,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> IntFunctionLocalId {
+        let local = IntFunctionLocalId(self.next_int_function_local);
+        self.next_int_function_local += 1;
+        self.bindings.insert(
+            name,
+            LocalBinding::Function(FunctionLocalBinding::Int { local, type_ }),
+        );
+        local
+    }
+
+    pub(super) fn define_string_function_local(
+        &mut self,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> StringFunctionLocalId {
+        let local = StringFunctionLocalId(self.next_string_function_local);
+        self.next_string_function_local += 1;
+        self.bindings.insert(
+            name,
+            LocalBinding::Function(FunctionLocalBinding::String { local, type_ }),
+        );
+        local
+    }
+
+    pub(super) fn define_bool_function_local(
+        &mut self,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> BoolFunctionLocalId {
+        let local = BoolFunctionLocalId(self.next_bool_function_local);
+        self.next_bool_function_local += 1;
+        self.bindings.insert(
+            name,
+            LocalBinding::Function(FunctionLocalBinding::Bool { local, type_ }),
+        );
+        local
+    }
+
+    pub(super) fn define_nil_function_local(
+        &mut self,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> NilFunctionLocalId {
+        let local = NilFunctionLocalId(self.next_nil_function_local);
+        self.next_nil_function_local += 1;
+        self.bindings.insert(
+            name,
+            LocalBinding::Function(FunctionLocalBinding::Nil { local, type_ }),
+        );
+        local
     }
 
     pub(super) fn define_int_local(&mut self, name: EcoString) -> IntLocalId {
@@ -143,9 +224,9 @@ impl<'a> PlanContext<'a> {
         self.functions.get(name).cloned()
     }
 
-    pub(super) fn lookup_function_value(&self, name: &EcoString) -> Option<FunctionValue> {
+    pub(super) fn lookup_function_local(&self, name: &EcoString) -> Option<FunctionLocalBinding> {
         match self.bindings.get(name)? {
-            LocalBinding::Function(value) => Some(value.clone()),
+            LocalBinding::Function(binding) => Some(binding.clone()),
             LocalBinding::Primitive { .. } => None,
         }
     }
@@ -242,9 +323,11 @@ impl ValueType {
 
 #[cfg(test)]
 mod tests {
+    use super::FunctionLocalBinding;
     use super::{FunctionInfo, FunctionRuntimeIds, PlanContext};
     use crate::plan::{
-        FunctionValue, IntFunctionId, IntLocalId, LocalId, RuntimeFunctionId, ValueType,
+        FunctionValue, IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId, RuntimeFunctionId,
+        ValueType,
     };
     use ecow::EcoString;
     use std::collections::HashMap;
@@ -270,42 +353,54 @@ mod tests {
     }
 
     #[test]
-    fn define_function_alias_records_value() {
+    fn define_function_local_records_binding() {
         let module = EcoString::from("main");
         let functions = HashMap::<EcoString, FunctionInfo>::new();
         let mut context = PlanContext::new(&module, &functions);
         let value = function_value();
 
-        context.define_function_alias("f".into(), value.clone());
+        let local = context.define_int_function_local("f".into(), value.type_());
 
-        assert_eq!(context.lookup_function_value(&"f".into()), Some(value));
+        assert_eq!(
+            context.lookup_function_local(&"f".into()),
+            Some(FunctionLocalBinding::Int {
+                local,
+                type_: value.type_(),
+            })
+        );
         assert_eq!(context.lookup_local(&"f".into()), None);
     }
 
     #[test]
-    fn function_alias_shadows_primitive_binding() {
+    fn function_local_shadows_primitive_binding() {
         let module = EcoString::from("main");
         let functions = HashMap::<EcoString, FunctionInfo>::new();
         let mut context = PlanContext::new(&module, &functions);
         let value = function_value();
 
         context.define_int_local("f".into());
-        context.define_function_alias("f".into(), value.clone());
+        context.define_int_function_local("f".into(), value.type_());
 
-        assert_eq!(context.lookup_function_value(&"f".into()), Some(value));
+        assert_eq!(
+            context.lookup_function_local(&"f".into()),
+            Some(FunctionLocalBinding::Int {
+                local: IntFunctionLocalId(0),
+                type_: value.type_(),
+            })
+        );
         assert_eq!(context.lookup_local(&"f".into()), None);
     }
 
     #[test]
-    fn primitive_binding_shadows_function_alias() {
+    fn primitive_binding_shadows_function_local() {
         let module = EcoString::from("main");
         let functions = HashMap::<EcoString, FunctionInfo>::new();
         let mut context = PlanContext::new(&module, &functions);
 
-        context.define_function_alias("f".into(), function_value());
+        context.define_int_function_local("f".into(), function_value().type_());
         let local = context.define_int_local("f".into());
 
-        assert_eq!(context.lookup_function_value(&"f".into()), None);
+        assert_eq!(context.lookup_function_local(&"f".into()), None);
         assert_eq!(
             context.lookup_local(&"f".into()),
             Some((LocalId::Int(local), ValueType::Int))

--- a/src/planner/dsl.rs
+++ b/src/planner/dsl.rs
@@ -3,11 +3,15 @@ mod function;
 mod module;
 
 pub(crate) use expression::{
-    block_bool, block_function, block_int, block_nil, block_string, bool_, bool_arg,
-    bool_case_bool, bool_case_int, bool_case_nil, bool_case_string, call_bool, call_int, call_nil,
+    block_bool, block_function, block_int, block_int_function, block_nil, block_string, bool_,
+    bool_arg, bool_case_bool, bool_case_int, bool_case_int_function, bool_case_nil,
+    bool_case_string, bool_function_ref, call_bool, call_int, call_int_function, call_nil,
     call_string, equal, evaluate_step, function_ref, int, int_arg, int_case_bool, int_case_int,
-    int_case_nil, int_case_string, let_bool_step, let_int_step, let_nil_step, let_string_step,
-    local_bool, local_int, local_nil, local_string, nil, nil_arg, not_equal, string, string_arg,
+    int_case_int_function, int_case_nil, int_case_string, int_function_ref, let_bool_function_step,
+    let_bool_step, let_int_function_step, let_int_step, let_nil_function_step, let_nil_step,
+    let_string_function_step, let_string_step, local_bool, local_int, local_int_function,
+    local_nil, local_string, nil, nil_arg, nil_function_ref, not_equal, string, string_arg,
+    string_function_ref,
 };
 pub(crate) use function::function;
 pub(crate) use module::module;

--- a/src/planner/dsl/expression.rs
+++ b/src/planner/dsl/expression.rs
@@ -1,7 +1,11 @@
 use crate::plan::{
-    BoolExpr, BoolFunctionId, BoolLocalId, CallArg, Expr, FunctionExpr, FunctionValue, IntExpr,
-    IntFunctionId, IntLocalId, LocalId, NilExpr, NilFunctionId, NilLocalId, ReturnExpr,
-    RuntimeFunctionId, Step, StringExpr, StringFunctionId, StringLocalId,
+    BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue,
+    BoolLocalId, CallArg, Expr, FunctionArgumentType, FunctionExpr, FunctionExprKind, FunctionType,
+    FunctionValue, IntExpr, IntFunctionExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue,
+    IntLocalId, LocalId, NilExpr, NilFunctionExpr, NilFunctionId, NilFunctionLocalId,
+    NilFunctionValue, NilLocalId, ReturnExpr, RuntimeFunctionId, Step, StringExpr,
+    StringFunctionExpr, StringFunctionId, StringFunctionLocalId, StringFunctionValue,
+    StringLocalId, ValueType,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -15,6 +19,14 @@ pub(crate) struct Bool(BoolExpr);
 pub(crate) struct Nil(NilExpr);
 
 pub(crate) struct Function(FunctionExpr);
+
+pub(crate) struct IntFunction(IntFunctionExpr);
+
+pub(crate) struct StringFunction(StringFunctionExpr);
+
+pub(crate) struct BoolFunction(BoolFunctionExpr);
+
+pub(crate) struct NilFunction(NilFunctionExpr);
 
 pub(crate) fn int(value: i64) -> Int {
     Int(IntExpr::value(BigInt::from(value)))
@@ -40,6 +52,58 @@ pub(crate) fn function_ref(
         runtime_id,
         params.into_iter().collect(),
     )))
+}
+
+pub(crate) fn int_function_ref(
+    runtime_id: usize,
+    params: impl IntoIterator<Item = LocalId>,
+) -> IntFunction {
+    IntFunction(IntFunctionExpr::value(IntFunctionValue::new(
+        IntFunctionId(runtime_id),
+        params.into_iter().collect(),
+    )))
+}
+
+pub(crate) fn string_function_ref(
+    runtime_id: usize,
+    params: impl IntoIterator<Item = LocalId>,
+) -> StringFunction {
+    StringFunction(StringFunctionExpr::value(StringFunctionValue::new(
+        StringFunctionId(runtime_id),
+        params.into_iter().collect(),
+    )))
+}
+
+pub(crate) fn bool_function_ref(
+    runtime_id: usize,
+    params: impl IntoIterator<Item = LocalId>,
+) -> BoolFunction {
+    BoolFunction(BoolFunctionExpr::value(BoolFunctionValue::new(
+        BoolFunctionId(runtime_id),
+        params.into_iter().collect(),
+    )))
+}
+
+pub(crate) fn nil_function_ref(
+    runtime_id: usize,
+    params: impl IntoIterator<Item = LocalId>,
+) -> NilFunction {
+    NilFunction(NilFunctionExpr::value(NilFunctionValue::new(
+        NilFunctionId(runtime_id),
+        params.into_iter().collect(),
+    )))
+}
+
+pub(crate) fn local_int_function(
+    local: usize,
+    name: impl Into<EcoString>,
+    params: impl IntoIterator<Item = LocalId>,
+) -> IntFunction {
+    IntFunction(IntFunctionExpr::local_get(
+        IntFunctionLocalId(local),
+        name.into(),
+        int_function_type(params),
+    ))
 }
 
 pub(crate) fn equal(left: impl Into<Expr>, right: impl Into<Expr>) -> Bool {
@@ -76,6 +140,54 @@ pub(crate) fn bool_case_bool(subject: Bool, true_: Bool, false_: Bool) -> Bool {
 
 pub(crate) fn bool_case_nil(subject: Bool, true_: Nil, false_: Nil) -> Nil {
     Nil(NilExpr::bool_case(
+        subject.into(),
+        true_.into(),
+        false_.into(),
+    ))
+}
+
+pub(crate) fn bool_case_int_function(
+    subject: Bool,
+    true_: IntFunction,
+    false_: IntFunction,
+) -> IntFunction {
+    IntFunction(IntFunctionExpr::bool_case(
+        subject.into(),
+        true_.into(),
+        false_.into(),
+    ))
+}
+
+pub(crate) fn bool_case_string_function(
+    subject: Bool,
+    true_: StringFunction,
+    false_: StringFunction,
+) -> StringFunction {
+    StringFunction(StringFunctionExpr::bool_case(
+        subject.into(),
+        true_.into(),
+        false_.into(),
+    ))
+}
+
+pub(crate) fn bool_case_bool_function(
+    subject: Bool,
+    true_: BoolFunction,
+    false_: BoolFunction,
+) -> BoolFunction {
+    BoolFunction(BoolFunctionExpr::bool_case(
+        subject.into(),
+        true_.into(),
+        false_.into(),
+    ))
+}
+
+pub(crate) fn bool_case_nil_function(
+    subject: Bool,
+    true_: NilFunction,
+    false_: NilFunction,
+) -> NilFunction {
+    NilFunction(NilFunctionExpr::bool_case(
         subject.into(),
         true_.into(),
         false_.into(),
@@ -142,6 +254,66 @@ pub(crate) fn int_case_nil(
     ))
 }
 
+pub(crate) fn int_case_int_function(
+    subject: Int,
+    clauses: impl IntoIterator<Item = (i64, IntFunction)>,
+    fallback: IntFunction,
+) -> IntFunction {
+    IntFunction(IntFunctionExpr::int_case(
+        subject.into(),
+        clauses
+            .into_iter()
+            .map(|(value, branch)| (BigInt::from(value), branch.into()))
+            .collect(),
+        fallback.into(),
+    ))
+}
+
+pub(crate) fn int_case_string_function(
+    subject: Int,
+    clauses: impl IntoIterator<Item = (i64, StringFunction)>,
+    fallback: StringFunction,
+) -> StringFunction {
+    StringFunction(StringFunctionExpr::int_case(
+        subject.into(),
+        clauses
+            .into_iter()
+            .map(|(value, branch)| (BigInt::from(value), branch.into()))
+            .collect(),
+        fallback.into(),
+    ))
+}
+
+pub(crate) fn int_case_bool_function(
+    subject: Int,
+    clauses: impl IntoIterator<Item = (i64, BoolFunction)>,
+    fallback: BoolFunction,
+) -> BoolFunction {
+    BoolFunction(BoolFunctionExpr::int_case(
+        subject.into(),
+        clauses
+            .into_iter()
+            .map(|(value, branch)| (BigInt::from(value), branch.into()))
+            .collect(),
+        fallback.into(),
+    ))
+}
+
+pub(crate) fn int_case_nil_function(
+    subject: Int,
+    clauses: impl IntoIterator<Item = (i64, NilFunction)>,
+    fallback: NilFunction,
+) -> NilFunction {
+    NilFunction(NilFunctionExpr::int_case(
+        subject.into(),
+        clauses
+            .into_iter()
+            .map(|(value, branch)| (BigInt::from(value), branch.into()))
+            .collect(),
+        fallback.into(),
+    ))
+}
+
 pub(crate) fn block_int(steps: impl IntoIterator<Item = Step>, return_: Int) -> Int {
     Int(IntExpr::block(steps.into_iter().collect(), return_.into()))
 }
@@ -162,7 +334,24 @@ pub(crate) fn block_nil(steps: impl IntoIterator<Item = Step>, return_: Nil) -> 
 }
 
 pub(crate) fn block_function(steps: impl IntoIterator<Item = Step>, return_: Function) -> Function {
-    Function(FunctionExpr::block(
+    let steps = steps.into_iter().collect();
+    Function(match FunctionExpr::from(return_).into_kind() {
+        FunctionExprKind::Int(return_) => FunctionExpr::int(IntFunctionExpr::block(steps, return_)),
+        FunctionExprKind::String(return_) => {
+            FunctionExpr::string(StringFunctionExpr::block(steps, return_))
+        }
+        FunctionExprKind::Bool(return_) => {
+            FunctionExpr::bool(BoolFunctionExpr::block(steps, return_))
+        }
+        FunctionExprKind::Nil(return_) => FunctionExpr::nil(NilFunctionExpr::block(steps, return_)),
+    })
+}
+
+pub(crate) fn block_int_function(
+    steps: impl IntoIterator<Item = Step>,
+    return_: IntFunction,
+) -> IntFunction {
+    IntFunction(IntFunctionExpr::block(
         steps.into_iter().collect(),
         return_.into(),
     ))
@@ -182,6 +371,38 @@ pub(crate) fn let_bool_step(local: usize, name: impl Into<EcoString>, value: Boo
 
 pub(crate) fn let_nil_step(local: usize, name: impl Into<EcoString>, value: Nil) -> Step {
     Step::let_nil(NilLocalId(local), name.into(), value.into())
+}
+
+pub(crate) fn let_int_function_step(
+    local: usize,
+    name: impl Into<EcoString>,
+    value: IntFunction,
+) -> Step {
+    Step::let_int_function(IntFunctionLocalId(local), name.into(), value.into())
+}
+
+pub(crate) fn let_string_function_step(
+    local: usize,
+    name: impl Into<EcoString>,
+    value: StringFunction,
+) -> Step {
+    Step::let_string_function(StringFunctionLocalId(local), name.into(), value.into())
+}
+
+pub(crate) fn let_bool_function_step(
+    local: usize,
+    name: impl Into<EcoString>,
+    value: BoolFunction,
+) -> Step {
+    Step::let_bool_function(BoolFunctionLocalId(local), name.into(), value.into())
+}
+
+pub(crate) fn let_nil_function_step(
+    local: usize,
+    name: impl Into<EcoString>,
+    value: NilFunction,
+) -> Step {
+    Step::let_nil_function(NilFunctionLocalId(local), name.into(), value.into())
 }
 
 pub(crate) fn evaluate_step(value: impl Into<Expr>) -> Step {
@@ -228,6 +449,16 @@ pub(crate) fn call_bool(function: usize, args: impl IntoIterator<Item = CallArg>
 pub(crate) fn call_nil(function: usize, args: impl IntoIterator<Item = CallArg>) -> Nil {
     Nil(NilExpr::call(
         NilFunctionId(function),
+        args.into_iter().collect(),
+    ))
+}
+
+pub(crate) fn call_int_function(
+    function: IntFunction,
+    args: impl IntoIterator<Item = CallArg>,
+) -> Int {
+    Int(IntExpr::function_call(
+        function.into(),
         args.into_iter().collect(),
     ))
 }
@@ -394,12 +625,58 @@ impl From<Function> for FunctionExpr {
     }
 }
 
+impl From<IntFunction> for Function {
+    fn from(value: IntFunction) -> Self {
+        Function(FunctionExpr::int(value.into()))
+    }
+}
+
+impl From<IntFunction> for FunctionExpr {
+    fn from(value: IntFunction) -> Self {
+        FunctionExpr::int(value.into())
+    }
+}
+
+impl From<IntFunction> for IntFunctionExpr {
+    fn from(value: IntFunction) -> Self {
+        value.0
+    }
+}
+
+impl From<StringFunction> for StringFunctionExpr {
+    fn from(value: StringFunction) -> Self {
+        value.0
+    }
+}
+
+impl From<BoolFunction> for BoolFunctionExpr {
+    fn from(value: BoolFunction) -> Self {
+        value.0
+    }
+}
+
+impl From<NilFunction> for NilFunctionExpr {
+    fn from(value: NilFunction) -> Self {
+        value.0
+    }
+}
+
+fn int_function_type(params: impl IntoIterator<Item = LocalId>) -> FunctionType {
+    FunctionType::new(
+        params
+            .into_iter()
+            .map(|param| FunctionArgumentType::from_local(&param))
+            .collect(),
+        ValueType::Int,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::plan::{
-        BoolExprKind, CallArgKind, ExprKind, FunctionExprKind, IntExprKind, NilExprKind,
-        RuntimeFunctionId, StepKind, StringExprKind,
+        BoolExprKind, CallArgKind, ExprKind, FunctionExprKind, IntExprKind, IntFunctionExprKind,
+        NilExprKind, RuntimeFunctionId, StepKind, StringExprKind,
     };
 
     #[test]
@@ -568,7 +845,7 @@ mod tests {
                 [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
             ))
             .kind(),
-            FunctionExprKind::Value(_),
+            FunctionExprKind::Int(_),
         ));
         assert!(matches!(
             FunctionExpr::from(block_function(
@@ -579,7 +856,141 @@ mod tests {
                 ),
             ))
             .kind(),
-            FunctionExprKind::Block { .. },
+            FunctionExprKind::Int(_),
+        ));
+        assert!(matches!(
+            FunctionExpr::from(block_function(
+                [],
+                function_ref(
+                    RuntimeFunctionId::String(crate::plan::StringFunctionId(0)),
+                    [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+                ),
+            ))
+            .kind(),
+            FunctionExprKind::String(_),
+        ));
+        assert!(matches!(
+            FunctionExpr::from(block_function(
+                [],
+                function_ref(
+                    RuntimeFunctionId::Bool(crate::plan::BoolFunctionId(0)),
+                    [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))],
+                ),
+            ))
+            .kind(),
+            FunctionExprKind::Bool(_),
+        ));
+        assert!(matches!(
+            FunctionExpr::from(block_function(
+                [],
+                function_ref(
+                    RuntimeFunctionId::Nil(crate::plan::NilFunctionId(0)),
+                    [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))],
+                ),
+            ))
+            .kind(),
+            FunctionExprKind::Nil(_),
+        ));
+        assert!(matches!(
+            FunctionExpr::from(Function::from(int_function_ref(
+                0,
+                [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+            )))
+            .kind(),
+            FunctionExprKind::Int(_),
+        ));
+        assert!(matches!(
+            block_int_function(
+                [],
+                int_function_ref(0, [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))]),
+            )
+            .0
+            .kind(),
+            IntFunctionExprKind::Block { .. },
+        ));
+        assert!(matches!(
+            bool_case_string_function(
+                bool_(true),
+                string_function_ref(
+                    0,
+                    [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+                ),
+                string_function_ref(
+                    1,
+                    [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+                ),
+            )
+            .0
+            .kind(),
+            crate::plan::StringFunctionExprKind::BoolCase { .. },
+        ));
+        assert!(matches!(
+            bool_case_bool_function(
+                bool_(true),
+                bool_function_ref(0, [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))]),
+                bool_function_ref(1, [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))]),
+            )
+            .0
+            .kind(),
+            crate::plan::BoolFunctionExprKind::BoolCase { .. },
+        ));
+        assert!(matches!(
+            bool_case_nil_function(
+                bool_(true),
+                nil_function_ref(0, [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))]),
+                nil_function_ref(1, [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))]),
+            )
+            .0
+            .kind(),
+            crate::plan::NilFunctionExprKind::BoolCase { .. },
+        ));
+        assert!(matches!(
+            int_case_string_function(
+                int(1),
+                [(
+                    1,
+                    string_function_ref(
+                        0,
+                        [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+                    ),
+                )],
+                string_function_ref(
+                    1,
+                    [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+                ),
+            )
+            .0
+            .kind(),
+            crate::plan::StringFunctionExprKind::IntCase { .. },
+        ));
+        assert!(matches!(
+            int_case_bool_function(
+                int(1),
+                [(
+                    1,
+                    bool_function_ref(
+                        0,
+                        [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))],
+                    ),
+                )],
+                bool_function_ref(1, [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))]),
+            )
+            .0
+            .kind(),
+            crate::plan::BoolFunctionExprKind::IntCase { .. },
+        ));
+        assert!(matches!(
+            int_case_nil_function(
+                int(1),
+                [(
+                    1,
+                    nil_function_ref(0, [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))]),
+                )],
+                nil_function_ref(1, [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))]),
+            )
+            .0
+            .kind(),
+            crate::plan::NilFunctionExprKind::IntCase { .. },
         ));
     }
 
@@ -636,6 +1047,45 @@ mod tests {
 
     #[test]
     fn step_dsl() {
+        assert!(matches!(
+            let_int_function_step(
+                0,
+                "f",
+                int_function_ref(0, [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))]),
+            )
+            .kind(),
+            StepKind::LetIntFunction { .. },
+        ));
+        assert!(matches!(
+            let_string_function_step(
+                0,
+                "f",
+                string_function_ref(
+                    0,
+                    [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+                ),
+            )
+            .kind(),
+            StepKind::LetStringFunction { .. },
+        ));
+        assert!(matches!(
+            let_bool_function_step(
+                0,
+                "f",
+                bool_function_ref(0, [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))]),
+            )
+            .kind(),
+            StepKind::LetBoolFunction { .. },
+        ));
+        assert!(matches!(
+            let_nil_function_step(
+                0,
+                "f",
+                nil_function_ref(0, [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))]),
+            )
+            .kind(),
+            StepKind::LetNilFunction { .. },
+        ));
         assert!(matches!(
             evaluate_step(int(1)).kind(),
             StepKind::Evaluate(_),

--- a/src/planner/dsl/function.rs
+++ b/src/planner/dsl/function.rs
@@ -93,6 +93,11 @@ impl FunctionDsl {
         self
     }
 
+    pub(crate) fn step(mut self, step: Step) -> Self {
+        self.steps.push(step);
+        self
+    }
+
     pub(crate) fn build(self, id: FunctionId) -> FunctionPlan {
         FunctionPlan::new(id, self.name, self.params, self.steps, self.return_)
     }
@@ -115,16 +120,17 @@ mod tests {
             .let_string(1, "y", string("a"))
             .let_bool(1, "z", bool_(true))
             .let_nil(1, "n", nil())
+            .step(Step::evaluate(int(4).into()))
             .evaluate(int(3))
             .build(FunctionId::new(0));
 
         assert_eq!(function.name(), "main");
         assert_eq!(function.params().len(), 4);
-        assert_eq!(function.steps().len(), 5);
+        assert_eq!(function.steps().len(), 6);
         assert!(matches!(
             function.steps()[0].kind(),
             StepKind::LetInt { .. }
         ));
-        assert!(matches!(function.steps()[4].kind(), StepKind::Evaluate(_)));
+        assert!(matches!(function.steps()[5].kind(), StepKind::Evaluate(_)));
     }
 }

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -46,8 +46,6 @@ pub enum UnsupportedStatementKind {
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedAssignmentKind {
-    #[error("non-value function assignment")]
-    NonValueFunction,
     #[error("let assert")]
     LetAssert,
 }

--- a/src/planner/expression/block.rs
+++ b/src/planner/expression/block.rs
@@ -1,4 +1,7 @@
-use crate::plan::{BoolExpr, Expr, ExprKind, FunctionExpr, IntExpr, NilExpr, Step, StringExpr};
+use crate::plan::{
+    BoolExpr, BoolFunctionExpr, Expr, ExprKind, FunctionExpr, FunctionExprKind, IntExpr,
+    IntFunctionExpr, NilExpr, NilFunctionExpr, Step, StringExpr, StringFunctionExpr,
+};
 use crate::planner::context::PlanContext;
 use crate::planner::error::PlanError;
 use crate::planner::statement::plan_non_empty_steps_and_return;
@@ -22,7 +25,20 @@ pub(super) fn block_expr(steps: Vec<Step>, return_: Expr) -> Expr {
         ExprKind::String(return_) => Expr::string(StringExpr::block(steps, return_)),
         ExprKind::Bool(return_) => Expr::bool(BoolExpr::block(steps, return_)),
         ExprKind::Nil(return_) => Expr::nil(NilExpr::block(steps, return_)),
-        ExprKind::Function(return_) => Expr::function(FunctionExpr::block(steps, return_)),
+        ExprKind::Function(return_) => match return_.into_kind() {
+            FunctionExprKind::Int(return_) => {
+                Expr::function(FunctionExpr::int(IntFunctionExpr::block(steps, return_)))
+            }
+            FunctionExprKind::String(return_) => Expr::function(FunctionExpr::string(
+                StringFunctionExpr::block(steps, return_),
+            )),
+            FunctionExprKind::Bool(return_) => {
+                Expr::function(FunctionExpr::bool(BoolFunctionExpr::block(steps, return_)))
+            }
+            FunctionExprKind::Nil(return_) => {
+                Expr::function(FunctionExpr::nil(NilFunctionExpr::block(steps, return_)))
+            }
+        },
     }
 }
 
@@ -31,8 +47,8 @@ mod tests {
     use crate::plan::{IntFunctionId, LocalId, RuntimeFunctionId};
     use crate::planner::dsl::{
         block_bool, block_function, block_int, block_nil, block_string, bool_, evaluate_step,
-        function, function_ref, int, let_int_step, let_nil_step, local_int, local_nil, module, nil,
-        string,
+        function, function_ref, int, let_int_step, let_nil_step, local_bool, local_int, local_nil,
+        local_string, module, nil, string,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, expect_plan_error};
@@ -76,8 +92,23 @@ fn identity(value: Int) {
   value
 }
 
+fn string_identity(value: String) {
+  value
+}
+
+fn bool_identity(value: Bool) {
+  value
+}
+
+fn nil_identity(value: Nil) {
+  value
+}
+
 pub fn main() {
   { identity }
+  { string_identity }
+  { bool_identity }
+  { nil_identity }
   1
 }
 "#,
@@ -85,14 +116,41 @@ pub fn main() {
         .expect("source should plan");
         let expected = module(
             "main",
-            function("main", int(1)).evaluate(block_function(
-                [],
-                function_ref(
-                    RuntimeFunctionId::Int(IntFunctionId(1)),
-                    [LocalId::Int(crate::plan::IntLocalId(0))],
-                ),
-            )),
-            [function("identity", local_int(0, "value")).param_int(0, "value")],
+            function("main", int(1))
+                .evaluate(block_function(
+                    [],
+                    function_ref(
+                        RuntimeFunctionId::Int(IntFunctionId(1)),
+                        [LocalId::Int(crate::plan::IntLocalId(0))],
+                    ),
+                ))
+                .evaluate(block_function(
+                    [],
+                    function_ref(
+                        RuntimeFunctionId::String(crate::plan::StringFunctionId(0)),
+                        [LocalId::String(crate::plan::StringLocalId(0))],
+                    ),
+                ))
+                .evaluate(block_function(
+                    [],
+                    function_ref(
+                        RuntimeFunctionId::Bool(crate::plan::BoolFunctionId(0)),
+                        [LocalId::Bool(crate::plan::BoolLocalId(0))],
+                    ),
+                ))
+                .evaluate(block_function(
+                    [],
+                    function_ref(
+                        RuntimeFunctionId::Nil(crate::plan::NilFunctionId(0)),
+                        [LocalId::Nil(crate::plan::NilLocalId(0))],
+                    ),
+                )),
+            [
+                function("identity", local_int(0, "value")).param_int(0, "value"),
+                function("string_identity", local_string(0, "value")).param_string(0, "value"),
+                function("bool_identity", local_bool(0, "value")).param_bool(0, "value"),
+                function("nil_identity", local_nil(0, "value")).param_nil(0, "value"),
+            ],
         );
 
         assert_eq!(actual, expected);

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -1,8 +1,7 @@
 use super::{invalid_expression_type, plan_expr};
 use crate::plan::{
-    BoolCaseBranches, BoolExpr, CallArg, Expr, ExprKind, FunctionArgumentType, FunctionExpr,
-    FunctionExprKind, IntCaseBranches, IntExpr, LocalId, NilExpr, RuntimeFunctionId, StringExpr,
-    ValueType,
+    BoolExpr, CallArg, Expr, FunctionArgumentType, FunctionExpr, IntExpr, LocalId, NilExpr,
+    RuntimeFunctionId, StringExpr, ValueType,
 };
 use crate::planner::context::{FunctionInfo, FunctionParam, PlanContext};
 use crate::planner::error::{
@@ -297,51 +296,9 @@ fn plan_function_value_call(
     }
 
     let params = function_call_params(&function_type);
-    plan_function_expr_call(function, arguments, &params, context, capture)
-}
+    let args = plan_call_args(arguments, &params, context, capture)?;
 
-fn plan_function_expr_call(
-    function: FunctionExpr,
-    arguments: Vec<GleamCallArg<TypedExpr>>,
-    params: &[FunctionParam],
-    context: &mut PlanContext<'_>,
-    capture: Option<&CaptureSubstitution>,
-) -> Result<Expr, PlanError> {
-    match function.kind().clone() {
-        FunctionExprKind::Value(function) => {
-            let args = plan_call_args(arguments, params, context, capture)?;
-            Ok(call_expr(function.runtime_id(), args))
-        }
-        FunctionExprKind::BoolCase {
-            subject,
-            true_,
-            false_,
-        } => {
-            let true_ =
-                plan_function_expr_call(*true_, arguments.clone(), params, context, capture)?;
-            let false_ = plan_function_expr_call(*false_, arguments, params, context, capture)?;
-            bool_case_call_expr(*subject, true_, false_)
-        }
-        FunctionExprKind::IntCase {
-            subject,
-            clauses,
-            fallback,
-        } => {
-            let mut call_clauses = Vec::with_capacity(clauses.len());
-            for (pattern, branch) in clauses {
-                call_clauses.push((
-                    pattern,
-                    plan_function_expr_call(branch, arguments.clone(), params, context, capture)?,
-                ));
-            }
-            let fallback = plan_function_expr_call(*fallback, arguments, params, context, capture)?;
-            int_case_call_expr(*subject, call_clauses, fallback)
-        }
-        FunctionExprKind::Block { steps, return_ } => {
-            let return_ = plan_function_expr_call(*return_, arguments, params, context, capture)?;
-            block_call_expr(steps, return_)
-        }
-    }
+    function_call_expr(function, args, return_type)
 }
 
 fn plan_call_args(
@@ -465,6 +422,54 @@ fn call_expr(function: RuntimeFunctionId, args: Vec<CallArg>) -> Expr {
     }
 }
 
+fn function_call_expr(
+    function: FunctionExpr,
+    args: Vec<CallArg>,
+    return_type: ValueType,
+) -> Result<Expr, PlanError> {
+    match return_type {
+        ValueType::Int => match function.into_int() {
+            Ok(function) => Ok(Expr::int(IntExpr::function_call(function, args))),
+            Err(_) => Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
+                },
+            }),
+        },
+        ValueType::String => match function.into_string() {
+            Ok(function) => Ok(Expr::string(StringExpr::function_call(function, args))),
+            Err(_) => Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
+                },
+            }),
+        },
+        ValueType::Bool => match function.into_bool() {
+            Ok(function) => Ok(Expr::bool(crate::plan::BoolExpr::function_call(
+                function, args,
+            ))),
+            Err(_) => Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
+                },
+            }),
+        },
+        ValueType::Nil => match function.into_nil() {
+            Ok(function) => Ok(Expr::nil(NilExpr::function_call(function, args))),
+            Err(_) => Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
+                },
+            }),
+        },
+        ValueType::Function(_) => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::FunctionCallUnsupportedReturnType,
+            },
+        }),
+    }
+}
+
 fn function_call_params(function_type: &crate::plan::FunctionType) -> Vec<FunctionParam> {
     let mut next_int = 0;
     let mut next_string = 0;
@@ -506,156 +511,18 @@ fn function_call_params(function_type: &crate::plan::FunctionType) -> Vec<Functi
         .collect()
 }
 
-fn bool_case_call_expr(subject: BoolExpr, true_: Expr, false_: Expr) -> Result<Expr, PlanError> {
-    let branches = match (true_.into_kind(), false_.into_kind()) {
-        (ExprKind::Int(true_), ExprKind::Int(false_)) => BoolCaseBranches::Int { true_, false_ },
-        (ExprKind::String(true_), ExprKind::String(false_)) => {
-            BoolCaseBranches::String { true_, false_ }
-        }
-        (ExprKind::Bool(true_), ExprKind::Bool(false_)) => BoolCaseBranches::Bool { true_, false_ },
-        (ExprKind::Nil(true_), ExprKind::Nil(false_)) => BoolCaseBranches::Nil { true_, false_ },
-        _ => {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            });
-        }
-    };
-
-    Ok(Expr::bool_case(subject, branches))
-}
-
-fn int_case_call_expr(
-    subject: IntExpr,
-    clauses: Vec<(num_bigint::BigInt, Expr)>,
-    fallback: Expr,
-) -> Result<Expr, PlanError> {
-    let branches = match fallback.into_kind() {
-        ExprKind::Int(fallback) => IntCaseBranches::Int {
-            clauses: int_call_clauses(clauses)?,
-            fallback,
-        },
-        ExprKind::String(fallback) => IntCaseBranches::String {
-            clauses: string_call_clauses(clauses)?,
-            fallback,
-        },
-        ExprKind::Bool(fallback) => IntCaseBranches::Bool {
-            clauses: bool_call_clauses(clauses)?,
-            fallback,
-        },
-        ExprKind::Nil(fallback) => IntCaseBranches::Nil {
-            clauses: nil_call_clauses(clauses)?,
-            fallback,
-        },
-        ExprKind::Function(_) => {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            });
-        }
-    };
-
-    Ok(Expr::int_case(subject, branches))
-}
-
-fn int_call_clauses(
-    clauses: Vec<(num_bigint::BigInt, Expr)>,
-) -> Result<Vec<(num_bigint::BigInt, IntExpr)>, PlanError> {
-    let mut typed = Vec::with_capacity(clauses.len());
-    for (pattern, clause) in clauses {
-        let ExprKind::Int(clause) = clause.into_kind() else {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            });
-        };
-        typed.push((pattern, clause));
-    }
-    Ok(typed)
-}
-
-fn string_call_clauses(
-    clauses: Vec<(num_bigint::BigInt, Expr)>,
-) -> Result<Vec<(num_bigint::BigInt, StringExpr)>, PlanError> {
-    let mut typed = Vec::with_capacity(clauses.len());
-    for (pattern, clause) in clauses {
-        let ExprKind::String(clause) = clause.into_kind() else {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            });
-        };
-        typed.push((pattern, clause));
-    }
-    Ok(typed)
-}
-
-fn bool_call_clauses(
-    clauses: Vec<(num_bigint::BigInt, Expr)>,
-) -> Result<Vec<(num_bigint::BigInt, BoolExpr)>, PlanError> {
-    let mut typed = Vec::with_capacity(clauses.len());
-    for (pattern, clause) in clauses {
-        let ExprKind::Bool(clause) = clause.into_kind() else {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            });
-        };
-        typed.push((pattern, clause));
-    }
-    Ok(typed)
-}
-
-fn nil_call_clauses(
-    clauses: Vec<(num_bigint::BigInt, Expr)>,
-) -> Result<Vec<(num_bigint::BigInt, NilExpr)>, PlanError> {
-    let mut typed = Vec::with_capacity(clauses.len());
-    for (pattern, clause) in clauses {
-        let ExprKind::Nil(clause) = clause.into_kind() else {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            });
-        };
-        typed.push((pattern, clause));
-    }
-    Ok(typed)
-}
-
-fn block_call_expr(steps: Vec<crate::plan::Step>, return_: Expr) -> Result<Expr, PlanError> {
-    Ok(match return_.into_kind() {
-        ExprKind::Int(return_) => Expr::int(IntExpr::block(steps, return_)),
-        ExprKind::String(return_) => Expr::string(StringExpr::block(steps, return_)),
-        ExprKind::Bool(return_) => Expr::bool(BoolExpr::block(steps, return_)),
-        ExprKind::Nil(return_) => Expr::nil(NilExpr::block(steps, return_)),
-        ExprKind::Function(_) => {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            });
-        }
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::{typed_int_expr, typed_string_expr};
     use crate::plan::{
-        BoolLocalId, IntFunctionId, IntLocalId, LocalId, NilLocalId, RuntimeFunctionId,
-        StringFunctionId, StringLocalId,
+        BoolFunctionId, BoolLocalId, ExprKind, FunctionArgumentType, FunctionExpr, FunctionType,
+        IntLocalId, LocalId, NilFunctionId, NilLocalId, RuntimeFunctionId, StringFunctionId,
+        StringLocalId, ValueType,
     };
-    use crate::plan::{FunctionArgumentType, FunctionExpr, FunctionType, ValueType};
     use crate::planner::dsl::{
-        block_bool, block_int, block_nil, block_string, bool_, bool_case_bool, bool_case_int,
-        bool_case_nil, bool_case_string, call_int, function, function_ref, int, int_arg,
-        int_case_bool, int_case_int, int_case_nil, int_case_string, local_int, module, nil, string,
+        block_int_function, bool_, bool_case_int_function, call_int_function, function,
+        function_ref, int, int_arg, int_case_int_function, int_function_ref, let_int_function_step,
+        local_int, local_int_function, module,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, compile_minimal_module, dummy_span};
@@ -663,7 +530,6 @@ mod tests {
         InvalidCallShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
         UnsupportedExpressionKind,
     };
-    use ecow::EcoString;
     use gleam_core::ast::{
         CallArg, ImplicitCallArgOrigin, Statement, TypedExpr, TypedModule, TypedStatement,
     };
@@ -698,7 +564,18 @@ pub fn main() {
         .expect("source should plan");
         let expected = module(
             "main",
-            function("main", call_int(1, [int_arg(0, int(1))])),
+            function(
+                "main",
+                call_int_function(
+                    local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
+                    [int_arg(0, int(1))],
+                ),
+            )
+            .step(let_int_function_step(
+                0,
+                "function",
+                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+            )),
             [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
         );
 
@@ -731,14 +608,28 @@ pub fn primitive_shadow() {
             function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value");
         let expected = module(
             "main",
-            function("main", call_int(1, [int_arg(0, int(1))])).let_int(0, "function", int(1)),
+            function(
+                "main",
+                call_int_function(
+                    local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
+                    [int_arg(0, int(1))],
+                ),
+            )
+            .let_int(0, "function", int(1))
+            .step(let_int_function_step(
+                0,
+                "function",
+                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+            )),
             [
                 add_one,
-                function("primitive_shadow", local_int(0, "function").add_int(int(1))).let_int(
-                    0,
-                    "function",
-                    int(1),
-                ),
+                function("primitive_shadow", local_int(0, "function").add_int(int(1)))
+                    .step(let_int_function_step(
+                        0,
+                        "function",
+                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                    ))
+                    .let_int(0, "function", int(1)),
             ],
         );
 
@@ -761,7 +652,13 @@ pub fn main() {
         .expect("source should plan");
         let expected = module(
             "main",
-            function("main", block_int([], call_int(1, [int_arg(0, int(1))]))),
+            function(
+                "main",
+                call_int_function(
+                    block_int_function([], int_function_ref(1, [LocalId::Int(IntLocalId(0))])),
+                    [int_arg(0, int(1))],
+                ),
+            ),
             [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
         );
 
@@ -807,19 +704,25 @@ pub fn main() {
             .let_int(
                 0,
                 "bool_result",
-                bool_case_int(
-                    bool_(true),
-                    call_int(1, [int_arg(0, int(1))]),
-                    call_int(2, [int_arg(0, int(1))]),
+                call_int_function(
+                    bool_case_int_function(
+                        bool_(true),
+                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                        int_function_ref(2, [LocalId::Int(IntLocalId(0))]),
+                    ),
+                    [int_arg(0, int(1))],
                 ),
             )
             .let_int(
                 1,
                 "int_result",
-                int_case_int(
-                    int(0),
-                    [(0, call_int(2, [int_arg(0, int(1))]))],
-                    call_int(1, [int_arg(0, int(1))]),
+                call_int_function(
+                    int_case_int_function(
+                        int(0),
+                        [(0, int_function_ref(2, [LocalId::Int(IntLocalId(0))]))],
+                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                    ),
+                    [int_arg(0, int(1))],
                 ),
             ),
             [add_one, add_ten],
@@ -987,102 +890,6 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_margin_function_value_call_lowering_shape_mismatch() {
-        assert_eq!(
-            super::bool_case_call_expr(bool_(true).into(), int(1).into(), string("wrong").into()),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::int_case_call_expr(
-                int(1).into(),
-                vec![(1.into(), string("wrong").into())],
-                int(0).into()
-            ),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::int_case_call_expr(
-                int(1).into(),
-                vec![(1.into(), int(1).into())],
-                string("fallback").into()
-            ),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::int_case_call_expr(
-                int(1).into(),
-                vec![(1.into(), int(1).into())],
-                bool_(false).into()
-            ),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::int_case_call_expr(int(1).into(), vec![(1.into(), int(1).into())], nil().into()),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::int_case_call_expr(int(1).into(), Vec::new(), function_expr()),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::block_call_expr(Vec::new(), function_expr()),
-            Err(function_call_return_type_mismatch()),
-        );
-    }
-
-    #[test]
-    fn plan_function_value_call_lowering_return_shapes() {
-        assert_eq!(
-            super::bool_case_call_expr(
-                bool_(true).into(),
-                string("yes").into(),
-                string("no").into(),
-            ),
-            Ok(bool_case_string(bool_(true), string("yes"), string("no")).into()),
-        );
-        assert_eq!(
-            super::bool_case_call_expr(bool_(true).into(), bool_(true).into(), bool_(false).into()),
-            Ok(bool_case_bool(bool_(true), bool_(true), bool_(false)).into()),
-        );
-        assert_eq!(
-            super::bool_case_call_expr(bool_(true).into(), nil().into(), nil().into()),
-            Ok(bool_case_nil(bool_(true), nil(), nil()).into()),
-        );
-        assert_eq!(
-            super::int_case_call_expr(
-                int(1).into(),
-                vec![(1.into(), string("one").into())],
-                string("other").into(),
-            ),
-            Ok(int_case_string(int(1), [(1, string("one"))], string("other")).into()),
-        );
-        assert_eq!(
-            super::int_case_call_expr(
-                int(1).into(),
-                vec![(1.into(), bool_(true).into())],
-                bool_(false).into(),
-            ),
-            Ok(int_case_bool(int(1), [(1, bool_(true))], bool_(false)).into()),
-        );
-        assert_eq!(
-            super::int_case_call_expr(int(1).into(), vec![(1.into(), nil().into())], nil().into()),
-            Ok(int_case_nil(int(1), [(1, nil())], nil()).into()),
-        );
-        assert_eq!(
-            super::block_call_expr(Vec::new(), string("value").into()),
-            Ok(block_string([], string("value")).into()),
-        );
-        assert_eq!(
-            super::block_call_expr(Vec::new(), bool_(true).into()),
-            Ok(block_bool([], bool_(true)).into()),
-        );
-        assert_eq!(
-            super::block_call_expr(Vec::new(), nil().into()),
-            Ok(block_nil([], nil()).into()),
-        );
-    }
-
-    #[test]
     fn function_call_params_supports_primitive_argument_shapes() {
         let params = super::function_call_params(&FunctionType::new(
             vec![
@@ -1099,127 +906,91 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_margin_function_value_call_recursive_lowering_errors() {
-        let module = EcoString::from("main");
-        let functions = std::collections::HashMap::<EcoString, super::FunctionInfo>::new();
-        let mut context = super::PlanContext::new(&module, &functions);
-        let params = [super::FunctionParam {
-            local: LocalId::Int(IntLocalId(0)),
-            name: EcoString::default(),
-        }];
-        let string_argument = call_arguments(typed_string_expr("wrong"));
-        let int_argument = call_arguments(typed_int_expr(1));
-        let expected_type_error = Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::ExpressionType {
-                expected: InvalidExpressionType::Int,
-                actual: InvalidExpressionType::String,
-            },
-        });
-        let expected_shape_error = Err(function_call_return_type_mismatch());
-
-        assert_eq!(
-            super::plan_function_expr_call(
-                FunctionExpr::bool_case(
-                    bool_(true).into(),
-                    int_function_expr(),
-                    int_function_expr()
-                ),
-                string_argument.clone(),
-                &params,
-                &mut context,
-                None,
-            ),
-            expected_type_error,
-        );
-        assert_eq!(
-            super::plan_function_expr_call(
-                FunctionExpr::bool_case(
-                    bool_(true).into(),
-                    int_function_expr(),
-                    mismatched_function_case(),
-                ),
-                int_argument.clone(),
-                &params,
-                &mut context,
-                None,
-            ),
-            expected_shape_error.clone(),
-        );
-        assert_eq!(
-            super::plan_function_expr_call(
-                FunctionExpr::int_case(
-                    int(1).into(),
-                    vec![(1.into(), mismatched_function_case())],
-                    int_function_expr(),
-                ),
-                int_argument.clone(),
-                &params,
-                &mut context,
-                None,
-            ),
-            expected_shape_error.clone(),
-        );
-        assert_eq!(
-            super::plan_function_expr_call(
-                FunctionExpr::int_case(
-                    int(1).into(),
-                    vec![(1.into(), int_function_expr())],
-                    mismatched_function_case(),
-                ),
-                int_argument.clone(),
-                &params,
-                &mut context,
-                None,
-            ),
-            expected_shape_error.clone(),
-        );
-        assert_eq!(
-            super::plan_function_expr_call(
-                FunctionExpr::block(Vec::new(), mismatched_function_case()),
-                int_argument,
-                &params,
-                &mut context,
-                None,
-            ),
-            expected_shape_error,
-        );
-    }
-
-    fn function_expr() -> crate::plan::Expr {
-        function_ref(
-            RuntimeFunctionId::Int(IntFunctionId(0)),
-            [LocalId::Int(IntLocalId(0))],
-        )
-        .into()
-    }
-
-    fn int_function_expr() -> FunctionExpr {
-        function_ref(
-            RuntimeFunctionId::Int(IntFunctionId(0)),
-            [LocalId::Int(IntLocalId(0))],
-        )
-        .into()
-    }
-
-    fn mismatched_function_case() -> FunctionExpr {
-        FunctionExpr::bool_case(
-            bool_(true).into(),
-            int_function_expr(),
-            function_ref(
-                RuntimeFunctionId::String(StringFunctionId(0)),
-                [LocalId::Int(IntLocalId(0))],
+    fn function_call_expr_preserves_return_family() {
+        assert!(matches!(
+            super::function_call_expr(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::String(StringFunctionId(0)),
+                    [],
+                )),
+                Vec::new(),
+                ValueType::String,
             )
-            .into(),
-        )
+            .expect("string function call")
+            .kind(),
+            ExprKind::String(_),
+        ));
+        assert!(matches!(
+            super::function_call_expr(
+                FunctionExpr::from(function_ref(RuntimeFunctionId::Bool(BoolFunctionId(0)), [],)),
+                Vec::new(),
+                ValueType::Bool,
+            )
+            .expect("bool function call")
+            .kind(),
+            ExprKind::Bool(_),
+        ));
+        assert!(matches!(
+            super::function_call_expr(
+                FunctionExpr::from(function_ref(RuntimeFunctionId::Nil(NilFunctionId(0)), [],)),
+                Vec::new(),
+                ValueType::Nil,
+            )
+            .expect("nil function call")
+            .kind(),
+            ExprKind::Nil(_),
+        ));
     }
 
-    fn call_arguments(value: TypedExpr) -> Vec<CallArg<TypedExpr>> {
-        vec![CallArg {
-            label: None,
-            location: dummy_span(),
-            value,
-            implicit: None,
-        }]
+    #[test]
+    fn reject_margin_function_call_expr_return_family_mismatch() {
+        assert_eq!(
+            super::function_call_expr(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::String(StringFunctionId(0)),
+                    [],
+                )),
+                Vec::new(),
+                ValueType::Int,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::function_call_expr(
+                FunctionExpr::from(int_function_ref(0, [])),
+                Vec::new(),
+                ValueType::String,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::function_call_expr(
+                FunctionExpr::from(int_function_ref(0, [])),
+                Vec::new(),
+                ValueType::Bool,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::function_call_expr(
+                FunctionExpr::from(int_function_ref(0, [])),
+                Vec::new(),
+                ValueType::Nil,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::function_call_expr(
+                FunctionExpr::from(int_function_ref(0, [])),
+                Vec::new(),
+                ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallUnsupportedReturnType,
+                },
+            }),
+        );
     }
 
     fn function_call_return_type_mismatch() -> PlanError {

--- a/src/planner/expression/case/bool_subject.rs
+++ b/src/planner/expression/case/bool_subject.rs
@@ -135,10 +135,8 @@ fn bool_case_expr(subject: BoolExpr, true_: Expr, false_: Expr) -> Result<Expr, 
         }
         (ExprKind::Bool(true_), ExprKind::Bool(false_)) => BoolCaseBranches::Bool { true_, false_ },
         (ExprKind::Nil(true_), ExprKind::Nil(false_)) => BoolCaseBranches::Nil { true_, false_ },
-        (ExprKind::Function(true_), ExprKind::Function(false_))
-            if true_.type_() == false_.type_() =>
-        {
-            BoolCaseBranches::Function { true_, false_ }
+        (ExprKind::Function(true_), ExprKind::Function(false_)) => {
+            bool_function_case_branches(true_, false_)?
         }
         _ => {
             return Err(invalid_case_shape(
@@ -150,11 +148,40 @@ fn bool_case_expr(subject: BoolExpr, true_: Expr, false_: Expr) -> Result<Expr, 
     Ok(Expr::bool_case(subject, branches))
 }
 
+fn bool_function_case_branches(
+    true_: crate::plan::FunctionExpr,
+    false_: crate::plan::FunctionExpr,
+) -> Result<BoolCaseBranches, PlanError> {
+    match (true_.into_kind(), false_.into_kind()) {
+        (crate::plan::FunctionExprKind::Int(true_), crate::plan::FunctionExprKind::Int(false_)) => {
+            Ok(BoolCaseBranches::IntFunction { true_, false_ })
+        }
+        (
+            crate::plan::FunctionExprKind::String(true_),
+            crate::plan::FunctionExprKind::String(false_),
+        ) => Ok(BoolCaseBranches::StringFunction { true_, false_ }),
+        (
+            crate::plan::FunctionExprKind::Bool(true_),
+            crate::plan::FunctionExprKind::Bool(false_),
+        ) => Ok(BoolCaseBranches::BoolFunction { true_, false_ }),
+        (crate::plan::FunctionExprKind::Nil(true_), crate::plan::FunctionExprKind::Nil(false_)) => {
+            Ok(BoolCaseBranches::NilFunction { true_, false_ })
+        }
+        _ => Err(invalid_case_shape(
+            InvalidCaseShapeReason::BranchReturnTypeMismatch,
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::plan::{
+        BoolFunctionId, FunctionExpr, IntFunctionId, IntLocalId, LocalId, NilFunctionId,
+        RuntimeFunctionId, StringFunctionId,
+    };
     use crate::planner::dsl::{
         bool_, bool_case_bool, bool_case_int, bool_case_nil, bool_case_string, call_bool, function,
-        int, local_bool, module, nil, string,
+        function_ref, int, local_bool, module, nil, string,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -330,6 +357,87 @@ fn duplicate_true(value: Bool) {
         );
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_margin_bool_case_function_branch_type_mismatch_direct() {
+        assert!(matches!(
+            super::bool_function_case_branches(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Int(IntFunctionId(0)),
+                    [LocalId::Int(IntLocalId(0))],
+                )),
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::String(StringFunctionId(0)),
+                    [LocalId::Int(IntLocalId(0))],
+                )),
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            }),
+        ));
+        assert!(matches!(
+            super::bool_function_case_branches(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Bool(BoolFunctionId(0)),
+                    [LocalId::Int(IntLocalId(0))],
+                )),
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::String(StringFunctionId(0)),
+                    [LocalId::Int(IntLocalId(0))],
+                )),
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            }),
+        ));
+    }
+
+    #[test]
+    fn plan_bool_case_function_branch_return_families_direct() {
+        assert!(matches!(
+            super::bool_function_case_branches(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::String(StringFunctionId(0)),
+                    [LocalId::String(crate::plan::StringLocalId(0))],
+                )),
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::String(StringFunctionId(1)),
+                    [LocalId::String(crate::plan::StringLocalId(0))],
+                )),
+            ),
+            Ok(crate::plan::BoolCaseBranches::StringFunction { .. }),
+        ));
+        assert!(matches!(
+            super::bool_function_case_branches(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Bool(BoolFunctionId(0)),
+                    [LocalId::Bool(crate::plan::BoolLocalId(0))],
+                )),
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Bool(BoolFunctionId(1)),
+                    [LocalId::Bool(crate::plan::BoolLocalId(0))],
+                )),
+            ),
+            Ok(crate::plan::BoolCaseBranches::BoolFunction { .. }),
+        ));
+        assert!(matches!(
+            super::bool_function_case_branches(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Nil(NilFunctionId(0)),
+                    [LocalId::Nil(crate::plan::NilLocalId(0))],
+                )),
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Nil(NilFunctionId(1)),
+                    [LocalId::Nil(crate::plan::NilLocalId(0))],
+                )),
+            ),
+            Ok(crate::plan::BoolCaseBranches::NilFunction { .. }),
+        ));
     }
 
     #[test]

--- a/src/planner/expression/case/int_subject.rs
+++ b/src/planner/expression/case/int_subject.rs
@@ -2,7 +2,7 @@ use super::{
     invalid_case_shape, single_case_pattern, unsupported_case, validate_case_branch_type,
     validate_clause_shape,
 };
-use crate::plan::{Expr, ExprKind, FunctionType, IntCaseBranches, IntExpr};
+use crate::plan::{Expr, ExprKind, IntCaseBranches, IntExpr};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
@@ -123,10 +123,7 @@ fn int_case_expr(
             clauses: nil_case_clauses(clauses)?,
             fallback,
         },
-        ExprKind::Function(fallback) => IntCaseBranches::Function {
-            clauses: function_case_clauses(clauses, fallback.type_())?,
-            fallback,
-        },
+        ExprKind::Function(fallback) => function_case_branches(clauses, fallback)?,
     };
 
     Ok(Expr::int_case(subject, branches))
@@ -184,18 +181,89 @@ fn nil_case_clauses(
     Ok(typed_clauses)
 }
 
-fn function_case_clauses(
+fn function_case_branches(
     clauses: Vec<(BigInt, Expr)>,
-    expected: &FunctionType,
-) -> Result<Vec<(BigInt, crate::plan::FunctionExpr)>, PlanError> {
+    fallback: crate::plan::FunctionExpr,
+) -> Result<IntCaseBranches, PlanError> {
+    match fallback.into_kind() {
+        crate::plan::FunctionExprKind::Int(fallback) => Ok(IntCaseBranches::IntFunction {
+            clauses: int_function_case_clauses(clauses)?,
+            fallback,
+        }),
+        crate::plan::FunctionExprKind::String(fallback) => Ok(IntCaseBranches::StringFunction {
+            clauses: string_function_case_clauses(clauses)?,
+            fallback,
+        }),
+        crate::plan::FunctionExprKind::Bool(fallback) => Ok(IntCaseBranches::BoolFunction {
+            clauses: bool_function_case_clauses(clauses)?,
+            fallback,
+        }),
+        crate::plan::FunctionExprKind::Nil(fallback) => Ok(IntCaseBranches::NilFunction {
+            clauses: nil_function_case_clauses(clauses)?,
+            fallback,
+        }),
+    }
+}
+
+fn int_function_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::IntFunctionExpr)>, PlanError> {
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
             return Err(branch_return_type_mismatch());
         };
-        if clause.type_() != expected {
+        let Ok(clause) = clause.into_int() else {
             return Err(branch_return_type_mismatch());
-        }
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn string_function_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::StringFunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        let Ok(clause) = clause.into_string() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn bool_function_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::BoolFunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        let Ok(clause) = clause.into_bool() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn nil_function_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::NilFunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        let Ok(clause) = clause.into_nil() else {
+            return Err(branch_return_type_mismatch());
+        };
         typed_clauses.push((value, clause));
     }
     Ok(typed_clauses)
@@ -208,7 +276,8 @@ fn branch_return_type_mismatch() -> PlanError {
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        FunctionExpr, IntFunctionId, IntLocalId, LocalId, RuntimeFunctionId, StringFunctionId,
+        BoolFunctionId, Expr, FunctionExpr, IntFunctionExpr, IntFunctionId, IntLocalId, LocalId,
+        NilFunctionId, RuntimeFunctionId, StringFunctionId,
     };
     use crate::planner::dsl::{
         bool_, function, function_ref, int, int_case_bool, int_case_int, int_case_nil,
@@ -343,23 +412,85 @@ fn duplicate_literal(value: Int) {
             vec![(BigInt::from(1), int_function_ref_expr(0))],
             int_function_ref_expr(0),
         );
-        let branch: FunctionExpr = function_ref(
+        let branch = FunctionExpr::from(function_ref(
             RuntimeFunctionId::Int(IntFunctionId(0)),
             [LocalId::Int(IntLocalId(0))],
-        )
-        .into();
-        let fallback: FunctionExpr = function_ref(
+        ))
+        .into_int()
+        .expect("int function expression");
+        let fallback = FunctionExpr::from(function_ref(
             RuntimeFunctionId::Int(IntFunctionId(0)),
             [LocalId::Int(IntLocalId(0))],
-        )
-        .into();
-        let expected = Ok(crate::plan::Expr::function(FunctionExpr::int_case(
-            int(1).into(),
-            vec![(BigInt::from(1), branch)],
-            fallback,
+        ))
+        .into_int()
+        .expect("int function expression");
+        let expected = Ok(crate::plan::Expr::function(FunctionExpr::int(
+            IntFunctionExpr::int_case(int(1).into(), vec![(BigInt::from(1), branch)], fallback),
         )));
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_margin_int_case_function_clause_family_mismatch_direct() {
+        assert_eq!(
+            super::string_function_case_clauses(vec![(BigInt::from(1), Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::string_function_case_clauses(vec![(BigInt::from(1), int_function_ref_expr(0))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::bool_function_case_clauses(vec![(BigInt::from(1), Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::bool_function_case_clauses(vec![(BigInt::from(1), int_function_ref_expr(0))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::nil_function_case_clauses(vec![(BigInt::from(1), Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::nil_function_case_clauses(vec![(BigInt::from(1), int_function_ref_expr(0))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+    }
+
+    #[test]
+    fn plan_int_case_function_branch_return_families_direct() {
+        assert!(matches!(
+            super::function_case_branches(
+                vec![(BigInt::from(1), string_function_ref_expr(0))],
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::String(StringFunctionId(1)),
+                    [LocalId::String(crate::plan::StringLocalId(0))],
+                )),
+            ),
+            Ok(crate::plan::IntCaseBranches::StringFunction { .. }),
+        ));
+        assert!(matches!(
+            super::function_case_branches(
+                vec![(BigInt::from(1), bool_function_ref_expr(0))],
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Bool(BoolFunctionId(1)),
+                    [LocalId::Bool(crate::plan::BoolLocalId(0))],
+                )),
+            ),
+            Ok(crate::plan::IntCaseBranches::BoolFunction { .. }),
+        ));
+        assert!(matches!(
+            super::function_case_branches(
+                vec![(BigInt::from(1), nil_function_ref_expr(0))],
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Nil(NilFunctionId(1)),
+                    [LocalId::Nil(crate::plan::NilLocalId(0))],
+                )),
+            ),
+            Ok(crate::plan::IntCaseBranches::NilFunction { .. }),
+        ));
     }
 
     #[test]
@@ -607,6 +738,30 @@ pub fn main() {
         function_ref(
             RuntimeFunctionId::Int(IntFunctionId(id)),
             [LocalId::Int(IntLocalId(0))],
+        )
+        .into()
+    }
+
+    fn string_function_ref_expr(id: usize) -> crate::plan::Expr {
+        function_ref(
+            RuntimeFunctionId::String(StringFunctionId(id)),
+            [LocalId::String(crate::plan::StringLocalId(0))],
+        )
+        .into()
+    }
+
+    fn bool_function_ref_expr(id: usize) -> crate::plan::Expr {
+        function_ref(
+            RuntimeFunctionId::Bool(BoolFunctionId(id)),
+            [LocalId::Bool(crate::plan::BoolLocalId(0))],
+        )
+        .into()
+    }
+
+    fn nil_function_ref_expr(id: usize) -> crate::plan::Expr {
+        function_ref(
+            RuntimeFunctionId::Nil(NilFunctionId(id)),
+            [LocalId::Nil(crate::plan::NilLocalId(0))],
         )
         .into()
     }

--- a/src/planner/expression/pipeline.rs
+++ b/src/planner/expression/pipeline.rs
@@ -16,13 +16,9 @@ pub(super) fn plan(
 ) -> Result<Expr, PlanError> {
     context.with_local_scope(|context| {
         let mut steps = Vec::with_capacity(assignments.len() + 1);
-        if let Some(step) = plan_first_assignment(first_value, context)? {
-            steps.push(step);
-        }
+        steps.push(plan_first_assignment(first_value, context)?);
         for (assignment, kind) in assignments {
-            if let Some(step) = plan_assignment(assignment, kind, context)? {
-                steps.push(step);
-            }
+            steps.push(plan_assignment(assignment, kind, context)?);
         }
         let return_ = plan_pipeline_value(finally, finally_kind, context)?;
 
@@ -33,7 +29,7 @@ pub(super) fn plan(
 fn plan_first_assignment(
     assignment: TypedPipelineAssignment,
     context: &mut PlanContext<'_>,
-) -> Result<Option<Step>, PlanError> {
+) -> Result<Step, PlanError> {
     let value = plan_expr(*assignment.value, context)?;
 
     plan_variable_runtime_step(assignment.name, value, context)
@@ -43,7 +39,7 @@ fn plan_assignment(
     assignment: TypedPipelineAssignment,
     kind: PipelineAssignmentKind,
     context: &mut PlanContext<'_>,
-) -> Result<Option<Step>, PlanError> {
+) -> Result<Step, PlanError> {
     let value = plan_pipeline_value(*assignment.value, kind, context)?;
 
     plan_variable_runtime_step(assignment.name, value, context)

--- a/src/planner/expression/var.rs
+++ b/src/planner/expression/var.rs
@@ -1,5 +1,8 @@
-use crate::plan::{BoolExpr, Expr, FunctionExpr, IntExpr, LocalId, NilExpr, StringExpr, ValueType};
-use crate::planner::context::PlanContext;
+use crate::plan::{
+    BoolExpr, BoolFunctionExpr, Expr, FunctionExpr, IntExpr, IntFunctionExpr, LocalId, NilExpr,
+    NilFunctionExpr, StringExpr, StringFunctionExpr, ValueType,
+};
+use crate::planner::context::{FunctionLocalBinding, PlanContext};
 use crate::planner::error::{InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError};
 use ecow::EcoString;
 use gleam_core::type_::{PRELUDE_MODULE_NAME, ValueConstructor, ValueConstructorVariant};
@@ -14,8 +17,8 @@ pub(super) fn plan_var(
             if let Some((local, type_)) = context.lookup_local(&name) {
                 return local_get(local, name, type_);
             }
-            if let Some(value) = context.lookup_function_value(&name) {
-                return Ok(Expr::function(FunctionExpr::value(value)));
+            if let Some(binding) = context.lookup_function_local(&name) {
+                return Ok(function_local_get(binding, name));
             }
 
             Err(PlanError::InvalidTypedAst {
@@ -71,6 +74,23 @@ pub(super) fn plan_var(
                 kind: InvalidExpressionShapeKind::RecordConstructor,
             },
         }),
+    }
+}
+
+fn function_local_get(binding: FunctionLocalBinding, name: EcoString) -> Expr {
+    match binding {
+        FunctionLocalBinding::Int { local, type_ } => Expr::function(FunctionExpr::int(
+            IntFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::String { local, type_ } => Expr::function(FunctionExpr::string(
+            StringFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::Bool { local, type_ } => Expr::function(FunctionExpr::bool(
+            BoolFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::Nil { local, type_ } => Expr::function(FunctionExpr::nil(
+            NilFunctionExpr::local_get(local, name, type_),
+        )),
     }
 }
 

--- a/src/planner/statement.rs
+++ b/src/planner/statement.rs
@@ -42,9 +42,7 @@ fn plan_ordered_steps_and_return(
 ) -> Result<PlannedStatements, PlanError> {
     let mut steps = Vec::new();
     for statement in statements {
-        if let Some(step) = plan_runtime_step(statement, context)? {
-            steps.push(step);
-        }
+        steps.push(plan_runtime_step(statement, context)?);
     }
 
     let return_ = match last_statement {
@@ -72,11 +70,9 @@ fn plan_ordered_steps_and_return(
 pub(super) fn plan_runtime_step(
     statement: gleam_core::ast::TypedStatement,
     context: &mut PlanContext<'_>,
-) -> Result<Option<Step>, PlanError> {
+) -> Result<Step, PlanError> {
     match statement {
-        Statement::Expression(expression) => {
-            Ok(Some(Step::evaluate(plan_expr(expression, context)?)))
-        }
+        Statement::Expression(expression) => Ok(Step::evaluate(plan_expr(expression, context)?)),
         Statement::Assignment(assignment) => plan_assignment(*assignment, context),
         Statement::Use(_) => Err(PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::UseStatement,
@@ -90,7 +86,7 @@ pub(super) fn plan_runtime_step(
 fn plan_assignment(
     assignment: TypedAssignment,
     context: &mut PlanContext<'_>,
-) -> Result<Option<Step>, PlanError> {
+) -> Result<Step, PlanError> {
     match assignment.kind {
         AssignmentKind::Let => {}
         AssignmentKind::Generated => {
@@ -114,33 +110,43 @@ pub(in crate::planner) fn plan_variable_runtime_step(
     name: EcoString,
     value: crate::plan::Expr,
     context: &mut PlanContext<'_>,
-) -> Result<Option<Step>, PlanError> {
+) -> Result<Step, PlanError> {
     match value.into_kind() {
         ExprKind::Int(value) => {
             let local = context.define_int_local(name.clone());
-            Ok(Some(Step::let_int(local, name, value)))
+            Ok(Step::let_int(local, name, value))
         }
         ExprKind::String(value) => {
             let local = context.define_string_local(name.clone());
-            Ok(Some(Step::let_string(local, name, value)))
+            Ok(Step::let_string(local, name, value))
         }
         ExprKind::Bool(value) => {
             let local = context.define_bool_local(name.clone());
-            Ok(Some(Step::let_bool(local, name, value)))
+            Ok(Step::let_bool(local, name, value))
         }
         ExprKind::Nil(value) => {
             let local = context.define_nil_local(name.clone());
-            Ok(Some(Step::let_nil(local, name, value)))
+            Ok(Step::let_nil(local, name, value))
         }
-        ExprKind::Function(value) => {
-            let FunctionExprKind::Value(function_value) = value.kind() else {
-                return Err(PlanError::UnsupportedAssignment {
-                    kind: UnsupportedAssignmentKind::NonValueFunction,
-                });
-            };
-            context.define_function_alias(name, function_value.clone());
-            Ok(None)
-        }
+        ExprKind::Function(value) => Ok(match value.into_kind() {
+            FunctionExprKind::Int(value) => {
+                let local = context.define_int_function_local(name.clone(), value.type_().clone());
+                Step::let_int_function(local, name, value)
+            }
+            FunctionExprKind::String(value) => {
+                let local =
+                    context.define_string_function_local(name.clone(), value.type_().clone());
+                Step::let_string_function(local, name, value)
+            }
+            FunctionExprKind::Bool(value) => {
+                let local = context.define_bool_function_local(name.clone(), value.type_().clone());
+                Step::let_bool_function(local, name, value)
+            }
+            FunctionExprKind::Nil(value) => {
+                let local = context.define_nil_function_local(name.clone(), value.type_().clone());
+                Step::let_nil_function(local, name, value)
+            }
+        }),
     }
 }
 
@@ -173,7 +179,13 @@ fn plan_variable_pattern(pattern: TypedPattern) -> Result<EcoString, PlanError> 
 #[cfg(test)]
 mod tests {
     use super::plan_variable_pattern;
-    use crate::planner::dsl::{function, int, local_int, module};
+    use crate::plan::{BoolLocalId, IntLocalId, LocalId, NilLocalId, StringLocalId};
+    use crate::planner::dsl::{
+        bool_, bool_case_int_function, bool_function_ref, function, int, int_function_ref,
+        let_bool_function_step, let_int_function_step, let_nil_function_step,
+        let_string_function_step, local_bool, local_int, local_nil, local_string, module,
+        nil_function_ref, string_function_ref,
+    };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, compile_minimal_module, dummy_span, expect_plan_error};
     use crate::planner::{
@@ -226,12 +238,23 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_non_value_function_assignment() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+    fn plan_function_valued_assignment() {
+        let actual = plan_module(compile(
+            r#"
 fn add_one(value: Int) {
   value + 1
+}
+
+fn string_identity(value: String) {
+  value
+}
+
+fn bool_identity(value: Bool) {
+  value
+}
+
+fn nil_identity(value: Nil) {
+  value
 }
 
 pub fn main() {
@@ -239,14 +262,50 @@ pub fn main() {
     True -> add_one
     False -> add_one
   }
+  let string = string_identity
+  let bool = bool_identity
+  let nil = nil_identity
   1
 }
 "#,
-            ),
-            PlanError::UnsupportedAssignment {
-                kind: UnsupportedAssignmentKind::NonValueFunction,
-            },
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", int(1))
+                .step(let_int_function_step(
+                    0,
+                    "function",
+                    bool_case_int_function(
+                        bool_(true),
+                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                    ),
+                ))
+                .step(let_string_function_step(
+                    0,
+                    "string",
+                    string_function_ref(0, [LocalId::String(StringLocalId(0))]),
+                ))
+                .step(let_bool_function_step(
+                    0,
+                    "bool",
+                    bool_function_ref(0, [LocalId::Bool(BoolLocalId(0))]),
+                ))
+                .step(let_nil_function_step(
+                    0,
+                    "nil",
+                    nil_function_ref(0, [LocalId::Nil(NilLocalId(0))]),
+                )),
+            [
+                function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value"),
+                function("string_identity", local_string(0, "value")).param_string(0, "value"),
+                function("bool_identity", local_bool(0, "value")).param_bool(0, "value"),
+                function("nil_identity", local_nil(0, "value")).param_nil(0, "value"),
+            ],
         );
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/src/runtime/expression.rs
+++ b/src/runtime/expression.rs
@@ -8,7 +8,13 @@ use crate::plan::{ExecutionPlan, Expr, ExprKind, Value};
 use crate::runtime::frame::Frame;
 
 pub(super) use self::{
-    bool::eval_bool_expr, function::eval_function_expr, int::eval_int_expr, nil::eval_nil_expr,
+    bool::eval_bool_expr,
+    function::{
+        eval_bool_function_expr, eval_function_expr, eval_int_function_expr,
+        eval_nil_function_expr, eval_string_function_expr,
+    },
+    int::eval_int_expr,
+    nil::eval_nil_expr,
     string::eval_string_expr,
 };
 

--- a/src/runtime/expression/bool.rs
+++ b/src/runtime/expression/bool.rs
@@ -14,6 +14,9 @@ pub(in crate::runtime) fn eval_bool_expr(
         BoolExprKind::Call { function, args } => {
             function::run_bool_call(plan, *function, args, frame)
         }
+        BoolExprKind::FunctionCall { function, args } => {
+            function::run_bool_function_call(plan, function, args, frame)
+        }
         BoolExprKind::Not(value) => !eval_bool_expr(plan, frame, value),
         BoolExprKind::LtInt { left, right } => {
             eval_int_expr(plan, frame, left) < eval_int_expr(plan, frame, right)

--- a/src/runtime/expression/function.rs
+++ b/src/runtime/expression/function.rs
@@ -1,5 +1,10 @@
 use super::{eval_bool_expr, eval_int_expr};
-use crate::plan::{ExecutionPlan, FunctionExpr, FunctionExprKind, FunctionValue};
+use crate::plan::{
+    BoolFunctionExpr, BoolFunctionExprKind, BoolFunctionValue, ExecutionPlan, FunctionExpr,
+    FunctionExprKind, FunctionValue, IntFunctionExpr, IntFunctionExprKind, IntFunctionValue,
+    NilFunctionExpr, NilFunctionExprKind, NilFunctionValue, StringFunctionExpr,
+    StringFunctionExprKind, StringFunctionValue,
+};
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
 
@@ -9,19 +14,37 @@ pub(in crate::runtime) fn eval_function_expr(
     expression: &FunctionExpr,
 ) -> FunctionValue {
     match expression.kind() {
-        FunctionExprKind::Value(value) => value.clone(),
-        FunctionExprKind::BoolCase {
+        FunctionExprKind::Int(expression) => eval_int_function_expr(plan, frame, expression).into(),
+        FunctionExprKind::String(expression) => {
+            eval_string_function_expr(plan, frame, expression).into()
+        }
+        FunctionExprKind::Bool(expression) => {
+            eval_bool_function_expr(plan, frame, expression).into()
+        }
+        FunctionExprKind::Nil(expression) => eval_nil_function_expr(plan, frame, expression).into(),
+    }
+}
+
+pub(in crate::runtime) fn eval_int_function_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &IntFunctionExpr,
+) -> IntFunctionValue {
+    match expression.kind() {
+        IntFunctionExprKind::Value(value) => value.clone(),
+        IntFunctionExprKind::LocalGet { local, .. } => frame.get_int_function(*local),
+        IntFunctionExprKind::BoolCase {
             subject,
             true_,
             false_,
         } => {
             if eval_bool_expr(plan, frame, subject) {
-                eval_function_expr(plan, frame, true_)
+                eval_int_function_expr(plan, frame, true_)
             } else {
-                eval_function_expr(plan, frame, false_)
+                eval_int_function_expr(plan, frame, false_)
             }
         }
-        FunctionExprKind::IntCase {
+        IntFunctionExprKind::IntCase {
             subject,
             clauses,
             fallback,
@@ -29,25 +52,147 @@ pub(in crate::runtime) fn eval_function_expr(
             let subject = eval_int_expr(plan, frame, subject);
             for (pattern, branch) in clauses {
                 if pattern == &subject {
-                    return eval_function_expr(plan, frame, branch);
+                    return eval_int_function_expr(plan, frame, branch);
                 }
             }
-            eval_function_expr(plan, frame, fallback)
+            eval_int_function_expr(plan, frame, fallback)
         }
-        FunctionExprKind::Block { steps, return_ } => {
+        IntFunctionExprKind::Block { steps, return_ } => {
             function::execute_steps(plan, steps, frame);
-            eval_function_expr(plan, frame, return_)
+            eval_int_function_expr(plan, frame, return_)
+        }
+    }
+}
+
+pub(in crate::runtime) fn eval_string_function_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &StringFunctionExpr,
+) -> StringFunctionValue {
+    match expression.kind() {
+        StringFunctionExprKind::Value(value) => value.clone(),
+        StringFunctionExprKind::LocalGet { local, .. } => frame.get_string_function(*local),
+        StringFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, frame, subject) {
+                eval_string_function_expr(plan, frame, true_)
+            } else {
+                eval_string_function_expr(plan, frame, false_)
+            }
+        }
+        StringFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, frame, subject);
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_string_function_expr(plan, frame, branch);
+                }
+            }
+            eval_string_function_expr(plan, frame, fallback)
+        }
+        StringFunctionExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, steps, frame);
+            eval_string_function_expr(plan, frame, return_)
+        }
+    }
+}
+
+pub(in crate::runtime) fn eval_bool_function_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &BoolFunctionExpr,
+) -> BoolFunctionValue {
+    match expression.kind() {
+        BoolFunctionExprKind::Value(value) => value.clone(),
+        BoolFunctionExprKind::LocalGet { local, .. } => frame.get_bool_function(*local),
+        BoolFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, frame, subject) {
+                eval_bool_function_expr(plan, frame, true_)
+            } else {
+                eval_bool_function_expr(plan, frame, false_)
+            }
+        }
+        BoolFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, frame, subject);
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_bool_function_expr(plan, frame, branch);
+                }
+            }
+            eval_bool_function_expr(plan, frame, fallback)
+        }
+        BoolFunctionExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, steps, frame);
+            eval_bool_function_expr(plan, frame, return_)
+        }
+    }
+}
+
+pub(in crate::runtime) fn eval_nil_function_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &NilFunctionExpr,
+) -> NilFunctionValue {
+    match expression.kind() {
+        NilFunctionExprKind::Value(value) => value.clone(),
+        NilFunctionExprKind::LocalGet { local, .. } => frame.get_nil_function(*local),
+        NilFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, frame, subject) {
+                eval_nil_function_expr(plan, frame, true_)
+            } else {
+                eval_nil_function_expr(plan, frame, false_)
+            }
+        }
+        NilFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, frame, subject);
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_nil_function_expr(plan, frame, branch);
+                }
+            }
+            eval_nil_function_expr(plan, frame, fallback)
+        }
+        NilFunctionExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, steps, frame);
+            eval_nil_function_expr(plan, frame, return_)
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::eval_function_expr;
+    use super::{
+        eval_bool_function_expr, eval_function_expr, eval_int_function_expr,
+        eval_nil_function_expr, eval_string_function_expr,
+    };
     use crate::plan::{
-        BoolExpr, ExecutionPlan, Expr, FunctionArgumentType, FunctionExpr, FunctionId,
-        FunctionPlan, FunctionType, FunctionValue, IntExpr, IntFunctionId, RuntimeFunctionId, Step,
-        ValueType,
+        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, BoolLocalId, ExecutionPlan,
+        Expr, FunctionArgumentType, FunctionExpr, FunctionId, FunctionPlan, FunctionType,
+        FunctionValue, IntExpr, IntFunctionExpr, IntFunctionId, IntFunctionValue, IntLocalId,
+        LocalId, NilFunctionExpr, NilFunctionId, NilFunctionValue, NilLocalId, RuntimeFunctionId,
+        Step, StringFunctionExpr, StringFunctionId, StringFunctionValue, StringLocalId, ValueType,
     };
     use crate::runtime::frame::Frame;
     use num_bigint::BigInt;
@@ -56,90 +201,289 @@ mod tests {
     fn eval_function_value() {
         let plan = plan_with_int_main(Vec::new());
         let mut frame = Frame::default();
-        let function = eval_function_expr(
-            &plan,
-            &mut frame,
-            &FunctionExpr::value(int_function_value()),
-        );
+        let function =
+            eval_function_expr(&plan, &mut frame, &FunctionExpr::value(function_value()));
 
         assert_int_function(function);
     }
 
     #[test]
-    fn eval_function_bool_case_branches() {
+    fn eval_function_value_return_families() {
         let plan = plan_with_int_main(Vec::new());
         let mut frame = Frame::default();
-        let function = eval_function_expr(
+
+        assert_eq!(
+            eval_function_expr(
+                &plan,
+                &mut frame,
+                &FunctionExpr::value(string_function_value())
+            )
+            .type_()
+            .return_(),
+            &ValueType::String,
+        );
+        assert_eq!(
+            eval_function_expr(
+                &plan,
+                &mut frame,
+                &FunctionExpr::value(bool_function_value())
+            )
+            .type_()
+            .return_(),
+            &ValueType::Bool,
+        );
+        assert_eq!(
+            eval_function_expr(
+                &plan,
+                &mut frame,
+                &FunctionExpr::value(nil_function_value())
+            )
+            .type_()
+            .return_(),
+            &ValueType::Nil,
+        );
+    }
+
+    #[test]
+    fn eval_int_function_bool_case_branches() {
+        let plan = plan_with_int_main(Vec::new());
+        let mut frame = Frame::default();
+        let function = eval_int_function_expr(
             &plan,
             &mut frame,
-            &FunctionExpr::bool_case(
+            &IntFunctionExpr::bool_case(
                 BoolExpr::value(true),
-                FunctionExpr::value(int_function_value()),
-                FunctionExpr::value(other_int_function_value()),
+                int_function_value(),
+                other_int_function_value(),
             ),
         );
 
-        assert_int_function(function);
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
 
-        let function = eval_function_expr(
+        let function = eval_int_function_expr(
             &plan,
             &mut frame,
-            &FunctionExpr::bool_case(
+            &IntFunctionExpr::bool_case(
                 BoolExpr::value(false),
-                FunctionExpr::value(other_int_function_value()),
-                FunctionExpr::value(int_function_value()),
+                other_int_function_value(),
+                int_function_value(),
             ),
         );
 
-        assert_int_function(function);
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
     }
 
     #[test]
-    fn eval_function_int_case_branches() {
+    fn eval_int_function_int_case_branches() {
         let plan = plan_with_int_main(Vec::new());
         let mut frame = Frame::default();
-        let function = eval_function_expr(
+        let function = eval_int_function_expr(
             &plan,
             &mut frame,
-            &FunctionExpr::int_case(
+            &IntFunctionExpr::int_case(
                 IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), FunctionExpr::value(int_function_value()))],
-                FunctionExpr::value(other_int_function_value()),
+                vec![(BigInt::from(1), int_function_value())],
+                other_int_function_value(),
             ),
         );
 
-        assert_int_function(function);
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
 
-        let function = eval_function_expr(
+        let function = eval_int_function_expr(
             &plan,
             &mut frame,
-            &FunctionExpr::int_case(
+            &IntFunctionExpr::int_case(
                 IntExpr::value(BigInt::from(2)),
-                vec![(
-                    BigInt::from(1),
-                    FunctionExpr::value(other_int_function_value()),
-                )],
-                FunctionExpr::value(int_function_value()),
+                vec![(BigInt::from(1), other_int_function_value())],
+                int_function_value(),
             ),
         );
 
-        assert_int_function(function);
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
     }
 
     #[test]
-    fn eval_function_block() {
+    fn eval_int_function_block() {
         let plan = plan_with_int_main(Vec::new());
         let mut frame = Frame::default();
-        let function = eval_function_expr(
+        let function = eval_int_function_expr(
             &plan,
             &mut frame,
-            &FunctionExpr::block(
+            &IntFunctionExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1))))],
-                FunctionExpr::value(int_function_value()),
+                int_function_value(),
             ),
         );
 
-        assert_int_function(function);
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
+    }
+
+    #[test]
+    fn eval_string_bool_nil_function_branches() {
+        let plan = plan_with_int_main(Vec::new());
+        let mut frame = Frame::default();
+
+        let string = eval_string_function_expr(
+            &plan,
+            &mut frame,
+            &StringFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                string_function_expr(),
+                other_string_function_expr(),
+            ),
+        );
+        assert_eq!(string.runtime_id(), StringFunctionId(0));
+
+        let string = eval_string_function_expr(
+            &plan,
+            &mut frame,
+            &StringFunctionExpr::bool_case(
+                BoolExpr::value(false),
+                other_string_function_expr(),
+                string_function_expr(),
+            ),
+        );
+        assert_eq!(string.runtime_id(), StringFunctionId(0));
+
+        let string = eval_string_function_expr(
+            &plan,
+            &mut frame,
+            &StringFunctionExpr::int_case(
+                IntExpr::value(BigInt::from(1)),
+                vec![(BigInt::from(1), string_function_expr())],
+                other_string_function_expr(),
+            ),
+        );
+        assert_eq!(string.runtime_id(), StringFunctionId(0));
+
+        let string = eval_string_function_expr(
+            &plan,
+            &mut frame,
+            &StringFunctionExpr::int_case(
+                IntExpr::value(BigInt::from(2)),
+                vec![(BigInt::from(1), other_string_function_expr())],
+                string_function_expr(),
+            ),
+        );
+        assert_eq!(string.runtime_id(), StringFunctionId(0));
+
+        let string = eval_string_function_expr(
+            &plan,
+            &mut frame,
+            &StringFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1))))],
+                string_function_expr(),
+            ),
+        );
+        assert_eq!(string.runtime_id(), StringFunctionId(0));
+
+        let bool_ = eval_bool_function_expr(
+            &plan,
+            &mut frame,
+            &BoolFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                bool_function_expr(),
+                other_bool_function_expr(),
+            ),
+        );
+        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
+
+        let bool_ = eval_bool_function_expr(
+            &plan,
+            &mut frame,
+            &BoolFunctionExpr::bool_case(
+                BoolExpr::value(false),
+                other_bool_function_expr(),
+                bool_function_expr(),
+            ),
+        );
+        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
+
+        let bool_ = eval_bool_function_expr(
+            &plan,
+            &mut frame,
+            &BoolFunctionExpr::int_case(
+                IntExpr::value(BigInt::from(1)),
+                vec![(BigInt::from(1), bool_function_expr())],
+                other_bool_function_expr(),
+            ),
+        );
+        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
+
+        let bool_ = eval_bool_function_expr(
+            &plan,
+            &mut frame,
+            &BoolFunctionExpr::int_case(
+                IntExpr::value(BigInt::from(2)),
+                vec![(BigInt::from(1), other_bool_function_expr())],
+                bool_function_expr(),
+            ),
+        );
+        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
+
+        let bool_ = eval_bool_function_expr(
+            &plan,
+            &mut frame,
+            &BoolFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1))))],
+                bool_function_expr(),
+            ),
+        );
+        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
+
+        let nil = eval_nil_function_expr(
+            &plan,
+            &mut frame,
+            &NilFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                nil_function_expr(),
+                other_nil_function_expr(),
+            ),
+        );
+        assert_eq!(nil.runtime_id(), NilFunctionId(0));
+
+        let nil = eval_nil_function_expr(
+            &plan,
+            &mut frame,
+            &NilFunctionExpr::bool_case(
+                BoolExpr::value(false),
+                other_nil_function_expr(),
+                nil_function_expr(),
+            ),
+        );
+        assert_eq!(nil.runtime_id(), NilFunctionId(0));
+
+        let nil = eval_nil_function_expr(
+            &plan,
+            &mut frame,
+            &NilFunctionExpr::int_case(
+                IntExpr::value(BigInt::from(1)),
+                vec![(BigInt::from(1), nil_function_expr())],
+                other_nil_function_expr(),
+            ),
+        );
+        assert_eq!(nil.runtime_id(), NilFunctionId(0));
+
+        let nil = eval_nil_function_expr(
+            &plan,
+            &mut frame,
+            &NilFunctionExpr::int_case(
+                IntExpr::value(BigInt::from(2)),
+                vec![(BigInt::from(1), other_nil_function_expr())],
+                nil_function_expr(),
+            ),
+        );
+        assert_eq!(nil.runtime_id(), NilFunctionId(0));
+
+        let nil = eval_nil_function_expr(
+            &plan,
+            &mut frame,
+            &NilFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1))))],
+                nil_function_expr(),
+            ),
+        );
+        assert_eq!(nil.runtime_id(), NilFunctionId(0));
     }
 
     fn plan_with_int_main(functions: Vec<FunctionPlan>) -> ExecutionPlan {
@@ -166,17 +510,87 @@ mod tests {
         assert_eq!(type_.return_(), &ValueType::Int);
     }
 
-    fn int_function_value() -> FunctionValue {
+    fn function_value() -> FunctionValue {
         FunctionValue::new(
             RuntimeFunctionId::Int(IntFunctionId(0)),
-            vec![crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+            vec![LocalId::Int(IntLocalId(0))],
         )
     }
 
-    fn other_int_function_value() -> FunctionValue {
+    fn string_function_value() -> FunctionValue {
         FunctionValue::new(
-            RuntimeFunctionId::Int(IntFunctionId(1)),
-            vec![crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+            RuntimeFunctionId::String(StringFunctionId(0)),
+            vec![LocalId::String(StringLocalId(0))],
         )
+    }
+
+    fn bool_function_value() -> FunctionValue {
+        FunctionValue::new(
+            RuntimeFunctionId::Bool(BoolFunctionId(0)),
+            vec![LocalId::Bool(BoolLocalId(0))],
+        )
+    }
+
+    fn nil_function_value() -> FunctionValue {
+        FunctionValue::new(
+            RuntimeFunctionId::Nil(NilFunctionId(0)),
+            vec![LocalId::Nil(NilLocalId(0))],
+        )
+    }
+
+    fn int_function_value() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(0),
+            vec![LocalId::Int(IntLocalId(0))],
+        ))
+    }
+
+    fn other_int_function_value() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(1),
+            vec![LocalId::Int(IntLocalId(0))],
+        ))
+    }
+
+    fn string_function_expr() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(
+            StringFunctionId(0),
+            vec![LocalId::String(StringLocalId(0))],
+        ))
+    }
+
+    fn other_string_function_expr() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(
+            StringFunctionId(1),
+            vec![LocalId::String(StringLocalId(0))],
+        ))
+    }
+
+    fn bool_function_expr() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(
+            BoolFunctionId(0),
+            vec![LocalId::Bool(BoolLocalId(0))],
+        ))
+    }
+
+    fn other_bool_function_expr() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(
+            BoolFunctionId(1),
+            vec![LocalId::Bool(BoolLocalId(0))],
+        ))
+    }
+
+    fn nil_function_expr() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(
+            NilFunctionId(0),
+            vec![LocalId::Nil(NilLocalId(0))],
+        ))
+    }
+
+    fn other_nil_function_expr() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(
+            NilFunctionId(1),
+            vec![LocalId::Nil(NilLocalId(0))],
+        ))
     }
 }

--- a/src/runtime/expression/int.rs
+++ b/src/runtime/expression/int.rs
@@ -15,6 +15,9 @@ pub(in crate::runtime) fn eval_int_expr(
         IntExprKind::Call { function, args } => {
             function::run_int_call(plan, *function, args, frame)
         }
+        IntExprKind::FunctionCall { function, args } => {
+            function::run_int_function_call(plan, function, args, frame)
+        }
         IntExprKind::Add { left, right } => {
             eval_int_expr(plan, frame, left) + eval_int_expr(plan, frame, right)
         }

--- a/src/runtime/expression/nil.rs
+++ b/src/runtime/expression/nil.rs
@@ -14,6 +14,9 @@ pub(in crate::runtime) fn eval_nil_expr(
         NilExprKind::Call { function, args } => {
             function::run_nil_call(plan, *function, args, frame)
         }
+        NilExprKind::FunctionCall { function, args } => {
+            function::run_nil_function_call(plan, function, args, frame)
+        }
         NilExprKind::BoolCase {
             subject,
             true_,

--- a/src/runtime/expression/string.rs
+++ b/src/runtime/expression/string.rs
@@ -15,6 +15,9 @@ pub(in crate::runtime) fn eval_string_expr(
         StringExprKind::Call { function, args } => {
             function::run_string_call(plan, *function, args, frame)
         }
+        StringExprKind::FunctionCall { function, args } => {
+            function::run_string_function_call(plan, function, args, frame)
+        }
         StringExprKind::Concatenate { left, right } => format!(
             "{}{}",
             eval_string_expr(plan, frame, left),

--- a/src/runtime/frame.rs
+++ b/src/runtime/frame.rs
@@ -1,11 +1,20 @@
-use crate::plan::{BoolLocalId, FrameLayout, IntLocalId, NilLocalId, StringLocalId};
+use crate::plan::{
+    BoolFunctionLocalId, BoolFunctionValue, BoolLocalId, FrameLayout, IntFunctionLocalId,
+    IntFunctionValue, IntLocalId, NilFunctionLocalId, NilFunctionValue, NilLocalId,
+    StringFunctionLocalId, StringFunctionValue, StringLocalId,
+};
 use ecow::EcoString;
 use num_bigint::BigInt;
+use std::collections::HashMap;
 
 pub(super) struct Frame {
     ints: Vec<BigInt>,
     strings: Vec<EcoString>,
     bools: Vec<bool>,
+    int_functions: HashMap<IntFunctionLocalId, IntFunctionValue>,
+    string_functions: HashMap<StringFunctionLocalId, StringFunctionValue>,
+    bool_functions: HashMap<BoolFunctionLocalId, BoolFunctionValue>,
+    nil_functions: HashMap<NilFunctionLocalId, NilFunctionValue>,
 }
 
 impl Frame {
@@ -14,6 +23,10 @@ impl Frame {
             ints: vec![BigInt::from(0); layout.ints()],
             strings: vec![EcoString::default(); layout.strings()],
             bools: vec![false; layout.bools()],
+            int_functions: HashMap::with_capacity(layout.int_functions()),
+            string_functions: HashMap::with_capacity(layout.string_functions()),
+            bool_functions: HashMap::with_capacity(layout.bool_functions()),
+            nil_functions: HashMap::with_capacity(layout.nil_functions()),
         }
     }
 
@@ -44,6 +57,46 @@ impl Frame {
     pub(super) fn set_nil(&mut self, _local: NilLocalId) {}
 
     pub(super) fn get_nil(&self, _local: NilLocalId) {}
+
+    pub(super) fn set_int_function(&mut self, local: IntFunctionLocalId, value: IntFunctionValue) {
+        self.int_functions.insert(local, value);
+    }
+
+    pub(super) fn get_int_function(&self, local: IntFunctionLocalId) -> IntFunctionValue {
+        self.int_functions[&local].clone()
+    }
+
+    pub(super) fn set_string_function(
+        &mut self,
+        local: StringFunctionLocalId,
+        value: StringFunctionValue,
+    ) {
+        self.string_functions.insert(local, value);
+    }
+
+    pub(super) fn get_string_function(&self, local: StringFunctionLocalId) -> StringFunctionValue {
+        self.string_functions[&local].clone()
+    }
+
+    pub(super) fn set_bool_function(
+        &mut self,
+        local: BoolFunctionLocalId,
+        value: BoolFunctionValue,
+    ) {
+        self.bool_functions.insert(local, value);
+    }
+
+    pub(super) fn get_bool_function(&self, local: BoolFunctionLocalId) -> BoolFunctionValue {
+        self.bool_functions[&local].clone()
+    }
+
+    pub(super) fn set_nil_function(&mut self, local: NilFunctionLocalId, value: NilFunctionValue) {
+        self.nil_functions.insert(local, value);
+    }
+
+    pub(super) fn get_nil_function(&self, local: NilFunctionLocalId) -> NilFunctionValue {
+        self.nil_functions[&local].clone()
+    }
 }
 
 impl Default for Frame {
@@ -59,23 +112,46 @@ fn set_slot<T>(slots: &mut [T], index: usize, value: T) {
 #[cfg(test)]
 mod tests {
     use super::Frame;
-    use crate::plan::{BoolLocalId, FrameLayout, IntLocalId, NilLocalId, StringLocalId};
+    use crate::plan::{
+        BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue, BoolLocalId, FrameLayout,
+        IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId, LocalId, NilFunctionId,
+        NilFunctionLocalId, NilFunctionValue, NilLocalId, StringFunctionId, StringFunctionLocalId,
+        StringFunctionValue, StringLocalId,
+    };
     use num_bigint::BigInt;
 
     #[test]
     fn frame_set_and_get_local() {
         let frame = frame_with_layout(1, 1, 1, 1);
         let mut frame = frame;
+        let int_function = int_function_value();
+        let string_function = string_function_value();
+        let bool_function = bool_function_value();
+        let nil_function = nil_function_value();
 
         frame.set_int(IntLocalId(0), int(1));
         frame.set_string(StringLocalId(0), "geam".into());
         frame.set_bool(BoolLocalId(0), true);
         frame.set_nil(NilLocalId(0));
+        frame.set_int_function(IntFunctionLocalId(0), int_function.clone());
+        frame.set_string_function(StringFunctionLocalId(0), string_function.clone());
+        frame.set_bool_function(BoolFunctionLocalId(0), bool_function.clone());
+        frame.set_nil_function(NilFunctionLocalId(0), nil_function.clone());
 
         assert_eq!(frame.get_int(IntLocalId(0)), int(1));
         assert_eq!(frame.get_string(StringLocalId(0)), "geam");
         assert!(frame.get_bool(BoolLocalId(0)));
         assert_eq!(frame.get_nil(NilLocalId(0)), ());
+        assert_eq!(frame.get_int_function(IntFunctionLocalId(0)), int_function);
+        assert_eq!(
+            frame.get_string_function(StringFunctionLocalId(0)),
+            string_function,
+        );
+        assert_eq!(
+            frame.get_bool_function(BoolFunctionLocalId(0)),
+            bool_function,
+        );
+        assert_eq!(frame.get_nil_function(NilFunctionLocalId(0)), nil_function);
     }
 
     #[test]
@@ -84,8 +160,14 @@ mod tests {
 
         frame.set_int(IntLocalId(0), int(1));
         frame.set_int(IntLocalId(0), int(2));
+        frame.set_int_function(IntFunctionLocalId(0), int_function_value());
+        frame.set_int_function(IntFunctionLocalId(0), other_int_function_value());
 
         assert_eq!(frame.get_int(IntLocalId(0)), int(2));
+        assert_eq!(
+            frame.get_int_function(IntFunctionLocalId(0)),
+            other_int_function_value(),
+        );
     }
 
     fn frame_with_layout(ints: usize, strings: usize, bools: usize, nils: usize) -> Frame {
@@ -102,10 +184,34 @@ mod tests {
         if nils > 0 {
             layout.include_nil(NilLocalId(nils - 1));
         }
+        layout.include_int_function(IntFunctionLocalId(0));
+        layout.include_string_function(StringFunctionLocalId(0));
+        layout.include_bool_function(BoolFunctionLocalId(0));
+        layout.include_nil_function(NilFunctionLocalId(0));
         Frame::new(layout)
     }
 
     fn int(value: i64) -> BigInt {
         BigInt::from(value)
+    }
+
+    fn int_function_value() -> IntFunctionValue {
+        IntFunctionValue::new(IntFunctionId(0), vec![LocalId::Int(IntLocalId(0))])
+    }
+
+    fn other_int_function_value() -> IntFunctionValue {
+        IntFunctionValue::new(IntFunctionId(1), vec![LocalId::Int(IntLocalId(0))])
+    }
+
+    fn string_function_value() -> StringFunctionValue {
+        StringFunctionValue::new(StringFunctionId(0), vec![LocalId::String(StringLocalId(0))])
+    }
+
+    fn bool_function_value() -> BoolFunctionValue {
+        BoolFunctionValue::new(BoolFunctionId(0), vec![LocalId::Bool(BoolLocalId(0))])
+    }
+
+    fn nil_function_value() -> NilFunctionValue {
+        NilFunctionValue::new(NilFunctionId(0), vec![LocalId::Int(IntLocalId(0))])
     }
 }

--- a/src/runtime/function.rs
+++ b/src/runtime/function.rs
@@ -3,7 +3,8 @@ use crate::plan::{
     RuntimeFunctionId, StepKind, StringFunctionId, Value,
 };
 use crate::runtime::expression::{
-    eval_bool_expr, eval_expr, eval_int_expr, eval_nil_expr, eval_string_expr,
+    eval_bool_expr, eval_bool_function_expr, eval_expr, eval_int_expr, eval_int_function_expr,
+    eval_nil_expr, eval_nil_function_expr, eval_string_expr, eval_string_function_expr,
 };
 use crate::runtime::frame::Frame;
 use ecow::EcoString;
@@ -99,6 +100,22 @@ pub(in crate::runtime) fn execute_steps(
                 eval_nil_expr(plan, frame, value);
                 frame.set_nil(*local);
             }
+            StepKind::LetIntFunction { local, value, .. } => {
+                let value = eval_int_function_expr(plan, frame, value);
+                frame.set_int_function(*local, value);
+            }
+            StepKind::LetStringFunction { local, value, .. } => {
+                let value = eval_string_function_expr(plan, frame, value);
+                frame.set_string_function(*local, value);
+            }
+            StepKind::LetBoolFunction { local, value, .. } => {
+                let value = eval_bool_function_expr(plan, frame, value);
+                frame.set_bool_function(*local, value);
+            }
+            StepKind::LetNilFunction { local, value, .. } => {
+                let value = eval_nil_function_expr(plan, frame, value);
+                frame.set_nil_function(*local, value);
+            }
             StepKind::Evaluate(expression) => {
                 let _ = eval_expr(plan, frame, expression);
             }
@@ -136,6 +153,46 @@ fn bind_arguments(
     }
 
     frame
+}
+
+pub(in crate::runtime) fn run_int_function_call(
+    plan: &ExecutionPlan,
+    function: &crate::plan::IntFunctionExpr,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> BigInt {
+    let function = eval_int_function_expr(plan, caller_frame, function);
+    run_int_call(plan, function.runtime_id(), args, caller_frame)
+}
+
+pub(in crate::runtime) fn run_string_function_call(
+    plan: &ExecutionPlan,
+    function: &crate::plan::StringFunctionExpr,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> EcoString {
+    let function = eval_string_function_expr(plan, caller_frame, function);
+    run_string_call(plan, function.runtime_id(), args, caller_frame)
+}
+
+pub(in crate::runtime) fn run_bool_function_call(
+    plan: &ExecutionPlan,
+    function: &crate::plan::BoolFunctionExpr,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> bool {
+    let function = eval_bool_function_expr(plan, caller_frame, function);
+    run_bool_call(plan, function.runtime_id(), args, caller_frame)
+}
+
+pub(in crate::runtime) fn run_nil_function_call(
+    plan: &ExecutionPlan,
+    function: &crate::plan::NilFunctionExpr,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) {
+    let function = eval_nil_function_expr(plan, caller_frame, function);
+    run_nil_call(plan, function.runtime_id(), args, caller_frame);
 }
 
 #[cfg(test)]
@@ -196,6 +253,54 @@ pub fn main() {
 "#,
             ),
             int(2),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+fn identity(value: String) {
+  value
+}
+
+pub fn main() {
+  let function = identity
+  function("geam")
+}
+"#,
+            ),
+            Value::String("geam".into()),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+fn identity(value: Bool) {
+  value
+}
+
+pub fn main() {
+  let function = identity
+  function(True)
+}
+"#,
+            ),
+            Value::Bool(true),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+fn identity(value: Nil) {
+  value
+}
+
+pub fn main() {
+  let function = identity
+  function(Nil)
+}
+"#,
+            ),
+            Value::Nil,
         );
     }
 

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -24,7 +24,16 @@ execution_case!(bool_case_fallback, "bool_case_fallback.gleam");
 execution_case!(int_case, "int_case.gleam");
 execution_case!(block_expression, "block_expression.gleam");
 execution_case!(pipeline, "pipeline.gleam");
-execution_case!(function_value, "function_value.gleam");
+execution_case!(function_value_local, "function_value_local.gleam");
+execution_case!(function_value_shadowing, "function_value_shadowing.gleam");
+execution_case!(
+    function_value_block_callee,
+    "function_value_block_callee.gleam"
+);
+execution_case!(
+    function_value_case_callee,
+    "function_value_case_callee.gleam"
+);
 execution_case!(nil_value, "nil_value.gleam");
 
 fn run_fixture(file_name: &str) {

--- a/tests/fixtures/execution/bool_case.gleam
+++ b/tests/fixtures/execution/bool_case.gleam
@@ -3,6 +3,21 @@ fn enabled() {
 }
 
 pub fn main() {
+  case True {
+    True -> "enabled"
+    False -> "disabled"
+  }
+
+  case True {
+    True -> True
+    False -> False
+  }
+
+  case True {
+    True -> Nil
+    False -> Nil
+  }
+
   case enabled() {
     True -> 42
     False -> 0

--- a/tests/fixtures/execution/function_value_block_callee.gleam
+++ b/tests/fixtures/execution/function_value_block_callee.gleam
@@ -1,0 +1,25 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn string_identity(value: String) {
+  value
+}
+
+fn bool_identity(value: Bool) {
+  value
+}
+
+fn nil_identity(value: Nil) {
+  value
+}
+
+pub fn main() {
+  { string_identity }("geam")
+  { bool_identity }(True)
+  { nil_identity }(Nil)
+
+  { add_one }(41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/function_value_case_callee.gleam
+++ b/tests/fixtures/execution/function_value_case_callee.gleam
@@ -19,21 +19,11 @@ fn nil_identity(value: Nil) {
 }
 
 pub fn main() {
-  let add = 1
-  let add = add_one
-  let string = string_identity
-  let bool = bool_identity
-  let nil = nil_identity
-
-  string("geam")
-  bool(True)
-  nil(Nil)
-
-  { string_identity }("geam")
-  { bool_identity }(True)
-  { nil_identity }(Nil)
-
   case True {
+    True -> string_identity
+    False -> string_identity
+  }("geam")
+  case False {
     True -> string_identity
     False -> string_identity
   }("geam")
@@ -41,7 +31,15 @@ pub fn main() {
     True -> bool_identity
     False -> bool_identity
   }(True)
+  case False {
+    True -> bool_identity
+    False -> bool_identity
+  }(True)
   case True {
+    True -> nil_identity
+    False -> nil_identity
+  }(Nil)
+  case False {
     True -> nil_identity
     False -> nil_identity
   }(Nil)
@@ -50,7 +48,15 @@ pub fn main() {
     0 -> string_identity
     _ -> string_identity
   }("geam")
+  case 1 {
+    0 -> string_identity
+    _ -> string_identity
+  }("geam")
   case 0 {
+    0 -> bool_identity
+    _ -> bool_identity
+  }(True)
+  case 1 {
     0 -> bool_identity
     _ -> bool_identity
   }(True)
@@ -58,29 +64,29 @@ pub fn main() {
     0 -> nil_identity
     _ -> nil_identity
   }(Nil)
+  case 1 {
+    0 -> nil_identity
+    _ -> nil_identity
+  }(Nil)
 
-  let inner = {
-    let add = add_ten
-    add(10)
-  }
-
-  let int_shadow = {
-    let add = add_one
-    let add = 5
-    add + 2
-  }
-
-  let block_call = { add_one }(1)
-  let bool_case_call = case True {
+  let bool_hit = case True {
     True -> add_one
     False -> add_ten
   }(1)
-  let int_case_call = case 0 {
+  let bool_miss = case False {
+    True -> add_one
+    False -> add_ten
+  }(1)
+  let int_hit = case 0 {
+    0 -> add_ten
+    _ -> add_one
+  }(1)
+  let int_fallback = case 1 {
     0 -> add_ten
     _ -> add_one
   }(1)
 
-  inner + int_shadow + add(1) + block_call + bool_case_call + int_case_call
+  bool_hit + bool_miss + int_hit + int_fallback
 }
 
-// geam:expect Int(44)
+// geam:expect Int(26)

--- a/tests/fixtures/execution/function_value_local.gleam
+++ b/tests/fixtures/execution/function_value_local.gleam
@@ -1,0 +1,33 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn string_identity(value: String) {
+  value
+}
+
+fn bool_identity(value: Bool) {
+  value
+}
+
+fn nil_identity(value: Nil) {
+  value
+}
+
+pub fn main() {
+  let add = add_one
+  let string = "geam"
+  let string = string_identity
+  let bool = False
+  let bool = bool_identity
+  let nil = Nil
+  let nil = nil_identity
+
+  string("geam")
+  bool(True)
+  nil(Nil)
+
+  add(41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/function_value_shadowing.gleam
+++ b/tests/fixtures/execution/function_value_shadowing.gleam
@@ -1,0 +1,28 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn add_ten(value: Int) {
+  value + 10
+}
+
+pub fn main() {
+  let add = 1
+  let add = add_one
+  let outer = add(1)
+
+  let inner = {
+    let add = add_ten
+    add(10)
+  }
+
+  let primitive_shadow = {
+    let add = add_one
+    let add = 5
+    add + 2
+  }
+
+  outer + inner + primitive_shadow + add(1)
+}
+
+// geam:expect Int(31)

--- a/tests/fixtures/execution/int_case.gleam
+++ b/tests/fixtures/execution/int_case.gleam
@@ -22,6 +22,21 @@ fn duplicate_literal(value: Int) {
 }
 
 pub fn main() {
+  case 1 {
+    1 -> "one"
+    _ -> "other"
+  }
+
+  case 1 {
+    1 -> True
+    _ -> False
+  }
+
+  case 1 {
+    1 -> Nil
+    _ -> Nil
+  }
+
   classify(1) + classify(9) + fallback_first(1) + duplicate_literal(1)
 }
 


### PR DESCRIPTION
- Allow current-module function references to be bound with let and called through local variables.
- Unify primitive and function bindings in planner scope so shadowing follows Gleam semantics.
- Add typed function-local plan shapes, frame layout/runtime storage, and focused execution fixtures.