### PR TITLE
Prepare function return families

### DIFF
--- a/src/plan/expression/function.rs
+++ b/src/plan/expression/function.rs
@@ -1,39 +1,21 @@
-use super::{BoolExpr, IntExpr};
-use crate::plan::{
-    BoolFunctionLocalId, BoolFunctionValue, FunctionType, FunctionValue, FunctionValueKind,
-    IntFunctionLocalId, IntFunctionValue, NilFunctionLocalId, NilFunctionValue, Step,
-    StringFunctionLocalId, StringFunctionValue,
+mod bool;
+mod int;
+mod nil;
+mod string;
+
+use crate::plan::{FunctionType, FunctionValue, FunctionValueKind};
+
+pub use self::{
+    bool::BoolFunctionExpr, int::IntFunctionExpr, nil::NilFunctionExpr, string::StringFunctionExpr,
 };
-use ecow::EcoString;
-use num_bigint::BigInt;
+pub(crate) use self::{
+    bool::BoolFunctionExprKind, int::IntFunctionExprKind, nil::NilFunctionExprKind,
+    string::StringFunctionExprKind,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionExpr {
     kind: FunctionExprKind,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct IntFunctionExpr {
-    type_: FunctionType,
-    kind: IntFunctionExprKind,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct StringFunctionExpr {
-    type_: FunctionType,
-    kind: StringFunctionExprKind,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct BoolFunctionExpr {
-    type_: FunctionType,
-    kind: BoolFunctionExprKind,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct NilFunctionExpr {
-    type_: FunctionType,
-    kind: NilFunctionExprKind,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -42,98 +24,6 @@ pub(crate) enum FunctionExprKind {
     String(StringFunctionExpr),
     Bool(BoolFunctionExpr),
     Nil(NilFunctionExpr),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum IntFunctionExprKind {
-    Value(IntFunctionValue),
-    LocalGet {
-        local: IntFunctionLocalId,
-        name: EcoString,
-    },
-    BoolCase {
-        subject: Box<BoolExpr>,
-        true_: Box<IntFunctionExpr>,
-        false_: Box<IntFunctionExpr>,
-    },
-    IntCase {
-        subject: Box<IntExpr>,
-        clauses: Vec<(BigInt, IntFunctionExpr)>,
-        fallback: Box<IntFunctionExpr>,
-    },
-    Block {
-        steps: Vec<Step>,
-        return_: Box<IntFunctionExpr>,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum StringFunctionExprKind {
-    Value(StringFunctionValue),
-    LocalGet {
-        local: StringFunctionLocalId,
-        name: EcoString,
-    },
-    BoolCase {
-        subject: Box<BoolExpr>,
-        true_: Box<StringFunctionExpr>,
-        false_: Box<StringFunctionExpr>,
-    },
-    IntCase {
-        subject: Box<IntExpr>,
-        clauses: Vec<(BigInt, StringFunctionExpr)>,
-        fallback: Box<StringFunctionExpr>,
-    },
-    Block {
-        steps: Vec<Step>,
-        return_: Box<StringFunctionExpr>,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum BoolFunctionExprKind {
-    Value(BoolFunctionValue),
-    LocalGet {
-        local: BoolFunctionLocalId,
-        name: EcoString,
-    },
-    BoolCase {
-        subject: Box<BoolExpr>,
-        true_: Box<BoolFunctionExpr>,
-        false_: Box<BoolFunctionExpr>,
-    },
-    IntCase {
-        subject: Box<IntExpr>,
-        clauses: Vec<(BigInt, BoolFunctionExpr)>,
-        fallback: Box<BoolFunctionExpr>,
-    },
-    Block {
-        steps: Vec<Step>,
-        return_: Box<BoolFunctionExpr>,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum NilFunctionExprKind {
-    Value(NilFunctionValue),
-    LocalGet {
-        local: NilFunctionLocalId,
-        name: EcoString,
-    },
-    BoolCase {
-        subject: Box<BoolExpr>,
-        true_: Box<NilFunctionExpr>,
-        false_: Box<NilFunctionExpr>,
-    },
-    IntCase {
-        subject: Box<IntExpr>,
-        clauses: Vec<(BigInt, NilFunctionExpr)>,
-        fallback: Box<NilFunctionExpr>,
-    },
-    Block {
-        steps: Vec<Step>,
-        return_: Box<NilFunctionExpr>,
-    },
 }
 
 impl FunctionExpr {
@@ -218,278 +108,6 @@ impl FunctionExpr {
     }
 }
 
-impl IntFunctionExpr {
-    pub(crate) fn value(value: IntFunctionValue) -> Self {
-        Self {
-            type_: value.type_(),
-            kind: IntFunctionExprKind::Value(value),
-        }
-    }
-
-    pub(crate) fn local_get(
-        local: IntFunctionLocalId,
-        name: EcoString,
-        type_: FunctionType,
-    ) -> Self {
-        Self {
-            type_,
-            kind: IntFunctionExprKind::LocalGet { local, name },
-        }
-    }
-
-    pub(crate) fn bool_case(
-        subject: BoolExpr,
-        true_: IntFunctionExpr,
-        false_: IntFunctionExpr,
-    ) -> Self {
-        Self {
-            type_: true_.type_.clone(),
-            kind: IntFunctionExprKind::BoolCase {
-                subject: Box::new(subject),
-                true_: Box::new(true_),
-                false_: Box::new(false_),
-            },
-        }
-    }
-
-    pub(crate) fn int_case(
-        subject: IntExpr,
-        clauses: Vec<(BigInt, IntFunctionExpr)>,
-        fallback: IntFunctionExpr,
-    ) -> Self {
-        Self {
-            type_: fallback.type_.clone(),
-            kind: IntFunctionExprKind::IntCase {
-                subject: Box::new(subject),
-                clauses,
-                fallback: Box::new(fallback),
-            },
-        }
-    }
-
-    pub(crate) fn block(steps: Vec<Step>, return_: IntFunctionExpr) -> Self {
-        Self {
-            type_: return_.type_.clone(),
-            kind: IntFunctionExprKind::Block {
-                steps,
-                return_: Box::new(return_),
-            },
-        }
-    }
-
-    pub fn type_(&self) -> &FunctionType {
-        &self.type_
-    }
-
-    pub(crate) fn kind(&self) -> &IntFunctionExprKind {
-        &self.kind
-    }
-}
-
-impl StringFunctionExpr {
-    pub(crate) fn value(value: StringFunctionValue) -> Self {
-        Self {
-            type_: value.type_(),
-            kind: StringFunctionExprKind::Value(value),
-        }
-    }
-
-    pub(crate) fn local_get(
-        local: StringFunctionLocalId,
-        name: EcoString,
-        type_: FunctionType,
-    ) -> Self {
-        Self {
-            type_,
-            kind: StringFunctionExprKind::LocalGet { local, name },
-        }
-    }
-
-    pub(crate) fn bool_case(
-        subject: BoolExpr,
-        true_: StringFunctionExpr,
-        false_: StringFunctionExpr,
-    ) -> Self {
-        Self {
-            type_: true_.type_.clone(),
-            kind: StringFunctionExprKind::BoolCase {
-                subject: Box::new(subject),
-                true_: Box::new(true_),
-                false_: Box::new(false_),
-            },
-        }
-    }
-
-    pub(crate) fn int_case(
-        subject: IntExpr,
-        clauses: Vec<(BigInt, StringFunctionExpr)>,
-        fallback: StringFunctionExpr,
-    ) -> Self {
-        Self {
-            type_: fallback.type_.clone(),
-            kind: StringFunctionExprKind::IntCase {
-                subject: Box::new(subject),
-                clauses,
-                fallback: Box::new(fallback),
-            },
-        }
-    }
-
-    pub(crate) fn block(steps: Vec<Step>, return_: StringFunctionExpr) -> Self {
-        Self {
-            type_: return_.type_.clone(),
-            kind: StringFunctionExprKind::Block {
-                steps,
-                return_: Box::new(return_),
-            },
-        }
-    }
-
-    pub fn type_(&self) -> &FunctionType {
-        &self.type_
-    }
-
-    pub(crate) fn kind(&self) -> &StringFunctionExprKind {
-        &self.kind
-    }
-}
-
-impl BoolFunctionExpr {
-    pub(crate) fn value(value: BoolFunctionValue) -> Self {
-        Self {
-            type_: value.type_(),
-            kind: BoolFunctionExprKind::Value(value),
-        }
-    }
-
-    pub(crate) fn local_get(
-        local: BoolFunctionLocalId,
-        name: EcoString,
-        type_: FunctionType,
-    ) -> Self {
-        Self {
-            type_,
-            kind: BoolFunctionExprKind::LocalGet { local, name },
-        }
-    }
-
-    pub(crate) fn bool_case(
-        subject: BoolExpr,
-        true_: BoolFunctionExpr,
-        false_: BoolFunctionExpr,
-    ) -> Self {
-        Self {
-            type_: true_.type_.clone(),
-            kind: BoolFunctionExprKind::BoolCase {
-                subject: Box::new(subject),
-                true_: Box::new(true_),
-                false_: Box::new(false_),
-            },
-        }
-    }
-
-    pub(crate) fn int_case(
-        subject: IntExpr,
-        clauses: Vec<(BigInt, BoolFunctionExpr)>,
-        fallback: BoolFunctionExpr,
-    ) -> Self {
-        Self {
-            type_: fallback.type_.clone(),
-            kind: BoolFunctionExprKind::IntCase {
-                subject: Box::new(subject),
-                clauses,
-                fallback: Box::new(fallback),
-            },
-        }
-    }
-
-    pub(crate) fn block(steps: Vec<Step>, return_: BoolFunctionExpr) -> Self {
-        Self {
-            type_: return_.type_.clone(),
-            kind: BoolFunctionExprKind::Block {
-                steps,
-                return_: Box::new(return_),
-            },
-        }
-    }
-
-    pub fn type_(&self) -> &FunctionType {
-        &self.type_
-    }
-
-    pub(crate) fn kind(&self) -> &BoolFunctionExprKind {
-        &self.kind
-    }
-}
-
-impl NilFunctionExpr {
-    pub(crate) fn value(value: NilFunctionValue) -> Self {
-        Self {
-            type_: value.type_(),
-            kind: NilFunctionExprKind::Value(value),
-        }
-    }
-
-    pub(crate) fn local_get(
-        local: NilFunctionLocalId,
-        name: EcoString,
-        type_: FunctionType,
-    ) -> Self {
-        Self {
-            type_,
-            kind: NilFunctionExprKind::LocalGet { local, name },
-        }
-    }
-
-    pub(crate) fn bool_case(
-        subject: BoolExpr,
-        true_: NilFunctionExpr,
-        false_: NilFunctionExpr,
-    ) -> Self {
-        Self {
-            type_: true_.type_.clone(),
-            kind: NilFunctionExprKind::BoolCase {
-                subject: Box::new(subject),
-                true_: Box::new(true_),
-                false_: Box::new(false_),
-            },
-        }
-    }
-
-    pub(crate) fn int_case(
-        subject: IntExpr,
-        clauses: Vec<(BigInt, NilFunctionExpr)>,
-        fallback: NilFunctionExpr,
-    ) -> Self {
-        Self {
-            type_: fallback.type_.clone(),
-            kind: NilFunctionExprKind::IntCase {
-                subject: Box::new(subject),
-                clauses,
-                fallback: Box::new(fallback),
-            },
-        }
-    }
-
-    pub(crate) fn block(steps: Vec<Step>, return_: NilFunctionExpr) -> Self {
-        Self {
-            type_: return_.type_.clone(),
-            kind: NilFunctionExprKind::Block {
-                steps,
-                return_: Box::new(return_),
-            },
-        }
-    }
-
-    pub fn type_(&self) -> &FunctionType {
-        &self.type_
-    }
-
-    pub(crate) fn kind(&self) -> &NilFunctionExprKind {
-        &self.kind
-    }
-}
-
 impl From<IntFunctionExpr> for FunctionExpr {
     fn from(expression: IntFunctionExpr) -> Self {
         Self::int(expression)
@@ -517,15 +135,13 @@ impl From<NilFunctionExpr> for FunctionExpr {
 #[cfg(test)]
 mod tests {
     use super::{
-        BoolFunctionExpr, BoolFunctionExprKind, FunctionExpr, FunctionExprKind, IntFunctionExpr,
-        IntFunctionExprKind, NilFunctionExpr, NilFunctionExprKind, StringFunctionExpr,
-        StringFunctionExprKind,
+        BoolFunctionExpr, FunctionExpr, FunctionExprKind, IntFunctionExpr, NilFunctionExpr,
+        StringFunctionExpr,
     };
     use crate::plan::{
-        BoolExpr, BoolFunctionLocalId, BoolFunctionValue, Expr, FunctionType, FunctionValue,
-        IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId,
-        NilFunctionLocalId, NilFunctionValue, ParamLocal, RuntimeFunctionId, Step,
-        StringFunctionLocalId, StringFunctionValue, ValueType,
+        BoolFunctionId, BoolFunctionValue, FunctionValue, IntFunctionId, IntFunctionValue,
+        NilFunctionId, NilFunctionValue, ParamLocal, RuntimeFunctionId, StringFunctionId,
+        StringFunctionValue,
     };
 
     #[test]
@@ -593,178 +209,38 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn int_function_expr_kind_accessors() {
-        assert_eq!(
-            int_function_type(),
-            FunctionType::new(vec![crate::plan::ValueType::Int], ValueType::Int),
-        );
-        assert!(matches!(
-            IntFunctionExpr::local_get(IntFunctionLocalId(0), "f".into(), int_function_type(),)
-                .kind(),
-            IntFunctionExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
-            IntFunctionExpr::int_case(
-                IntExpr::value(1.into()),
-                vec![(1.into(), int_function_value())],
-                int_function_value(),
-            )
-            .kind(),
-            IntFunctionExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
-            IntFunctionExpr::block(
-                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
-                int_function_value(),
-            )
-            .kind(),
-            IntFunctionExprKind::Block { .. }
-        ));
-        assert!(matches!(
-            IntFunctionExpr::bool_case(
-                BoolExpr::value(true),
-                int_function_value(),
-                int_function_value(),
-            )
-            .kind(),
-            IntFunctionExprKind::BoolCase { .. }
-        ));
-    }
-
-    #[test]
-    fn string_bool_nil_function_expr_kind_accessors() {
-        assert!(matches!(
-            StringFunctionExpr::local_get(
-                StringFunctionLocalId(0),
-                "f".into(),
-                string_function_value().type_().clone(),
-            )
-            .kind(),
-            StringFunctionExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
-            StringFunctionExpr::bool_case(
-                BoolExpr::value(true),
-                string_function_value(),
-                string_function_value(),
-            )
-            .kind(),
-            StringFunctionExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
-            StringFunctionExpr::int_case(
-                IntExpr::value(1.into()),
-                vec![(1.into(), string_function_value())],
-                string_function_value(),
-            )
-            .kind(),
-            StringFunctionExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
-            StringFunctionExpr::block(Vec::new(), string_function_value()).kind(),
-            StringFunctionExprKind::Block { .. }
-        ));
-        assert!(matches!(
-            BoolFunctionExpr::local_get(
-                BoolFunctionLocalId(0),
-                "f".into(),
-                bool_function_value().type_().clone(),
-            )
-            .kind(),
-            BoolFunctionExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
-            BoolFunctionExpr::bool_case(
-                BoolExpr::value(true),
-                bool_function_value(),
-                bool_function_value(),
-            )
-            .kind(),
-            BoolFunctionExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
-            BoolFunctionExpr::int_case(
-                IntExpr::value(1.into()),
-                vec![(1.into(), bool_function_value())],
-                bool_function_value(),
-            )
-            .kind(),
-            BoolFunctionExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
-            BoolFunctionExpr::block(Vec::new(), bool_function_value()).kind(),
-            BoolFunctionExprKind::Block { .. }
-        ));
-        assert!(matches!(
-            NilFunctionExpr::local_get(
-                NilFunctionLocalId(0),
-                "f".into(),
-                nil_function_value().type_().clone(),
-            )
-            .kind(),
-            NilFunctionExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
-            NilFunctionExpr::bool_case(
-                BoolExpr::value(true),
-                nil_function_value(),
-                nil_function_value(),
-            )
-            .kind(),
-            NilFunctionExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
-            NilFunctionExpr::int_case(
-                IntExpr::value(1.into()),
-                vec![(1.into(), nil_function_value())],
-                nil_function_value(),
-            )
-            .kind(),
-            NilFunctionExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
-            NilFunctionExpr::block(Vec::new(), nil_function_value()).kind(),
-            NilFunctionExprKind::Block { .. }
-        ));
-    }
-
     fn function_value() -> FunctionValue {
-        FunctionValue::new(RuntimeFunctionId::Int(IntFunctionId(0)), vec![int_param(0)])
+        FunctionValue::new(
+            RuntimeFunctionId::Int(IntFunctionId(0)),
+            vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+        )
     }
 
     fn int_function_value() -> IntFunctionExpr {
-        IntFunctionExpr::value(IntFunctionValue::new(IntFunctionId(0), vec![int_param(0)]))
+        IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(0),
+            vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+        ))
     }
 
     fn string_function_value() -> StringFunctionExpr {
         StringFunctionExpr::value(StringFunctionValue::new(
-            crate::plan::StringFunctionId(0),
-            vec![crate::plan::ParamLocal::string(crate::plan::StringLocalId(
-                0,
-            ))],
+            StringFunctionId(0),
+            vec![ParamLocal::string(crate::plan::StringLocalId(0))],
         ))
     }
 
     fn bool_function_value() -> BoolFunctionExpr {
         BoolFunctionExpr::value(BoolFunctionValue::new(
-            crate::plan::BoolFunctionId(0),
-            vec![crate::plan::ParamLocal::bool(crate::plan::BoolLocalId(0))],
+            BoolFunctionId(0),
+            vec![ParamLocal::bool(crate::plan::BoolLocalId(0))],
         ))
     }
 
     fn nil_function_value() -> NilFunctionExpr {
         NilFunctionExpr::value(NilFunctionValue::new(
-            crate::plan::NilFunctionId(0),
-            vec![crate::plan::ParamLocal::nil(crate::plan::NilLocalId(0))],
+            NilFunctionId(0),
+            vec![ParamLocal::nil(crate::plan::NilLocalId(0))],
         ))
-    }
-
-    fn int_function_type() -> FunctionType {
-        FunctionType::new(vec![crate::plan::ValueType::Int], ValueType::Int)
-    }
-
-    fn int_param(index: usize) -> ParamLocal {
-        ParamLocal::int(IntLocalId(index))
     }
 }

--- a/src/plan/expression/function/bool.rs
+++ b/src/plan/expression/function/bool.rs
@@ -1,0 +1,155 @@
+use crate::plan::{BoolExpr, BoolFunctionLocalId, BoolFunctionValue, FunctionType, IntExpr, Step};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BoolFunctionExpr {
+    type_: FunctionType,
+    kind: BoolFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum BoolFunctionExprKind {
+    Value(BoolFunctionValue),
+    LocalGet {
+        local: BoolFunctionLocalId,
+        name: EcoString,
+    },
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<BoolFunctionExpr>,
+        false_: Box<BoolFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, BoolFunctionExpr)>,
+        fallback: Box<BoolFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<BoolFunctionExpr>,
+    },
+}
+
+impl BoolFunctionExpr {
+    pub(crate) fn value(value: BoolFunctionValue) -> Self {
+        Self {
+            type_: value.type_(),
+            kind: BoolFunctionExprKind::Value(value),
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: BoolFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: BoolFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: BoolFunctionExpr,
+        false_: BoolFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: BoolFunctionExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, BoolFunctionExpr)>,
+        fallback: BoolFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: BoolFunctionExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: BoolFunctionExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: BoolFunctionExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &BoolFunctionExprKind {
+        &self.kind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BoolFunctionExpr, BoolFunctionExprKind};
+    use crate::plan::{
+        BoolExpr, BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue, BoolLocalId, Expr,
+        FunctionType, IntExpr, ParamLocal, Step, ValueType,
+    };
+
+    #[test]
+    fn bool_function_expr_kind_accessors() {
+        assert!(matches!(
+            BoolFunctionExpr::local_get(BoolFunctionLocalId(0), "f".into(), function_type()).kind(),
+            BoolFunctionExprKind::LocalGet { .. },
+        ));
+        assert!(matches!(
+            BoolFunctionExpr::bool_case(BoolExpr::value(true), function_value(), function_value(),)
+                .kind(),
+            BoolFunctionExprKind::BoolCase { .. },
+        ));
+        assert!(matches!(
+            BoolFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), function_value())],
+                function_value(),
+            )
+            .kind(),
+            BoolFunctionExprKind::IntCase { .. },
+        ));
+        assert!(matches!(
+            BoolFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                function_value(),
+            )
+            .kind(),
+            BoolFunctionExprKind::Block { .. },
+        ));
+    }
+
+    #[test]
+    fn bool_function_expr_type() {
+        assert_eq!(function_value().type_(), &function_type());
+    }
+
+    fn function_value() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(
+            BoolFunctionId(0),
+            vec![ParamLocal::bool(BoolLocalId(0))],
+        ))
+    }
+
+    fn function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Bool], ValueType::Bool)
+    }
+}

--- a/src/plan/expression/function/int.rs
+++ b/src/plan/expression/function/int.rs
@@ -1,0 +1,177 @@
+use crate::plan::{BoolExpr, FunctionType, IntExpr, IntFunctionLocalId, IntFunctionValue, Step};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IntFunctionExpr {
+    type_: FunctionType,
+    kind: IntFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum IntFunctionExprKind {
+    Value(IntFunctionValue),
+    LocalGet {
+        local: IntFunctionLocalId,
+        name: EcoString,
+    },
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<IntFunctionExpr>,
+        false_: Box<IntFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, IntFunctionExpr)>,
+        fallback: Box<IntFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<IntFunctionExpr>,
+    },
+}
+
+impl IntFunctionExpr {
+    pub(crate) fn value(value: IntFunctionValue) -> Self {
+        Self {
+            type_: value.type_(),
+            kind: IntFunctionExprKind::Value(value),
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: IntFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: IntFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: IntFunctionExpr,
+        false_: IntFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: IntFunctionExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, IntFunctionExpr)>,
+        fallback: IntFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: IntFunctionExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: IntFunctionExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: IntFunctionExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &IntFunctionExprKind {
+        &self.kind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IntFunctionExpr, IntFunctionExprKind};
+    use crate::plan::{
+        BoolExpr, Expr, FunctionType, IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue,
+        IntLocalId, ParamLocal, Step, ValueType,
+    };
+
+    #[test]
+    fn int_function_expr_kind_accessors() {
+        assert_eq!(
+            int_function_type(),
+            FunctionType::new(vec![ValueType::Int], ValueType::Int),
+        );
+        assert!(matches!(
+            IntFunctionExpr::local_get(IntFunctionLocalId(0), "f".into(), int_function_type(),)
+                .kind(),
+            IntFunctionExprKind::LocalGet { .. }
+        ));
+        assert!(matches!(
+            IntFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), int_function_value())],
+                int_function_value(),
+            )
+            .kind(),
+            IntFunctionExprKind::IntCase { .. }
+        ));
+        assert!(matches!(
+            IntFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                int_function_value(),
+            )
+            .kind(),
+            IntFunctionExprKind::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn int_function_expr_type() {
+        assert_eq!(int_function_value().type_(), &int_function_type());
+        assert_eq!(
+            IntFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                int_function_value(),
+                int_function_value(),
+            )
+            .type_(),
+            &int_function_type(),
+        );
+        assert_eq!(
+            IntFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), int_function_value())],
+                int_function_value(),
+            )
+            .type_(),
+            &int_function_type(),
+        );
+        assert_eq!(
+            IntFunctionExpr::block(Vec::new(), int_function_value()).type_(),
+            &int_function_type(),
+        );
+    }
+
+    fn int_function_value() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(0),
+            vec![ParamLocal::int(IntLocalId(0))],
+        ))
+    }
+
+    fn int_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Int], ValueType::Int)
+    }
+}

