### PR TITLE
Support function-typed arguments

### DIFF
--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -99,6 +99,9 @@ Errors make boundaries visible:
   Test-only references do not justify keeping an error variant.
 - When feature scope changes, re-audit newly added error variants and remove any
   that are only test-referenced or speculative.
+- Use `Option` for lookups or partial conversions when the caller owns the
+  boundary meaning of absence. If all callers translate `None` into the same
+  failure boundary, return `Result` or a structured reason instead.
 - When the accepted profile grows into an area that was previously rejected by a
   broad `Unsupported*` variant, revisit that variant. Rename or split it if the
   old name also describes behavior that is now supported.
@@ -124,8 +127,12 @@ in the test name. Prefer explicit names such as `function_valued_block` over
 short names that hide the reviewed result family.
 
 Unit tests live next to the module they validate. Do not use large detached
-`tests.rs` files for complex modules. Integration tests document the public
-execution pipeline from source fixture to runtime value.
+`tests.rs` files for complex modules. Integration tests are fixture-based and
+document accepted Gleam source running through the public execution pipeline to
+a runtime value.
+
+Planner rejection coverage belongs in the owning planner unit test unless it is
+represented by a dedicated fixture-based integration case.
 
 ## Helper And DSL Rules
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -11,17 +11,17 @@ use ecow::EcoString;
 use std::fmt;
 
 pub(crate) use expression::{
-    BoolCaseBranches, BoolExprKind, BoolFunctionExprKind, CallArgKind, ExprKind, FunctionExprKind,
-    IntCaseBranches, IntExprKind, IntFunctionExprKind, NilExprKind, NilFunctionExprKind,
-    StringExprKind, StringFunctionExprKind,
+    BoolCaseBranches, BoolExprKind, BoolFunctionExprKind, CallArgKind, ExprKind,
+    FunctionCallArgKind, FunctionExprKind, IntCaseBranches, IntExprKind, IntFunctionExprKind,
+    NilExprKind, NilFunctionExprKind, StringExprKind, StringFunctionExprKind,
 };
 pub use expression::{
-    BoolExpr, BoolFunctionExpr, CallArg, Expr, FunctionExpr, IntExpr, IntFunctionExpr, NilExpr,
-    NilFunctionExpr, StringExpr, StringFunctionExpr,
+    BoolExpr, BoolFunctionExpr, CallArg, Expr, FunctionCallArg, FunctionExpr, IntExpr,
+    IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr,
 };
 pub(crate) use frame::FrameLayout;
 pub use function::{FunctionPlan, Param, ReturnExpr};
-pub(crate) use function::{ReturnExprKind, RuntimeFunction};
+pub(crate) use function::{ParamLocal, ReturnExprKind, RuntimeFunction};
 pub(crate) use id::RuntimeFunctionId;
 pub use id::{
     BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FunctionId, IntFunctionId,
@@ -31,8 +31,7 @@ pub use id::{
 pub use step::Step;
 pub(crate) use step::StepKind;
 pub(crate) use value::{
-    BoolFunctionValue, FunctionArgumentType, FunctionValueKind, IntFunctionValue, NilFunctionValue,
-    StringFunctionValue,
+    BoolFunctionValue, FunctionValueKind, IntFunctionValue, NilFunctionValue, StringFunctionValue,
 };
 pub use value::{FunctionType, FunctionValue, Value, ValueType};
 

--- a/src/plan/expression.rs
+++ b/src/plan/expression.rs
@@ -5,7 +5,11 @@ mod int;
 mod nil;
 mod string;
 
-use super::id::{BoolLocalId, IntLocalId, LocalId, NilLocalId, StringLocalId};
+use super::function::ParamLocal;
+use super::id::{
+    BoolFunctionLocalId, BoolLocalId, IntFunctionLocalId, IntLocalId, NilFunctionLocalId,
+    NilLocalId, StringFunctionLocalId, StringLocalId,
+};
 use super::value::{Value, ValueType};
 
 pub(crate) use self::case::{BoolCaseBranches, IntCaseBranches};
@@ -49,6 +53,11 @@ pub struct CallArg {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct FunctionCallArg {
+    kind: FunctionCallArgKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum CallArgKind {
     Int {
         local: IntLocalId,
@@ -66,6 +75,34 @@ pub(crate) enum CallArgKind {
         local: NilLocalId,
         value: NilExpr,
     },
+    IntFunction {
+        local: IntFunctionLocalId,
+        value: IntFunctionExpr,
+    },
+    StringFunction {
+        local: StringFunctionLocalId,
+        value: StringFunctionExpr,
+    },
+    BoolFunction {
+        local: BoolFunctionLocalId,
+        value: BoolFunctionExpr,
+    },
+    NilFunction {
+        local: NilFunctionLocalId,
+        value: NilFunctionExpr,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum FunctionCallArgKind {
+    Int(IntExpr),
+    String(StringExpr),
+    Bool(BoolExpr),
+    Nil(NilExpr),
+    IntFunction(IntFunctionExpr),
+    StringFunction(StringFunctionExpr),
+    BoolFunction(BoolFunctionExpr),
+    NilFunction(NilFunctionExpr),
 }
 
 impl Expr {
@@ -213,12 +250,74 @@ impl Expr {
         }
     }
 
-    pub(crate) fn into_call_arg(self, local: LocalId) -> Result<CallArg, Self> {
+    pub(crate) fn into_call_arg(self, local: &ParamLocal) -> Result<CallArg, Self> {
         match (local, self.kind) {
-            (LocalId::Int(local), ExprKind::Int(value)) => Ok(CallArg::int(local, value)),
-            (LocalId::String(local), ExprKind::String(value)) => Ok(CallArg::string(local, value)),
-            (LocalId::Bool(local), ExprKind::Bool(value)) => Ok(CallArg::bool(local, value)),
-            (LocalId::Nil(local), ExprKind::Nil(value)) => Ok(CallArg::nil(local, value)),
+            (ParamLocal::Int(local), ExprKind::Int(value)) => Ok(CallArg::int(*local, value)),
+            (ParamLocal::String(local), ExprKind::String(value)) => {
+                Ok(CallArg::string(*local, value))
+            }
+            (ParamLocal::Bool(local), ExprKind::Bool(value)) => Ok(CallArg::bool(*local, value)),
+            (ParamLocal::Nil(local), ExprKind::Nil(value)) => Ok(CallArg::nil(*local, value)),
+            (
+                ParamLocal::IntFunction {
+                    local,
+                    type_: expected,
+                },
+                ExprKind::Function(value),
+            ) if value.type_() == expected => match value.into_int() {
+                Ok(value) => Ok(CallArg::int_function(*local, value)),
+                Err(value) => Err(Expr::function(value)),
+            },
+            (
+                ParamLocal::StringFunction {
+                    local,
+                    type_: expected,
+                },
+                ExprKind::Function(value),
+            ) if value.type_() == expected => match value.into_string() {
+                Ok(value) => Ok(CallArg::string_function(*local, value)),
+                Err(value) => Err(Expr::function(value)),
+            },
+            (
+                ParamLocal::BoolFunction {
+                    local,
+                    type_: expected,
+                },
+                ExprKind::Function(value),
+            ) if value.type_() == expected => match value.into_bool() {
+                Ok(value) => Ok(CallArg::bool_function(*local, value)),
+                Err(value) => Err(Expr::function(value)),
+            },
+            (
+                ParamLocal::NilFunction {
+                    local,
+                    type_: expected,
+                },
+                ExprKind::Function(value),
+            ) if value.type_() == expected => match value.into_nil() {
+                Ok(value) => Ok(CallArg::nil_function(*local, value)),
+                Err(value) => Err(Expr::function(value)),
+            },
+            (_, kind) => Err(Self { kind }),
+        }
+    }
+
+    pub(crate) fn into_function_call_arg(self, type_: &ValueType) -> Result<FunctionCallArg, Self> {
+        match (type_, self.kind) {
+            (ValueType::Int, ExprKind::Int(value)) => Ok(FunctionCallArg::int(value)),
+            (ValueType::String, ExprKind::String(value)) => Ok(FunctionCallArg::string(value)),
+            (ValueType::Bool, ExprKind::Bool(value)) => Ok(FunctionCallArg::bool(value)),
+            (ValueType::Nil, ExprKind::Nil(value)) => Ok(FunctionCallArg::nil(value)),
+            (ValueType::Function(expected), ExprKind::Function(value))
+                if value.type_() == expected.as_ref() =>
+            {
+                match value.into_kind() {
+                    FunctionExprKind::Int(value) => Ok(FunctionCallArg::int_function(value)),
+                    FunctionExprKind::String(value) => Ok(FunctionCallArg::string_function(value)),
+                    FunctionExprKind::Bool(value) => Ok(FunctionCallArg::bool_function(value)),
+                    FunctionExprKind::Nil(value) => Ok(FunctionCallArg::nil_function(value)),
+                }
+            }
             (_, kind) => Err(Self { kind }),
         }
     }
@@ -249,7 +348,85 @@ impl CallArg {
         }
     }
 
+    pub(crate) fn int_function(local: IntFunctionLocalId, value: IntFunctionExpr) -> Self {
+        Self {
+            kind: CallArgKind::IntFunction { local, value },
+        }
+    }
+
+    pub(crate) fn string_function(local: StringFunctionLocalId, value: StringFunctionExpr) -> Self {
+        Self {
+            kind: CallArgKind::StringFunction { local, value },
+        }
+    }
+
+    pub(crate) fn bool_function(local: BoolFunctionLocalId, value: BoolFunctionExpr) -> Self {
+        Self {
+            kind: CallArgKind::BoolFunction { local, value },
+        }
+    }
+
+    pub(crate) fn nil_function(local: NilFunctionLocalId, value: NilFunctionExpr) -> Self {
+        Self {
+            kind: CallArgKind::NilFunction { local, value },
+        }
+    }
+
     pub(crate) fn kind(&self) -> &CallArgKind {
+        &self.kind
+    }
+}
+
+impl FunctionCallArg {
+    pub(crate) fn int(value: IntExpr) -> Self {
+        Self {
+            kind: FunctionCallArgKind::Int(value),
+        }
+    }
+
+    pub(crate) fn string(value: StringExpr) -> Self {
+        Self {
+            kind: FunctionCallArgKind::String(value),
+        }
+    }
+
+    pub(crate) fn bool(value: BoolExpr) -> Self {
+        Self {
+            kind: FunctionCallArgKind::Bool(value),
+        }
+    }
+
+    pub(crate) fn nil(value: NilExpr) -> Self {
+        Self {
+            kind: FunctionCallArgKind::Nil(value),
+        }
+    }
+
+    pub(crate) fn int_function(value: IntFunctionExpr) -> Self {
+        Self {
+            kind: FunctionCallArgKind::IntFunction(value),
+        }
+    }
+
+    pub(crate) fn string_function(value: StringFunctionExpr) -> Self {
+        Self {
+            kind: FunctionCallArgKind::StringFunction(value),
+        }
+    }
+
+    pub(crate) fn bool_function(value: BoolFunctionExpr) -> Self {
+        Self {
+            kind: FunctionCallArgKind::BoolFunction(value),
+        }
+    }
+
+    pub(crate) fn nil_function(value: NilFunctionExpr) -> Self {
+        Self {
+            kind: FunctionCallArgKind::NilFunction(value),
+        }
+    }
+
+    pub(crate) fn kind(&self) -> &FunctionCallArgKind {
         &self.kind
     }
 }
@@ -269,15 +446,14 @@ impl From<Value> for Expr {
 #[cfg(test)]
 mod tests {
     use super::{
-        BoolCaseBranches, BoolExpr, BoolFunctionExpr, CallArgKind, Expr, FunctionExpr,
+        BoolCaseBranches, BoolExpr, BoolFunctionExpr, CallArg, Expr, FunctionCallArg, FunctionExpr,
         IntCaseBranches, IntExpr, IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr,
         StringFunctionExpr,
     };
     use crate::plan::{
-        BoolFunctionId, BoolFunctionValue, BoolLocalId, FunctionArgumentType, FunctionType,
-        FunctionValue, IntFunctionId, IntFunctionValue, IntLocalId, LocalId, NilFunctionId,
-        NilFunctionValue, NilLocalId, RuntimeFunctionId, StringFunctionId, StringFunctionValue,
-        StringLocalId, Value, ValueType,
+        BoolFunctionId, BoolFunctionValue, BoolLocalId, FunctionType, FunctionValue, IntFunctionId,
+        IntFunctionValue, IntLocalId, NilFunctionId, NilFunctionValue, NilLocalId, ParamLocal,
+        RuntimeFunctionId, StringFunctionId, StringFunctionValue, StringLocalId, Value, ValueType,
     };
     use num_bigint::BigInt;
 
@@ -587,53 +763,176 @@ mod tests {
 
     #[test]
     fn expr_into_call_arg() {
-        assert!(matches!(
+        assert_eq!(
             Expr::int(IntExpr::value(BigInt::from(1)))
-                .into_call_arg(LocalId::Int(IntLocalId(0)))
-                .expect("int call arg")
-                .kind(),
-            CallArgKind::Int {
-                local: IntLocalId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
+                .into_call_arg(&ParamLocal::int(IntLocalId(0))),
+            Ok(CallArg::int(IntLocalId(0), IntExpr::value(BigInt::from(1)),)),
+        );
+        assert_eq!(
             Expr::string(StringExpr::value("geam".into()))
-                .into_call_arg(LocalId::String(StringLocalId(0)))
-                .expect("string call arg")
-                .kind(),
-            CallArgKind::String {
-                local: StringLocalId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
-            Expr::bool(BoolExpr::value(true))
-                .into_call_arg(LocalId::Bool(BoolLocalId(0)))
-                .expect("bool call arg")
-                .kind(),
-            CallArgKind::Bool {
-                local: BoolLocalId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
-            Expr::nil(NilExpr::value())
-                .into_call_arg(LocalId::Nil(NilLocalId(0)))
-                .expect("nil call arg")
-                .kind(),
-            CallArgKind::Nil {
-                local: NilLocalId(0),
-                ..
-            },
-        ));
+                .into_call_arg(&ParamLocal::string(StringLocalId(0))),
+            Ok(CallArg::string(
+                StringLocalId(0),
+                StringExpr::value("geam".into()),
+            )),
+        );
+        assert_eq!(
+            Expr::bool(BoolExpr::value(true)).into_call_arg(&ParamLocal::bool(BoolLocalId(0))),
+            Ok(CallArg::bool(BoolLocalId(0), BoolExpr::value(true))),
+        );
+        assert_eq!(
+            Expr::nil(NilExpr::value()).into_call_arg(&ParamLocal::nil(NilLocalId(0))),
+            Ok(CallArg::nil(NilLocalId(0), NilExpr::value())),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::value(function_value())).into_call_arg(
+                &ParamLocal::int_function(
+                    crate::plan::IntFunctionLocalId(0),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                )
+            ),
+            Ok(CallArg::int_function(
+                crate::plan::IntFunctionLocalId(0),
+                int_function_expr(),
+            )),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::string(string_function_expr())).into_call_arg(
+                &ParamLocal::string_function(
+                    crate::plan::StringFunctionLocalId(0),
+                    FunctionType::new(vec![ValueType::String], ValueType::String),
+                )
+            ),
+            Ok(CallArg::string_function(
+                crate::plan::StringFunctionLocalId(0),
+                string_function_expr(),
+            )),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::bool(bool_function_expr())).into_call_arg(
+                &ParamLocal::bool_function(
+                    crate::plan::BoolFunctionLocalId(0),
+                    FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
+                )
+            ),
+            Ok(CallArg::bool_function(
+                crate::plan::BoolFunctionLocalId(0),
+                bool_function_expr(),
+            )),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::nil(nil_function_expr())).into_call_arg(
+                &ParamLocal::nil_function(
+                    crate::plan::NilFunctionLocalId(0),
+                    FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+                )
+            ),
+            Ok(CallArg::nil_function(
+                crate::plan::NilFunctionLocalId(0),
+                nil_function_expr(),
+            )),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::string(malformed_string_function_expr(
+                function_type(),
+            )))
+            .into_call_arg(&ParamLocal::int_function(
+                crate::plan::IntFunctionLocalId(0),
+                function_type(),
+            )),
+            Err(Expr::function(FunctionExpr::string(
+                malformed_string_function_expr(function_type()),
+            ))),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::bool(malformed_bool_function_expr(
+                string_function_type(),
+            )))
+            .into_call_arg(&ParamLocal::string_function(
+                crate::plan::StringFunctionLocalId(0),
+                string_function_type(),
+            )),
+            Err(Expr::function(FunctionExpr::bool(
+                malformed_bool_function_expr(string_function_type()),
+            ))),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::nil(malformed_nil_function_expr(
+                bool_function_type(),
+            )))
+            .into_call_arg(&ParamLocal::bool_function(
+                crate::plan::BoolFunctionLocalId(0),
+                bool_function_type(),
+            )),
+            Err(Expr::function(FunctionExpr::nil(
+                malformed_nil_function_expr(bool_function_type()),
+            ))),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::int(malformed_int_function_expr(
+                nil_function_type(),
+            )))
+            .into_call_arg(&ParamLocal::nil_function(
+                crate::plan::NilFunctionLocalId(0),
+                nil_function_type(),
+            )),
+            Err(Expr::function(FunctionExpr::int(
+                malformed_int_function_expr(nil_function_type()),
+            ))),
+        );
         assert_eq!(
             Expr::function(FunctionExpr::value(function_value()))
-                .into_call_arg(LocalId::Int(IntLocalId(0))),
+                .into_call_arg(&ParamLocal::int(IntLocalId(0))),
             Err(Expr::function(FunctionExpr::value(function_value()))),
         );
         assert_eq!(
-            Expr::int(IntExpr::value(BigInt::from(1))).into_call_arg(LocalId::Bool(BoolLocalId(0))),
+            Expr::int(IntExpr::value(BigInt::from(1)))
+                .into_call_arg(&ParamLocal::bool(BoolLocalId(0))),
+            Err(Expr::int(IntExpr::value(BigInt::from(1)))),
+        );
+    }
+
+    #[test]
+    fn expr_into_function_call_arg() {
+        assert_eq!(
+            Expr::int(IntExpr::value(BigInt::from(1))).into_function_call_arg(&ValueType::Int),
+            Ok(FunctionCallArg::int(IntExpr::value(BigInt::from(1)))),
+        );
+        assert_eq!(
+            Expr::string(StringExpr::value("geam".into()))
+                .into_function_call_arg(&ValueType::String),
+            Ok(FunctionCallArg::string(StringExpr::value("geam".into()))),
+        );
+        assert_eq!(
+            Expr::bool(BoolExpr::value(true)).into_function_call_arg(&ValueType::Bool),
+            Ok(FunctionCallArg::bool(BoolExpr::value(true))),
+        );
+        assert_eq!(
+            Expr::nil(NilExpr::value()).into_function_call_arg(&ValueType::Nil),
+            Ok(FunctionCallArg::nil(NilExpr::value())),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::int(int_function_expr()))
+                .into_function_call_arg(&ValueType::Function(Box::new(function_type())),),
+            Ok(FunctionCallArg::int_function(int_function_expr())),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::string(string_function_expr()))
+                .into_function_call_arg(&ValueType::Function(Box::new(string_function_type())),),
+            Ok(FunctionCallArg::string_function(string_function_expr())),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::bool(bool_function_expr()))
+                .into_function_call_arg(&ValueType::Function(Box::new(bool_function_type())),),
+            Ok(FunctionCallArg::bool_function(bool_function_expr())),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::nil(nil_function_expr()))
+                .into_function_call_arg(&ValueType::Function(Box::new(nil_function_type())),),
+            Ok(FunctionCallArg::nil_function(nil_function_expr())),
+        );
+        assert_eq!(
+            Expr::int(IntExpr::value(BigInt::from(1))).into_function_call_arg(&ValueType::Bool),
             Err(Expr::int(IntExpr::value(BigInt::from(1)))),
         );
     }
