### PR TITLE
Support non-capturing anonymous functions

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -42,17 +42,29 @@ pub struct ExecutionPlan {
     module: EcoString,
     main: FunctionPlan,
     functions: Vec<FunctionPlan>,
+    anonymous_functions: Vec<FunctionPlan>,
     runtime: RuntimePlan,
 }
 
 impl ExecutionPlan {
+    #[cfg(test)]
     pub(crate) fn new(module: EcoString, main: FunctionPlan, functions: Vec<FunctionPlan>) -> Self {
-        let runtime = RuntimePlan::new(&main, &functions);
+        Self::new_with_anonymous(module, main, functions, Vec::new())
+    }
+
+    pub(crate) fn new_with_anonymous(
+        module: EcoString,
+        main: FunctionPlan,
+        functions: Vec<FunctionPlan>,
+        anonymous_functions: Vec<FunctionPlan>,
+    ) -> Self {
+        let runtime = RuntimePlan::new(&main, &functions, &anonymous_functions);
 
         Self {
             module,
             main,
             functions,
+            anonymous_functions,
             runtime,
         }
     }
@@ -67,6 +79,11 @@ impl ExecutionPlan {
 
     pub fn functions(&self) -> &[FunctionPlan] {
         &self.functions
+    }
+
+    #[cfg(test)]
+    pub(crate) fn anonymous_functions(&self) -> &[FunctionPlan] {
+        &self.anonymous_functions
     }
 
     pub(crate) fn main_runtime(&self) -> RuntimeFunctionId {
@@ -132,13 +149,17 @@ impl fmt::Debug for ExecutionPlan {
             .field("module", &self.module)
             .field("main", &self.main)
             .field("functions", &self.functions)
+            .field("anonymous_functions", &self.anonymous_functions)
             .finish()
     }
 }
 
 impl PartialEq for ExecutionPlan {
     fn eq(&self, other: &Self) -> bool {
-        self.module == other.module && self.main == other.main && self.functions == other.functions
+        self.module == other.module
+            && self.main == other.main
+            && self.functions == other.functions
+            && self.anonymous_functions == other.anonymous_functions
     }
 }
 
@@ -166,12 +187,22 @@ mod tests {
             Vec::new(),
             ReturnExpr::int(IntFunctionId(1), IntExpr::value(BigInt::from(2))),
         );
-        let plan = ExecutionPlan::new("main".into(), main, vec![helper]);
+        let anonymous = FunctionPlan::new(
+            FunctionId::new(2),
+            "<anonymous:0>".into(),
+            Vec::new(),
+            Vec::new(),
+            ReturnExpr::int(IntFunctionId(2), IntExpr::value(BigInt::from(3))),
+        );
+        let plan =
+            ExecutionPlan::new_with_anonymous("main".into(), main, vec![helper], vec![anonymous]);
 
         assert_eq!(plan.module(), "main");
         assert_eq!(plan.main_function().name(), "main");
         assert_eq!(plan.functions().len(), 1);
         assert_eq!(plan.functions()[0].name(), "helper");
+        assert_eq!(plan.anonymous_functions().len(), 1);
+        assert_eq!(plan.anonymous_functions()[0].name(), "<anonymous:0>");
     }
 
     #[test]
@@ -225,6 +256,7 @@ mod tests {
         assert!(debug.contains("module"));
         assert!(debug.contains("main"));
         assert!(debug.contains("functions"));
+        assert!(debug.contains("anonymous_functions"));
         assert!(!debug.contains("runtime:"));
         assert!(!debug.contains("RuntimePlan"));
     }

--- a/src/plan/runtime.rs
+++ b/src/plan/runtime.rs
@@ -20,12 +20,19 @@ pub(super) struct RuntimePlan {
 }
 
 impl RuntimePlan {
-    pub(super) fn new(main: &FunctionPlan, functions: &[FunctionPlan]) -> Self {
+    pub(super) fn new(
+        main: &FunctionPlan,
+        functions: &[FunctionPlan],
+        anonymous_functions: &[FunctionPlan],
+    ) -> Self {
         let mut runtime = RuntimePlanBuilder::default();
         let main_runtime = main.return_().runtime_id();
         runtime.push(main);
 
         for function in functions {
+            runtime.push(function);
+        }
+        for function in anonymous_functions {
             runtime.push(function);
         }
 

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -1,14 +1,14 @@
 use crate::plan::{
     BoolFunctionFunctionId, BoolFunctionId, BoolFunctionLocalId, BoolLocalId,
     FunctionFunctionFunctionId, FunctionFunctionId, FunctionFunctionLocalId, FunctionId,
-    FunctionType, FunctionValue, IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId,
-    IntLocalId, LocalId, NilFunctionFunctionId, NilFunctionId, NilFunctionLocalId, NilLocalId,
-    ParamLocal, RuntimeFunctionId, StringFunctionFunctionId, StringFunctionId,
-    StringFunctionLocalId, StringLocalId, ValueType,
+    FunctionPlan, FunctionType, FunctionValue, IntFunctionFunctionId, IntFunctionId,
+    IntFunctionLocalId, IntLocalId, LocalId, NilFunctionFunctionId, NilFunctionId,
+    NilFunctionLocalId, NilLocalId, ParamLocal, RuntimeFunctionId, StringFunctionFunctionId,
+    StringFunctionId, StringFunctionLocalId, StringLocalId, ValueType,
 };
 use ecow::EcoString;
 use gleam_core::type_::Type;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone)]
 pub(super) struct FunctionInfo {
@@ -27,7 +27,9 @@ pub(super) struct FunctionParam {
 pub(super) struct PlanContext<'a> {
     pub(super) module_name: &'a EcoString,
     functions: &'a HashMap<EcoString, FunctionInfo>,
+    anonymous_functions: &'a mut AnonymousFunctions,
     bindings: HashMap<EcoString, LocalBinding>,
+    outer_binding_names: HashSet<EcoString>,
     next_int_local: usize,
     next_string_local: usize,
     next_bool_local: usize,
@@ -73,11 +75,14 @@ impl<'a> PlanContext<'a> {
     pub(super) fn new(
         module_name: &'a EcoString,
         functions: &'a HashMap<EcoString, FunctionInfo>,
+        anonymous_functions: &'a mut AnonymousFunctions,
     ) -> Self {
         Self {
             module_name,
             functions,
+            anonymous_functions,
             bindings: HashMap::new(),
+            outer_binding_names: HashSet::new(),
             next_int_local: 0,
             next_string_local: 0,
             next_bool_local: 0,
@@ -322,6 +327,48 @@ impl<'a> PlanContext<'a> {
         }
     }
 
+    pub(super) fn anonymous_function_error_name(&self) -> EcoString {
+        self.anonymous_functions.next_name()
+    }
+
+    pub(super) fn allocate_anonymous_function(
+        &mut self,
+        return_type: ValueType,
+        params: Vec<FunctionParam>,
+    ) -> (EcoString, FunctionInfo) {
+        self.anonymous_functions.allocate(return_type, params)
+    }
+
+    pub(super) fn push_anonymous_function(&mut self, function: FunctionPlan) {
+        self.anonymous_functions.push(function);
+    }
+
+    pub(super) fn anonymous_function_context(&mut self) -> PlanContext<'_> {
+        let mut outer_binding_names = self.outer_binding_names.clone();
+        outer_binding_names.extend(self.bindings.keys().cloned());
+
+        PlanContext {
+            module_name: self.module_name,
+            functions: self.functions,
+            anonymous_functions: self.anonymous_functions,
+            bindings: HashMap::new(),
+            outer_binding_names,
+            next_int_local: 0,
+            next_string_local: 0,
+            next_bool_local: 0,
+            next_nil_local: 0,
+            next_int_function_local: 0,
+            next_string_function_local: 0,
+            next_bool_function_local: 0,
+            next_nil_function_local: 0,
+            next_function_function_local: 0,
+        }
+    }
+
+    pub(super) fn is_outer_binding_name(&self, name: &EcoString) -> bool {
+        self.bindings.contains_key(name) || self.outer_binding_names.contains(name)
+    }
+
     pub(super) fn with_local_scope<T, E>(
         &mut self,
         f: impl FnOnce(&mut Self) -> Result<T, E>,
@@ -330,6 +377,63 @@ impl<'a> PlanContext<'a> {
         let result = f(self);
         self.bindings = bindings;
         result
+    }
+}
+
+pub(in crate::planner) struct AnonymousFunctions {
+    next_function_index: usize,
+    next_anonymous_index: usize,
+    runtime_ids: FunctionRuntimeIds,
+    functions: Vec<FunctionPlan>,
+}
+
+impl AnonymousFunctions {
+    pub(in crate::planner) fn new(
+        next_function_index: usize,
+        runtime_ids: FunctionRuntimeIds,
+    ) -> Self {
+        Self {
+            next_function_index,
+            next_anonymous_index: 0,
+            runtime_ids,
+            functions: Vec::new(),
+        }
+    }
+
+    pub(in crate::planner) fn into_functions(self) -> Vec<FunctionPlan> {
+        self.functions
+    }
+
+    fn next_name(&self) -> EcoString {
+        format!("<anonymous:{}>", self.next_anonymous_index).into()
+    }
+
+    fn allocate(
+        &mut self,
+        return_type: ValueType,
+        params: Vec<FunctionParam>,
+    ) -> (EcoString, FunctionInfo) {
+        let name = self.next_name();
+        let runtime_id = self.runtime_ids.next(&return_type);
+        let info = FunctionInfo {
+            id: FunctionId::new(self.next_function_index),
+            runtime_id,
+            return_type,
+            params,
+        };
+        self.next_function_index += 1;
+        self.next_anonymous_index += 1;
+        (name, info)
+    }
+
+    fn push(&mut self, function: FunctionPlan) {
+        self.functions.push(function);
+    }
+}
+
+impl Default for AnonymousFunctions {
+    fn default() -> Self {
+        Self::new(0, FunctionRuntimeIds::default())
     }
 }
 
@@ -474,7 +578,7 @@ impl ValueType {
 #[cfg(test)]
 mod tests {
     use super::FunctionLocalBinding;
-    use super::{FunctionInfo, FunctionRuntimeIds, PlanContext};
+    use super::{AnonymousFunctions, FunctionInfo, FunctionRuntimeIds, PlanContext};
     use crate::plan::{
         FunctionValue, IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId, RuntimeFunctionId,
         ValueType,
@@ -486,7 +590,8 @@ mod tests {
     fn local_scope_restores_names_after_error_without_reusing_ids() {
         let module = EcoString::from("main");
         let functions = HashMap::<EcoString, FunctionInfo>::new();
-        let mut context = PlanContext::new(&module, &functions);
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
 
         assert_eq!(context.define_int_local("x".into()), IntLocalId(0));
         let result = context.with_local_scope(|context| {
@@ -506,7 +611,8 @@ mod tests {
     fn define_function_local_records_binding() {
         let module = EcoString::from("main");
         let functions = HashMap::<EcoString, FunctionInfo>::new();
-        let mut context = PlanContext::new(&module, &functions);
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
         let value = function_value();
 
         let local = context.define_int_function_local("f".into(), value.type_());
@@ -525,7 +631,8 @@ mod tests {
     fn function_local_shadows_primitive_binding() {
         let module = EcoString::from("main");
         let functions = HashMap::<EcoString, FunctionInfo>::new();
-        let mut context = PlanContext::new(&module, &functions);
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
         let value = function_value();
 
         context.define_int_local("f".into());
@@ -545,7 +652,8 @@ mod tests {
     fn primitive_binding_shadows_function_local() {
         let module = EcoString::from("main");
         let functions = HashMap::<EcoString, FunctionInfo>::new();
-        let mut context = PlanContext::new(&module, &functions);
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
 
         context.define_int_function_local("f".into(), function_value().type_());
         let local = context.define_int_local("f".into());

--- a/src/planner/dsl.rs
+++ b/src/planner/dsl.rs
@@ -15,4 +15,4 @@ pub(crate) use expression::{
     not_equal, string, string_arg, string_function_ref,
 };
 pub(crate) use function::function;
-pub(crate) use module::module;
+pub(crate) use module::{module, module_with_anonymous};

--- a/src/planner/dsl/module.rs
+++ b/src/planner/dsl/module.rs
@@ -8,35 +8,57 @@ pub(crate) fn module(
     main: FunctionDsl,
     functions: impl IntoIterator<Item = FunctionDsl>,
 ) -> ExecutionPlan {
+    module_with_anonymous(name, main, functions, [])
+}
+
+pub(crate) fn module_with_anonymous(
+    name: impl Into<EcoString>,
+    main: FunctionDsl,
+    functions: impl IntoIterator<Item = FunctionDsl>,
+    anonymous_functions: impl IntoIterator<Item = FunctionDsl>,
+) -> ExecutionPlan {
     let mut runtime_ids = FunctionRuntimeIds::default();
 
-    ExecutionPlan::new(
-        name.into(),
-        main.build(FunctionId::new(0), &mut runtime_ids),
-        functions
-            .into_iter()
-            .enumerate()
-            .map(|(index, function)| function.build(FunctionId::new(index + 1), &mut runtime_ids))
-            .collect(),
-    )
+    let main = main.build(FunctionId::new(0), &mut runtime_ids);
+    let functions = functions
+        .into_iter()
+        .enumerate()
+        .map(|(index, function)| function.build(FunctionId::new(index + 1), &mut runtime_ids))
+        .collect::<Vec<_>>();
+    let next_function_index = functions.len() + 1;
+    let anonymous_functions = anonymous_functions
+        .into_iter()
+        .enumerate()
+        .map(|(index, function)| {
+            function.build(
+                FunctionId::new(next_function_index + index),
+                &mut runtime_ids,
+            )
+        })
+        .collect();
+
+    ExecutionPlan::new_with_anonymous(name.into(), main, functions, anonymous_functions)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::module;
+    use super::module_with_anonymous;
     use crate::planner::dsl::expression::{int, nil};
     use crate::planner::dsl::function::function;
 
     #[test]
     fn module_dsl() {
-        let plan = module(
+        let plan = module_with_anonymous(
             "main",
             function("main", int(1)),
             [function("helper", nil())],
+            [function("<anonymous:0>", int(2))],
         );
 
         assert_eq!(plan.main_function().name(), "main");
         assert_eq!(plan.functions().len(), 1);
         assert_eq!(plan.functions()[0].name(), "helper");
+        assert_eq!(plan.anonymous_functions().len(), 1);
+        assert_eq!(plan.anonymous_functions()[0].name(), "<anonymous:0>");
     }
 }

--- a/src/planner/error/invalid.rs
+++ b/src/planner/error/invalid.rs
@@ -33,6 +33,8 @@ pub enum InvalidTypedAstReason {
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum InvalidFunctionShapeReason {
+    #[error("function argument types do not match signature")]
+    ArgumentTypeMismatch,
     #[error("anonymous functions are not module functions")]
     Anonymous,
     #[error("empty function bodies are not supported")]

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -64,14 +64,16 @@ pub enum UnsupportedPatternKind {
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedExpressionKind {
-    #[error("anonymous function")]
-    AnonymousFunction,
     #[error("bit array")]
     BitArray,
+    #[error("capturing closure")]
+    CapturingClosure,
     #[error("echo")]
     Echo,
     #[error("float")]
     Float,
+    #[error("function capture literal")]
+    FunctionCaptureLiteral,
     #[error("list")]
     List,
     #[error("panic")]
@@ -82,6 +84,8 @@ pub enum UnsupportedExpressionKind {
     Tuple,
     #[error("tuple index")]
     TupleIndex,
+    #[error("function literal type is not supported")]
+    UnsupportedFunctionLiteralType,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -677,7 +677,7 @@ mod tests {
         block_int_function, bool_, bool_case_int_function, call_int, call_int_function, function,
         function_function_ref, function_ref, int, int_arg, int_case_int_function, int_function_arg,
         int_function_call_arg, int_function_ref, let_int_function_step, local_int,
-        local_int_function, module,
+        local_int_function, module, module_with_anonymous,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, compile_minimal_module, dummy_span};
@@ -693,13 +693,23 @@ mod tests {
     };
 
     #[test]
-    fn reject_profile_anonymous_function_call() {
-        assert_eq!(
-            plan_module(compile(r#"pub fn main() { fn(x) { x }(1) }"#)),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::AnonymousFunction,
-            }),
+    fn plan_immediate_anonymous_function_call() {
+        let actual = plan_module(compile(r#"pub fn main() { fn(x) { x + 1 }(41) }"#))
+            .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                    [int_function_call_arg(0, int(41))],
+                ),
+            ),
+            [],
+            [function("<anonymous:0>", local_int(0, "x").add_int(int(1))).param_int(0, "x")],
         );
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -1,44 +1,286 @@
-use crate::plan::Expr;
+use crate::plan::{Expr, FunctionExpr, FunctionType, ValueType};
 use crate::planner::context::PlanContext;
-use crate::planner::error::{PlanError, UnsupportedExpressionKind};
+use crate::planner::error::{
+    InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
+    InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
+};
+use crate::planner::function::{anonymous_function_plan, plan_anonymous_function_body};
+use crate::planner::module::function_params;
 use gleam_core::ast::{FunctionLiteralKind, TypedArg, TypedStatement};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 use vec1::Vec1;
 
 pub(super) fn plan_anonymous(
-    _type_: Arc<Type>,
-    _kind: FunctionLiteralKind,
-    _arguments: Vec<TypedArg>,
-    _body: Vec1<TypedStatement>,
-    _context: &mut PlanContext<'_>,
+    type_: Arc<Type>,
+    kind: FunctionLiteralKind,
+    arguments: Vec<TypedArg>,
+    body: Vec1<TypedStatement>,
+    context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    Err(PlanError::UnsupportedExpression {
-        kind: UnsupportedExpressionKind::AnonymousFunction,
-    })
+    match kind {
+        FunctionLiteralKind::Anonymous { .. } => {}
+        FunctionLiteralKind::Capture { .. } => {
+            return Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::FunctionCaptureLiteral,
+            });
+        }
+        FunctionLiteralKind::Use { .. } => {
+            return Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: crate::planner::error::InvalidExpressionShapeKind::Invalid,
+                },
+            });
+        }
+    }
+
+    let function_type = anonymous_function_type(type_.as_ref())?;
+    let error_name = context.anonymous_function_error_name();
+    let params = function_params(error_name.clone(), &arguments)?;
+    validate_argument_types(&error_name, &function_type, &params)?;
+
+    let planned = {
+        let mut body_context = context.anonymous_function_context();
+        plan_anonymous_function_body(&params, body, &mut body_context)
+    };
+
+    match planned {
+        Ok(planned) => {
+            let (name, info) =
+                context.allocate_anonymous_function(function_type.return_().clone(), params);
+            let value = info.value();
+            let function = anonymous_function_plan(info, name, planned)?;
+            context.push_anonymous_function(function);
+            Ok(Expr::function(FunctionExpr::value(value)))
+        }
+        Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::UnknownLocal { name },
+        }) if context.is_outer_binding_name(&name) => Err(PlanError::UnsupportedExpression {
+            kind: UnsupportedExpressionKind::CapturingClosure,
+        }),
+        Err(error) => Err(error),
+    }
+}
+
+fn anonymous_function_type(type_: &Type) -> Result<FunctionType, PlanError> {
+    match ValueType::from_gleam(type_) {
+        Some(ValueType::Function(type_)) => Ok(*type_),
+        Some(ValueType::Int) => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionType {
+                expected: InvalidExpressionType::Function,
+                actual: InvalidExpressionType::Int,
+            },
+        }),
+        Some(ValueType::String) => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionType {
+                expected: InvalidExpressionType::Function,
+                actual: InvalidExpressionType::String,
+            },
+        }),
+        Some(ValueType::Bool) => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionType {
+                expected: InvalidExpressionType::Function,
+                actual: InvalidExpressionType::Bool,
+            },
+        }),
+        Some(ValueType::Nil) => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionType {
+                expected: InvalidExpressionType::Function,
+                actual: InvalidExpressionType::Nil,
+            },
+        }),
+        None if type_.fn_types().is_some() => Err(PlanError::UnsupportedExpression {
+            kind: UnsupportedExpressionKind::UnsupportedFunctionLiteralType,
+        }),
+        None => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionShape {
+                kind: InvalidExpressionShapeKind::Invalid,
+            },
+        }),
+    }
+}
+
+fn validate_argument_types(
+    name: &ecow::EcoString,
+    type_: &FunctionType,
+    params: &[crate::planner::context::FunctionParam],
+) -> Result<(), PlanError> {
+    let actual = params
+        .iter()
+        .map(|param| param.local.value_type())
+        .collect::<Vec<_>>();
+
+    if actual == type_.argument_types() {
+        Ok(())
+    } else {
+        Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::FunctionShape {
+                name: name.clone(),
+                reason: InvalidFunctionShapeReason::ArgumentTypeMismatch,
+            },
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::planner::error::{PlanError, UnsupportedExpressionKind};
+    use crate::plan::{
+        FunctionFunctionId, FunctionType, IntFunctionFunctionId, IntFunctionId, IntLocalId,
+        LocalId, ParamLocal, RuntimeFunctionId, ValueType,
+    };
+    use crate::planner::dsl::{
+        call_int, call_int_function, function, function_function_ref, function_ref, int, int_arg,
+        int_function_call_arg, int_function_ref, let_int_function_step, local_int,
+        local_int_function, module_with_anonymous,
+    };
+    use crate::planner::error::{
+        InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
+        InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
+    };
     use crate::planner::plan_module;
-    use crate::planner::support::compile;
+    use crate::planner::support::{compile, dummy_span};
+    use gleam_core::ast::{FunctionLiteralKind, Statement, TypedArg, TypedExpr, TypedModule};
 
     #[test]
-    fn reject_profile_anonymous_function() {
-        assert_eq!(
-            plan_module(compile(
-                r#"
+    fn plan_non_capturing_anonymous_function() {
+        let actual = plan_module(compile(
+            r#"
 pub fn main() {
-  fn(value) { value }
-  1
+  let add_one = fn(value) { value + 1 }
+  add_one(41)
 }
 "#,
+        ))
+        .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    local_int_function(0, "add_one", [LocalId::Int(IntLocalId(0))]),
+                    [int_function_call_arg(0, int(41))],
+                ),
+            )
+            .step(let_int_function_step(
+                0,
+                "add_one",
+                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
             )),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::AnonymousFunction,
-            }),
+            [],
+            [
+                function("<anonymous:0>", local_int(0, "value").add_int(int(1)))
+                    .param_int(0, "value"),
+            ],
         );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_anonymous_function_referencing_top_level_function() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let wrapped = fn(value) { add_one(value) }
+  wrapped(41)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    local_int_function(0, "wrapped", [LocalId::Int(IntLocalId(0))]),
+                    [int_function_call_arg(0, int(41))],
+                ),
+            )
+            .step(let_int_function_step(
+                0,
+                "wrapped",
+                int_function_ref(2, [LocalId::Int(IntLocalId(0))]),
+            )),
+            [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
+            [function(
+                "<anonymous:0>",
+                call_int(1, [int_arg(0, local_int(0, "value"))]),
+            )
+            .param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_main_returning_anonymous_function() {
+        let actual = plan_module(compile(
+            r#"
+pub fn main() {
+  fn(value) { value + 1 }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                function_ref(
+                    RuntimeFunctionId::Int(IntFunctionId(0)),
+                    [LocalId::Int(IntLocalId(0))],
+                ),
+            ),
+            [],
+            [
+                function("<anonymous:0>", local_int(0, "value").add_int(int(1)))
+                    .param_int(0, "value"),
+            ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_nested_anonymous_function_storage_in_postorder() {
+        let actual = plan_module(compile(
+            r#"
+pub fn main() {
+  fn() { fn(value) { value + 1 } }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                    returned_function_type.clone(),
+                ),
+            ),
+            [],
+            [
+                function("<anonymous:0>", local_int(0, "value").add_int(int(1)))
+                    .param_int(0, "value"),
+                function(
+                    "<anonymous:1>",
+                    function_ref(
+                        RuntimeFunctionId::Int(IntFunctionId(0)),
+                        [LocalId::Int(IntLocalId(0))],
+                    ),
+                ),
+            ],
+        );
+
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -54,8 +296,196 @@ pub fn main() {
 "#,
             )),
             Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::AnonymousFunction,
+                kind: UnsupportedExpressionKind::CapturingClosure,
             }),
         );
+    }
+
+    #[test]
+    fn reject_profile_nested_capturing_anonymous_function() {
+        assert_eq!(
+            plan_module(compile(
+                r#"
+pub fn main() {
+  let value = 1
+  fn() { fn() { value } }
+  1
+}
+"#,
+            )),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::CapturingClosure,
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_profile_function_capture_literal() {
+        assert_eq!(
+            plan_module(compile(
+                r#"
+fn add(left: Int, right: Int) {
+  left + right
+}
+
+pub fn main() {
+  let add_one = add(1, _)
+  add_one(41)
+}
+"#,
+            )),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::FunctionCaptureLiteral,
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_profile_unsupported_anonymous_function_type() {
+        assert_eq!(
+            plan_module(compile(
+                r#"
+pub fn main() {
+  fn(value) { [value] }
+  1
+}
+"#,
+            )),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::UnsupportedFunctionLiteralType,
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_non_function_literal_type() {
+        for (type_, actual) in [
+            (gleam_core::type_::int(), InvalidExpressionType::Int),
+            (gleam_core::type_::string(), InvalidExpressionType::String),
+            (gleam_core::type_::bool(), InvalidExpressionType::Bool),
+            (gleam_core::type_::nil(), InvalidExpressionType::Nil),
+        ] {
+            let mut module = anonymous_function_module();
+            let (expression_type, _, _) = anonymous_function_expression_mut(&mut module);
+            *expression_type = type_;
+
+            assert_eq!(
+                plan_module(module),
+                Err(PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::Function,
+                        actual,
+                    },
+                }),
+            );
+        }
+    }
+
+    #[test]
+    fn reject_margin_anonymous_function_argument_type_mismatch() {
+        let mut module = anonymous_function_module();
+        let (_, arguments, _) = anonymous_function_expression_mut(&mut module);
+        arguments[0].type_ = gleam_core::type_::string();
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::FunctionShape {
+                    name: "<anonymous:0>".into(),
+                    reason: InvalidFunctionShapeReason::ArgumentTypeMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_anonymous_function_return_type_mismatch() {
+        let mut module = anonymous_function_module();
+        let (type_, _, _) = anonymous_function_expression_mut(&mut module);
+        *type_ =
+            gleam_core::type_::fn_(vec![gleam_core::type_::int()], gleam_core::type_::string());
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::FunctionShape {
+                    name: "<anonymous:0>".into(),
+                    reason: InvalidFunctionShapeReason::ReturnTypeMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_non_supported_non_function_literal_type() {
+        let mut module = anonymous_function_module();
+        let (type_, _, _) = anonymous_function_expression_mut(&mut module);
+        *type_ = gleam_core::type_::list(gleam_core::type_::int());
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_use_function_literal_expression_kind() {
+        let mut module = anonymous_function_module();
+        let (_, _, kind) = anonymous_function_expression_mut(&mut module);
+        *kind = FunctionLiteralKind::Use {
+            location: dummy_span(),
+        };
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "expected anonymous function expression statement")]
+    fn anonymous_function_expression_mut_panics_on_non_function_statement() {
+        let mut module = compile(r#"pub fn main() { 1 }"#);
+
+        let _ = anonymous_function_expression_mut(&mut module);
+    }
+
+    fn anonymous_function_module() -> TypedModule {
+        compile(
+            r#"
+pub fn main() {
+  fn(value) { value + 1 }
+  1
+}
+"#,
+        )
+    }
+
+    fn anonymous_function_expression_mut(
+        module: &mut TypedModule,
+    ) -> (
+        &mut std::sync::Arc<gleam_core::type_::Type>,
+        &mut Vec<TypedArg>,
+        &mut FunctionLiteralKind,
+    ) {
+        let Statement::Expression(TypedExpr::Fn {
+            type_,
+            arguments,
+            kind,
+            ..
+        }) = &mut module.definitions.functions[0].body[0]
+        else {
+            panic!("expected anonymous function expression statement");
+        };
+
+        (type_, arguments, kind)
     }
 }

--- a/src/planner/function.rs
+++ b/src/planner/function.rs
@@ -1,21 +1,29 @@
 use crate::plan::{
-    Expr, ExprKind, FunctionFunctionId, FunctionPlan, Param, ReturnExpr, RuntimeFunctionId,
+    Expr, ExprKind, FunctionFunctionId, FunctionPlan, Param, ReturnExpr, RuntimeFunctionId, Step,
     ValueType,
 };
-use crate::planner::context::{FunctionInfo, PlanContext};
+use crate::planner::context::{AnonymousFunctions, FunctionInfo, FunctionParam, PlanContext};
 use crate::planner::error::{
     InvalidFunctionShapeReason, InvalidTypedAstReason, PlanError, UnsupportedFunctionReason,
 };
 use crate::planner::statement::plan_steps_and_return;
 use ecow::EcoString;
-use gleam_core::ast::TypedFunction;
+use gleam_core::ast::{TypedFunction, TypedStatement};
 use std::collections::HashMap;
+use vec1::Vec1;
+
+pub(super) struct PlannedFunctionBody {
+    pub(super) params: Vec<Param>,
+    pub(super) steps: Vec<Step>,
+    pub(super) return_: Expr,
+}
 
 pub(super) fn plan_function(
     info: FunctionInfo,
     module_name: &EcoString,
     functions: &HashMap<EcoString, FunctionInfo>,
     function: TypedFunction,
+    anonymous_functions: &mut AnonymousFunctions,
 ) -> Result<FunctionPlan, PlanError> {
     let name = function_name(&function)?;
 
@@ -26,15 +34,8 @@ pub(super) fn plan_function(
         });
     }
 
-    let mut context = PlanContext::new(module_name, functions);
-    let params = info
-        .params
-        .iter()
-        .map(|param| {
-            context.define_existing_param(param.name.clone(), &param.local);
-            Param::new(param.local.clone(), param.name.clone())
-        })
-        .collect();
+    let mut context = PlanContext::new(module_name, functions, anonymous_functions);
+    let params = define_params(&info.params, &mut context);
     let planned = plan_steps_and_return(
         function.body,
         &mut context,
@@ -59,6 +60,52 @@ pub(super) fn plan_function(
         planned.steps,
         return_,
     ))
+}
+
+pub(super) fn plan_anonymous_function_body(
+    params: &[FunctionParam],
+    body: Vec1<TypedStatement>,
+    context: &mut PlanContext<'_>,
+) -> Result<PlannedFunctionBody, PlanError> {
+    let params = define_params(params, context);
+    let planned = crate::planner::statement::plan_non_empty_steps_and_return(body, context)?;
+
+    Ok(PlannedFunctionBody {
+        params,
+        steps: planned.steps,
+        return_: planned.return_,
+    })
+}
+
+pub(super) fn anonymous_function_plan(
+    info: FunctionInfo,
+    name: EcoString,
+    planned: PlannedFunctionBody,
+) -> Result<FunctionPlan, PlanError> {
+    let return_ = function_return_expr(
+        &name,
+        &info.return_type(),
+        &info.runtime_id,
+        planned.return_,
+    )?;
+
+    Ok(FunctionPlan::new(
+        info.id,
+        name,
+        planned.params,
+        planned.steps,
+        return_,
+    ))
+}
+
+fn define_params(params: &[FunctionParam], context: &mut PlanContext<'_>) -> Vec<Param> {
+    params
+        .iter()
+        .map(|param| {
+            context.define_existing_param(param.name.clone(), &param.local);
+            Param::new(param.local.clone(), param.name.clone())
+        })
+        .collect()
 }
 
 fn function_return_expr(
@@ -550,9 +597,16 @@ pub fn main() {
             return_type: ValueType::Int,
             params: Vec::new(),
         };
+        let mut anonymous = crate::planner::context::AnonymousFunctions::default();
 
         assert_eq!(
-            super::plan_function(info, &"main".into(), &Default::default(), function),
+            super::plan_function(
+                info,
+                &"main".into(),
+                &Default::default(),
+                function,
+                &mut anonymous,
+            ),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::FunctionShape {
                     name: "<anonymous>".into(),

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -2,7 +2,9 @@ use crate::plan::{
     ExecutionPlan, FunctionFunctionLocalId, FunctionId, FunctionType, IntFunctionLocalId,
     ParamLocal, ValueType,
 };
-use crate::planner::context::{FunctionInfo, FunctionParam, FunctionRuntimeIds};
+use crate::planner::context::{
+    AnonymousFunctions, FunctionInfo, FunctionParam, FunctionRuntimeIds,
+};
 use crate::planner::error::{
     PlanError, UnsupportedArgumentReason, UnsupportedFunctionReason, UnsupportedTopLevelKind,
 };
@@ -47,23 +49,48 @@ pub fn plan_module(module: TypedModule) -> Result<ExecutionPlan, PlanError> {
         main,
         functions_before_main,
         functions_after_main,
+        mut anonymous_functions,
     } = function_table(&definitions.functions)?;
     let main = validate_main_function(main)?;
     let mut functions = Vec::new();
 
     for function in functions_before_main {
-        let planned = plan_function(function.info, &module_name, &by_name, function.function)?;
+        let planned = plan_function(
+            function.info,
+            &module_name,
+            &by_name,
+            function.function,
+            &mut anonymous_functions,
+        )?;
         functions.push(planned);
     }
 
-    let main = plan_function(main.info, &module_name, &by_name, main.function)?;
+    let main = plan_function(
+        main.info,
+        &module_name,
+        &by_name,
+        main.function,
+        &mut anonymous_functions,
+    )?;
 
     for function in functions_after_main {
-        let planned = plan_function(function.info, &module_name, &by_name, function.function)?;
+        let planned = plan_function(
+            function.info,
+            &module_name,
+            &by_name,
+            function.function,
+            &mut anonymous_functions,
+        )?;
         functions.push(planned);
     }
+    let anonymous_functions = anonymous_functions.into_functions();
 
-    Ok(ExecutionPlan::new(module_name, main, functions))
+    Ok(ExecutionPlan::new_with_anonymous(
+        module_name,
+        main,
+        functions,
+        anonymous_functions,
+    ))
 }
 
 struct FunctionTable {
@@ -71,6 +98,7 @@ struct FunctionTable {
     main: FunctionToPlan,
     functions_before_main: Vec<FunctionToPlan>,
     functions_after_main: Vec<FunctionToPlan>,
+    anonymous_functions: AnonymousFunctions,
 }
 
 struct FunctionToPlan {
@@ -138,11 +166,14 @@ fn function_table(
         }
     }
 
+    let anonymous_functions = AnonymousFunctions::new(next_function_index, runtime_ids);
+
     Ok(FunctionTable {
         by_name,
         main,
         functions_before_main,
         functions_after_main,
+        anonymous_functions,
     })
 }
 
@@ -175,7 +206,7 @@ fn function_return_type(name: EcoString, type_: &Type) -> Result<ValueType, Plan
     })
 }
 
-fn function_params(
+pub(super) fn function_params(
     function_name: EcoString,
     arguments: &[gleam_core::ast::TypedArg],
 ) -> Result<Vec<FunctionParam>, PlanError> {

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -113,6 +113,17 @@ mod functions {
             function_returning_function_recursive,
         );
     }
+
+    mod anonymous {
+        execution_cases!("functions/anonymous";
+            anonymous_function_local_call,
+            anonymous_function_immediate_call,
+            anonymous_function_argument,
+            anonymous_function_return_shapes,
+            anonymous_function_returning_function,
+            anonymous_function_main_returning_function,
+        );
+    }
 }
 
 mod rejection {
@@ -147,6 +158,12 @@ mod rejection {
             argument_discard,
             argument_labelled,
             argument_unsupported_type,
+        );
+    }
+
+    mod anonymous {
+        rejection_cases!("anonymous";
+            capturing_closure,
         );
     }
 }

--- a/tests/fixtures/execution/functions/anonymous/anonymous_function_argument.gleam
+++ b/tests/fixtures/execution/functions/anonymous/anonymous_function_argument.gleam
@@ -1,0 +1,9 @@
+fn apply(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  apply(fn(value) { value + 1 }, 41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/anonymous/anonymous_function_immediate_call.gleam
+++ b/tests/fixtures/execution/functions/anonymous/anonymous_function_immediate_call.gleam
@@ -1,0 +1,5 @@
+pub fn main() {
+  fn(value) { value + 1 }(41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/anonymous/anonymous_function_local_call.gleam
+++ b/tests/fixtures/execution/functions/anonymous/anonymous_function_local_call.gleam
@@ -1,0 +1,7 @@
+pub fn main() {
+  let add_one = fn(value) { value + 1 }
+
+  add_one(41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/anonymous/anonymous_function_main_returning_function.gleam
+++ b/tests/fixtures/execution/functions/anonymous/anonymous_function_main_returning_function.gleam
@@ -1,0 +1,5 @@
+pub fn main() {
+  fn(value) { value + 1 }
+}
+
+// geam:expect Function(fn(Int) -> Int)

--- a/tests/fixtures/execution/functions/anonymous/anonymous_function_return_shapes.gleam
+++ b/tests/fixtures/execution/functions/anonymous/anonymous_function_return_shapes.gleam
@@ -1,0 +1,25 @@
+fn apply_int(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+fn apply_string(function: fn(String) -> String, value: String) {
+  function(value)
+}
+
+fn apply_bool(function: fn(Bool) -> Bool, value: Bool) {
+  function(value)
+}
+
+fn apply_nil(function: fn(Nil) -> Nil, value: Nil) {
+  function(value)
+}
+
+pub fn main() {
+  apply_string(fn(value) { value }, "geam")
+  apply_bool(fn(value) { value }, True)
+  apply_nil(fn(value) { value }, Nil)
+
+  apply_int(fn(value) { value + 1 }, 41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/anonymous/anonymous_function_returning_function.gleam
+++ b/tests/fixtures/execution/functions/anonymous/anonymous_function_returning_function.gleam
@@ -1,0 +1,12 @@
+fn apply(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  let getter = fn() { fn(value) { value + 1 } }
+  let add_one = getter()
+
+  apply(add_one, 41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/rejection/anonymous/capturing_closure.gleam
+++ b/tests/fixtures/rejection/anonymous/capturing_closure.gleam
@@ -1,0 +1,6 @@
+pub fn main() {
+  let value = 1
+  let add_value = fn(other) { value + other }
+
+  add_value(41)
+}


### PR DESCRIPTION
- Lower anonymous function literals into private planned functions.
- Keep anonymous functions out of public top-level function inspection.
- Reuse function-value calls for local, immediate, argument, and returned anonymous functions.
- Reject capturing closures and unsupported function literal forms during planning.
- Add execution and rejection fixtures for anonymous function behavior.

ref #7 