--- a/src/plan/expression/function/nil.rs
+++ b/src/plan/expression/function/nil.rs
@@ -1,0 +1,155 @@
+use crate::plan::{BoolExpr, FunctionType, IntExpr, NilFunctionLocalId, NilFunctionValue, Step};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NilFunctionExpr {
+    type_: FunctionType,
+    kind: NilFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum NilFunctionExprKind {
+    Value(NilFunctionValue),
+    LocalGet {
+        local: NilFunctionLocalId,
+        name: EcoString,
+    },
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<NilFunctionExpr>,
+        false_: Box<NilFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, NilFunctionExpr)>,
+        fallback: Box<NilFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<NilFunctionExpr>,
+    },
+}
+
+impl NilFunctionExpr {
+    pub(crate) fn value(value: NilFunctionValue) -> Self {
+        Self {
+            type_: value.type_(),
+            kind: NilFunctionExprKind::Value(value),
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: NilFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: NilFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: NilFunctionExpr,
+        false_: NilFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: NilFunctionExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, NilFunctionExpr)>,
+        fallback: NilFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: NilFunctionExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: NilFunctionExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: NilFunctionExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &NilFunctionExprKind {
+        &self.kind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NilFunctionExpr, NilFunctionExprKind};
+    use crate::plan::{
+        BoolExpr, Expr, FunctionType, IntExpr, NilFunctionId, NilFunctionLocalId, NilFunctionValue,
+        NilLocalId, ParamLocal, Step, ValueType,
+    };
+
+    #[test]
+    fn nil_function_expr_kind_accessors() {
+        assert!(matches!(
+            NilFunctionExpr::local_get(NilFunctionLocalId(0), "f".into(), function_type()).kind(),
+            NilFunctionExprKind::LocalGet { .. },
+        ));
+        assert!(matches!(
+            NilFunctionExpr::bool_case(BoolExpr::value(true), function_value(), function_value(),)
+                .kind(),
+            NilFunctionExprKind::BoolCase { .. },
+        ));
+        assert!(matches!(
+            NilFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), function_value())],
+                function_value(),
+            )
+            .kind(),
+            NilFunctionExprKind::IntCase { .. },
+        ));
+        assert!(matches!(
+            NilFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                function_value(),
+            )
+            .kind(),
+            NilFunctionExprKind::Block { .. },
+        ));
+    }
+
+    #[test]
+    fn nil_function_expr_type() {
+        assert_eq!(function_value().type_(), &function_type());
+    }
+
+    fn function_value() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(
+            NilFunctionId(0),
+            vec![ParamLocal::nil(NilLocalId(0))],
+        ))
+    }
+
+    fn function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Nil], ValueType::Nil)
+    }
+}