@@ -641,39 +940,67 @@ mod tests {
     fn function_value() -> FunctionValue {
         FunctionValue::new(
             RuntimeFunctionId::Int(IntFunctionId(0)),
-            vec![LocalId::Int(IntLocalId(0))],
+            vec![ParamLocal::int(IntLocalId(0))],
         )
     }
 
     fn int_function_expr() -> IntFunctionExpr {
         IntFunctionExpr::value(IntFunctionValue::new(
             IntFunctionId(0),
-            vec![LocalId::Int(IntLocalId(0))],
+            vec![ParamLocal::int(IntLocalId(0))],
         ))
     }
 
     fn string_function_expr() -> StringFunctionExpr {
         StringFunctionExpr::value(StringFunctionValue::new(
             StringFunctionId(0),
-            vec![LocalId::String(StringLocalId(0))],
+            vec![ParamLocal::string(StringLocalId(0))],
         ))
     }
 
     fn bool_function_expr() -> BoolFunctionExpr {
         BoolFunctionExpr::value(BoolFunctionValue::new(
             BoolFunctionId(0),
-            vec![LocalId::Bool(BoolLocalId(0))],
+            vec![ParamLocal::bool(BoolLocalId(0))],
         ))
     }
 
     fn nil_function_expr() -> NilFunctionExpr {
         NilFunctionExpr::value(NilFunctionValue::new(
             NilFunctionId(0),
-            vec![LocalId::Nil(NilLocalId(0))],
+            vec![ParamLocal::nil(NilLocalId(0))],
         ))
     }
 
+    fn malformed_int_function_expr(type_: FunctionType) -> IntFunctionExpr {
+        IntFunctionExpr::local_get(crate::plan::IntFunctionLocalId(0), "f".into(), type_)
+    }
+
+    fn malformed_string_function_expr(type_: FunctionType) -> StringFunctionExpr {
+        StringFunctionExpr::local_get(crate::plan::StringFunctionLocalId(0), "f".into(), type_)
+    }
+
+    fn malformed_bool_function_expr(type_: FunctionType) -> BoolFunctionExpr {
+        BoolFunctionExpr::local_get(crate::plan::BoolFunctionLocalId(0), "f".into(), type_)
+    }
+
+    fn malformed_nil_function_expr(type_: FunctionType) -> NilFunctionExpr {
+        NilFunctionExpr::local_get(crate::plan::NilFunctionLocalId(0), "f".into(), type_)
+    }
+
     fn function_type() -> FunctionType {
-        FunctionType::new(vec![FunctionArgumentType::Int], ValueType::Int)
+        FunctionType::new(vec![ValueType::Int], ValueType::Int)
+    }
+
+    fn string_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::String], ValueType::String)
+    }
+
+    fn bool_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Bool], ValueType::Bool)
+    }
+
+    fn nil_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Nil], ValueType::Nil)
     }
 }