--- a/src/plan/expression/function/string.rs
+++ b/src/plan/expression/function/string.rs
@@ -1,0 +1,162 @@
+use crate::plan::{
+    BoolExpr, FunctionType, IntExpr, Step, StringFunctionLocalId, StringFunctionValue,
+};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StringFunctionExpr {
+    type_: FunctionType,
+    kind: StringFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum StringFunctionExprKind {
+    Value(StringFunctionValue),
+    LocalGet {
+        local: StringFunctionLocalId,
+        name: EcoString,
+    },
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<StringFunctionExpr>,
+        false_: Box<StringFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, StringFunctionExpr)>,
+        fallback: Box<StringFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<StringFunctionExpr>,
+    },
+}
+
+impl StringFunctionExpr {
+    pub(crate) fn value(value: StringFunctionValue) -> Self {
+        Self {
+            type_: value.type_(),
+            kind: StringFunctionExprKind::Value(value),
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: StringFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: StringFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: StringFunctionExpr,
+        false_: StringFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: StringFunctionExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, StringFunctionExpr)>,
+        fallback: StringFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: StringFunctionExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: StringFunctionExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: StringFunctionExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &StringFunctionExprKind {
+        &self.kind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StringFunctionExpr, StringFunctionExprKind};
+    use crate::plan::{
+        BoolExpr, Expr, FunctionType, IntExpr, ParamLocal, Step, StringFunctionId,
+        StringFunctionLocalId, StringFunctionValue, StringLocalId, ValueType,
+    };
+
+    #[test]
+    fn string_function_expr_kind_accessors() {
+        assert!(matches!(
+            StringFunctionExpr::local_get(StringFunctionLocalId(0), "f".into(), function_type())
+                .kind(),
+            StringFunctionExprKind::LocalGet { .. },
+        ));
+        assert!(matches!(
+            StringFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                function_value(),
+                function_value(),
+            )
+            .kind(),
+            StringFunctionExprKind::BoolCase { .. },
+        ));
+        assert!(matches!(
+            StringFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), function_value())],
+                function_value(),
+            )
+            .kind(),
+            StringFunctionExprKind::IntCase { .. },
+        ));
+        assert!(matches!(
+            StringFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                function_value(),
+            )
+            .kind(),
+            StringFunctionExprKind::Block { .. },
+        ));
+    }
+
+    #[test]
+    fn string_function_expr_type() {
+        assert_eq!(function_value().type_(), &function_type());
+    }
+
+    fn function_value() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(
+            StringFunctionId(0),
+            vec![ParamLocal::string(StringLocalId(0))],
+        ))
+    }
+
+    fn function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::String], ValueType::String)
+    }
+}

--- a/src/plan/id.rs
+++ b/src/plan/id.rs
@@ -64,49 +64,16 @@ impl FunctionId {
     }
 }
 
-impl RuntimeFunctionId {
-    pub(crate) fn value_type(self) -> crate::plan::ValueType {
-        match self {
-            Self::Int(_) => crate::plan::ValueType::Int,
-            Self::String(_) => crate::plan::ValueType::String,
-            Self::Bool(_) => crate::plan::ValueType::Bool,
-            Self::Nil(_) => crate::plan::ValueType::Nil,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
-        BoolFunctionId, BoolFunctionLocalId, FunctionId, IntFunctionId, IntFunctionLocalId,
-        NilFunctionId, NilFunctionLocalId, RuntimeFunctionId, StringFunctionId,
+        BoolFunctionLocalId, FunctionId, IntFunctionLocalId, NilFunctionLocalId,
         StringFunctionLocalId,
     };
-    use crate::plan::ValueType;
 
     #[test]
     fn function_id_index() {
         assert_eq!(FunctionId::new(5).index(), 5);
-    }
-
-    #[test]
-    fn runtime_function_id_value_type() {
-        assert_eq!(
-            RuntimeFunctionId::Int(IntFunctionId(0)).value_type(),
-            ValueType::Int
-        );
-        assert_eq!(
-            RuntimeFunctionId::String(StringFunctionId(0)).value_type(),
-            ValueType::String
-        );
-        assert_eq!(
-            RuntimeFunctionId::Bool(BoolFunctionId(0)).value_type(),
-            ValueType::Bool
-        );
-        assert_eq!(
-            RuntimeFunctionId::Nil(NilFunctionId(0)).value_type(),
-            ValueType::Nil
-        );
     }
 
     #[test]

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 pub(super) struct FunctionInfo {
     pub(super) id: FunctionId,
     pub(super) runtime_id: RuntimeFunctionId,
+    pub(super) return_type: ValueType,
     pub(super) params: Vec<FunctionParam>,
 }
 
@@ -305,7 +306,7 @@ impl FunctionInfo {
     }
 
     pub(super) fn return_type(&self) -> ValueType {
-        self.runtime_id.value_type()
+        self.return_type.clone()
     }
 
     pub(super) fn value(&self) -> FunctionValue {

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -155,6 +155,7 @@ fn function_info(
     FunctionInfo {
         id: FunctionId::new(function_index),
         runtime_id,
+        return_type: seed.return_type.value_type(),
         params: seed.params.clone(),
     }
 }
@@ -199,6 +200,15 @@ impl FunctionReturnType {
             Self::String => runtime_ids.next_string(),
             Self::Bool => runtime_ids.next_bool(),
             Self::Nil => runtime_ids.next_nil(),
+        }
+    }
+
+    fn value_type(self) -> ValueType {
+        match self {
+            Self::Int => ValueType::Int,
+            Self::String => ValueType::String,
+            Self::Bool => ValueType::Bool,
+            Self::Nil => ValueType::Nil,
         }
     }
 }

--- a/src/runtime/expression/function.rs
+++ b/src/runtime/expression/function.rs
@@ -1,12 +1,15 @@
-use super::{eval_bool_expr, eval_int_expr};
-use crate::plan::{
-    BoolFunctionExpr, BoolFunctionExprKind, BoolFunctionValue, ExecutionPlan, FunctionExpr,
-    FunctionExprKind, FunctionValue, IntFunctionExpr, IntFunctionExprKind, IntFunctionValue,
-    NilFunctionExpr, NilFunctionExprKind, NilFunctionValue, StringFunctionExpr,
-    StringFunctionExprKind, StringFunctionValue,
-};
+mod bool;
+mod int;
+mod nil;
+mod string;
+
+use crate::plan::{ExecutionPlan, FunctionExpr, FunctionExprKind, FunctionValue};
 use crate::runtime::frame::Frame;
-use crate::runtime::function;
+
+pub(in crate::runtime) use self::{
+    bool::eval_bool_function_expr, int::eval_int_function_expr, nil::eval_nil_function_expr,
+    string::eval_string_function_expr,
+};
 
 pub(in crate::runtime) fn eval_function_expr(
     plan: &ExecutionPlan,
@@ -25,181 +28,19 @@ pub(in crate::runtime) fn eval_function_expr(
     }
 }
 
-pub(in crate::runtime) fn eval_int_function_expr(
-    plan: &ExecutionPlan,
-    frame: &mut Frame,
-    expression: &IntFunctionExpr,
-) -> IntFunctionValue {
-    match expression.kind() {
-        IntFunctionExprKind::Value(value) => value.clone(),
-        IntFunctionExprKind::LocalGet { local, .. } => frame.get_int_function(*local),
-        IntFunctionExprKind::BoolCase {
-            subject,
-            true_,
-            false_,
-        } => {
-            if eval_bool_expr(plan, frame, subject) {
-                eval_int_function_expr(plan, frame, true_)
-            } else {
-                eval_int_function_expr(plan, frame, false_)
-            }
-        }
-        IntFunctionExprKind::IntCase {
-            subject,
-            clauses,
-            fallback,
-        } => {
-            let subject = eval_int_expr(plan, frame, subject);
-            for (pattern, branch) in clauses {
-                if pattern == &subject {
-                    return eval_int_function_expr(plan, frame, branch);
-                }
-            }
-            eval_int_function_expr(plan, frame, fallback)
-        }
-        IntFunctionExprKind::Block { steps, return_ } => {
-            function::execute_steps(plan, steps, frame);
-            eval_int_function_expr(plan, frame, return_)
-        }
-    }
-}
-
-pub(in crate::runtime) fn eval_string_function_expr(
-    plan: &ExecutionPlan,
-    frame: &mut Frame,
-    expression: &StringFunctionExpr,
-) -> StringFunctionValue {
-    match expression.kind() {
-        StringFunctionExprKind::Value(value) => value.clone(),
-        StringFunctionExprKind::LocalGet { local, .. } => frame.get_string_function(*local),
-        StringFunctionExprKind::BoolCase {
-            subject,
-            true_,
-            false_,
-        } => {
-            if eval_bool_expr(plan, frame, subject) {
-                eval_string_function_expr(plan, frame, true_)
-            } else {
-                eval_string_function_expr(plan, frame, false_)
-            }
-        }
-        StringFunctionExprKind::IntCase {
-            subject,
-            clauses,
-            fallback,
-        } => {
-            let subject = eval_int_expr(plan, frame, subject);
-            for (pattern, branch) in clauses {
-                if pattern == &subject {
-                    return eval_string_function_expr(plan, frame, branch);
-                }
-            }
-            eval_string_function_expr(plan, frame, fallback)
-        }
-        StringFunctionExprKind::Block { steps, return_ } => {
-            function::execute_steps(plan, steps, frame);
-            eval_string_function_expr(plan, frame, return_)
-        }
-    }
-}
-
-pub(in crate::runtime) fn eval_bool_function_expr(
-    plan: &ExecutionPlan,
-    frame: &mut Frame,
-    expression: &BoolFunctionExpr,
-) -> BoolFunctionValue {
-    match expression.kind() {
-        BoolFunctionExprKind::Value(value) => value.clone(),
-        BoolFunctionExprKind::LocalGet { local, .. } => frame.get_bool_function(*local),
-        BoolFunctionExprKind::BoolCase {
-            subject,
-            true_,
-            false_,
-        } => {
-            if eval_bool_expr(plan, frame, subject) {
-                eval_bool_function_expr(plan, frame, true_)
-            } else {
-                eval_bool_function_expr(plan, frame, false_)
-            }
-        }
-        BoolFunctionExprKind::IntCase {
-            subject,
-            clauses,
-            fallback,
-        } => {
-            let subject = eval_int_expr(plan, frame, subject);
-            for (pattern, branch) in clauses {
-                if pattern == &subject {
-                    return eval_bool_function_expr(plan, frame, branch);
-                }
-            }
-            eval_bool_function_expr(plan, frame, fallback)
-        }
-        BoolFunctionExprKind::Block { steps, return_ } => {
-            function::execute_steps(plan, steps, frame);
-            eval_bool_function_expr(plan, frame, return_)
-        }
-    }
-}
-
-pub(in crate::runtime) fn eval_nil_function_expr(
-    plan: &ExecutionPlan,
-    frame: &mut Frame,
-    expression: &NilFunctionExpr,
-) -> NilFunctionValue {
-    match expression.kind() {
-        NilFunctionExprKind::Value(value) => value.clone(),
-        NilFunctionExprKind::LocalGet { local, .. } => frame.get_nil_function(*local),
-        NilFunctionExprKind::BoolCase {
-            subject,
-            true_,
-            false_,
-        } => {
-            if eval_bool_expr(plan, frame, subject) {
-                eval_nil_function_expr(plan, frame, true_)
-            } else {
-                eval_nil_function_expr(plan, frame, false_)
-            }
-        }
-        NilFunctionExprKind::IntCase {
-            subject,
-            clauses,
-            fallback,
-        } => {
-            let subject = eval_int_expr(plan, frame, subject);
-            for (pattern, branch) in clauses {
-                if pattern == &subject {
-                    return eval_nil_function_expr(plan, frame, branch);
-                }
-            }
-            eval_nil_function_expr(plan, frame, fallback)
-        }
-        NilFunctionExprKind::Block { steps, return_ } => {
-            function::execute_steps(plan, steps, frame);
-            eval_nil_function_expr(plan, frame, return_)
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        eval_bool_function_expr, eval_function_expr, eval_int_function_expr,
-        eval_nil_function_expr, eval_string_function_expr,
-    };
+    use super::eval_function_expr;
     use crate::plan::{
-        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, ExecutionPlan, Expr,
-        FunctionExpr, FunctionId, FunctionPlan, FunctionType, FunctionValue, IntExpr,
-        IntFunctionExpr, IntFunctionId, IntFunctionValue, IntLocalId, NilFunctionExpr,
-        NilFunctionId, NilFunctionValue, NilLocalId, ParamLocal, RuntimeFunctionId, Step,
-        StringFunctionExpr, StringFunctionId, StringFunctionValue, StringLocalId, ValueType,
+        BoolFunctionId, FunctionExpr, FunctionPlan, FunctionType, FunctionValue, IntExpr,
+        IntFunctionId, IntLocalId, NilFunctionId, NilLocalId, ParamLocal, RuntimeFunctionId,
+        StringFunctionId, StringLocalId, ValueType,
     };
     use crate::runtime::frame::Frame;
-    use num_bigint::BigInt;
 
     #[test]
     fn eval_function_value() {
-        let plan = plan_with_int_main(Vec::new());
+        let plan = plan();
         let mut frame = Frame::default();
         let function =
             eval_function_expr(&plan, &mut frame, &FunctionExpr::value(function_value()));
@@ -209,7 +50,7 @@ mod tests {
 
     #[test]
     fn eval_function_value_return_families() {
-        let plan = plan_with_int_main(Vec::new());
+        let plan = plan();
         let mut frame = Frame::default();
 
         assert_eq!(
@@ -244,259 +85,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn eval_int_function_bool_case_branches() {
-        let plan = plan_with_int_main(Vec::new());
-        let mut frame = Frame::default();
-        let function = eval_int_function_expr(
-            &plan,
-            &mut frame,
-            &IntFunctionExpr::bool_case(
-                BoolExpr::value(true),
-                int_function_value(),
-                other_int_function_value(),
-            ),
-        );
-
-        assert_eq!(function.runtime_id(), IntFunctionId(0));
-
-        let function = eval_int_function_expr(
-            &plan,
-            &mut frame,
-            &IntFunctionExpr::bool_case(
-                BoolExpr::value(false),
-                other_int_function_value(),
-                int_function_value(),
-            ),
-        );
-
-        assert_eq!(function.runtime_id(), IntFunctionId(0));
-    }
-
-    #[test]
-    fn eval_int_function_int_case_branches() {
-        let plan = plan_with_int_main(Vec::new());
-        let mut frame = Frame::default();
-        let function = eval_int_function_expr(
-            &plan,
-            &mut frame,
-            &IntFunctionExpr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), int_function_value())],
-                other_int_function_value(),
-            ),
-        );
-
-        assert_eq!(function.runtime_id(), IntFunctionId(0));
-
-        let function = eval_int_function_expr(
-            &plan,
-            &mut frame,
-            &IntFunctionExpr::int_case(
-                IntExpr::value(BigInt::from(2)),
-                vec![(BigInt::from(1), other_int_function_value())],
-                int_function_value(),
-            ),
-        );
-
-        assert_eq!(function.runtime_id(), IntFunctionId(0));
-    }
-
-    #[test]
-    fn eval_int_function_block() {
-        let plan = plan_with_int_main(Vec::new());
-        let mut frame = Frame::default();
-        let function = eval_int_function_expr(
-            &plan,
-            &mut frame,
-            &IntFunctionExpr::block(
-                vec![Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1))))],
-                int_function_value(),
-            ),
-        );
-
-        assert_eq!(function.runtime_id(), IntFunctionId(0));
-    }
-
-    #[test]
-    fn eval_string_bool_nil_function_branches() {
-        let plan = plan_with_int_main(Vec::new());
-        let mut frame = Frame::default();
-
-        let string = eval_string_function_expr(
-            &plan,
-            &mut frame,
-            &StringFunctionExpr::bool_case(
-                BoolExpr::value(true),
-                string_function_expr(),
-                other_string_function_expr(),
-            ),
-        );
-        assert_eq!(string.runtime_id(), StringFunctionId(0));
-
-        let string = eval_string_function_expr(
-            &plan,
-            &mut frame,
-            &StringFunctionExpr::bool_case(
-                BoolExpr::value(false),
-                other_string_function_expr(),
-                string_function_expr(),
-            ),
-        );
-        assert_eq!(string.runtime_id(), StringFunctionId(0));
-
-        let string = eval_string_function_expr(
-            &plan,
-            &mut frame,
-            &StringFunctionExpr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), string_function_expr())],
-                other_string_function_expr(),
-            ),
-        );
-        assert_eq!(string.runtime_id(), StringFunctionId(0));
-
-        let string = eval_string_function_expr(
-            &plan,
-            &mut frame,
-            &StringFunctionExpr::int_case(
-                IntExpr::value(BigInt::from(2)),
-                vec![(BigInt::from(1), other_string_function_expr())],
-                string_function_expr(),
-            ),
-        );
-        assert_eq!(string.runtime_id(), StringFunctionId(0));
-
-        let string = eval_string_function_expr(
-            &plan,
-            &mut frame,
-            &StringFunctionExpr::block(
-                vec![Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1))))],
-                string_function_expr(),
-            ),
-        );
-        assert_eq!(string.runtime_id(), StringFunctionId(0));
-
-        let bool_ = eval_bool_function_expr(
-            &plan,
-            &mut frame,
-            &BoolFunctionExpr::bool_case(
-                BoolExpr::value(true),
-                bool_function_expr(),
-                other_bool_function_expr(),
-            ),
-        );
-        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
-
-        let bool_ = eval_bool_function_expr(
-            &plan,
-            &mut frame,
-            &BoolFunctionExpr::bool_case(
-                BoolExpr::value(false),
-                other_bool_function_expr(),
-                bool_function_expr(),
-            ),
-        );
-        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
-
-        let bool_ = eval_bool_function_expr(
-            &plan,
-            &mut frame,
-            &BoolFunctionExpr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), bool_function_expr())],
-                other_bool_function_expr(),
-            ),
-        );
-        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
-
-        let bool_ = eval_bool_function_expr(
-            &plan,
-            &mut frame,
-            &BoolFunctionExpr::int_case(
-                IntExpr::value(BigInt::from(2)),
-                vec![(BigInt::from(1), other_bool_function_expr())],
-                bool_function_expr(),
-            ),
-        );
-        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
-
-        let bool_ = eval_bool_function_expr(
-            &plan,
-            &mut frame,
-            &BoolFunctionExpr::block(
-                vec![Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1))))],
-                bool_function_expr(),
-            ),
-        );
-        assert_eq!(bool_.runtime_id(), BoolFunctionId(0));
-
-        let nil = eval_nil_function_expr(
-            &plan,
-            &mut frame,
-            &NilFunctionExpr::bool_case(
-                BoolExpr::value(true),
-                nil_function_expr(),
-                other_nil_function_expr(),
-            ),
-        );
-        assert_eq!(nil.runtime_id(), NilFunctionId(0));
-
-        let nil = eval_nil_function_expr(
-            &plan,
-            &mut frame,
-            &NilFunctionExpr::bool_case(
-                BoolExpr::value(false),
-                other_nil_function_expr(),
-                nil_function_expr(),
-            ),
-        );
-        assert_eq!(nil.runtime_id(), NilFunctionId(0));
-
-        let nil = eval_nil_function_expr(
-            &plan,
-            &mut frame,
-            &NilFunctionExpr::int_case(
-                IntExpr::value(BigInt::from(1)),
-                vec![(BigInt::from(1), nil_function_expr())],
-                other_nil_function_expr(),
-            ),
-        );
-        assert_eq!(nil.runtime_id(), NilFunctionId(0));
-
-        let nil = eval_nil_function_expr(
-            &plan,
-            &mut frame,
-            &NilFunctionExpr::int_case(
-                IntExpr::value(BigInt::from(2)),
-                vec![(BigInt::from(1), other_nil_function_expr())],
-                nil_function_expr(),
-            ),
-        );
-        assert_eq!(nil.runtime_id(), NilFunctionId(0));
-
-        let nil = eval_nil_function_expr(
-            &plan,
-            &mut frame,
-            &NilFunctionExpr::block(
-                vec![Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1))))],
-                nil_function_expr(),
-            ),
-        );
-        assert_eq!(nil.runtime_id(), NilFunctionId(0));
-    }
-
-    fn plan_with_int_main(functions: Vec<FunctionPlan>) -> ExecutionPlan {
-        ExecutionPlan::new(
+    fn plan() -> crate::plan::ExecutionPlan {
+        crate::plan::ExecutionPlan::new(
             "main".into(),
             FunctionPlan::new(
-                FunctionId::new(0),
+                crate::plan::FunctionId::new(0),
                 "main".into(),
                 Vec::new(),
                 Vec::new(),
-                crate::plan::ReturnExpr::int(IntExpr::value(BigInt::from(1))),
+                crate::plan::ReturnExpr::int(IntExpr::value(1.into())),
             ),
-            functions,
+            Vec::new(),
         )
     }
 
@@ -536,61 +135,5 @@ mod tests {
             RuntimeFunctionId::Nil(NilFunctionId(0)),
             vec![ParamLocal::nil(NilLocalId(0))],
         )
-    }
-
-    fn int_function_value() -> IntFunctionExpr {
-        IntFunctionExpr::value(IntFunctionValue::new(
-            IntFunctionId(0),
-            vec![ParamLocal::int(IntLocalId(0))],
-        ))
-    }
-
-    fn other_int_function_value() -> IntFunctionExpr {
-        IntFunctionExpr::value(IntFunctionValue::new(
-            IntFunctionId(1),
-            vec![ParamLocal::int(IntLocalId(0))],
-        ))
-    }
-
-    fn string_function_expr() -> StringFunctionExpr {
-        StringFunctionExpr::value(StringFunctionValue::new(
-            StringFunctionId(0),
-            vec![ParamLocal::string(StringLocalId(0))],
-        ))
-    }
-
-    fn other_string_function_expr() -> StringFunctionExpr {
-        StringFunctionExpr::value(StringFunctionValue::new(
-            StringFunctionId(1),
-            vec![ParamLocal::string(StringLocalId(0))],
-        ))
-    }
-
-    fn bool_function_expr() -> BoolFunctionExpr {
-        BoolFunctionExpr::value(BoolFunctionValue::new(
-            BoolFunctionId(0),
-            vec![ParamLocal::bool(crate::plan::BoolLocalId(0))],
-        ))
-    }
-
-    fn other_bool_function_expr() -> BoolFunctionExpr {
-        BoolFunctionExpr::value(BoolFunctionValue::new(
-            BoolFunctionId(1),
-            vec![ParamLocal::bool(crate::plan::BoolLocalId(0))],
-        ))
-    }
-
-    fn nil_function_expr() -> NilFunctionExpr {
-        NilFunctionExpr::value(NilFunctionValue::new(
-            NilFunctionId(0),
-            vec![ParamLocal::nil(NilLocalId(0))],
-        ))
-    }
-
-    fn other_nil_function_expr() -> NilFunctionExpr {
-        NilFunctionExpr::value(NilFunctionValue::new(
-            NilFunctionId(1),
-            vec![ParamLocal::nil(NilLocalId(0))],
-        ))
     }
 }