--- a/src/plan/expression/bool.rs
+++ b/src/plan/expression/bool.rs
@@ -1,4 +1,4 @@
-use super::{BoolFunctionExpr, CallArg, Expr, IntExpr};
+use super::{BoolFunctionExpr, CallArg, Expr, FunctionCallArg, IntExpr};
 use crate::plan::{BoolFunctionId, BoolLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -21,7 +21,7 @@ pub(crate) enum BoolExprKind {
     },
     FunctionCall {
         function: Box<BoolFunctionExpr>,
-        args: Vec<CallArg>,
+        args: Vec<FunctionCallArg>,
     },
     Not(Box<BoolExpr>),
     LtInt {
@@ -91,7 +91,7 @@ impl BoolExpr {
         }
     }
 
-    pub(crate) fn function_call(function: BoolFunctionExpr, args: Vec<CallArg>) -> Self {
+    pub(crate) fn function_call(function: BoolFunctionExpr, args: Vec<FunctionCallArg>) -> Self {
         Self {
             kind: BoolExprKind::FunctionCall {
                 function: Box::new(function),
@@ -219,9 +219,7 @@ impl BoolExpr {
 #[cfg(test)]
 mod tests {
     use super::{BoolExpr, BoolExprKind};
-    use crate::plan::{
-        BoolFunctionId, BoolFunctionValue, BoolLocalId, Expr, IntExpr, LocalId, Step,
-    };
+    use crate::plan::{BoolFunctionId, BoolFunctionValue, Expr, IntExpr, Step};
 
     #[test]
     fn bool_expr_kind_accessors() {
@@ -270,9 +268,6 @@ mod tests {
     }
 
     fn function_expr() -> crate::plan::BoolFunctionExpr {
-        crate::plan::BoolFunctionExpr::value(BoolFunctionValue::new(
-            BoolFunctionId(0),
-            vec![LocalId::Bool(BoolLocalId(0))],
-        ))
+        crate::plan::BoolFunctionExpr::value(BoolFunctionValue::new(BoolFunctionId(0), Vec::new()))
     }
 }

--- a/src/plan/expression/function.rs
+++ b/src/plan/expression/function.rs
@@ -522,9 +522,9 @@ mod tests {
         StringFunctionExprKind,
     };
     use crate::plan::{
-        BoolExpr, BoolFunctionLocalId, BoolFunctionValue, BoolLocalId, Expr, FunctionType,
-        FunctionValue, IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId,
-        LocalId, NilFunctionLocalId, NilFunctionValue, RuntimeFunctionId, Step,
+        BoolExpr, BoolFunctionLocalId, BoolFunctionValue, Expr, FunctionType, FunctionValue,
+        IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId,
+        NilFunctionLocalId, NilFunctionValue, ParamLocal, RuntimeFunctionId, Step,
         StringFunctionLocalId, StringFunctionValue, ValueType,
     };
 
@@ -597,7 +597,7 @@ mod tests {
     fn int_function_expr_kind_accessors() {
         assert_eq!(
             int_function_type(),
-            FunctionType::new(vec![crate::plan::FunctionArgumentType::Int], ValueType::Int),
+            FunctionType::new(vec![crate::plan::ValueType::Int], ValueType::Int),
         );
         assert!(matches!(
             IntFunctionExpr::local_get(IntFunctionLocalId(0), "f".into(), int_function_type(),)
@@ -730,41 +730,41 @@ mod tests {
     }
 
     fn function_value() -> FunctionValue {
-        FunctionValue::new(
-            RuntimeFunctionId::Int(IntFunctionId(0)),
-            vec![LocalId::Int(IntLocalId(0))],
-        )
+        FunctionValue::new(RuntimeFunctionId::Int(IntFunctionId(0)), vec![int_param(0)])
     }
 
     fn int_function_value() -> IntFunctionExpr {
-        IntFunctionExpr::value(IntFunctionValue::new(
-            IntFunctionId(0),
-            vec![LocalId::Int(IntLocalId(0))],
-        ))
+        IntFunctionExpr::value(IntFunctionValue::new(IntFunctionId(0), vec![int_param(0)]))
     }
 
     fn string_function_value() -> StringFunctionExpr {
         StringFunctionExpr::value(StringFunctionValue::new(
             crate::plan::StringFunctionId(0),
-            vec![LocalId::String(crate::plan::StringLocalId(0))],
+            vec![crate::plan::ParamLocal::string(crate::plan::StringLocalId(
+                0,
+            ))],
         ))
     }
 
     fn bool_function_value() -> BoolFunctionExpr {
         BoolFunctionExpr::value(BoolFunctionValue::new(
             crate::plan::BoolFunctionId(0),
-            vec![LocalId::Bool(BoolLocalId(0))],
+            vec![crate::plan::ParamLocal::bool(crate::plan::BoolLocalId(0))],
         ))
     }
 
     fn nil_function_value() -> NilFunctionExpr {
         NilFunctionExpr::value(NilFunctionValue::new(
             crate::plan::NilFunctionId(0),
-            vec![LocalId::Nil(crate::plan::NilLocalId(0))],
+            vec![crate::plan::ParamLocal::nil(crate::plan::NilLocalId(0))],
         ))
     }
 
     fn int_function_type() -> FunctionType {
-        FunctionType::new(vec![crate::plan::FunctionArgumentType::Int], ValueType::Int)
+        FunctionType::new(vec![crate::plan::ValueType::Int], ValueType::Int)
+    }
+
+    fn int_param(index: usize) -> ParamLocal {
+        ParamLocal::int(IntLocalId(index))
     }
 }

--- a/src/plan/expression/int.rs
+++ b/src/plan/expression/int.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg, IntFunctionExpr};
+use super::{BoolExpr, CallArg, FunctionCallArg, IntFunctionExpr};
 use crate::plan::{IntFunctionId, IntLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -21,7 +21,7 @@ pub(crate) enum IntExprKind {
     },
     FunctionCall {
         function: Box<IntFunctionExpr>,
-        args: Vec<CallArg>,
+        args: Vec<FunctionCallArg>,
     },
     Add {
         left: Box<IntExpr>,
@@ -79,7 +79,7 @@ impl IntExpr {
         }
     }
 
-    pub(crate) fn function_call(function: IntFunctionExpr, args: Vec<CallArg>) -> Self {
+    pub(crate) fn function_call(function: IntFunctionExpr, args: Vec<FunctionCallArg>) -> Self {
         Self {
             kind: IntExprKind::FunctionCall {
                 function: Box::new(function),
@@ -180,7 +180,7 @@ impl IntExpr {
 #[cfg(test)]
 mod tests {
     use super::{IntExpr, IntExprKind};
-    use crate::plan::{BoolExpr, Expr, IntFunctionId, IntFunctionValue, IntLocalId, LocalId, Step};
+    use crate::plan::{BoolExpr, Expr, IntFunctionId, IntFunctionValue, Step};
 
     #[test]
     fn int_expr_kind_accessors() {
@@ -221,9 +221,6 @@ mod tests {
     }
 
     fn function_expr() -> crate::plan::IntFunctionExpr {
-        crate::plan::IntFunctionExpr::value(IntFunctionValue::new(
-            IntFunctionId(0),
-            vec![LocalId::Int(IntLocalId(0))],
-        ))
+        crate::plan::IntFunctionExpr::value(IntFunctionValue::new(IntFunctionId(0), Vec::new()))
     }
 }

--- a/src/plan/expression/nil.rs
+++ b/src/plan/expression/nil.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg, IntExpr, NilFunctionExpr};
+use super::{BoolExpr, CallArg, FunctionCallArg, IntExpr, NilFunctionExpr};
 use crate::plan::{NilFunctionId, NilLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -21,7 +21,7 @@ pub(crate) enum NilExprKind {
     },
     FunctionCall {
         function: Box<NilFunctionExpr>,
-        args: Vec<CallArg>,
+        args: Vec<FunctionCallArg>,
     },
     BoolCase {
         subject: Box<BoolExpr>,
@@ -58,7 +58,7 @@ impl NilExpr {
         }
     }
 
-    pub(crate) fn function_call(function: NilFunctionExpr, args: Vec<CallArg>) -> Self {
+    pub(crate) fn function_call(function: NilFunctionExpr, args: Vec<FunctionCallArg>) -> Self {
         Self {
             kind: NilExprKind::FunctionCall {
                 function: Box::new(function),
@@ -108,9 +108,7 @@ impl NilExpr {
 #[cfg(test)]
 mod tests {
     use super::{NilExpr, NilExprKind};
-    use crate::plan::{
-        BoolExpr, Expr, IntExpr, LocalId, NilFunctionId, NilFunctionValue, NilLocalId, Step,
-    };
+    use crate::plan::{BoolExpr, Expr, IntExpr, NilFunctionId, NilFunctionValue, Step};
 
     #[test]
     fn nil_expr_kind_accessors() {
@@ -143,9 +141,6 @@ mod tests {
     }
 
     fn function_expr() -> crate::plan::NilFunctionExpr {
-        crate::plan::NilFunctionExpr::value(NilFunctionValue::new(
-            NilFunctionId(0),
-            vec![LocalId::Nil(NilLocalId(0))],
-        ))
+        crate::plan::NilFunctionExpr::value(NilFunctionValue::new(NilFunctionId(0), Vec::new()))
     }
 }

--- a/src/plan/expression/string.rs
+++ b/src/plan/expression/string.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg, IntExpr, StringFunctionExpr};
+use super::{BoolExpr, CallArg, FunctionCallArg, IntExpr, StringFunctionExpr};
 use crate::plan::{Step, StringFunctionId, StringLocalId};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -21,7 +21,7 @@ pub(crate) enum StringExprKind {
     },
     FunctionCall {
         function: Box<StringFunctionExpr>,
-        args: Vec<CallArg>,
+        args: Vec<FunctionCallArg>,
     },
     Concatenate {
         left: Box<StringExpr>,
@@ -62,7 +62,7 @@ impl StringExpr {
         }
     }
 
-    pub(crate) fn function_call(function: StringFunctionExpr, args: Vec<CallArg>) -> Self {
+    pub(crate) fn function_call(function: StringFunctionExpr, args: Vec<FunctionCallArg>) -> Self {
         Self {
             kind: StringExprKind::FunctionCall {
                 function: Box::new(function),
@@ -121,10 +121,7 @@ impl StringExpr {
 #[cfg(test)]
 mod tests {
     use super::{StringExpr, StringExprKind};
-    use crate::plan::{
-        BoolExpr, Expr, IntExpr, LocalId, Step, StringFunctionId, StringFunctionValue,
-        StringLocalId,
-    };
+    use crate::plan::{BoolExpr, Expr, IntExpr, Step, StringFunctionId, StringFunctionValue};
 
     #[test]
     fn string_expr_kind_accessors() {
@@ -167,7 +164,7 @@ mod tests {
     fn function_expr() -> crate::plan::StringFunctionExpr {
         crate::plan::StringFunctionExpr::value(StringFunctionValue::new(
             StringFunctionId(0),
-            vec![LocalId::String(StringLocalId(0))],
+            Vec::new(),
         ))
     }
 }

--- a/src/plan/frame.rs
+++ b/src/plan/frame.rs
@@ -1,17 +1,17 @@
 use super::expression::{
-    BoolExpr, BoolFunctionExpr, CallArg, Expr, FunctionExpr, IntExpr, IntFunctionExpr, NilExpr,
-    NilFunctionExpr, StringExpr, StringFunctionExpr,
+    BoolExpr, BoolFunctionExpr, CallArg, Expr, FunctionCallArg, FunctionExpr, IntExpr,
+    IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr,
 };
-use super::function::{Param, ReturnExpr};
+use super::function::{Param, ParamLocal, ReturnExpr};
 use super::id::{
-    BoolFunctionLocalId, BoolLocalId, IntFunctionLocalId, IntLocalId, LocalId, NilFunctionLocalId,
+    BoolFunctionLocalId, BoolLocalId, IntFunctionLocalId, IntLocalId, NilFunctionLocalId,
     NilLocalId, StringFunctionLocalId, StringLocalId,
 };
 use super::step::Step;
 use super::{
-    BoolExprKind, BoolFunctionExprKind, CallArgKind, ExprKind, FunctionExprKind, IntExprKind,
-    IntFunctionExprKind, NilExprKind, NilFunctionExprKind, ReturnExprKind, StepKind,
-    StringExprKind, StringFunctionExprKind,
+    BoolExprKind, BoolFunctionExprKind, CallArgKind, ExprKind, FunctionCallArgKind,
+    FunctionExprKind, IntExprKind, IntFunctionExprKind, NilExprKind, NilFunctionExprKind,
+    ReturnExprKind, StepKind, StringExprKind, StringFunctionExprKind,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -43,12 +43,16 @@ impl FrameLayout {
         layout
     }
 
-    pub(crate) fn include_local(&mut self, local: LocalId) {
+    pub(crate) fn include_local(&mut self, local: &ParamLocal) {
         match local {
-            LocalId::Int(local) => self.include_int(local),
-            LocalId::String(local) => self.include_string(local),
-            LocalId::Bool(local) => self.include_bool(local),
-            LocalId::Nil(local) => self.include_nil(local),
+            ParamLocal::Int(local) => self.include_int(*local),
+            ParamLocal::String(local) => self.include_string(*local),
+            ParamLocal::Bool(local) => self.include_bool(*local),
+            ParamLocal::Nil(local) => self.include_nil(*local),
+            ParamLocal::IntFunction { local, .. } => self.include_int_function(*local),
+            ParamLocal::StringFunction { local, .. } => self.include_string_function(*local),
+            ParamLocal::BoolFunction { local, .. } => self.include_bool_function(*local),
+            ParamLocal::NilFunction { local, .. } => self.include_nil_function(*local),
         }
     }
 
@@ -187,6 +191,29 @@ impl FrameLayout {
                 CallArgKind::String { value, .. } => self.include_string_expr(value),
                 CallArgKind::Bool { value, .. } => self.include_bool_expr(value),
                 CallArgKind::Nil { value, .. } => self.include_nil_expr(value),
+                CallArgKind::IntFunction { value, .. } => self.include_int_function_expr(value),
+                CallArgKind::StringFunction { value, .. } => {
+                    self.include_string_function_expr(value);
+                }
+                CallArgKind::BoolFunction { value, .. } => self.include_bool_function_expr(value),
+                CallArgKind::NilFunction { value, .. } => self.include_nil_function_expr(value),
+            }
+        }
+    }
+
+    fn include_function_call_args(&mut self, args: &[FunctionCallArg]) {
+        for arg in args {
+            match arg.kind() {
+                FunctionCallArgKind::Int(value) => self.include_int_expr(value),
+                FunctionCallArgKind::String(value) => self.include_string_expr(value),
+                FunctionCallArgKind::Bool(value) => self.include_bool_expr(value),
+                FunctionCallArgKind::Nil(value) => self.include_nil_expr(value),
+                FunctionCallArgKind::IntFunction(value) => self.include_int_function_expr(value),
+                FunctionCallArgKind::StringFunction(value) => {
+                    self.include_string_function_expr(value);
+                }
+                FunctionCallArgKind::BoolFunction(value) => self.include_bool_function_expr(value),
+                FunctionCallArgKind::NilFunction(value) => self.include_nil_function_expr(value),
             }
         }
     }
@@ -198,7 +225,7 @@ impl FrameLayout {
             IntExprKind::Call { args, .. } => self.include_call_args(args),
             IntExprKind::FunctionCall { function, args } => {
                 self.include_int_function_expr(function);
-                self.include_call_args(args);
+                self.include_function_call_args(args);
             }
             IntExprKind::Add { left, right }
             | IntExprKind::Sub { left, right }
@@ -243,7 +270,7 @@ impl FrameLayout {
             StringExprKind::Call { args, .. } => self.include_call_args(args),
             StringExprKind::FunctionCall { function, args } => {
                 self.include_string_function_expr(function);
-                self.include_call_args(args);
+                self.include_function_call_args(args);
             }
             StringExprKind::Concatenate { left, right } => {
                 self.include_string_expr(left);
@@ -283,7 +310,7 @@ impl FrameLayout {
             BoolExprKind::Call { args, .. } => self.include_call_args(args),
             BoolExprKind::FunctionCall { function, args } => {
                 self.include_bool_function_expr(function);
-                self.include_call_args(args);
+                self.include_function_call_args(args);
             }
             BoolExprKind::Not(value) => self.include_bool_expr(value),
             BoolExprKind::LtInt { left, right }
@@ -335,7 +362,7 @@ impl FrameLayout {
             NilExprKind::Call { args, .. } => self.include_call_args(args),
             NilExprKind::FunctionCall { function, args } => {
                 self.include_nil_function_expr(function);
-                self.include_call_args(args);
+                self.include_function_call_args(args);
             }
             NilExprKind::BoolCase {
                 subject,
@@ -506,8 +533,8 @@ mod tests {
     use crate::plan::{
         BoolExpr, BoolFunctionExpr, BoolFunctionLocalId, BoolFunctionValue, BoolLocalId, Expr,
         FunctionExpr, IntExpr, IntFunctionExpr, IntFunctionId, IntFunctionLocalId,
-        IntFunctionValue, IntLocalId, LocalId, NilExpr, NilFunctionExpr, NilFunctionLocalId,
-        NilFunctionValue, NilLocalId, ReturnExpr, Step, StringExpr, StringFunctionExpr,
+        IntFunctionValue, IntLocalId, NilExpr, NilFunctionExpr, NilFunctionLocalId,
+        NilFunctionValue, NilLocalId, ParamLocal, ReturnExpr, Step, StringExpr, StringFunctionExpr,
         StringFunctionLocalId, StringFunctionValue, StringLocalId,
     };
 
@@ -515,10 +542,10 @@ mod tests {
     fn frame_layout_includes_local_ids() {
         let mut layout = FrameLayout::default();
 
-        layout.include_local(LocalId::Int(IntLocalId(1)));
-        layout.include_local(LocalId::String(StringLocalId(2)));
-        layout.include_local(LocalId::Bool(BoolLocalId(3)));
-        layout.include_local(LocalId::Nil(NilLocalId(4)));
+        layout.include_local(&ParamLocal::int(IntLocalId(1)));
+        layout.include_local(&ParamLocal::string(StringLocalId(2)));
+        layout.include_local(&ParamLocal::bool(BoolLocalId(3)));
+        layout.include_local(&ParamLocal::nil(NilLocalId(4)));
         layout.include_int_function(IntFunctionLocalId(5));
         layout.include_nil_function(NilFunctionLocalId(6));
 
@@ -734,28 +761,28 @@ mod tests {
     fn int_function_expr() -> IntFunctionExpr {
         IntFunctionExpr::value(IntFunctionValue::new(
             IntFunctionId(0),
-            vec![crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+            vec![ParamLocal::int(IntLocalId(0))],
         ))
     }
 
     fn string_function_expr() -> StringFunctionExpr {
         StringFunctionExpr::value(StringFunctionValue::new(
             crate::plan::StringFunctionId(0),
-            vec![crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+            vec![ParamLocal::string(StringLocalId(0))],
         ))
     }
 
     fn bool_function_expr() -> BoolFunctionExpr {
         BoolFunctionExpr::value(BoolFunctionValue::new(
             crate::plan::BoolFunctionId(0),
-            vec![crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))],
+            vec![ParamLocal::bool(BoolLocalId(0))],
         ))
     }
 
     fn nil_function_expr() -> NilFunctionExpr {
         NilFunctionExpr::value(NilFunctionValue::new(
             crate::plan::NilFunctionId(0),
-            vec![crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))],
+            vec![ParamLocal::nil(NilLocalId(0))],
         ))
     }
 }

--- a/src/plan/function.rs
+++ b/src/plan/function.rs
@@ -1,8 +1,11 @@
 use super::FrameLayout;
 use super::expression::{BoolExpr, IntExpr, NilExpr, StringExpr};
-use super::id::{FunctionId, LocalId};
+use super::id::{
+    BoolFunctionLocalId, BoolLocalId, FunctionId, IntFunctionLocalId, IntLocalId,
+    NilFunctionLocalId, NilLocalId, StringFunctionLocalId, StringLocalId,
+};
 use super::step::Step;
-use super::value::ValueType;
+use super::value::{FunctionType, ValueType};
 use ecow::EcoString;
 
 #[derive(Debug, PartialEq)]
@@ -17,8 +20,32 @@ pub struct FunctionPlan {
 
 #[derive(Debug, PartialEq)]
 pub struct Param {
-    local: LocalId,
+    local: ParamLocal,
     name: EcoString,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ParamLocal {
+    Int(IntLocalId),
+    String(StringLocalId),
+    Bool(BoolLocalId),
+    Nil(NilLocalId),
+    IntFunction {
+        local: IntFunctionLocalId,
+        type_: FunctionType,
+    },
+    StringFunction {
+        local: StringFunctionLocalId,
+        type_: FunctionType,
+    },
+    BoolFunction {
+        local: BoolFunctionLocalId,
+        type_: FunctionType,
+    },
+    NilFunction {
+        local: NilFunctionLocalId,
+        type_: FunctionType,
+    },
 }
 
 pub(crate) struct RuntimeFunction<Return> {
@@ -147,7 +174,7 @@ impl<Return> RuntimeFunction<Return> {
 }
 
 impl Param {
-    pub(crate) fn new(local: LocalId, name: EcoString) -> Self {
+    pub(crate) fn new(local: ParamLocal, name: EcoString) -> Self {
         Self { local, name }
     }
 
@@ -155,23 +182,71 @@ impl Param {
         &self.name
     }
 
-    pub(crate) fn local(&self) -> LocalId {
-        self.local
+    pub(crate) fn local(&self) -> &ParamLocal {
+        &self.local
+    }
+}
+
+impl ParamLocal {
+    pub(crate) fn int(local: IntLocalId) -> Self {
+        Self::Int(local)
+    }
+
+    pub(crate) fn string(local: StringLocalId) -> Self {
+        Self::String(local)
+    }
+
+    pub(crate) fn bool(local: BoolLocalId) -> Self {
+        Self::Bool(local)
+    }
+
+    pub(crate) fn nil(local: NilLocalId) -> Self {
+        Self::Nil(local)
+    }
+
+    pub(crate) fn int_function(local: IntFunctionLocalId, type_: FunctionType) -> Self {
+        Self::IntFunction { local, type_ }
+    }
+
+    pub(crate) fn string_function(local: StringFunctionLocalId, type_: FunctionType) -> Self {
+        Self::StringFunction { local, type_ }
+    }
+
+    pub(crate) fn bool_function(local: BoolFunctionLocalId, type_: FunctionType) -> Self {
+        Self::BoolFunction { local, type_ }
+    }
+
+    pub(crate) fn nil_function(local: NilFunctionLocalId, type_: FunctionType) -> Self {
+        Self::NilFunction { local, type_ }
+    }
+
+    pub(crate) fn value_type(&self) -> ValueType {
+        match self {
+            Self::Int(_) => ValueType::Int,
+            Self::String(_) => ValueType::String,
+            Self::Bool(_) => ValueType::Bool,
+            Self::Nil(_) => ValueType::Nil,
+            Self::IntFunction { type_, .. }
+            | Self::StringFunction { type_, .. }
+            | Self::BoolFunction { type_, .. }
+            | Self::NilFunction { type_, .. } => ValueType::Function(Box::new(type_.clone())),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{FunctionPlan, Param, ReturnExpr, RuntimeFunction};
+    use super::{FunctionPlan, Param, ParamLocal, ReturnExpr, RuntimeFunction};
     use crate::plan::{
-        BoolExpr, FrameLayout, FunctionId, IntExpr, IntLocalId, LocalId, NilExpr, StringExpr,
-        ValueType,
+        BoolExpr, BoolFunctionLocalId, BoolLocalId, FrameLayout, FunctionId, FunctionType, IntExpr,
+        IntFunctionLocalId, IntLocalId, NilExpr, NilFunctionLocalId, StringExpr,
+        StringFunctionLocalId, ValueType,
     };
     use num_bigint::BigInt;
 
     #[test]
     fn function_plan_accessors() {
-        let param = Param::new(LocalId::Int(IntLocalId(0)), "x".into());
+        let param = Param::new(ParamLocal::int(IntLocalId(0)), "x".into());
         let return_ = ReturnExpr::int(IntExpr::value(BigInt::from(1)));
         let function = FunctionPlan::new(
             FunctionId::new(0),
@@ -215,9 +290,70 @@ mod tests {
 
     #[test]
     fn param_name_accessor() {
-        let param = Param::new(LocalId::Int(IntLocalId(0)), "x".into());
+        let param = Param::new(ParamLocal::int(IntLocalId(0)), "x".into());
 
         assert_eq!(param.name(), "x");
+    }
+
+    #[test]
+    fn param_local_value_type() {
+        assert_eq!(ParamLocal::int(IntLocalId(0)).value_type(), ValueType::Int);
+        assert_eq!(
+            ParamLocal::string(crate::plan::StringLocalId(0)).value_type(),
+            ValueType::String,
+        );
+        assert_eq!(
+            ParamLocal::bool(BoolLocalId(0)).value_type(),
+            ValueType::Bool,
+        );
+        assert_eq!(
+            ParamLocal::nil(crate::plan::NilLocalId(0)).value_type(),
+            ValueType::Nil,
+        );
+        assert_eq!(
+            ParamLocal::int_function(
+                IntFunctionLocalId(0),
+                FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            )
+            .value_type(),
+            ValueType::Function(Box::new(FunctionType::new(
+                vec![ValueType::Int],
+                ValueType::Int,
+            ))),
+        );
+        assert_eq!(
+            ParamLocal::string_function(
+                StringFunctionLocalId(0),
+                FunctionType::new(vec![ValueType::String], ValueType::String),
+            )
+            .value_type(),
+            ValueType::Function(Box::new(FunctionType::new(
+                vec![ValueType::String],
+                ValueType::String,
+            ))),
+        );
+        assert_eq!(
+            ParamLocal::bool_function(
+                BoolFunctionLocalId(0),
+                FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
+            )
+            .value_type(),
+            ValueType::Function(Box::new(FunctionType::new(
+                vec![ValueType::Bool],
+                ValueType::Bool,
+            ))),
+        );
+        assert_eq!(
+            ParamLocal::nil_function(
+                NilFunctionLocalId(0),
+                FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+            )
+            .value_type(),
+            ValueType::Function(Box::new(FunctionType::new(
+                vec![ValueType::Nil],
+                ValueType::Nil,
+            ))),
+        );
     }
 
     #[test]

--- a/src/plan/id.rs
+++ b/src/plan/id.rs
@@ -64,17 +64,6 @@ impl FunctionId {
     }
 }
 
-impl LocalId {
-    pub(crate) fn value_type(self) -> crate::plan::ValueType {
-        match self {
-            Self::Int(_) => crate::plan::ValueType::Int,
-            Self::String(_) => crate::plan::ValueType::String,
-            Self::Bool(_) => crate::plan::ValueType::Bool,
-            Self::Nil(_) => crate::plan::ValueType::Nil,
-        }
-    }
-}
-
 impl RuntimeFunctionId {
     pub(crate) fn value_type(self) -> crate::plan::ValueType {
         match self {
@@ -89,26 +78,15 @@ impl RuntimeFunctionId {
 #[cfg(test)]
 mod tests {
     use super::{
-        BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FunctionId, IntFunctionId,
-        IntFunctionLocalId, IntLocalId, LocalId, NilFunctionId, NilFunctionLocalId, NilLocalId,
-        RuntimeFunctionId, StringFunctionId, StringFunctionLocalId, StringLocalId,
+        BoolFunctionId, BoolFunctionLocalId, FunctionId, IntFunctionId, IntFunctionLocalId,
+        NilFunctionId, NilFunctionLocalId, RuntimeFunctionId, StringFunctionId,
+        StringFunctionLocalId,
     };
     use crate::plan::ValueType;
 
     #[test]
     fn function_id_index() {
         assert_eq!(FunctionId::new(5).index(), 5);
-    }
-
-    #[test]
-    fn local_id_value_type() {
-        assert_eq!(LocalId::Int(IntLocalId(0)).value_type(), ValueType::Int);
-        assert_eq!(
-            LocalId::String(StringLocalId(0)).value_type(),
-            ValueType::String
-        );
-        assert_eq!(LocalId::Bool(BoolLocalId(0)).value_type(), ValueType::Bool);
-        assert_eq!(LocalId::Nil(NilLocalId(0)).value_type(), ValueType::Nil);
     }
 
     #[test]

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -138,7 +138,7 @@ impl Step {
 mod tests {
     use super::{Step, StepKind};
     use crate::plan::{
-        Expr, IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId, LocalId,
+        Expr, IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId, ParamLocal,
     };
     use num_bigint::BigInt;
 
@@ -161,7 +161,7 @@ mod tests {
     fn function_expr() -> crate::plan::IntFunctionExpr {
         crate::plan::IntFunctionExpr::value(IntFunctionValue::new(
             IntFunctionId(0),
-            vec![LocalId::Int(IntLocalId(0))],
+            vec![ParamLocal::int(IntLocalId(0))],
         ))
     }
 }

--- a/src/plan/value.rs
+++ b/src/plan/value.rs
@@ -2,7 +2,7 @@ use ecow::EcoString;
 use num_bigint::BigInt;
 
 use super::{
-    BoolFunctionId, IntFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringFunctionId,
+    BoolFunctionId, IntFunctionId, NilFunctionId, ParamLocal, RuntimeFunctionId, StringFunctionId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,16 +16,8 @@ pub enum ValueType {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionType {
-    arguments: Vec<FunctionArgumentType>,
+    arguments: Vec<ValueType>,
     return_: Box<ValueType>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum FunctionArgumentType {
-    Int,
-    String,
-    Bool,
-    Nil,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,25 +36,25 @@ pub(crate) enum FunctionValueKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct IntFunctionValue {
     runtime_id: IntFunctionId,
-    params: Vec<LocalId>,
+    params: Vec<ParamLocal>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StringFunctionValue {
     runtime_id: StringFunctionId,
-    params: Vec<LocalId>,
+    params: Vec<ParamLocal>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BoolFunctionValue {
     runtime_id: BoolFunctionId,
-    params: Vec<LocalId>,
+    params: Vec<ParamLocal>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct NilFunctionValue {
     runtime_id: NilFunctionId,
-    params: Vec<LocalId>,
+    params: Vec<ParamLocal>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -75,45 +67,28 @@ pub enum Value {
 }
 
 impl FunctionType {
-    pub(crate) fn new(arguments: Vec<FunctionArgumentType>, return_: ValueType) -> Self {
+    pub(crate) fn new(arguments: Vec<ValueType>, return_: ValueType) -> Self {
         Self {
             arguments,
             return_: Box::new(return_),
         }
     }
 
+    pub(crate) fn from_params(params: &[ParamLocal], return_: ValueType) -> Self {
+        Self::new(params.iter().map(ParamLocal::value_type).collect(), return_)
+    }
+
     pub fn return_(&self) -> &ValueType {
         &self.return_
     }
 
-    pub(crate) fn argument_types(&self) -> &[FunctionArgumentType] {
+    pub(crate) fn argument_types(&self) -> &[ValueType] {
         &self.arguments
     }
 }
 
-impl FunctionArgumentType {
-    pub(crate) fn from_value_type(type_: &ValueType) -> Option<Self> {
-        match type_ {
-            ValueType::Int => Some(Self::Int),
-            ValueType::String => Some(Self::String),
-            ValueType::Bool => Some(Self::Bool),
-            ValueType::Nil => Some(Self::Nil),
-            ValueType::Function(_) => None,
-        }
-    }
-
-    pub(crate) fn from_local(local: &LocalId) -> Self {
-        match local {
-            LocalId::Int(_) => Self::Int,
-            LocalId::String(_) => Self::String,
-            LocalId::Bool(_) => Self::Bool,
-            LocalId::Nil(_) => Self::Nil,
-        }
-    }
-}
-
 impl FunctionValue {
-    pub(crate) fn new(runtime_id: RuntimeFunctionId, params: Vec<LocalId>) -> Self {
+    pub(crate) fn new(runtime_id: RuntimeFunctionId, params: Vec<ParamLocal>) -> Self {
         let kind = match runtime_id {
             RuntimeFunctionId::Int(runtime_id) => {
                 FunctionValueKind::Int(IntFunctionValue::new(runtime_id, params))
@@ -144,72 +119,88 @@ impl FunctionValue {
     pub(crate) fn kind(&self) -> &FunctionValueKind {
         &self.kind
     }
+
+    #[cfg(test)]
+    pub(crate) fn params(&self) -> &[ParamLocal] {
+        match &self.kind {
+            FunctionValueKind::Int(value) => value.params(),
+            FunctionValueKind::String(value) => value.params(),
+            FunctionValueKind::Bool(value) => value.params(),
+            FunctionValueKind::Nil(value) => value.params(),
+        }
+    }
 }
 
 impl IntFunctionValue {
-    pub(crate) fn new(runtime_id: IntFunctionId, params: Vec<LocalId>) -> Self {
+    pub(crate) fn new(runtime_id: IntFunctionId, params: Vec<ParamLocal>) -> Self {
         Self { runtime_id, params }
     }
 
     pub(crate) fn type_(&self) -> FunctionType {
-        function_type(&self.params, ValueType::Int)
+        FunctionType::from_params(&self.params, ValueType::Int)
     }
 
     pub(crate) fn runtime_id(&self) -> IntFunctionId {
         self.runtime_id
     }
+
+    pub(crate) fn params(&self) -> &[ParamLocal] {
+        &self.params
+    }
 }
 
 impl StringFunctionValue {
-    pub(crate) fn new(runtime_id: StringFunctionId, params: Vec<LocalId>) -> Self {
+    pub(crate) fn new(runtime_id: StringFunctionId, params: Vec<ParamLocal>) -> Self {
         Self { runtime_id, params }
     }
 
     pub(crate) fn type_(&self) -> FunctionType {
-        function_type(&self.params, ValueType::String)
+        FunctionType::from_params(&self.params, ValueType::String)
     }
 
     pub(crate) fn runtime_id(&self) -> StringFunctionId {
         self.runtime_id
     }
+
+    pub(crate) fn params(&self) -> &[ParamLocal] {
+        &self.params
+    }
 }
 
 impl BoolFunctionValue {
-    pub(crate) fn new(runtime_id: BoolFunctionId, params: Vec<LocalId>) -> Self {
+    pub(crate) fn new(runtime_id: BoolFunctionId, params: Vec<ParamLocal>) -> Self {
         Self { runtime_id, params }
     }
 
     pub(crate) fn type_(&self) -> FunctionType {
-        function_type(&self.params, ValueType::Bool)
+        FunctionType::from_params(&self.params, ValueType::Bool)
     }
 
     pub(crate) fn runtime_id(&self) -> BoolFunctionId {
         self.runtime_id
     }
+
+    pub(crate) fn params(&self) -> &[ParamLocal] {
+        &self.params
+    }
 }
 
 impl NilFunctionValue {
-    pub(crate) fn new(runtime_id: NilFunctionId, params: Vec<LocalId>) -> Self {
+    pub(crate) fn new(runtime_id: NilFunctionId, params: Vec<ParamLocal>) -> Self {
         Self { runtime_id, params }
     }
 
     pub(crate) fn type_(&self) -> FunctionType {
-        function_type(&self.params, ValueType::Nil)
+        FunctionType::from_params(&self.params, ValueType::Nil)
     }
 
     pub(crate) fn runtime_id(&self) -> NilFunctionId {
         self.runtime_id
     }
-}
 
-fn function_type(params: &[LocalId], return_: ValueType) -> FunctionType {
-    FunctionType::new(
-        params
-            .iter()
-            .map(FunctionArgumentType::from_local)
-            .collect(),
-        return_,
-    )
+    pub(crate) fn params(&self) -> &[ParamLocal] {
+        &self.params
+    }
 }
 
 impl From<IntFunctionValue> for FunctionValue {
@@ -247,25 +238,26 @@ impl From<NilFunctionValue> for FunctionValue {
 #[cfg(test)]
 mod tests {
     use super::{
-        BoolFunctionValue, FunctionArgumentType, FunctionType, FunctionValue, IntFunctionValue,
-        NilFunctionValue, StringFunctionValue, ValueType,
+        BoolFunctionValue, FunctionType, FunctionValue, IntFunctionValue, NilFunctionValue,
+        StringFunctionValue, ValueType,
     };
     use crate::plan::{
-        BoolFunctionId, BoolLocalId, IntFunctionId, IntLocalId, LocalId, NilFunctionId, NilLocalId,
-        RuntimeFunctionId, StringFunctionId, StringLocalId,
+        BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FunctionValueKind, IntFunctionId,
+        IntLocalId, NilFunctionId, NilLocalId, ParamLocal, RuntimeFunctionId, StringFunctionId,
+        StringLocalId,
     };
 
     #[test]
     fn function_value_accepts_matching_shape() {
         let value = FunctionValue::new(
             RuntimeFunctionId::String(StringFunctionId(0)),
-            vec![LocalId::Int(IntLocalId(0))],
+            vec![int_param(0)],
         );
         let type_ = value.type_();
 
         assert_eq!(
             type_,
-            FunctionType::new(vec![FunctionArgumentType::Int], ValueType::String),
+            FunctionType::new(vec![ValueType::Int], ValueType::String),
         );
         assert_eq!(type_.return_(), &ValueType::String);
     }
@@ -292,44 +284,16 @@ mod tests {
     }
 
     #[test]
-    fn function_argument_type_rejects_function_shape() {
-        assert_eq!(
-            FunctionArgumentType::from_value_type(&ValueType::Function(Box::new(
-                FunctionType::new(Vec::new(), ValueType::Int),
-            ))),
-            None,
-        );
-    }
-
-    #[test]
-    fn function_argument_type_accepts_primitive_shapes() {
-        assert_eq!(
-            FunctionArgumentType::from_value_type(&ValueType::Int),
-            Some(FunctionArgumentType::Int),
-        );
-        assert_eq!(
-            FunctionArgumentType::from_value_type(&ValueType::String),
-            Some(FunctionArgumentType::String),
-        );
-        assert_eq!(
-            FunctionArgumentType::from_value_type(&ValueType::Bool),
-            Some(FunctionArgumentType::Bool),
-        );
-        assert_eq!(
-            FunctionArgumentType::from_value_type(&ValueType::Nil),
-            Some(FunctionArgumentType::Nil),
-        );
-    }
-
-    #[test]
     fn function_value_type_uses_all_parameter_shapes() {
+        let argument_function = FunctionType::new(vec![ValueType::String], ValueType::Bool);
         let value = FunctionValue::new(
             RuntimeFunctionId::Int(IntFunctionId(0)),
             vec![
-                LocalId::Int(IntLocalId(0)),
-                LocalId::String(StringLocalId(0)),
-                LocalId::Bool(BoolLocalId(0)),
-                LocalId::Nil(NilLocalId(0)),
+                int_param(0),
+                string_param(0),
+                bool_param(0),
+                nil_param(0),
+                ParamLocal::bool_function(BoolFunctionLocalId(0), argument_function.clone()),
             ],
         );
 
@@ -337,13 +301,48 @@ mod tests {
             value.type_(),
             FunctionType::new(
                 vec![
-                    FunctionArgumentType::Int,
-                    FunctionArgumentType::String,
-                    FunctionArgumentType::Bool,
-                    FunctionArgumentType::Nil,
+                    ValueType::Int,
+                    ValueType::String,
+                    ValueType::Bool,
+                    ValueType::Nil,
+                    ValueType::Function(Box::new(argument_function)),
                 ],
                 ValueType::Int,
             ),
         );
+    }
+
+    #[test]
+    fn function_value_preserves_exact_parameter_slots() {
+        let params = vec![int_param(2), bool_param(1)];
+        let int = FunctionValue::new(RuntimeFunctionId::Int(IntFunctionId(0)), params.clone());
+        let string = FunctionValue::new(
+            RuntimeFunctionId::String(StringFunctionId(0)),
+            params.clone(),
+        );
+        let bool = FunctionValue::new(RuntimeFunctionId::Bool(BoolFunctionId(0)), params.clone());
+        let nil = FunctionValue::new(RuntimeFunctionId::Nil(NilFunctionId(0)), params.clone());
+
+        assert_eq!(int.params(), params);
+        assert_eq!(string.params(), params);
+        assert_eq!(bool.params(), params);
+        assert_eq!(nil.params(), params);
+        assert!(matches!(int.kind(), FunctionValueKind::Int(_)));
+    }
+
+    fn int_param(index: usize) -> ParamLocal {
+        ParamLocal::int(IntLocalId(index))
+    }
+
+    fn string_param(index: usize) -> ParamLocal {
+        ParamLocal::string(StringLocalId(index))
+    }
+
+    fn bool_param(index: usize) -> ParamLocal {
+        ParamLocal::bool(BoolLocalId(index))
+    }
+
+    fn nil_param(index: usize) -> ParamLocal {
+        ParamLocal::nil(NilLocalId(index))
     }
 }

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -1,8 +1,8 @@
 use crate::plan::{
-    BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FunctionArgumentType, FunctionId,
-    FunctionType, FunctionValue, IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId,
-    NilFunctionId, NilFunctionLocalId, NilLocalId, RuntimeFunctionId, StringFunctionId,
-    StringFunctionLocalId, StringLocalId, ValueType,
+    BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FunctionId, FunctionType, FunctionValue,
+    IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId, NilFunctionId, NilFunctionLocalId,
+    NilLocalId, ParamLocal, RuntimeFunctionId, StringFunctionId, StringFunctionLocalId,
+    StringLocalId, ValueType,
 };
 use ecow::EcoString;
 use gleam_core::type_::Type;
@@ -17,7 +17,7 @@ pub(super) struct FunctionInfo {
 
 #[derive(Clone)]
 pub(super) struct FunctionParam {
-    pub(super) local: LocalId,
+    pub(super) local: ParamLocal,
     pub(super) name: EcoString,
 }
 
@@ -103,6 +103,63 @@ impl<'a> PlanContext<'a> {
         }
         self.bindings
             .insert(name, LocalBinding::Primitive { local, type_ });
+    }
+
+    pub(super) fn define_existing_param(&mut self, name: EcoString, local: &ParamLocal) {
+        match local {
+            ParamLocal::Int(local) => {
+                self.define_existing_local(name, LocalId::Int(*local), ValueType::Int);
+            }
+            ParamLocal::String(local) => {
+                self.define_existing_local(name, LocalId::String(*local), ValueType::String);
+            }
+            ParamLocal::Bool(local) => {
+                self.define_existing_local(name, LocalId::Bool(*local), ValueType::Bool);
+            }
+            ParamLocal::Nil(local) => {
+                self.define_existing_local(name, LocalId::Nil(*local), ValueType::Nil);
+            }
+            ParamLocal::IntFunction { local, type_ } => {
+                self.next_int_function_local = self.next_int_function_local.max(local.0 + 1);
+                self.bindings.insert(
+                    name,
+                    LocalBinding::Function(FunctionLocalBinding::Int {
+                        local: *local,
+                        type_: type_.clone(),
+                    }),
+                );
+            }
+            ParamLocal::StringFunction { local, type_ } => {
+                self.next_string_function_local = self.next_string_function_local.max(local.0 + 1);
+                self.bindings.insert(
+                    name,
+                    LocalBinding::Function(FunctionLocalBinding::String {
+                        local: *local,
+                        type_: type_.clone(),
+                    }),
+                );
+            }
+            ParamLocal::BoolFunction { local, type_ } => {
+                self.next_bool_function_local = self.next_bool_function_local.max(local.0 + 1);
+                self.bindings.insert(
+                    name,
+                    LocalBinding::Function(FunctionLocalBinding::Bool {
+                        local: *local,
+                        type_: type_.clone(),
+                    }),
+                );
+            }
+            ParamLocal::NilFunction { local, type_ } => {
+                self.next_nil_function_local = self.next_nil_function_local.max(local.0 + 1);
+                self.bindings.insert(
+                    name,
+                    LocalBinding::Function(FunctionLocalBinding::Nil {
+                        local: *local,
+                        type_: type_.clone(),
+                    }),
+                );
+            }
+        }
     }
 
     pub(super) fn define_int_function_local(
@@ -254,7 +311,10 @@ impl FunctionInfo {
     pub(super) fn value(&self) -> FunctionValue {
         FunctionValue::new(
             self.runtime_id,
-            self.params.iter().map(|param| param.local).collect(),
+            self.params
+                .iter()
+                .map(|param| param.local.clone())
+                .collect(),
         )
     }
 }
@@ -306,10 +366,7 @@ impl ValueType {
         } else if let Some((arguments, return_)) = type_.fn_types() {
             let arguments = arguments
                 .iter()
-                .map(|argument| {
-                    Self::from_gleam(argument.as_ref())
-                        .and_then(|type_| FunctionArgumentType::from_value_type(&type_))
-                })
+                .map(|argument| Self::from_gleam(argument.as_ref()))
                 .collect::<Option<Vec<_>>>()?;
             let return_ = Self::from_gleam(return_.as_ref())?;
             Some(Self::Function(Box::new(FunctionType::new(

--- a/src/planner/dsl.rs
+++ b/src/planner/dsl.rs
@@ -7,11 +7,11 @@ pub(crate) use expression::{
     bool_arg, bool_case_bool, bool_case_int, bool_case_int_function, bool_case_nil,
     bool_case_string, bool_function_ref, call_bool, call_int, call_int_function, call_nil,
     call_string, equal, evaluate_step, function_ref, int, int_arg, int_case_bool, int_case_int,
-    int_case_int_function, int_case_nil, int_case_string, int_function_ref, let_bool_function_step,
-    let_bool_step, let_int_function_step, let_int_step, let_nil_function_step, let_nil_step,
-    let_string_function_step, let_string_step, local_bool, local_int, local_int_function,
-    local_nil, local_string, nil, nil_arg, nil_function_ref, not_equal, string, string_arg,
-    string_function_ref,
+    int_case_int_function, int_case_nil, int_case_string, int_function_arg, int_function_call_arg,
+    int_function_ref, let_bool_function_step, let_bool_step, let_int_function_step, let_int_step,
+    let_nil_function_step, let_nil_step, let_string_function_step, let_string_step, local_bool,
+    local_int, local_int_function, local_nil, local_string, nil, nil_arg, nil_function_ref,
+    not_equal, string, string_arg, string_function_ref,
 };
 pub(crate) use function::function;
 pub(crate) use module::module;

--- a/src/planner/dsl/expression.rs
+++ b/src/planner/dsl/expression.rs
@@ -1,9 +1,9 @@
 use crate::plan::{
     BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue,
-    BoolLocalId, CallArg, Expr, FunctionArgumentType, FunctionExpr, FunctionExprKind, FunctionType,
+    BoolLocalId, CallArg, Expr, FunctionCallArg, FunctionExpr, FunctionExprKind, FunctionType,
     FunctionValue, IntExpr, IntFunctionExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue,
     IntLocalId, LocalId, NilExpr, NilFunctionExpr, NilFunctionId, NilFunctionLocalId,
-    NilFunctionValue, NilLocalId, ReturnExpr, RuntimeFunctionId, Step, StringExpr,
+    NilFunctionValue, NilLocalId, ParamLocal, ReturnExpr, RuntimeFunctionId, Step, StringExpr,
     StringFunctionExpr, StringFunctionId, StringFunctionLocalId, StringFunctionValue,
     StringLocalId, ValueType,
 };
@@ -28,6 +28,14 @@ pub(crate) struct BoolFunction(BoolFunctionExpr);
 
 pub(crate) struct NilFunction(NilFunctionExpr);
 
+pub(crate) trait IntoValueType {
+    fn into_value_type(self) -> ValueType;
+}
+
+pub(crate) trait IntoParamLocal {
+    fn into_param_local(self) -> ParamLocal;
+}
+
 pub(crate) fn int(value: i64) -> Int {
     Int(IntExpr::value(BigInt::from(value)))
 }
@@ -46,63 +54,114 @@ pub(crate) fn nil() -> Nil {
 
 pub(crate) fn function_ref(
     runtime_id: RuntimeFunctionId,
-    params: impl IntoIterator<Item = LocalId>,
+    params: impl IntoIterator<Item = impl IntoParamLocal>,
 ) -> Function {
     Function(FunctionExpr::value(FunctionValue::new(
         runtime_id,
-        params.into_iter().collect(),
+        params
+            .into_iter()
+            .map(IntoParamLocal::into_param_local)
+            .collect(),
     )))
 }
 
 pub(crate) fn int_function_ref(
     runtime_id: usize,
-    params: impl IntoIterator<Item = LocalId>,
+    params: impl IntoIterator<Item = impl IntoParamLocal>,
 ) -> IntFunction {
     IntFunction(IntFunctionExpr::value(IntFunctionValue::new(
         IntFunctionId(runtime_id),
-        params.into_iter().collect(),
+        params
+            .into_iter()
+            .map(IntoParamLocal::into_param_local)
+            .collect(),
     )))
 }
 
 pub(crate) fn string_function_ref(
     runtime_id: usize,
-    params: impl IntoIterator<Item = LocalId>,
+    params: impl IntoIterator<Item = impl IntoParamLocal>,
 ) -> StringFunction {
     StringFunction(StringFunctionExpr::value(StringFunctionValue::new(
         StringFunctionId(runtime_id),
-        params.into_iter().collect(),
+        params
+            .into_iter()
+            .map(IntoParamLocal::into_param_local)
+            .collect(),
     )))
 }
 
 pub(crate) fn bool_function_ref(
     runtime_id: usize,
-    params: impl IntoIterator<Item = LocalId>,
+    params: impl IntoIterator<Item = impl IntoParamLocal>,
 ) -> BoolFunction {
     BoolFunction(BoolFunctionExpr::value(BoolFunctionValue::new(
         BoolFunctionId(runtime_id),
-        params.into_iter().collect(),
+        params
+            .into_iter()
+            .map(IntoParamLocal::into_param_local)
+            .collect(),
     )))
 }
 
 pub(crate) fn nil_function_ref(
     runtime_id: usize,
-    params: impl IntoIterator<Item = LocalId>,
+    params: impl IntoIterator<Item = impl IntoParamLocal>,
 ) -> NilFunction {
     NilFunction(NilFunctionExpr::value(NilFunctionValue::new(
         NilFunctionId(runtime_id),
-        params.into_iter().collect(),
+        params
+            .into_iter()
+            .map(IntoParamLocal::into_param_local)
+            .collect(),
     )))
 }
 
 pub(crate) fn local_int_function(
     local: usize,
     name: impl Into<EcoString>,
-    params: impl IntoIterator<Item = LocalId>,
+    params: impl IntoIterator<Item = impl IntoValueType>,
 ) -> IntFunction {
     IntFunction(IntFunctionExpr::local_get(
         IntFunctionLocalId(local),
         name.into(),
         int_function_type(params),
+    ))
+}
+
+pub(crate) fn local_string_function(
+    local: usize,
+    name: impl Into<EcoString>,
+    params: impl IntoIterator<Item = impl IntoValueType>,
+) -> StringFunction {
+    StringFunction(StringFunctionExpr::local_get(
+        StringFunctionLocalId(local),
+        name.into(),
+        string_function_type(params),
+    ))
+}
+
+pub(crate) fn local_bool_function(
+    local: usize,
+    name: impl Into<EcoString>,
+    params: impl IntoIterator<Item = impl IntoValueType>,
+) -> BoolFunction {
+    BoolFunction(BoolFunctionExpr::local_get(
+        BoolFunctionLocalId(local),
+        name.into(),
+        bool_function_type(params),
+    ))
+}
+
+pub(crate) fn local_nil_function(
+    local: usize,
+    name: impl Into<EcoString>,
+    params: impl IntoIterator<Item = impl IntoValueType>,
+) -> NilFunction {
+    NilFunction(NilFunctionExpr::local_get(
+        NilFunctionLocalId(local),
+        name.into(),
+        nil_function_type(params),
     ))
 }
 
@@ -455,7 +514,7 @@ pub(crate) fn call_nil(function: usize, args: impl IntoIterator<Item = CallArg>)
 
 pub(crate) fn call_int_function(
     function: IntFunction,
-    args: impl IntoIterator<Item = CallArg>,
+    args: impl IntoIterator<Item = FunctionCallArg>,
 ) -> Int {
     Int(IntExpr::function_call(
         function.into(),
@@ -467,16 +526,36 @@ pub(crate) fn int_arg(local: usize, value: Int) -> CallArg {
     CallArg::int(IntLocalId(local), value.into())
 }
 
+pub(crate) fn int_function_call_arg(value: Int) -> FunctionCallArg {
+    FunctionCallArg::int(value.into())
+}
+
+pub(crate) fn int_function_arg(local: usize, value: IntFunction) -> CallArg {
+    CallArg::int_function(IntFunctionLocalId(local), value.into())
+}
+
 pub(crate) fn string_arg(local: usize, value: String) -> CallArg {
     CallArg::string(StringLocalId(local), value.into())
+}
+
+pub(crate) fn string_function_arg(local: usize, value: StringFunction) -> CallArg {
+    CallArg::string_function(StringFunctionLocalId(local), value.into())
 }
 
 pub(crate) fn bool_arg(local: usize, value: Bool) -> CallArg {
     CallArg::bool(BoolLocalId(local), value.into())
 }
 
+pub(crate) fn bool_function_arg(local: usize, value: BoolFunction) -> CallArg {
+    CallArg::bool_function(BoolFunctionLocalId(local), value.into())
+}
+
 pub(crate) fn nil_arg(local: usize, value: Nil) -> CallArg {
     CallArg::nil(NilLocalId(local), value.into())
+}
+
+pub(crate) fn nil_function_arg(local: usize, value: NilFunction) -> CallArg {
+    CallArg::nil_function(NilFunctionLocalId(local), value.into())
 }
 
 impl Int {
@@ -661,14 +740,73 @@ impl From<NilFunction> for NilFunctionExpr {
     }
 }
 
-fn int_function_type(params: impl IntoIterator<Item = LocalId>) -> FunctionType {
+fn int_function_type(params: impl IntoIterator<Item = impl IntoValueType>) -> FunctionType {
+    function_type(params, ValueType::Int)
+}
+
+fn string_function_type(params: impl IntoIterator<Item = impl IntoValueType>) -> FunctionType {
+    function_type(params, ValueType::String)
+}
+
+fn bool_function_type(params: impl IntoIterator<Item = impl IntoValueType>) -> FunctionType {
+    function_type(params, ValueType::Bool)
+}
+
+fn nil_function_type(params: impl IntoIterator<Item = impl IntoValueType>) -> FunctionType {
+    function_type(params, ValueType::Nil)
+}
+
+fn function_type(
+    params: impl IntoIterator<Item = impl IntoValueType>,
+    return_: ValueType,
+) -> FunctionType {
     FunctionType::new(
         params
             .into_iter()
-            .map(|param| FunctionArgumentType::from_local(&param))
+            .map(IntoValueType::into_value_type)
             .collect(),
-        ValueType::Int,
+        return_,
     )
+}
+
+impl IntoValueType for ValueType {
+    fn into_value_type(self) -> ValueType {
+        self
+    }
+}
+
+impl IntoValueType for LocalId {
+    fn into_value_type(self) -> ValueType {
+        match self {
+            LocalId::Int(_) => ValueType::Int,
+            LocalId::String(_) => ValueType::String,
+            LocalId::Bool(_) => ValueType::Bool,
+            LocalId::Nil(_) => ValueType::Nil,
+        }
+    }
+}
+
+impl IntoValueType for ParamLocal {
+    fn into_value_type(self) -> ValueType {
+        self.value_type()
+    }
+}
+
+impl IntoParamLocal for LocalId {
+    fn into_param_local(self) -> ParamLocal {
+        match self {
+            LocalId::Int(local) => ParamLocal::int(local),
+            LocalId::String(local) => ParamLocal::string(local),
+            LocalId::Bool(local) => ParamLocal::bool(local),
+            LocalId::Nil(local) => ParamLocal::nil(local),
+        }
+    }
+}
+
+impl IntoParamLocal for ParamLocal {
+    fn into_param_local(self) -> ParamLocal {
+        self
+    }
 }
 
 #[cfg(test)]
@@ -995,6 +1133,15 @@ mod tests {
     }
 
     #[test]
+    fn value_type_dsl() {
+        assert_eq!(ValueType::Int.into_value_type(), ValueType::Int);
+        assert_eq!(
+            ParamLocal::int(crate::plan::IntLocalId(0)).into_value_type(),
+            ValueType::Int,
+        );
+    }
+
+    #[test]
     fn local_dsl() {
         assert!(matches!(
             local_int(0, "x").0.kind(),
@@ -1011,6 +1158,46 @@ mod tests {
         assert!(matches!(
             local_nil(0, "x").0.kind(),
             NilExprKind::LocalGet { .. },
+        ));
+        assert!(matches!(
+            local_int_function(
+                0,
+                "f",
+                [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))]
+            )
+            .0
+            .kind(),
+            IntFunctionExprKind::LocalGet { .. },
+        ));
+        assert!(matches!(
+            local_string_function(
+                0,
+                "f",
+                [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+            )
+            .0
+            .kind(),
+            crate::plan::StringFunctionExprKind::LocalGet { .. },
+        ));
+        assert!(matches!(
+            local_bool_function(
+                0,
+                "f",
+                [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))],
+            )
+            .0
+            .kind(),
+            crate::plan::BoolFunctionExprKind::LocalGet { .. },
+        ));
+        assert!(matches!(
+            local_nil_function(
+                0,
+                "f",
+                [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))],
+            )
+            .0
+            .kind(),
+            crate::plan::NilFunctionExprKind::LocalGet { .. },
         ));
     }
 
@@ -1035,14 +1222,30 @@ mod tests {
     fn call_arg_dsl() {
         assert!(matches!(int_arg(0, int(1)).kind(), CallArgKind::Int { .. },));
         assert!(matches!(
+            int_function_arg(0, int_function_ref(0, Vec::<ParamLocal>::new())).kind(),
+            CallArgKind::IntFunction { .. },
+        ));
+        assert!(matches!(
             string_arg(0, string("a")).kind(),
             CallArgKind::String { .. },
+        ));
+        assert!(matches!(
+            string_function_arg(0, string_function_ref(0, Vec::<ParamLocal>::new())).kind(),
+            CallArgKind::StringFunction { .. },
         ));
         assert!(matches!(
             bool_arg(0, bool_(true)).kind(),
             CallArgKind::Bool { .. },
         ));
+        assert!(matches!(
+            bool_function_arg(0, bool_function_ref(0, Vec::<ParamLocal>::new())).kind(),
+            CallArgKind::BoolFunction { .. },
+        ));
         assert!(matches!(nil_arg(0, nil()).kind(), CallArgKind::Nil { .. },));
+        assert!(matches!(
+            nil_function_arg(0, nil_function_ref(0, Vec::<ParamLocal>::new())).kind(),
+            CallArgKind::NilFunction { .. },
+        ));
     }
 
     #[test]

--- a/src/planner/dsl/function.rs
+++ b/src/planner/dsl/function.rs
@@ -1,6 +1,7 @@
 use crate::plan::{
-    BoolLocalId, Expr, FunctionId, FunctionPlan, IntLocalId, LocalId, NilLocalId, Param,
-    ReturnExpr, Step, StringLocalId,
+    BoolFunctionLocalId, BoolLocalId, Expr, FunctionId, FunctionPlan, FunctionType,
+    IntFunctionLocalId, IntLocalId, NilFunctionLocalId, NilLocalId, Param, ParamLocal, ReturnExpr,
+    Step, StringFunctionLocalId, StringLocalId, ValueType,
 };
 use crate::planner::dsl::expression::{Bool, Int, Nil, String};
 use ecow::EcoString;
@@ -24,27 +25,93 @@ pub(crate) fn function(name: impl Into<EcoString>, return_: impl Into<ReturnExpr
 impl FunctionDsl {
     pub(crate) fn param_int(mut self, local: usize, name: impl Into<EcoString>) -> Self {
         self.params
-            .push(Param::new(LocalId::Int(IntLocalId(local)), name.into()));
+            .push(Param::new(ParamLocal::int(IntLocalId(local)), name.into()));
         self
     }
 
     pub(crate) fn param_string(mut self, local: usize, name: impl Into<EcoString>) -> Self {
         self.params.push(Param::new(
-            LocalId::String(StringLocalId(local)),
+            ParamLocal::string(StringLocalId(local)),
             name.into(),
         ));
         self
     }
 
     pub(crate) fn param_bool(mut self, local: usize, name: impl Into<EcoString>) -> Self {
-        self.params
-            .push(Param::new(LocalId::Bool(BoolLocalId(local)), name.into()));
+        self.params.push(Param::new(
+            ParamLocal::bool(BoolLocalId(local)),
+            name.into(),
+        ));
         self
     }
 
     pub(crate) fn param_nil(mut self, local: usize, name: impl Into<EcoString>) -> Self {
         self.params
-            .push(Param::new(LocalId::Nil(NilLocalId(local)), name.into()));
+            .push(Param::new(ParamLocal::nil(NilLocalId(local)), name.into()));
+        self
+    }
+
+    pub(crate) fn param_int_function(
+        mut self,
+        local: usize,
+        name: impl Into<EcoString>,
+        arguments: impl IntoIterator<Item = ValueType>,
+    ) -> Self {
+        self.params.push(Param::new(
+            ParamLocal::int_function(
+                IntFunctionLocalId(local),
+                FunctionType::new(arguments.into_iter().collect(), ValueType::Int),
+            ),
+            name.into(),
+        ));
+        self
+    }
+
+    pub(crate) fn param_string_function(
+        mut self,
+        local: usize,
+        name: impl Into<EcoString>,
+        arguments: impl IntoIterator<Item = ValueType>,
+    ) -> Self {
+        self.params.push(Param::new(
+            ParamLocal::string_function(
+                StringFunctionLocalId(local),
+                FunctionType::new(arguments.into_iter().collect(), ValueType::String),
+            ),
+            name.into(),
+        ));
+        self
+    }
+
+    pub(crate) fn param_bool_function(
+        mut self,
+        local: usize,
+        name: impl Into<EcoString>,
+        arguments: impl IntoIterator<Item = ValueType>,
+    ) -> Self {
+        self.params.push(Param::new(
+            ParamLocal::bool_function(
+                BoolFunctionLocalId(local),
+                FunctionType::new(arguments.into_iter().collect(), ValueType::Bool),
+            ),
+            name.into(),
+        ));
+        self
+    }
+
+    pub(crate) fn param_nil_function(
+        mut self,
+        local: usize,
+        name: impl Into<EcoString>,
+        arguments: impl IntoIterator<Item = ValueType>,
+    ) -> Self {
+        self.params.push(Param::new(
+            ParamLocal::nil_function(
+                NilFunctionLocalId(local),
+                FunctionType::new(arguments.into_iter().collect(), ValueType::Nil),
+            ),
+            name.into(),
+        ));
         self
     }
 
@@ -116,6 +183,10 @@ mod tests {
             .param_string(0, "b")
             .param_bool(0, "c")
             .param_nil(0, "d")
+            .param_int_function(0, "f", [ValueType::Int])
+            .param_string_function(0, "g", [ValueType::String])
+            .param_bool_function(0, "h", [ValueType::Bool])
+            .param_nil_function(0, "i", [ValueType::Nil])
             .let_int(1, "x", int(2))
             .let_string(1, "y", string("a"))
             .let_bool(1, "z", bool_(true))
@@ -125,7 +196,7 @@ mod tests {
             .build(FunctionId::new(0));
 
         assert_eq!(function.name(), "main");
-        assert_eq!(function.params().len(), 4);
+        assert_eq!(function.params().len(), 8);
         assert_eq!(function.steps().len(), 6);
         assert!(matches!(
             function.steps()[0].kind(),

--- a/src/planner/error/invalid.rs
+++ b/src/planner/error/invalid.rs
@@ -79,6 +79,10 @@ pub enum InvalidExpressionType {
 pub enum InvalidCallShapeReason {
     #[error("function value call arity mismatch")]
     FunctionCallArityMismatch,
+    #[error("function value call argument type mismatch")]
+    FunctionCallArgumentTypeMismatch,
+    #[error("function value call argument type is not supported")]
+    FunctionCallUnsupportedArgumentType,
     #[error("function value call return type mismatch")]
     FunctionCallReturnTypeMismatch,
     #[error("function value call return type is not supported")]

--- a/src/planner/error/invalid.rs
+++ b/src/planner/error/invalid.rs
@@ -81,8 +81,6 @@ pub enum InvalidCallShapeReason {
     FunctionCallArityMismatch,
     #[error("function value call argument type mismatch")]
     FunctionCallArgumentTypeMismatch,
-    #[error("function value call argument type is not supported")]
-    FunctionCallUnsupportedArgumentType,
     #[error("function value call return type mismatch")]
     FunctionCallReturnTypeMismatch,
     #[error("function value call return type is not supported")]

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -42,6 +42,8 @@ pub enum UnsupportedStatementKind {
     AssertAsFinalStatement,
     #[error("assignment as final statement")]
     AssignmentAsFinalStatement,
+    #[error("use")]
+    Use,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -28,6 +28,8 @@ pub enum UnsupportedFunctionReason {
 pub enum UnsupportedArgumentReason {
     #[error("discard arguments are not supported")]
     Discard,
+    #[error("function arguments must not return functions")]
+    FunctionReturningFunction,
     #[error("labelled arguments are not supported")]
     Labelled,
     #[error("argument type is not supported")]

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -1,9 +1,9 @@
 use super::{invalid_expression_type, plan_expr};
 use crate::plan::{
-    BoolExpr, CallArg, Expr, FunctionArgumentType, FunctionExpr, IntExpr, LocalId, NilExpr,
+    BoolExpr, CallArg, Expr, FunctionCallArg, FunctionExpr, IntExpr, NilExpr, ParamLocal,
     RuntimeFunctionId, StringExpr, ValueType,
 };
-use crate::planner::context::{FunctionInfo, FunctionParam, PlanContext};
+use crate::planner::context::{FunctionInfo, PlanContext};
 use crate::planner::error::{
     InvalidCallShapeReason, InvalidExpressionType, InvalidPipelineShapeReason,
     InvalidTypedAstReason, PlanError, UnsupportedPipelineReason,
@@ -253,7 +253,12 @@ fn plan_direct_function_call(
             },
         });
     }
-    let args = plan_call_args(arguments, &function.params, context, capture)?;
+    let args = plan_call_args(
+        arguments,
+        function.params.iter().map(|param| &param.local),
+        context,
+        capture,
+    )?;
 
     Ok(call_expr(function_id, args))
 }
@@ -295,36 +300,70 @@ fn plan_function_value_call(
         });
     }
 
-    let params = function_call_params(&function_type);
-    let args = plan_call_args(arguments, &params, context, capture)?;
+    let args =
+        plan_function_call_args(arguments, function_type.argument_types(), context, capture)?;
 
     function_call_expr(function, args, return_type)
 }
 
-fn plan_call_args(
+fn plan_call_args<'a>(
     arguments: Vec<GleamCallArg<TypedExpr>>,
-    params: &[FunctionParam],
+    params: impl IntoIterator<Item = &'a ParamLocal>,
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
 ) -> Result<Vec<CallArg>, PlanError> {
     let mut args = Vec::with_capacity(arguments.len());
     for (argument, param) in arguments.into_iter().zip(params) {
         let expression = plan_argument_value(argument.value, capture, context)?;
-        let arg = match expression.into_call_arg(param.local) {
+        let arg = match expression.into_call_arg(param) {
             Ok(arg) => arg,
-            Err(other) => {
-                let expected = match param.local {
-                    LocalId::Int(_) => InvalidExpressionType::Int,
-                    LocalId::String(_) => InvalidExpressionType::String,
-                    LocalId::Bool(_) => InvalidExpressionType::Bool,
-                    LocalId::Nil(_) => InvalidExpressionType::Nil,
-                };
-                return Err(invalid_expression_type(expected, &other));
-            }
+            Err(other) => return Err(call_arg_type_mismatch(param.value_type(), &other)),
         };
         args.push(arg);
     }
     Ok(args)
+}
+
+fn plan_function_call_args(
+    arguments: Vec<GleamCallArg<TypedExpr>>,
+    params: &[ValueType],
+    context: &mut PlanContext<'_>,
+    capture: Option<&CaptureSubstitution>,
+) -> Result<Vec<FunctionCallArg>, PlanError> {
+    let mut args = Vec::with_capacity(arguments.len());
+    for (argument, type_) in arguments.into_iter().zip(params) {
+        let expression = plan_argument_value(argument.value, capture, context)?;
+        let arg = match expression.into_function_call_arg(type_) {
+            Ok(arg) => arg,
+            Err(other) => return Err(call_arg_type_mismatch(type_.clone(), &other)),
+        };
+        args.push(arg);
+    }
+    Ok(args)
+}
+
+fn call_arg_type_mismatch(expected: ValueType, actual: &Expr) -> PlanError {
+    if matches!(expected, ValueType::Function(_))
+        && matches!(actual.value_type(), ValueType::Function(_))
+    {
+        PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::FunctionCallArgumentTypeMismatch,
+            },
+        }
+    } else {
+        invalid_expression_type(invalid_expression_type_kind(expected), actual)
+    }
+}
+
+fn invalid_expression_type_kind(type_: ValueType) -> InvalidExpressionType {
+    match type_ {
+        ValueType::Int => InvalidExpressionType::Int,
+        ValueType::String => InvalidExpressionType::String,
+        ValueType::Bool => InvalidExpressionType::Bool,
+        ValueType::Nil => InvalidExpressionType::Nil,
+        ValueType::Function(_) => InvalidExpressionType::Function,
+    }
 }
 
 fn plan_argument_value(
@@ -424,7 +463,7 @@ fn call_expr(function: RuntimeFunctionId, args: Vec<CallArg>) -> Expr {
 
 fn function_call_expr(
     function: FunctionExpr,
-    args: Vec<CallArg>,
+    args: Vec<FunctionCallArg>,
     return_type: ValueType,
 ) -> Result<Expr, PlanError> {
     match return_type {
@@ -470,59 +509,17 @@ fn function_call_expr(
     }
 }
 
-fn function_call_params(function_type: &crate::plan::FunctionType) -> Vec<FunctionParam> {
-    let mut next_int = 0;
-    let mut next_string = 0;
-    let mut next_bool = 0;
-    let mut next_nil = 0;
-
-    function_type
-        .argument_types()
-        .iter()
-        .map(|type_| {
-            let local = match type_ {
-                FunctionArgumentType::Int => {
-                    let local = LocalId::Int(crate::plan::IntLocalId(next_int));
-                    next_int += 1;
-                    local
-                }
-                FunctionArgumentType::String => {
-                    let local = LocalId::String(crate::plan::StringLocalId(next_string));
-                    next_string += 1;
-                    local
-                }
-                FunctionArgumentType::Bool => {
-                    let local = LocalId::Bool(crate::plan::BoolLocalId(next_bool));
-                    next_bool += 1;
-                    local
-                }
-                FunctionArgumentType::Nil => {
-                    let local = LocalId::Nil(crate::plan::NilLocalId(next_nil));
-                    next_nil += 1;
-                    local
-                }
-            };
-
-            FunctionParam {
-                local,
-                name: EcoString::default(),
-            }
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::{typed_int_expr, typed_string_expr};
     use crate::plan::{
-        BoolFunctionId, BoolLocalId, ExprKind, FunctionArgumentType, FunctionExpr, FunctionType,
-        IntLocalId, LocalId, NilFunctionId, NilLocalId, RuntimeFunctionId, StringFunctionId,
-        StringLocalId, ValueType,
+        BoolFunctionId, ExprKind, FunctionExpr, FunctionType, IntLocalId, LocalId, NilFunctionId,
+        ParamLocal, RuntimeFunctionId, StringFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        block_int_function, bool_, bool_case_int_function, call_int_function, function,
-        function_ref, int, int_arg, int_case_int_function, int_function_ref, let_int_function_step,
-        local_int, local_int_function, module,
+        block_int_function, bool_, bool_case_int_function, call_int, call_int_function, function,
+        function_ref, int, int_arg, int_case_int_function, int_function_arg, int_function_call_arg,
+        int_function_ref, let_int_function_step, local_int, local_int_function, module,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, compile_minimal_module, dummy_span};
@@ -568,7 +565,7 @@ pub fn main() {
                 "main",
                 call_int_function(
                     local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
-                    [int_arg(0, int(1))],
+                    [int_function_call_arg(int(1))],
                 ),
             )
             .step(let_int_function_step(
@@ -577,6 +574,109 @@ pub fn main() {
                 int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
             )),
             [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_function_value_argument_direct_call() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn apply(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  apply(add_one, 41)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                call_int(
+                    2,
+                    [
+                        int_function_arg(0, int_function_ref(1, [LocalId::Int(IntLocalId(0))])),
+                        int_arg(0, int(41)),
+                    ],
+                ),
+            ),
+            [
+                function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value"),
+                function(
+                    "apply",
+                    call_int_function(
+                        local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
+                        [int_function_call_arg(local_int(0, "value"))],
+                    ),
+                )
+                .param_int_function(0, "function", [ValueType::Int])
+                .param_int(0, "value"),
+            ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_local_function_value_argument_direct_call() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn apply(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  let add = add_one
+  apply(add, 41)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                call_int(
+                    2,
+                    [
+                        int_function_arg(
+                            0,
+                            local_int_function(0, "add", [LocalId::Int(IntLocalId(0))]),
+                        ),
+                        int_arg(0, int(41)),
+                    ],
+                ),
+            )
+            .step(let_int_function_step(
+                0,
+                "add",
+                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+            )),
+            [
+                function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value"),
+                function(
+                    "apply",
+                    call_int_function(
+                        local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
+                        [int_function_call_arg(local_int(0, "value"))],
+                    ),
+                )
+                .param_int_function(0, "function", [ValueType::Int])
+                .param_int(0, "value"),
+            ],
         );
 
         assert_eq!(actual, expected);
@@ -612,7 +712,7 @@ pub fn primitive_shadow() {
                 "main",
                 call_int_function(
                     local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
-                    [int_arg(0, int(1))],
+                    [int_function_call_arg(int(1))],
                 ),
             )
             .let_int(0, "function", int(1))
@@ -656,7 +756,7 @@ pub fn main() {
                 "main",
                 call_int_function(
                     block_int_function([], int_function_ref(1, [LocalId::Int(IntLocalId(0))])),
-                    [int_arg(0, int(1))],
+                    [int_function_call_arg(int(1))],
                 ),
             ),
             [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
@@ -710,7 +810,7 @@ pub fn main() {
                         int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
                         int_function_ref(2, [LocalId::Int(IntLocalId(0))]),
                     ),
-                    [int_arg(0, int(1))],
+                    [int_function_call_arg(int(1))],
                 ),
             )
             .let_int(
@@ -722,7 +822,7 @@ pub fn main() {
                         [(0, int_function_ref(2, [LocalId::Int(IntLocalId(0))]))],
                         int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
                     ),
-                    [int_arg(0, int(1))],
+                    [int_function_call_arg(int(1))],
                 ),
             ),
             [add_one, add_ten],
@@ -890,19 +990,36 @@ pub fn main() {
     }
 
     #[test]
-    fn function_call_params_supports_primitive_argument_shapes() {
-        let params = super::function_call_params(&FunctionType::new(
-            vec![
-                FunctionArgumentType::String,
-                FunctionArgumentType::Bool,
-                FunctionArgumentType::Nil,
-            ],
-            ValueType::Int,
-        ));
-
-        assert!(matches!(params[0].local, LocalId::String(StringLocalId(0)),));
-        assert!(matches!(params[1].local, LocalId::Bool(BoolLocalId(0))));
-        assert!(matches!(params[2].local, LocalId::Nil(NilLocalId(0))));
+    fn call_arg_type_mismatch_reports_function_shapes() {
+        assert_eq!(
+            super::call_arg_type_mismatch(
+                ValueType::Function(Box::new(FunctionType::new(
+                    vec![ValueType::String],
+                    ValueType::String,
+                ))),
+                &crate::plan::Expr::function(FunctionExpr::from(int_function_ref(
+                    0,
+                    [LocalId::Int(IntLocalId(0))],
+                ))),
+            ),
+            PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallArgumentTypeMismatch,
+                },
+            },
+        );
+        assert_eq!(
+            super::call_arg_type_mismatch(
+                ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+                &call_int(0, []).into(),
+            ),
+            PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Function,
+                    actual: InvalidExpressionType::Int,
+                },
+            },
+        );
     }
 
     #[test]
@@ -911,7 +1028,7 @@ pub fn main() {
             super::function_call_expr(
                 FunctionExpr::from(function_ref(
                     RuntimeFunctionId::String(StringFunctionId(0)),
-                    [],
+                    Vec::<ParamLocal>::new(),
                 )),
                 Vec::new(),
                 ValueType::String,
@@ -922,7 +1039,10 @@ pub fn main() {
         ));
         assert!(matches!(
             super::function_call_expr(
-                FunctionExpr::from(function_ref(RuntimeFunctionId::Bool(BoolFunctionId(0)), [],)),
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Bool(BoolFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                )),
                 Vec::new(),
                 ValueType::Bool,
             )
@@ -932,7 +1052,10 @@ pub fn main() {
         ));
         assert!(matches!(
             super::function_call_expr(
-                FunctionExpr::from(function_ref(RuntimeFunctionId::Nil(NilFunctionId(0)), [],)),
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Nil(NilFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                )),
                 Vec::new(),
                 ValueType::Nil,
             )
@@ -948,7 +1071,7 @@ pub fn main() {
             super::function_call_expr(
                 FunctionExpr::from(function_ref(
                     RuntimeFunctionId::String(StringFunctionId(0)),
-                    [],
+                    Vec::<ParamLocal>::new(),
                 )),
                 Vec::new(),
                 ValueType::Int,
@@ -957,7 +1080,7 @@ pub fn main() {
         );
         assert_eq!(
             super::function_call_expr(
-                FunctionExpr::from(int_function_ref(0, [])),
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
                 Vec::new(),
                 ValueType::String,
             ),
@@ -965,7 +1088,7 @@ pub fn main() {
         );
         assert_eq!(
             super::function_call_expr(
-                FunctionExpr::from(int_function_ref(0, [])),
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
                 Vec::new(),
                 ValueType::Bool,
             ),
@@ -973,7 +1096,7 @@ pub fn main() {
         );
         assert_eq!(
             super::function_call_expr(
-                FunctionExpr::from(int_function_ref(0, [])),
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
                 Vec::new(),
                 ValueType::Nil,
             ),
@@ -981,7 +1104,7 @@ pub fn main() {
         );
         assert_eq!(
             super::function_call_expr(
-                FunctionExpr::from(int_function_ref(0, [])),
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
                 Vec::new(),
                 ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
             ),

--- a/src/planner/expression/var.rs
+++ b/src/planner/expression/var.rs
@@ -57,7 +57,9 @@ pub(super) fn plan_var(
                         reason: InvalidTypedAstReason::UnknownLocal { name: name.clone() },
                     })?;
 
-            Ok(Expr::function(FunctionExpr::value(function.value())))
+            let value = function.value();
+
+            Ok(Expr::function(FunctionExpr::value(value)))
         }
         ValueConstructorVariant::ModuleFn { .. } => Err(PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::ExpressionShape {
@@ -113,10 +115,13 @@ fn local_get(local: LocalId, name: EcoString, type_: ValueType) -> Result<Expr, 
 #[cfg(test)]
 mod tests {
     use super::super::{module_returning_typed_expr, typed_int_expr, typed_prelude_constructor};
-    use crate::plan::{IntFunctionId, IntLocalId, LocalId, RuntimeFunctionId, ValueType};
+    use crate::plan::{
+        FunctionType, IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId, ParamLocal,
+        RuntimeFunctionId, ValueType,
+    };
     use crate::planner::dsl::{
-        bool_, function, function_ref, int, local_bool, local_int, local_nil, local_string, module,
-        nil,
+        bool_, call_int_function, function, function_ref, int, int_function_call_arg, local_bool,
+        local_int, local_int_function, local_nil, local_string, module, nil,
     };
     use crate::planner::plan_module;
     use crate::planner::support::compile;
@@ -217,6 +222,54 @@ pub fn main() {
                 [LocalId::Int(IntLocalId(0))],
             )),
             [function("identity", local_int(0, "value")).param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_top_level_function_reference_with_function_argument() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn apply(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  apply
+  1
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", int(1)).evaluate(function_ref(
+                RuntimeFunctionId::Int(IntFunctionId(2)),
+                [
+                    ParamLocal::int_function(
+                        IntFunctionLocalId(0),
+                        FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                    ),
+                    ParamLocal::int(IntLocalId(0)),
+                ],
+            )),
+            [
+                function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value"),
+                function(
+                    "apply",
+                    call_int_function(
+                        local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
+                        [int_function_call_arg(local_int(0, "value"))],
+                    ),
+                )
+                .param_int_function(0, "function", [ValueType::Int])
+                .param_int(0, "value"),
+            ],
         );
 
         assert_eq!(actual, expected);

--- a/src/planner/function.rs
+++ b/src/planner/function.rs
@@ -28,12 +28,8 @@ pub(super) fn plan_function(
         .params
         .iter()
         .map(|param| {
-            context.define_existing_local(
-                param.name.clone(),
-                param.local,
-                param.local.value_type(),
-            );
-            Param::new(param.local, param.name.clone())
+            context.define_existing_param(param.name.clone(), &param.local);
+            Param::new(param.local.clone(), param.name.clone())
         })
         .collect();
     let planned = plan_steps_and_return(

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -1,4 +1,6 @@
-use crate::plan::{ExecutionPlan, FunctionId, LocalId, RuntimeFunctionId, ValueType};
+use crate::plan::{
+    ExecutionPlan, FunctionId, IntFunctionLocalId, ParamLocal, RuntimeFunctionId, ValueType,
+};
 use crate::planner::context::{FunctionInfo, FunctionParam, FunctionRuntimeIds};
 use crate::planner::error::{
     PlanError, UnsupportedArgumentReason, UnsupportedFunctionReason, UnsupportedTopLevelKind,
@@ -10,22 +12,33 @@ use gleam_core::type_::Type;
 use std::collections::HashMap;
 
 pub fn plan_module(module: TypedModule) -> Result<ExecutionPlan, PlanError> {
-    reject_top_level(
-        UnsupportedTopLevelKind::Import,
-        module.definitions.imports.len(),
-    )?;
-    reject_top_level(
-        UnsupportedTopLevelKind::Constant,
-        module.definitions.constants.len(),
-    )?;
-    reject_top_level(
-        UnsupportedTopLevelKind::CustomType,
-        module.definitions.custom_types.len(),
-    )?;
-    reject_top_level(
-        UnsupportedTopLevelKind::TypeAlias,
-        module.definitions.type_aliases.len(),
-    )?;
+    let definitions = module.definitions;
+
+    let imports = definitions.imports.len();
+    let constants = definitions.constants.len();
+    let custom_types = definitions.custom_types.len();
+    let type_aliases = definitions.type_aliases.len();
+
+    if imports != 0 {
+        return Err(PlanError::UnsupportedTopLevel {
+            kind: UnsupportedTopLevelKind::Import,
+        });
+    }
+    if constants != 0 {
+        return Err(PlanError::UnsupportedTopLevel {
+            kind: UnsupportedTopLevelKind::Constant,
+        });
+    }
+    if custom_types != 0 {
+        return Err(PlanError::UnsupportedTopLevel {
+            kind: UnsupportedTopLevelKind::CustomType,
+        });
+    }
+    if type_aliases != 0 {
+        return Err(PlanError::UnsupportedTopLevel {
+            kind: UnsupportedTopLevelKind::TypeAlias,
+        });
+    }
 
     let module_name = module.name;
     let FunctionTable {
@@ -33,7 +46,7 @@ pub fn plan_module(module: TypedModule) -> Result<ExecutionPlan, PlanError> {
         main,
         functions_before_main,
         functions_after_main,
-    } = function_table(&module.definitions.functions)?;
+    } = function_table(&definitions.functions)?;
     let main = validate_main_function(main)?;
     let mut functions = Vec::new();
 
@@ -197,6 +210,10 @@ fn function_params(
     let mut next_string = 0;
     let mut next_bool = 0;
     let mut next_nil = 0;
+    let mut next_int_function = 0;
+    let mut next_string_function = 0;
+    let mut next_bool_function = 0;
+    let mut next_nil_function = 0;
 
     arguments
         .iter()
@@ -223,35 +240,83 @@ fn function_params(
             };
             let local = match &type_ {
                 ValueType::Int => {
-                    let local = LocalId::Int(crate::plan::IntLocalId(next_int));
+                    let local = ParamLocal::int(crate::plan::IntLocalId(next_int));
                     next_int += 1;
                     local
                 }
                 ValueType::String => {
-                    let local = LocalId::String(crate::plan::StringLocalId(next_string));
+                    let local = ParamLocal::string(crate::plan::StringLocalId(next_string));
                     next_string += 1;
                     local
                 }
                 ValueType::Bool => {
-                    let local = LocalId::Bool(crate::plan::BoolLocalId(next_bool));
+                    let local = ParamLocal::bool(crate::plan::BoolLocalId(next_bool));
                     next_bool += 1;
                     local
                 }
                 ValueType::Nil => {
-                    let local = LocalId::Nil(crate::plan::NilLocalId(next_nil));
+                    let local = ParamLocal::nil(crate::plan::NilLocalId(next_nil));
                     next_nil += 1;
                     local
                 }
-                ValueType::Function(_) => {
-                    return Err(PlanError::UnsupportedArgument {
-                        function: function_name.clone(),
-                        reason: UnsupportedArgumentReason::UnsupportedType,
-                    });
-                }
+                ValueType::Function(type_) => function_param_local(
+                    &function_name,
+                    type_,
+                    &mut next_int_function,
+                    &mut next_string_function,
+                    &mut next_bool_function,
+                    &mut next_nil_function,
+                )?,
             };
             Ok(FunctionParam { local, name })
         })
         .collect()
+}
+
+fn function_param_local(
+    function_name: &EcoString,
+    type_: &crate::plan::FunctionType,
+    next_int_function: &mut usize,
+    next_string_function: &mut usize,
+    next_bool_function: &mut usize,
+    next_nil_function: &mut usize,
+) -> Result<ParamLocal, PlanError> {
+    match type_.return_() {
+        ValueType::Int => {
+            let local =
+                ParamLocal::int_function(IntFunctionLocalId(*next_int_function), type_.clone());
+            *next_int_function += 1;
+            Ok(local)
+        }
+        ValueType::String => {
+            let local = ParamLocal::string_function(
+                crate::plan::StringFunctionLocalId(*next_string_function),
+                type_.clone(),
+            );
+            *next_string_function += 1;
+            Ok(local)
+        }
+        ValueType::Bool => {
+            let local = ParamLocal::bool_function(
+                crate::plan::BoolFunctionLocalId(*next_bool_function),
+                type_.clone(),
+            );
+            *next_bool_function += 1;
+            Ok(local)
+        }
+        ValueType::Nil => {
+            let local = ParamLocal::nil_function(
+                crate::plan::NilFunctionLocalId(*next_nil_function),
+                type_.clone(),
+            );
+            *next_nil_function += 1;
+            Ok(local)
+        }
+        ValueType::Function(_) => Err(PlanError::UnsupportedArgument {
+            function: function_name.clone(),
+            reason: UnsupportedArgumentReason::UnsupportedType,
+        }),
+    }
 }
 
 fn validate_main_function(main: FunctionToPlan) -> Result<FunctionToPlan, PlanError> {
@@ -265,21 +330,15 @@ fn validate_main_function(main: FunctionToPlan) -> Result<FunctionToPlan, PlanEr
     Ok(main)
 }
 
-fn reject_top_level(kind: UnsupportedTopLevelKind, count: usize) -> Result<(), PlanError> {
-    if count == 0 {
-        Ok(())
-    } else {
-        Err(PlanError::UnsupportedTopLevel { kind })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::plan_module;
+    use crate::plan::{FunctionType, ValueType};
     use crate::planner::dsl::{function, int, module};
     use crate::planner::support::{compile, expect_plan_error};
     use crate::planner::{
-        PlanError, UnsupportedArgumentReason, UnsupportedFunctionReason, UnsupportedTopLevelKind,
+        PlanError, UnsupportedArgumentReason, UnsupportedExpressionKind, UnsupportedFunctionReason,
+        UnsupportedTopLevelKind,
     };
 
     #[test]
@@ -392,6 +451,46 @@ fn values() {
     }
 
     #[test]
+    fn reject_profile_function_body_before_main() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+fn helper() -> Int {
+  panic
+}
+
+pub fn main() {
+  1
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Panic,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_profile_function_body_after_main() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  1
+}
+
+fn helper() -> Int {
+  panic
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Panic,
+            },
+        );
+    }
+
+    #[test]
     fn reject_profile_function_return_type_after_main_reference() {
         assert_eq!(
             expect_plan_error(
@@ -444,7 +543,37 @@ fn get() {
     }
 
     #[test]
-    fn reject_profile_function_argument_type() {
+    fn plan_function_argument_with_function_argument_type() {
+        let actual = plan_module(compile(
+            r#"
+pub fn main() {
+  1
+}
+
+fn higher(callback: fn(fn(Int) -> Int) -> Int) {
+  1
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", int(1)),
+            [function("higher", int(1)).param_int_function(
+                0,
+                "callback",
+                [ValueType::Function(Box::new(FunctionType::new(
+                    vec![ValueType::Int],
+                    ValueType::Int,
+                )))],
+            )],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_profile_unsupported_function_argument_type() {
         assert_eq!(
             expect_plan_error(
                 r#"
@@ -460,6 +589,63 @@ fn count(values: List(Int)) {
             PlanError::UnsupportedArgument {
                 function: "count".into(),
                 reason: UnsupportedArgumentReason::UnsupportedType,
+            },
+        );
+
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  1
+}
+
+fn higher(callback: fn() -> fn(Int) -> Int) {
+  1
+}
+"#,
+            ),
+            PlanError::UnsupportedArgument {
+                function: "higher".into(),
+                reason: UnsupportedArgumentReason::UnsupportedType,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_profile_function_argument_name_shape() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+fn helper(_: Int) {
+  1
+}
+
+pub fn main() {
+  helper(1)
+}
+"#,
+            ),
+            PlanError::UnsupportedArgument {
+                function: "helper".into(),
+                reason: UnsupportedArgumentReason::Discard,
+            },
+        );
+
+        assert_eq!(
+            expect_plan_error(
+                r#"
+fn identity(value value: Int) {
+  value
+}
+
+pub fn main() {
+  identity(1)
+}
+"#,
+            ),
+            PlanError::UnsupportedArgument {
+                function: "identity".into(),
+                reason: UnsupportedArgumentReason::Labelled,
             },
         );
     }

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -1,5 +1,6 @@
 use crate::plan::{
-    ExecutionPlan, FunctionId, IntFunctionLocalId, ParamLocal, RuntimeFunctionId, ValueType,
+    ExecutionPlan, FunctionId, FunctionType, IntFunctionLocalId, ParamLocal, RuntimeFunctionId,
+    ValueType,
 };
 use crate::planner::context::{FunctionInfo, FunctionParam, FunctionRuntimeIds};
 use crate::planner::error::{
@@ -275,7 +276,7 @@ fn function_params(
 
 fn function_param_local(
     function_name: &EcoString,
-    type_: &crate::plan::FunctionType,
+    type_: &FunctionType,
     next_int_function: &mut usize,
     next_string_function: &mut usize,
     next_bool_function: &mut usize,
@@ -283,12 +284,14 @@ fn function_param_local(
 ) -> Result<ParamLocal, PlanError> {
     match type_.return_() {
         ValueType::Int => {
+            validate_function_argument_types(function_name, type_)?;
             let local =
                 ParamLocal::int_function(IntFunctionLocalId(*next_int_function), type_.clone());
             *next_int_function += 1;
             Ok(local)
         }
         ValueType::String => {
+            validate_function_argument_types(function_name, type_)?;
             let local = ParamLocal::string_function(
                 crate::plan::StringFunctionLocalId(*next_string_function),
                 type_.clone(),
@@ -297,6 +300,7 @@ fn function_param_local(
             Ok(local)
         }
         ValueType::Bool => {
+            validate_function_argument_types(function_name, type_)?;
             let local = ParamLocal::bool_function(
                 crate::plan::BoolFunctionLocalId(*next_bool_function),
                 type_.clone(),
@@ -305,6 +309,7 @@ fn function_param_local(
             Ok(local)
         }
         ValueType::Nil => {
+            validate_function_argument_types(function_name, type_)?;
             let local = ParamLocal::nil_function(
                 crate::plan::NilFunctionLocalId(*next_nil_function),
                 type_.clone(),
@@ -312,10 +317,34 @@ fn function_param_local(
             *next_nil_function += 1;
             Ok(local)
         }
-        ValueType::Function(_) => Err(PlanError::UnsupportedArgument {
-            function: function_name.clone(),
-            reason: UnsupportedArgumentReason::UnsupportedType,
-        }),
+        ValueType::Function(_) => Err(unsupported_function_returning_function(function_name)),
+    }
+}
+
+fn validate_function_argument_types(
+    function_name: &EcoString,
+    type_: &FunctionType,
+) -> Result<(), PlanError> {
+    for argument in type_.argument_types() {
+        if let ValueType::Function(type_) = argument {
+            match type_.return_() {
+                ValueType::Int | ValueType::String | ValueType::Bool | ValueType::Nil => {}
+                ValueType::Function(_) => {
+                    return Err(unsupported_function_returning_function(function_name));
+                }
+            }
+
+            validate_function_argument_types(function_name, type_)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn unsupported_function_returning_function(function_name: &EcoString) -> PlanError {
+    PlanError::UnsupportedArgument {
+        function: function_name.clone(),
+        reason: UnsupportedArgumentReason::FunctionReturningFunction,
     }
 }
 
@@ -606,7 +635,25 @@ fn higher(callback: fn() -> fn(Int) -> Int) {
             ),
             PlanError::UnsupportedArgument {
                 function: "higher".into(),
-                reason: UnsupportedArgumentReason::UnsupportedType,
+                reason: UnsupportedArgumentReason::FunctionReturningFunction,
+            },
+        );
+
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  1
+}
+
+fn higher(callback: fn(fn() -> fn(Int) -> Int) -> Int) {
+  1
+}
+"#,
+            ),
+            PlanError::UnsupportedArgument {
+                function: "higher".into(),
+                reason: UnsupportedArgumentReason::FunctionReturningFunction,
             },
         );
     }

--- a/src/planner/statement.rs
+++ b/src/planner/statement.rs
@@ -53,8 +53,8 @@ fn plan_ordered_steps_and_return(
             });
         }
         Statement::Use(_) => {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::UseStatement,
+            return Err(PlanError::UnsupportedStatement {
+                kind: UnsupportedStatementKind::Use,
             });
         }
         Statement::Assert(_) => {
@@ -386,9 +386,8 @@ fn pair(callback: fn() -> Int) {
 }
 "#,
             ),
-            PlanError::UnsupportedArgument {
-                function: "pair".into(),
-                reason: crate::planner::UnsupportedArgumentReason::UnsupportedType,
+            PlanError::UnsupportedStatement {
+                kind: UnsupportedStatementKind::Use,
             },
         );
     }
@@ -408,24 +407,6 @@ fn pair(callback: fn() -> Int) {
         ];
         assert_eq!(
             plan_module(step_use),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::UseStatement,
-            }),
-        );
-    }
-
-    #[test]
-    fn reject_margin_final_use_statement_shape() {
-        let mut final_use = compile_minimal_module();
-        final_use.definitions.functions[0].body = vec![Statement::Use(gleam_core::ast::Use {
-            call: Box::new(typed_int_expr(1)),
-            location: dummy_span(),
-            right_hand_side_location: dummy_span(),
-            assignments_location: dummy_span(),
-            assignments: Vec::new(),
-        })];
-        assert_eq!(
-            plan_module(final_use),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::UseStatement,
             }),

--- a/src/runtime/expression/function.rs
+++ b/src/runtime/expression/function.rs
@@ -188,11 +188,11 @@ mod tests {
         eval_nil_function_expr, eval_string_function_expr,
     };
     use crate::plan::{
-        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, BoolLocalId, ExecutionPlan,
-        Expr, FunctionArgumentType, FunctionExpr, FunctionId, FunctionPlan, FunctionType,
-        FunctionValue, IntExpr, IntFunctionExpr, IntFunctionId, IntFunctionValue, IntLocalId,
-        LocalId, NilFunctionExpr, NilFunctionId, NilFunctionValue, NilLocalId, RuntimeFunctionId,
-        Step, StringFunctionExpr, StringFunctionId, StringFunctionValue, StringLocalId, ValueType,
+        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, ExecutionPlan, Expr,
+        FunctionExpr, FunctionId, FunctionPlan, FunctionType, FunctionValue, IntExpr,
+        IntFunctionExpr, IntFunctionId, IntFunctionValue, IntLocalId, NilFunctionExpr,
+        NilFunctionId, NilFunctionValue, NilLocalId, ParamLocal, RuntimeFunctionId, Step,
+        StringFunctionExpr, StringFunctionId, StringFunctionValue, StringLocalId, ValueType,
     };
     use crate::runtime::frame::Frame;
     use num_bigint::BigInt;
@@ -505,7 +505,7 @@ mod tests {
 
         assert_eq!(
             type_,
-            FunctionType::new(vec![FunctionArgumentType::Int], ValueType::Int),
+            FunctionType::new(vec![ValueType::Int], ValueType::Int),
         );
         assert_eq!(type_.return_(), &ValueType::Int);
     }
@@ -513,84 +513,84 @@ mod tests {
     fn function_value() -> FunctionValue {
         FunctionValue::new(
             RuntimeFunctionId::Int(IntFunctionId(0)),
-            vec![LocalId::Int(IntLocalId(0))],
+            vec![ParamLocal::int(IntLocalId(0))],
         )
     }
 
     fn string_function_value() -> FunctionValue {
         FunctionValue::new(
             RuntimeFunctionId::String(StringFunctionId(0)),
-            vec![LocalId::String(StringLocalId(0))],
+            vec![ParamLocal::string(StringLocalId(0))],
         )
     }
 
     fn bool_function_value() -> FunctionValue {
         FunctionValue::new(
             RuntimeFunctionId::Bool(BoolFunctionId(0)),
-            vec![LocalId::Bool(BoolLocalId(0))],
+            vec![ParamLocal::bool(crate::plan::BoolLocalId(0))],
         )
     }
 
     fn nil_function_value() -> FunctionValue {
         FunctionValue::new(
             RuntimeFunctionId::Nil(NilFunctionId(0)),
-            vec![LocalId::Nil(NilLocalId(0))],
+            vec![ParamLocal::nil(NilLocalId(0))],
         )
     }
 
     fn int_function_value() -> IntFunctionExpr {
         IntFunctionExpr::value(IntFunctionValue::new(
             IntFunctionId(0),
-            vec![LocalId::Int(IntLocalId(0))],
+            vec![ParamLocal::int(IntLocalId(0))],
         ))
     }
 
     fn other_int_function_value() -> IntFunctionExpr {
         IntFunctionExpr::value(IntFunctionValue::new(
             IntFunctionId(1),
-            vec![LocalId::Int(IntLocalId(0))],
+            vec![ParamLocal::int(IntLocalId(0))],
         ))
     }
 
     fn string_function_expr() -> StringFunctionExpr {
         StringFunctionExpr::value(StringFunctionValue::new(
             StringFunctionId(0),
-            vec![LocalId::String(StringLocalId(0))],
+            vec![ParamLocal::string(StringLocalId(0))],
         ))
     }
 
     fn other_string_function_expr() -> StringFunctionExpr {
         StringFunctionExpr::value(StringFunctionValue::new(
             StringFunctionId(1),
-            vec![LocalId::String(StringLocalId(0))],
+            vec![ParamLocal::string(StringLocalId(0))],
         ))
     }
 
     fn bool_function_expr() -> BoolFunctionExpr {
         BoolFunctionExpr::value(BoolFunctionValue::new(
             BoolFunctionId(0),
-            vec![LocalId::Bool(BoolLocalId(0))],
+            vec![ParamLocal::bool(crate::plan::BoolLocalId(0))],
         ))
     }
 
     fn other_bool_function_expr() -> BoolFunctionExpr {
         BoolFunctionExpr::value(BoolFunctionValue::new(
             BoolFunctionId(1),
-            vec![LocalId::Bool(BoolLocalId(0))],
+            vec![ParamLocal::bool(crate::plan::BoolLocalId(0))],
         ))
     }
 
     fn nil_function_expr() -> NilFunctionExpr {
         NilFunctionExpr::value(NilFunctionValue::new(
             NilFunctionId(0),
-            vec![LocalId::Nil(NilLocalId(0))],
+            vec![ParamLocal::nil(NilLocalId(0))],
         ))
     }
 
     fn other_nil_function_expr() -> NilFunctionExpr {
         NilFunctionExpr::value(NilFunctionValue::new(
             NilFunctionId(1),
-            vec![LocalId::Nil(NilLocalId(0))],
+            vec![ParamLocal::nil(NilLocalId(0))],
         ))
     }
 }

--- a/src/runtime/frame.rs
+++ b/src/runtime/frame.rs
@@ -114,9 +114,9 @@ mod tests {
     use super::Frame;
     use crate::plan::{
         BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue, BoolLocalId, FrameLayout,
-        IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId, LocalId, NilFunctionId,
-        NilFunctionLocalId, NilFunctionValue, NilLocalId, StringFunctionId, StringFunctionLocalId,
-        StringFunctionValue, StringLocalId,
+        IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId, NilFunctionId,
+        NilFunctionLocalId, NilFunctionValue, NilLocalId, ParamLocal, StringFunctionId,
+        StringFunctionLocalId, StringFunctionValue, StringLocalId,
     };
     use num_bigint::BigInt;
 
@@ -196,22 +196,25 @@ mod tests {
     }
 
     fn int_function_value() -> IntFunctionValue {
-        IntFunctionValue::new(IntFunctionId(0), vec![LocalId::Int(IntLocalId(0))])
+        IntFunctionValue::new(IntFunctionId(0), vec![ParamLocal::int(IntLocalId(0))])
     }
 
     fn other_int_function_value() -> IntFunctionValue {
-        IntFunctionValue::new(IntFunctionId(1), vec![LocalId::Int(IntLocalId(0))])
+        IntFunctionValue::new(IntFunctionId(1), vec![ParamLocal::int(IntLocalId(0))])
     }
 
     fn string_function_value() -> StringFunctionValue {
-        StringFunctionValue::new(StringFunctionId(0), vec![LocalId::String(StringLocalId(0))])
+        StringFunctionValue::new(
+            StringFunctionId(0),
+            vec![ParamLocal::string(StringLocalId(0))],
+        )
     }
 
     fn bool_function_value() -> BoolFunctionValue {
-        BoolFunctionValue::new(BoolFunctionId(0), vec![LocalId::Bool(BoolLocalId(0))])
+        BoolFunctionValue::new(BoolFunctionId(0), vec![ParamLocal::bool(BoolLocalId(0))])
     }
 
     fn nil_function_value() -> NilFunctionValue {
-        NilFunctionValue::new(NilFunctionId(0), vec![LocalId::Int(IntLocalId(0))])
+        NilFunctionValue::new(NilFunctionId(0), vec![ParamLocal::int(IntLocalId(0))])
     }
 }

--- a/src/runtime/function.rs
+++ b/src/runtime/function.rs
@@ -1,7 +1,8 @@
 use crate::plan::{
     BoolFunctionId, CallArg, CallArgKind, ExecutionPlan, FrameLayout, IntFunctionId, NilFunctionId,
-    RuntimeFunctionId, StepKind, StringFunctionId, Value,
+    ParamLocal, RuntimeFunctionId, StepKind, StringFunctionId, Value,
 };
+use crate::plan::{FunctionCallArg, FunctionCallArgKind};
 use crate::runtime::expression::{
     eval_bool_expr, eval_bool_function_expr, eval_expr, eval_int_expr, eval_int_function_expr,
     eval_nil_expr, eval_nil_function_expr, eval_string_expr, eval_string_function_expr,
@@ -149,50 +150,271 @@ fn bind_arguments(
                 eval_nil_expr(plan, caller_frame, value);
                 frame.set_nil(*local);
             }
+            CallArgKind::IntFunction { local, value } => {
+                let value = eval_int_function_expr(plan, caller_frame, value);
+                frame.set_int_function(*local, value);
+            }
+            CallArgKind::StringFunction { local, value } => {
+                let value = eval_string_function_expr(plan, caller_frame, value);
+                frame.set_string_function(*local, value);
+            }
+            CallArgKind::BoolFunction { local, value } => {
+                let value = eval_bool_function_expr(plan, caller_frame, value);
+                frame.set_bool_function(*local, value);
+            }
+            CallArgKind::NilFunction { local, value } => {
+                let value = eval_nil_function_expr(plan, caller_frame, value);
+                frame.set_nil_function(*local, value);
+            }
         }
     }
 
     frame
 }
 
+fn bind_function_value_arguments(
+    plan: &ExecutionPlan,
+    args: &[FunctionCallArg],
+    params: &[ParamLocal],
+    caller_frame: &mut Frame,
+    frame_layout: FrameLayout,
+) -> Frame {
+    let mut frame = Frame::new(frame_layout);
+
+    for (arg, param) in args.iter().zip(params) {
+        match param {
+            ParamLocal::Int(local) => {
+                bind_int_function_value_argument(plan, arg, *local, caller_frame, &mut frame);
+            }
+            ParamLocal::String(local) => {
+                bind_string_function_value_argument(plan, arg, *local, caller_frame, &mut frame);
+            }
+            ParamLocal::Bool(local) => {
+                bind_bool_function_value_argument(plan, arg, *local, caller_frame, &mut frame);
+            }
+            ParamLocal::Nil(local) => {
+                bind_nil_function_value_argument(plan, arg, *local, caller_frame, &mut frame);
+            }
+            ParamLocal::IntFunction { local, .. } => {
+                bind_int_function_value_function_argument(
+                    plan,
+                    arg,
+                    *local,
+                    caller_frame,
+                    &mut frame,
+                );
+            }
+            ParamLocal::StringFunction { local, .. } => {
+                bind_string_function_value_function_argument(
+                    plan,
+                    arg,
+                    *local,
+                    caller_frame,
+                    &mut frame,
+                );
+            }
+            ParamLocal::BoolFunction { local, .. } => {
+                bind_bool_function_value_function_argument(
+                    plan,
+                    arg,
+                    *local,
+                    caller_frame,
+                    &mut frame,
+                );
+            }
+            ParamLocal::NilFunction { local, .. } => {
+                bind_nil_function_value_function_argument(
+                    plan,
+                    arg,
+                    *local,
+                    caller_frame,
+                    &mut frame,
+                );
+            }
+        }
+    }
+
+    frame
+}
+
+fn bind_int_function_value_argument(
+    plan: &ExecutionPlan,
+    arg: &FunctionCallArg,
+    local: crate::plan::IntLocalId,
+    caller_frame: &mut Frame,
+    frame: &mut Frame,
+) {
+    if let FunctionCallArgKind::Int(value) = arg.kind() {
+        let value = eval_int_expr(plan, caller_frame, value);
+        frame.set_int(local, value);
+    }
+}
+
+fn bind_string_function_value_argument(
+    plan: &ExecutionPlan,
+    arg: &FunctionCallArg,
+    local: crate::plan::StringLocalId,
+    caller_frame: &mut Frame,
+    frame: &mut Frame,
+) {
+    if let FunctionCallArgKind::String(value) = arg.kind() {
+        let value = eval_string_expr(plan, caller_frame, value);
+        frame.set_string(local, value);
+    }
+}
+
+fn bind_bool_function_value_argument(
+    plan: &ExecutionPlan,
+    arg: &FunctionCallArg,
+    local: crate::plan::BoolLocalId,
+    caller_frame: &mut Frame,
+    frame: &mut Frame,
+) {
+    if let FunctionCallArgKind::Bool(value) = arg.kind() {
+        let value = eval_bool_expr(plan, caller_frame, value);
+        frame.set_bool(local, value);
+    }
+}
+
+fn bind_nil_function_value_argument(
+    plan: &ExecutionPlan,
+    arg: &FunctionCallArg,
+    local: crate::plan::NilLocalId,
+    caller_frame: &mut Frame,
+    frame: &mut Frame,
+) {
+    if let FunctionCallArgKind::Nil(value) = arg.kind() {
+        eval_nil_expr(plan, caller_frame, value);
+        frame.set_nil(local);
+    }
+}
+
+fn bind_int_function_value_function_argument(
+    plan: &ExecutionPlan,
+    arg: &FunctionCallArg,
+    local: crate::plan::IntFunctionLocalId,
+    caller_frame: &mut Frame,
+    frame: &mut Frame,
+) {
+    if let FunctionCallArgKind::IntFunction(value) = arg.kind() {
+        let value = eval_int_function_expr(plan, caller_frame, value);
+        frame.set_int_function(local, value);
+    }
+}
+
+fn bind_string_function_value_function_argument(
+    plan: &ExecutionPlan,
+    arg: &FunctionCallArg,
+    local: crate::plan::StringFunctionLocalId,
+    caller_frame: &mut Frame,
+    frame: &mut Frame,
+) {
+    if let FunctionCallArgKind::StringFunction(value) = arg.kind() {
+        let value = eval_string_function_expr(plan, caller_frame, value);
+        frame.set_string_function(local, value);
+    }
+}
+
+fn bind_bool_function_value_function_argument(
+    plan: &ExecutionPlan,
+    arg: &FunctionCallArg,
+    local: crate::plan::BoolFunctionLocalId,
+    caller_frame: &mut Frame,
+    frame: &mut Frame,
+) {
+    if let FunctionCallArgKind::BoolFunction(value) = arg.kind() {
+        let value = eval_bool_function_expr(plan, caller_frame, value);
+        frame.set_bool_function(local, value);
+    }
+}
+
+fn bind_nil_function_value_function_argument(
+    plan: &ExecutionPlan,
+    arg: &FunctionCallArg,
+    local: crate::plan::NilFunctionLocalId,
+    caller_frame: &mut Frame,
+    frame: &mut Frame,
+) {
+    if let FunctionCallArgKind::NilFunction(value) = arg.kind() {
+        let value = eval_nil_function_expr(plan, caller_frame, value);
+        frame.set_nil_function(local, value);
+    }
+}
+
 pub(in crate::runtime) fn run_int_function_call(
     plan: &ExecutionPlan,
     function: &crate::plan::IntFunctionExpr,
-    args: &[CallArg],
+    args: &[FunctionCallArg],
     caller_frame: &mut Frame,
 ) -> BigInt {
     let function = eval_int_function_expr(plan, caller_frame, function);
-    run_int_call(plan, function.runtime_id(), args, caller_frame)
+    let runtime_function = plan.int_function(function.runtime_id());
+    let mut frame = bind_function_value_arguments(
+        plan,
+        args,
+        function.params(),
+        caller_frame,
+        runtime_function.frame_layout(),
+    );
+    execute_steps(plan, runtime_function.steps(), &mut frame);
+    eval_int_expr(plan, &mut frame, runtime_function.return_())
 }
 
 pub(in crate::runtime) fn run_string_function_call(
     plan: &ExecutionPlan,
     function: &crate::plan::StringFunctionExpr,
-    args: &[CallArg],
+    args: &[FunctionCallArg],
     caller_frame: &mut Frame,
 ) -> EcoString {
     let function = eval_string_function_expr(plan, caller_frame, function);
-    run_string_call(plan, function.runtime_id(), args, caller_frame)
+    let runtime_function = plan.string_function(function.runtime_id());
+    let mut frame = bind_function_value_arguments(
+        plan,
+        args,
+        function.params(),
+        caller_frame,
+        runtime_function.frame_layout(),
+    );
+    execute_steps(plan, runtime_function.steps(), &mut frame);
+    eval_string_expr(plan, &mut frame, runtime_function.return_())
 }
 
 pub(in crate::runtime) fn run_bool_function_call(
     plan: &ExecutionPlan,
     function: &crate::plan::BoolFunctionExpr,
-    args: &[CallArg],
+    args: &[FunctionCallArg],
     caller_frame: &mut Frame,
 ) -> bool {
     let function = eval_bool_function_expr(plan, caller_frame, function);
-    run_bool_call(plan, function.runtime_id(), args, caller_frame)
+    let runtime_function = plan.bool_function(function.runtime_id());
+    let mut frame = bind_function_value_arguments(
+        plan,
+        args,
+        function.params(),
+        caller_frame,
+        runtime_function.frame_layout(),
+    );
+    execute_steps(plan, runtime_function.steps(), &mut frame);
+    eval_bool_expr(plan, &mut frame, runtime_function.return_())
 }
 
 pub(in crate::runtime) fn run_nil_function_call(
     plan: &ExecutionPlan,
     function: &crate::plan::NilFunctionExpr,
-    args: &[CallArg],
+    args: &[FunctionCallArg],
     caller_frame: &mut Frame,
 ) {
     let function = eval_nil_function_expr(plan, caller_frame, function);
-    run_nil_call(plan, function.runtime_id(), args, caller_frame);
+    let runtime_function = plan.nil_function(function.runtime_id());
+    let mut frame = bind_function_value_arguments(
+        plan,
+        args,
+        function.params(),
+        caller_frame,
+        runtime_function.frame_layout(),
+    );
+    execute_steps(plan, runtime_function.steps(), &mut frame);
+    eval_nil_expr(plan, &mut frame, runtime_function.return_());
 }
 
 #[cfg(test)]

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -10,6 +10,15 @@ macro_rules! execution_case {
     };
 }
 
+macro_rules! rejection_case {
+    ($name:ident, $fixture:literal) => {
+        #[test]
+        fn $name() {
+            reject_fixture($fixture);
+        }
+    };
+}
+
 execution_case!(integer_return, "integer_return.gleam");
 execution_case!(integer_arithmetic, "integer_arithmetic.gleam");
 execution_case!(integer_comparison, "integer_comparison.gleam");
@@ -24,7 +33,36 @@ execution_case!(bool_case_fallback, "bool_case_fallback.gleam");
 execution_case!(int_case, "int_case.gleam");
 execution_case!(block_expression, "block_expression.gleam");
 execution_case!(pipeline, "pipeline.gleam");
+execution_case!(function_after_main, "function_after_main.gleam");
 execution_case!(function_value_local, "function_value_local.gleam");
+execution_case!(
+    function_value_argument_callback,
+    "function_value_argument_callback.gleam"
+);
+execution_case!(
+    function_value_argument_higher_order_alias,
+    "function_value_argument_higher_order_alias.gleam"
+);
+execution_case!(
+    function_value_argument_higher_order_return_shapes,
+    "function_value_argument_higher_order_return_shapes.gleam"
+);
+execution_case!(
+    function_value_argument_input_shapes,
+    "function_value_argument_input_shapes.gleam"
+);
+execution_case!(
+    function_value_argument_local_value,
+    "function_value_argument_local_value.gleam"
+);
+execution_case!(
+    function_value_argument_multi_arity,
+    "function_value_argument_multi_arity.gleam"
+);
+execution_case!(
+    function_value_argument_return_shapes,
+    "function_value_argument_return_shapes.gleam"
+);
 execution_case!(function_value_shadowing, "function_value_shadowing.gleam");
 execution_case!(
     function_value_block_callee,
@@ -36,6 +74,36 @@ execution_case!(
 );
 execution_case!(nil_value, "nil_value.gleam");
 
+rejection_case!(reject_top_level_import, "top_level_import.gleam");
+rejection_case!(reject_top_level_constant, "top_level_constant.gleam");
+rejection_case!(reject_top_level_custom_type, "top_level_custom_type.gleam");
+rejection_case!(reject_top_level_type_alias, "top_level_type_alias.gleam");
+rejection_case!(reject_missing_main, "missing_main.gleam");
+rejection_case!(reject_main_with_arguments, "main_with_arguments.gleam");
+rejection_case!(
+    reject_function_unsupported_return_type,
+    "function_unsupported_return_type.gleam"
+);
+rejection_case!(reject_argument_discard, "argument_discard.gleam");
+rejection_case!(reject_argument_labelled, "argument_labelled.gleam");
+rejection_case!(
+    reject_argument_unsupported_type,
+    "argument_unsupported_type.gleam"
+);
+rejection_case!(
+    reject_argument_function_return_shape,
+    "argument_function_return_shape.gleam"
+);
+rejection_case!(
+    reject_function_before_main_unsupported_body,
+    "function_before_main_unsupported_body.gleam"
+);
+rejection_case!(reject_main_unsupported_body, "main_unsupported_body.gleam");
+rejection_case!(
+    reject_function_after_main_unsupported_body,
+    "function_after_main_unsupported_body.gleam"
+);
+
 fn run_fixture(file_name: &str) {
     let path = format!("tests/fixtures/execution/{file_name}");
     let src = std::fs::read_to_string(&path).expect("fixture should be readable");
@@ -45,6 +113,14 @@ fn run_fixture(file_name: &str) {
     let actual = run_main(&plan);
 
     assert_eq!(actual, expected);
+}
+
+fn reject_fixture(file_name: &str) {
+    let path = format!("tests/fixtures/rejection/{file_name}");
+    let src = std::fs::read_to_string(&path).expect("fixture should be readable");
+    let module = compile_typed_module("main", path, &src).expect("fixture should compile");
+
+    assert!(plan_module(module).is_err());
 }
 
 fn parse_expected_value(src: &str) -> Value {

--- a/tests/fixtures/execution/function_after_main.gleam
+++ b/tests/fixtures/execution/function_after_main.gleam
@@ -1,0 +1,13 @@
+pub fn main() {
+  after_main(41)
+}
+
+fn after_main(value: Int) {
+  value + 1
+}
+
+pub fn after_main_unused() {
+  1
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/function_value_argument_callback.gleam
+++ b/tests/fixtures/execution/function_value_argument_callback.gleam
@@ -1,0 +1,13 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn apply_int(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  apply_int(add_one, 41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/function_value_argument_higher_order_alias.gleam
+++ b/tests/fixtures/execution/function_value_argument_higher_order_alias.gleam
@@ -1,0 +1,15 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn apply_int(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  let apply_alias = apply_int
+
+  apply_alias(add_one, 41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/function_value_argument_higher_order_return_shapes.gleam
+++ b/tests/fixtures/execution/function_value_argument_higher_order_return_shapes.gleam
@@ -1,0 +1,46 @@
+fn int_to_string(value: Int) {
+  case value == 1 {
+    True -> "one"
+    False -> "other"
+  }
+}
+
+fn int_to_bool(value: Int) {
+  value == 1
+}
+
+fn int_to_nil(value: Int) {
+  case value == 0 {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+fn apply_int_to_string(function: fn(Int) -> String, value: Int) {
+  function(value)
+}
+
+fn apply_int_to_bool(function: fn(Int) -> Bool, value: Int) {
+  function(value)
+}
+
+fn apply_int_to_nil(function: fn(Int) -> Nil, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  let string_apply_alias = apply_int_to_string
+  let bool_apply_alias = apply_int_to_bool
+  let nil_apply_alias = apply_int_to_nil
+  let string_result = string_apply_alias(int_to_string, 1)
+  let bool_result = bool_apply_alias(int_to_bool, 1)
+
+  nil_apply_alias(int_to_nil, 0)
+
+  case string_result == "one" && bool_result {
+    True -> 42
+    False -> 0
+  }
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/function_value_argument_input_shapes.gleam
+++ b/tests/fixtures/execution/function_value_argument_input_shapes.gleam
@@ -1,0 +1,37 @@
+fn append_suffix(value: String) {
+  value <> "-arg"
+}
+
+fn invert(value: Bool) {
+  !value
+}
+
+fn accept_nil(value: Nil) {
+  value
+}
+
+fn apply_string(function: fn(String) -> String, value: String) {
+  function(value)
+}
+
+fn apply_bool(function: fn(Bool) -> Bool, value: Bool) {
+  function(value)
+}
+
+fn apply_nil(function: fn(Nil) -> Nil, value: Nil) {
+  function(value)
+}
+
+pub fn main() {
+  let string_result = apply_string(append_suffix, "geam")
+  let bool_result = apply_bool(invert, False)
+
+  apply_nil(accept_nil, Nil)
+
+  case string_result == "geam-arg" && bool_result {
+    True -> 42
+    False -> 0
+  }
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/function_value_argument_local_value.gleam
+++ b/tests/fixtures/execution/function_value_argument_local_value.gleam
@@ -1,0 +1,15 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn apply_int(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  let add = add_one
+
+  apply_int(add, 41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/function_value_argument_multi_arity.gleam
+++ b/tests/fixtures/execution/function_value_argument_multi_arity.gleam
@@ -1,0 +1,13 @@
+fn add_pair(left: Int, right: Int) {
+  left + right
+}
+
+fn apply_int_pair(function: fn(Int, Int) -> Int, left: Int, right: Int) {
+  function(left, right)
+}
+
+pub fn main() {
+  apply_int_pair(add_pair, 20, 22)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/function_value_argument_return_shapes.gleam
+++ b/tests/fixtures/execution/function_value_argument_return_shapes.gleam
@@ -1,0 +1,43 @@
+fn int_to_string(value: Int) {
+  case value == 1 {
+    True -> "one"
+    False -> "other"
+  }
+}
+
+fn int_to_bool(value: Int) {
+  value == 1
+}
+
+fn int_to_nil(value: Int) {
+  case value == 0 {
+    True -> Nil
+    False -> Nil
+  }
+}
+
+fn apply_int_to_string(function: fn(Int) -> String, value: Int) {
+  function(value)
+}
+
+fn apply_int_to_bool(function: fn(Int) -> Bool, value: Int) {
+  function(value)
+}
+
+fn apply_int_to_nil(function: fn(Int) -> Nil, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  let string_result = apply_int_to_string(int_to_string, 1)
+  let bool_result = apply_int_to_bool(int_to_bool, 1)
+
+  apply_int_to_nil(int_to_nil, 0)
+
+  case string_result == "one" && bool_result {
+    True -> 42
+    False -> 0
+  }
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/rejection/argument_discard.gleam
+++ b/tests/fixtures/rejection/argument_discard.gleam
@@ -1,0 +1,7 @@
+fn helper(_: Int) {
+  1
+}
+
+pub fn main() {
+  helper(1)
+}

--- a/tests/fixtures/rejection/argument_function_return_shape.gleam
+++ b/tests/fixtures/rejection/argument_function_return_shape.gleam
@@ -1,0 +1,7 @@
+pub fn main() {
+  1
+}
+
+fn higher(callback: fn() -> fn(Int) -> Int) {
+  1
+}

--- a/tests/fixtures/rejection/argument_labelled.gleam
+++ b/tests/fixtures/rejection/argument_labelled.gleam
@@ -1,0 +1,7 @@
+fn identity(value value: Int) {
+  value
+}
+
+pub fn main() {
+  identity(1)
+}

--- a/tests/fixtures/rejection/argument_unsupported_type.gleam
+++ b/tests/fixtures/rejection/argument_unsupported_type.gleam
@@ -1,0 +1,7 @@
+pub fn main() {
+  1
+}
+
+fn count(values: List(Int)) {
+  1
+}

--- a/tests/fixtures/rejection/function_after_main_unsupported_body.gleam
+++ b/tests/fixtures/rejection/function_after_main_unsupported_body.gleam
@@ -1,0 +1,7 @@
+pub fn main() {
+  1
+}
+
+fn helper() -> Int {
+  panic
+}

--- a/tests/fixtures/rejection/function_before_main_unsupported_body.gleam
+++ b/tests/fixtures/rejection/function_before_main_unsupported_body.gleam
@@ -1,0 +1,7 @@
+fn helper() -> Int {
+  panic
+}
+
+pub fn main() {
+  1
+}

--- a/tests/fixtures/rejection/function_unsupported_return_type.gleam
+++ b/tests/fixtures/rejection/function_unsupported_return_type.gleam
@@ -1,0 +1,7 @@
+pub fn main() {
+  1
+}
+
+fn values() {
+  [1]
+}

--- a/tests/fixtures/rejection/main_unsupported_body.gleam
+++ b/tests/fixtures/rejection/main_unsupported_body.gleam
@@ -1,0 +1,3 @@
+pub fn main() -> Int {
+  panic
+}

--- a/tests/fixtures/rejection/main_with_arguments.gleam
+++ b/tests/fixtures/rejection/main_with_arguments.gleam
@@ -1,0 +1,3 @@
+pub fn main(value: Int) {
+  value
+}

--- a/tests/fixtures/rejection/missing_main.gleam
+++ b/tests/fixtures/rejection/missing_main.gleam
@@ -1,0 +1,3 @@
+pub fn other() {
+  1
+}

--- a/tests/fixtures/rejection/top_level_constant.gleam
+++ b/tests/fixtures/rejection/top_level_constant.gleam
@@ -1,0 +1,5 @@
+const answer = 42
+
+pub fn main() {
+  answer
+}

--- a/tests/fixtures/rejection/top_level_custom_type.gleam
+++ b/tests/fixtures/rejection/top_level_custom_type.gleam
@@ -1,0 +1,7 @@
+pub type Boxed {
+  Boxed(Int)
+}
+
+pub fn main() {
+  1
+}

--- a/tests/fixtures/rejection/top_level_import.gleam
+++ b/tests/fixtures/rejection/top_level_import.gleam
@@ -1,0 +1,5 @@
+import gleam
+
+pub fn main() {
+  1
+}

--- a/tests/fixtures/rejection/top_level_type_alias.gleam
+++ b/tests/fixtures/rejection/top_level_type_alias.gleam
@@ -1,0 +1,6 @@
+pub type UserId =
+  Int
+
+pub fn main() {
+  1
+}


### PR DESCRIPTION
- Allow supported function values and function-valued locals to flow into function-typed parameters.
- Add typed callback parameter plan/frame shapes and runtime binding for callback calls.
- Reject function-returning argument shapes until function-returning values enter the Geam profile.
- Add focused execution fixtures for callback arguments, local aliases, multi-arity callbacks, and input/return shape coverage.
- Refine planner rejection boundaries and review policy around fixture ownership and absence handling.

Refs #7