--- a/src/runtime/expression/function/bool.rs
+++ b/src/runtime/expression/function/bool.rs
@@ -1,0 +1,166 @@
+use crate::plan::{BoolFunctionExpr, BoolFunctionExprKind, BoolFunctionValue, ExecutionPlan};
+use crate::runtime::expression::{eval_bool_expr, eval_int_expr};
+use crate::runtime::frame::Frame;
+use crate::runtime::function;
+
+pub(in crate::runtime) fn eval_bool_function_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &BoolFunctionExpr,
+) -> BoolFunctionValue {
+    match expression.kind() {
+        BoolFunctionExprKind::Value(value) => value.clone(),
+        BoolFunctionExprKind::LocalGet { local, .. } => frame.get_bool_function(*local),
+        BoolFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, frame, subject) {
+                eval_bool_function_expr(plan, frame, true_)
+            } else {
+                eval_bool_function_expr(plan, frame, false_)
+            }
+        }
+        BoolFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, frame, subject);
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_bool_function_expr(plan, frame, branch);
+                }
+            }
+            eval_bool_function_expr(plan, frame, fallback)
+        }
+        BoolFunctionExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, steps, frame);
+            eval_bool_function_expr(plan, frame, return_)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::eval_bool_function_expr;
+    use crate::plan::{
+        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, BoolLocalId, ExecutionPlan,
+        Expr, FunctionId, FunctionPlan, IntExpr, ParamLocal, ReturnExpr, Step,
+    };
+    use crate::runtime::frame::Frame;
+
+    #[test]
+    fn eval_bool_function_bool_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::bool_case(
+                    BoolExpr::value(true),
+                    function_value(),
+                    other_function_value(),
+                ),
+            )
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::bool_case(
+                    BoolExpr::value(false),
+                    other_function_value(),
+                    function_value(),
+                ),
+            )
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+    }
+
+    #[test]
+    fn eval_bool_function_int_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::int_case(
+                    IntExpr::value(1.into()),
+                    vec![(1.into(), function_value())],
+                    other_function_value(),
+                ),
+            )
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::int_case(
+                    IntExpr::value(2.into()),
+                    vec![(1.into(), other_function_value())],
+                    function_value(),
+                ),
+            )
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+    }
+
+    #[test]
+    fn eval_bool_function_block() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                    function_value(),
+                ),
+            )
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+    }
+
+    fn plan() -> ExecutionPlan {
+        ExecutionPlan::new(
+            "main".into(),
+            FunctionPlan::new(
+                FunctionId::new(0),
+                "main".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int(IntExpr::value(1.into())),
+            ),
+            Vec::new(),
+        )
+    }
+
+    fn function_value() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(
+            BoolFunctionId(0),
+            vec![ParamLocal::bool(BoolLocalId(0))],
+        ))
+    }
+
+    fn other_function_value() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(
+            BoolFunctionId(1),
+            vec![ParamLocal::bool(BoolLocalId(0))],
+        ))
+    }
+}

--- a/src/runtime/expression/function/int.rs
+++ b/src/runtime/expression/function/int.rs
@@ -1,0 +1,155 @@
+use crate::plan::{ExecutionPlan, IntFunctionExpr, IntFunctionExprKind, IntFunctionValue};
+use crate::runtime::expression::{eval_bool_expr, eval_int_expr};
+use crate::runtime::frame::Frame;
+use crate::runtime::function;
+
+pub(in crate::runtime) fn eval_int_function_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &IntFunctionExpr,
+) -> IntFunctionValue {
+    match expression.kind() {
+        IntFunctionExprKind::Value(value) => value.clone(),
+        IntFunctionExprKind::LocalGet { local, .. } => frame.get_int_function(*local),
+        IntFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, frame, subject) {
+                eval_int_function_expr(plan, frame, true_)
+            } else {
+                eval_int_function_expr(plan, frame, false_)
+            }
+        }
+        IntFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, frame, subject);
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_int_function_expr(plan, frame, branch);
+                }
+            }
+            eval_int_function_expr(plan, frame, fallback)
+        }
+        IntFunctionExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, steps, frame);
+            eval_int_function_expr(plan, frame, return_)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::eval_int_function_expr;
+    use crate::plan::{
+        BoolExpr, ExecutionPlan, Expr, FunctionId, FunctionPlan, IntExpr, IntFunctionExpr,
+        IntFunctionId, IntFunctionValue, IntLocalId, ParamLocal, ReturnExpr, Step,
+    };
+    use crate::runtime::frame::Frame;
+
+    #[test]
+    fn eval_int_function_bool_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let function = eval_int_function_expr(
+            &plan,
+            &mut frame,
+            &IntFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                function_value(),
+                other_function_value(),
+            ),
+        );
+
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
+
+        let function = eval_int_function_expr(
+            &plan,
+            &mut frame,
+            &IntFunctionExpr::bool_case(
+                BoolExpr::value(false),
+                other_function_value(),
+                function_value(),
+            ),
+        );
+
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
+    }
+
+    #[test]
+    fn eval_int_function_int_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let function = eval_int_function_expr(
+            &plan,
+            &mut frame,
+            &IntFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), function_value())],
+                other_function_value(),
+            ),
+        );
+
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
+
+        let function = eval_int_function_expr(
+            &plan,
+            &mut frame,
+            &IntFunctionExpr::int_case(
+                IntExpr::value(2.into()),
+                vec![(1.into(), other_function_value())],
+                function_value(),
+            ),
+        );
+
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
+    }
+
+    #[test]
+    fn eval_int_function_block() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let function = eval_int_function_expr(
+            &plan,
+            &mut frame,
+            &IntFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                function_value(),
+            ),
+        );
+
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
+    }
+
+    fn plan() -> ExecutionPlan {
+        ExecutionPlan::new(
+            "main".into(),
+            FunctionPlan::new(
+                FunctionId::new(0),
+                "main".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int(IntExpr::value(1.into())),
+            ),
+            Vec::new(),
+        )
+    }
+
+    fn function_value() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(0),
+            vec![ParamLocal::int(IntLocalId(0))],
+        ))
+    }
+
+    fn other_function_value() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(
+            IntFunctionId(1),
+            vec![ParamLocal::int(IntLocalId(0))],
+        ))
+    }
+}

--- a/src/runtime/expression/function/nil.rs
+++ b/src/runtime/expression/function/nil.rs
@@ -1,0 +1,166 @@
+use crate::plan::{ExecutionPlan, NilFunctionExpr, NilFunctionExprKind, NilFunctionValue};
+use crate::runtime::expression::{eval_bool_expr, eval_int_expr};
+use crate::runtime::frame::Frame;
+use crate::runtime::function;
+
+pub(in crate::runtime) fn eval_nil_function_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &NilFunctionExpr,
+) -> NilFunctionValue {
+    match expression.kind() {
+        NilFunctionExprKind::Value(value) => value.clone(),
+        NilFunctionExprKind::LocalGet { local, .. } => frame.get_nil_function(*local),
+        NilFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, frame, subject) {
+                eval_nil_function_expr(plan, frame, true_)
+            } else {
+                eval_nil_function_expr(plan, frame, false_)
+            }
+        }
+        NilFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, frame, subject);
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_nil_function_expr(plan, frame, branch);
+                }
+            }
+            eval_nil_function_expr(plan, frame, fallback)
+        }
+        NilFunctionExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, steps, frame);
+            eval_nil_function_expr(plan, frame, return_)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::eval_nil_function_expr;
+    use crate::plan::{
+        BoolExpr, ExecutionPlan, Expr, FunctionId, FunctionPlan, IntExpr, NilFunctionExpr,
+        NilFunctionId, NilFunctionValue, NilLocalId, ParamLocal, ReturnExpr, Step,
+    };
+    use crate::runtime::frame::Frame;
+
+    #[test]
+    fn eval_nil_function_bool_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::bool_case(
+                    BoolExpr::value(true),
+                    function_value(),
+                    other_function_value(),
+                ),
+            )
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::bool_case(
+                    BoolExpr::value(false),
+                    other_function_value(),
+                    function_value(),
+                ),
+            )
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+    }
+
+    #[test]
+    fn eval_nil_function_int_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::int_case(
+                    IntExpr::value(1.into()),
+                    vec![(1.into(), function_value())],
+                    other_function_value(),
+                ),
+            )
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::int_case(
+                    IntExpr::value(2.into()),
+                    vec![(1.into(), other_function_value())],
+                    function_value(),
+                ),
+            )
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+    }
+
+    #[test]
+    fn eval_nil_function_block() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                    function_value(),
+                ),
+            )
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+    }
+
+    fn plan() -> ExecutionPlan {
+        ExecutionPlan::new(
+            "main".into(),
+            FunctionPlan::new(
+                FunctionId::new(0),
+                "main".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int(IntExpr::value(1.into())),
+            ),
+            Vec::new(),
+        )
+    }
+
+    fn function_value() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(
+            NilFunctionId(0),
+            vec![ParamLocal::nil(NilLocalId(0))],
+        ))
+    }
+
+    fn other_function_value() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(
+            NilFunctionId(1),
+            vec![ParamLocal::nil(NilLocalId(0))],
+        ))
+    }
+}

--- a/src/runtime/expression/function/string.rs
+++ b/src/runtime/expression/function/string.rs
@@ -1,0 +1,166 @@
+use crate::plan::{ExecutionPlan, StringFunctionExpr, StringFunctionExprKind, StringFunctionValue};
+use crate::runtime::expression::{eval_bool_expr, eval_int_expr};
+use crate::runtime::frame::Frame;
+use crate::runtime::function;
+
+pub(in crate::runtime) fn eval_string_function_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &StringFunctionExpr,
+) -> StringFunctionValue {
+    match expression.kind() {
+        StringFunctionExprKind::Value(value) => value.clone(),
+        StringFunctionExprKind::LocalGet { local, .. } => frame.get_string_function(*local),
+        StringFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, frame, subject) {
+                eval_string_function_expr(plan, frame, true_)
+            } else {
+                eval_string_function_expr(plan, frame, false_)
+            }
+        }
+        StringFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, frame, subject);
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_string_function_expr(plan, frame, branch);
+                }
+            }
+            eval_string_function_expr(plan, frame, fallback)
+        }
+        StringFunctionExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, steps, frame);
+            eval_string_function_expr(plan, frame, return_)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::eval_string_function_expr;
+    use crate::plan::{
+        BoolExpr, ExecutionPlan, Expr, FunctionId, FunctionPlan, IntExpr, ParamLocal, ReturnExpr,
+        Step, StringFunctionExpr, StringFunctionId, StringFunctionValue, StringLocalId,
+    };
+    use crate::runtime::frame::Frame;
+
+    #[test]
+    fn eval_string_function_bool_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::bool_case(
+                    BoolExpr::value(true),
+                    function_value(),
+                    other_function_value(),
+                ),
+            )
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::bool_case(
+                    BoolExpr::value(false),
+                    other_function_value(),
+                    function_value(),
+                ),
+            )
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+    }
+
+    #[test]
+    fn eval_string_function_int_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::int_case(
+                    IntExpr::value(1.into()),
+                    vec![(1.into(), function_value())],
+                    other_function_value(),
+                ),
+            )
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::int_case(
+                    IntExpr::value(2.into()),
+                    vec![(1.into(), other_function_value())],
+                    function_value(),
+                ),
+            )
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+    }
+
+    #[test]
+    fn eval_string_function_block() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                    function_value(),
+                ),
+            )
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+    }
+
+    fn plan() -> ExecutionPlan {
+        ExecutionPlan::new(
+            "main".into(),
+            FunctionPlan::new(
+                FunctionId::new(0),
+                "main".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int(IntExpr::value(1.into())),
+            ),
+            Vec::new(),
+        )
+    }
+
+    fn function_value() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(
+            StringFunctionId(0),
+            vec![ParamLocal::string(StringLocalId(0))],
+        ))
+    }
+
+    fn other_function_value() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(
+            StringFunctionId(1),
+            vec![ParamLocal::string(StringLocalId(0))],
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- Split function-valued plan expression families into focused return-family modules.
- Split matching runtime function expression evaluators.
- Store planned function return `ValueType` on `FunctionInfo` so runtime ids stay as ids before function-returning support.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo test --locked`
- `cargo clippy --all-targets -- -D warnings`
- `cargo llvm-cov --summary-only --fail-under-lines 100`
- `git diff --check`