### PR TITLE
Support use syntax callback lowering

### DIFF
--- a/src/planner.rs
+++ b/src/planner.rs
@@ -10,10 +10,10 @@ mod statement;
 pub use error::{
     InvalidCallShapeReason, InvalidCaseShapeReason, InvalidExpressionShapeKind,
     InvalidExpressionType, InvalidFunctionShapeReason, InvalidPipelineShapeReason,
-    InvalidTypedAstReason, PlanError, UnsupportedArgumentReason, UnsupportedAssignmentKind,
-    UnsupportedBinOpKind, UnsupportedCaseReason, UnsupportedExpressionKind,
-    UnsupportedFunctionReason, UnsupportedPatternKind, UnsupportedPipelineReason,
-    UnsupportedStatementKind, UnsupportedTopLevelKind,
+    InvalidTypedAstReason, InvalidUseShapeReason, PlanError, UnsupportedArgumentReason,
+    UnsupportedAssignmentKind, UnsupportedBinOpKind, UnsupportedCaseReason,
+    UnsupportedExpressionKind, UnsupportedFunctionReason, UnsupportedPatternKind,
+    UnsupportedPipelineReason, UnsupportedStatementKind, UnsupportedTopLevelKind,
 };
 pub use module::plan_module;
 

--- a/src/planner/error.rs
+++ b/src/planner/error.rs
@@ -7,7 +7,7 @@ mod unsupported;
 pub use invalid::{
     InvalidCallShapeReason, InvalidCaseShapeReason, InvalidExpressionShapeKind,
     InvalidExpressionType, InvalidFunctionShapeReason, InvalidPipelineShapeReason,
-    InvalidTypedAstReason,
+    InvalidTypedAstReason, InvalidUseShapeReason,
 };
 pub use unsupported::{
     UnsupportedArgumentReason, UnsupportedAssignmentKind, UnsupportedBinOpKind,

--- a/src/planner/error/invalid.rs
+++ b/src/planner/error/invalid.rs
@@ -27,6 +27,8 @@ pub enum InvalidTypedAstReason {
     CaseShape { reason: InvalidCaseShapeReason },
     #[error("pipeline shape: {reason}")]
     PipelineShape { reason: InvalidPipelineShapeReason },
+    #[error("use shape: {reason}")]
+    UseShape { reason: InvalidUseShapeReason },
     #[error("unknown local variable: {name}")]
     UnknownLocal { name: EcoString },
 }
@@ -141,6 +143,26 @@ pub enum InvalidPipelineShapeReason {
     MultiplePipeArguments,
     #[error("non-call pipeline step")]
     NonCallStep,
+    #[error("unsupported implicit argument")]
+    UnsupportedImplicitArgument,
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidUseShapeReason {
+    #[error("callback literal kind is not use")]
+    CallbackLiteralKindNotUse,
+    #[error("callback is not the last argument")]
+    CallbackNotLast,
+    #[error("callback argument is not a function literal")]
+    CallbackNotFunctionLiteral,
+    #[error("missing callback")]
+    MissingCallback,
+    #[error("multiple callbacks")]
+    MultipleCallbacks,
+    #[error("non-call use right hand side")]
+    NonCallRhs,
+    #[error("unexpected variable use assignment")]
+    UnexpectedVariableAssignment,
     #[error("unsupported implicit argument")]
     UnsupportedImplicitArgument,
 }

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -42,8 +42,6 @@ pub enum UnsupportedStatementKind {
     AssertAsFinalStatement,
     #[error("assignment as final statement")]
     AssignmentAsFinalStatement,
-    #[error("use")]
-    Use,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -111,6 +111,13 @@ pub(super) fn plan_expr(
     }
 }
 
+pub(super) fn plan_use_call(
+    call: TypedExpr,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    call::plan_use_call(call, context)
+}
+
 fn plan_int_expr(
     expression: TypedExpr,
     context: &mut PlanContext<'_>,

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -6,7 +6,7 @@ use crate::plan::{
 use crate::planner::context::{FunctionInfo, FunctionParam, PlanContext};
 use crate::planner::error::{
     InvalidCallShapeReason, InvalidExpressionType, InvalidPipelineShapeReason,
-    InvalidTypedAstReason, PlanError, UnsupportedPipelineReason,
+    InvalidTypedAstReason, InvalidUseShapeReason, PlanError, UnsupportedPipelineReason,
 };
 use ecow::EcoString;
 use gleam_core::ast::{
@@ -45,8 +45,35 @@ pub(super) fn plan_call(
         arguments,
         context,
         None,
+        CallArgumentMode::Normal,
         FunctionValueCallMode::Allow,
     )
+}
+
+pub(super) fn plan_use_call(
+    call: TypedExpr,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    match call {
+        TypedExpr::Call {
+            type_,
+            fun,
+            arguments,
+            ..
+        } => {
+            validate_use_call_arguments(&arguments)?;
+            plan_call_expression(
+                type_,
+                *fun,
+                arguments,
+                context,
+                None,
+                CallArgumentMode::Use,
+                FunctionValueCallMode::Allow,
+            )
+        }
+        _ => Err(invalid_use_shape(InvalidUseShapeReason::NonCallRhs)),
+    }
 }
 
 pub(super) fn plan_pipeline_direct_call(
@@ -63,6 +90,7 @@ pub(super) fn plan_pipeline_direct_call(
         arguments,
         context,
         None,
+        CallArgumentMode::Normal,
         FunctionValueCallMode::Reject,
     )
 }
@@ -135,6 +163,7 @@ pub(super) fn plan_pipeline_hole_call(
             name: capture_name,
             value: pipe_value,
         }),
+        CallArgumentMode::Normal,
         FunctionValueCallMode::Reject,
     )
 }
@@ -193,12 +222,19 @@ enum FunctionValueCallMode {
     Reject,
 }
 
+#[derive(Clone, Copy)]
+enum CallArgumentMode {
+    Normal,
+    Use,
+}
+
 fn plan_call_expression(
     type_: Arc<Type>,
     fun: TypedExpr,
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
+    call_argument_mode: CallArgumentMode,
     function_value_call_mode: FunctionValueCallMode,
 ) -> Result<Expr, PlanError> {
     if let TypedExpr::Var { constructor, .. } = &fun {
@@ -220,7 +256,14 @@ fn plan_call_expression(
                             reason: InvalidCallShapeReason::MissingCurrentModuleFunction,
                         },
                     })?;
-                return plan_direct_function_call(type_, function, arguments, context, capture);
+                return plan_direct_function_call(
+                    type_,
+                    function,
+                    arguments,
+                    context,
+                    capture,
+                    call_argument_mode,
+                );
             }
             ValueConstructorVariant::ModuleConstant { .. } => {
                 return Err(PlanError::InvalidTypedAst {
@@ -253,7 +296,7 @@ fn plan_call_expression(
         });
     }
 
-    plan_function_value_call(type_, fun, arguments, context, capture)
+    plan_function_value_call(type_, fun, arguments, context, capture, call_argument_mode)
 }
 
 fn plan_direct_function_call(
@@ -262,6 +305,7 @@ fn plan_direct_function_call(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
+    call_argument_mode: CallArgumentMode,
 ) -> Result<Expr, PlanError> {
     if function.arity() != arguments.len() {
         return Err(PlanError::InvalidTypedAst {
@@ -284,7 +328,13 @@ fn plan_direct_function_call(
             },
         });
     }
-    let args = plan_call_args(arguments, &function.params, context, capture)?;
+    let args = plan_call_args(
+        arguments,
+        &function.params,
+        context,
+        capture,
+        call_argument_mode,
+    )?;
 
     Ok(call_expr(function_id, args))
 }
@@ -295,6 +345,7 @@ fn plan_function_value_call(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
+    call_argument_mode: CallArgumentMode,
 ) -> Result<Expr, PlanError> {
     let function = {
         let expression = plan_expr(fun, context)?;
@@ -330,8 +381,13 @@ fn plan_function_value_call(
         });
     }
 
-    let args =
-        plan_function_call_args(arguments, function_type.argument_types(), context, capture)?;
+    let args = plan_function_call_args(
+        arguments,
+        function_type.argument_types(),
+        context,
+        capture,
+        call_argument_mode,
+    )?;
 
     function_call_expr(function, args, return_type)
 }
@@ -341,10 +397,11 @@ fn plan_call_args(
     params: &[FunctionParam],
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
+    call_argument_mode: CallArgumentMode,
 ) -> Result<Vec<CallArg>, PlanError> {
     let mut args = Vec::with_capacity(arguments.len());
     for (argument, param) in arguments.into_iter().zip(params) {
-        let expression = plan_argument_value(argument.value, capture, context)?;
+        let expression = plan_argument_value(argument, capture, context, call_argument_mode)?;
         let actual = expression.value_type();
         let arg = match expression.into_call_arg(&param.local) {
             Some(arg) => arg,
@@ -360,11 +417,12 @@ fn plan_function_call_args(
     params: &[ValueType],
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
+    call_argument_mode: CallArgumentMode,
 ) -> Result<Vec<CallArg>, PlanError> {
     let locals = function_call_param_locals(params);
     let mut args = Vec::with_capacity(arguments.len());
     for (argument, local) in arguments.into_iter().zip(&locals) {
-        let expression = plan_argument_value(argument.value, capture, context)?;
+        let expression = plan_argument_value(argument, capture, context, call_argument_mode)?;
         let actual = expression.value_type();
         let arg = match expression.into_call_arg(local) {
             Some(arg) => arg,
@@ -468,17 +526,89 @@ fn call_arg_type_mismatch(expected: ValueType, actual: ValueType) -> PlanError {
 }
 
 fn plan_argument_value(
-    argument: TypedExpr,
+    argument: GleamCallArg<TypedExpr>,
     capture: Option<&CaptureSubstitution>,
     context: &mut PlanContext<'_>,
+    call_argument_mode: CallArgumentMode,
 ) -> Result<Expr, PlanError> {
+    if matches!(call_argument_mode, CallArgumentMode::Use)
+        && matches!(argument.implicit, Some(ImplicitCallArgOrigin::Use))
+    {
+        return plan_use_callback_argument(argument.value, context);
+    }
+
     if let Some(capture) = capture
-        && is_capture_local(&argument, &capture.name)
+        && is_capture_local(&argument.value, &capture.name)
     {
         return Ok(capture.value.clone());
     }
 
-    plan_expr(argument, context)
+    plan_expr(argument.value, context)
+}
+
+fn plan_use_callback_argument(
+    argument: TypedExpr,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    match argument {
+        TypedExpr::Fn {
+            type_,
+            kind: FunctionLiteralKind::Use { .. },
+            arguments,
+            body,
+            ..
+        } => super::function::plan_use_callback(type_, arguments, body, context),
+        TypedExpr::Fn { .. } => Err(invalid_use_shape(
+            InvalidUseShapeReason::CallbackLiteralKindNotUse,
+        )),
+        _ => Err(invalid_use_shape(
+            InvalidUseShapeReason::CallbackNotFunctionLiteral,
+        )),
+    }
+}
+
+fn validate_use_call_arguments(arguments: &[GleamCallArg<TypedExpr>]) -> Result<(), PlanError> {
+    if arguments.iter().any(|argument| argument.label.is_some()) {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::LabelledArguments,
+            },
+        });
+    }
+
+    let mut callback_index = None;
+    for (index, argument) in arguments.iter().enumerate() {
+        match argument.implicit {
+            None => {}
+            Some(ImplicitCallArgOrigin::Use) => {
+                if callback_index.replace(index).is_some() {
+                    return Err(invalid_use_shape(InvalidUseShapeReason::MultipleCallbacks));
+                }
+            }
+            Some(
+                ImplicitCallArgOrigin::Pipe
+                | ImplicitCallArgOrigin::PatternFieldSpread
+                | ImplicitCallArgOrigin::IncorrectArityUse
+                | ImplicitCallArgOrigin::RecordUpdate,
+            ) => {
+                return Err(invalid_use_shape(
+                    InvalidUseShapeReason::UnsupportedImplicitArgument,
+                ));
+            }
+        }
+    }
+
+    match callback_index {
+        Some(index) if index + 1 == arguments.len() => Ok(()),
+        Some(_) => Err(invalid_use_shape(InvalidUseShapeReason::CallbackNotLast)),
+        None => Err(invalid_use_shape(InvalidUseShapeReason::MissingCallback)),
+    }
+}
+
+fn invalid_use_shape(reason: InvalidUseShapeReason) -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::UseShape { reason },
+    }
 }
 
 fn count_capture_arguments(

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -47,6 +47,27 @@ pub(super) fn plan_anonymous(
     })
 }
 
+pub(super) fn plan_use_callback(
+    type_: Arc<Type>,
+    arguments: Vec<TypedArg>,
+    body: Vec1<TypedStatement>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let function_type = anonymous_function_type(type_.as_ref())?;
+    let error_name = context.anonymous_function_error_name();
+    let params = function_params(error_name.clone(), &arguments)?;
+    validate_argument_types(&error_name, &function_type, &params).and_then(|()| {
+        plan_anonymous_with_valid_arguments(
+            function_type,
+            error_name,
+            params,
+            arguments,
+            body,
+            context,
+        )
+    })
+}
+
 fn plan_anonymous_with_valid_arguments(
     function_type: FunctionType,
     error_name: EcoString,
@@ -178,14 +199,20 @@ fn anonymous_function_type(type_: &Type) -> Result<FunctionType, PlanError> {
                 actual: InvalidExpressionType::Nil,
             },
         }),
-        None if type_.fn_types().is_some() => Err(PlanError::UnsupportedExpression {
+        None => Err(anonymous_function_type_error(type_)),
+    }
+}
+
+fn anonymous_function_type_error(type_: &Type) -> PlanError {
+    match type_.fn_types() {
+        Some(_) => PlanError::UnsupportedExpression {
             kind: UnsupportedExpressionKind::UnsupportedFunctionLiteralType,
-        }),
-        None => Err(PlanError::InvalidTypedAst {
+        },
+        None => PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::ExpressionShape {
                 kind: InvalidExpressionShapeKind::Invalid,
             },
-        }),
+        },
     }
 }
 
@@ -195,18 +222,24 @@ fn anonymous_free_variables(arguments: &[TypedArg], body: &Vec1<TypedStatement>)
         bound.extend(argument.get_variable_name().cloned());
     }
 
-    let mut free = FreeVariables::default();
+    let mut free = FreeVariables::new();
     collect_statements(body.as_slice(), &mut bound, &mut free);
     free.names
 }
 
-#[derive(Default)]
 struct FreeVariables {
     names: Vec<EcoString>,
     seen: HashSet<EcoString>,
 }
 
 impl FreeVariables {
+    fn new() -> Self {
+        Self {
+            names: Vec::new(),
+            seen: HashSet::new(),
+        }
+    }
+
     fn record(&mut self, name: &EcoString, bound: &HashSet<EcoString>) {
         if !bound.contains(name) && self.seen.insert(name.clone()) {
             self.names.push(name.clone());
@@ -235,7 +268,10 @@ fn collect_statement(
             collect_expr(&assignment.value, bound, free);
             collect_variable_pattern_bound_name(&assignment.pattern, bound);
         }
-        Statement::Use(_) | Statement::Assert(_) => {}
+        Statement::Use(use_) => {
+            collect_expr(&use_.call, bound, free);
+        }
+        Statement::Assert(_) => {}
     }
 }
 

--- a/src/planner/statement.rs
+++ b/src/planner/statement.rs
@@ -1,12 +1,14 @@
 use crate::plan::{ExprKind, FunctionExprKind, Step};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
-    InvalidTypedAstReason, PlanError, UnsupportedAssignmentKind, UnsupportedPatternKind,
-    UnsupportedStatementKind,
+    InvalidTypedAstReason, InvalidUseShapeReason, PlanError, UnsupportedAssignmentKind,
+    UnsupportedPatternKind, UnsupportedStatementKind,
 };
-use crate::planner::expression::plan_expr;
+use crate::planner::expression::{plan_expr, plan_use_call};
 use ecow::EcoString;
-use gleam_core::ast::{AssignmentKind, Pattern, Statement, TypedAssignment, TypedPattern};
+use gleam_core::ast::{
+    AssignmentKind, Pattern, Statement, TypedAssignment, TypedPattern, TypedUseAssignment,
+};
 use vec1::Vec1;
 
 pub(super) struct PlannedStatements {
@@ -52,11 +54,7 @@ fn plan_ordered_steps_and_return(
                 kind: UnsupportedStatementKind::AssignmentAsFinalStatement,
             });
         }
-        Statement::Use(_) => {
-            return Err(PlanError::UnsupportedStatement {
-                kind: UnsupportedStatementKind::Use,
-            });
-        }
+        Statement::Use(use_) => plan_use_statement(use_, context)?,
         Statement::Assert(_) => {
             return Err(PlanError::UnsupportedStatement {
                 kind: UnsupportedStatementKind::AssertAsFinalStatement,
@@ -65,6 +63,14 @@ fn plan_ordered_steps_and_return(
     };
 
     Ok(PlannedStatements { steps, return_ })
+}
+
+fn plan_use_statement(
+    use_: gleam_core::ast::TypedUse,
+    context: &mut PlanContext<'_>,
+) -> Result<crate::plan::Expr, PlanError> {
+    validate_use_assignments(&use_.assignments)?;
+    plan_use_call(*use_.call, context)
 }
 
 pub(super) fn plan_runtime_step(
@@ -158,48 +164,81 @@ pub(in crate::planner) fn plan_variable_runtime_step(
 fn plan_variable_pattern(pattern: TypedPattern) -> Result<EcoString, PlanError> {
     match pattern {
         Pattern::Variable { name, .. } => Ok(name),
-        Pattern::Assign { .. } => Err(PlanError::UnsupportedPattern {
+        pattern => Err(non_variable_pattern_error(&pattern)),
+    }
+}
+
+fn validate_use_assignments(assignments: &[TypedUseAssignment]) -> Result<(), PlanError> {
+    for assignment in assignments {
+        validate_use_assignment_pattern(&assignment.pattern)?;
+    }
+    Ok(())
+}
+
+fn validate_use_assignment_pattern(pattern: &TypedPattern) -> Result<(), PlanError> {
+    match pattern {
+        Pattern::Variable { .. } => Err(invalid_use_shape(
+            InvalidUseShapeReason::UnexpectedVariableAssignment,
+        )),
+        pattern => Err(non_variable_pattern_error(pattern)),
+    }
+}
+
+fn non_variable_pattern_error(pattern: &TypedPattern) -> PlanError {
+    match pattern {
+        Pattern::Assign { .. } => PlanError::UnsupportedPattern {
             kind: UnsupportedPatternKind::Assign,
-        }),
-        Pattern::Discard { .. } => Err(PlanError::UnsupportedPattern {
+        },
+        Pattern::Discard { .. } => PlanError::UnsupportedPattern {
             kind: UnsupportedPatternKind::Discard,
-        }),
-        Pattern::Tuple { .. } => Err(PlanError::UnsupportedPattern {
+        },
+        Pattern::Tuple { .. } => PlanError::UnsupportedPattern {
             kind: UnsupportedPatternKind::Tuple,
-        }),
+        },
         Pattern::Int { .. }
         | Pattern::Float { .. }
         | Pattern::String { .. }
+        | Pattern::BitArray { .. }
         | Pattern::BitArraySize(_)
         | Pattern::List { .. }
         | Pattern::Constructor { .. }
-        | Pattern::BitArray { .. }
         | Pattern::StringPrefix { .. }
-        | Pattern::Invalid { .. } => Err(PlanError::InvalidTypedAst {
+        | Pattern::Invalid { .. }
+        | Pattern::Variable { .. } => PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::InvalidPattern,
-        }),
+        },
+    }
+}
+
+fn invalid_use_shape(reason: InvalidUseShapeReason) -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::UseShape { reason },
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::plan_variable_pattern;
-    use crate::plan::{BoolLocalId, IntLocalId, LocalId, NilLocalId, StringLocalId};
+    use crate::plan::{BoolLocalId, IntLocalId, LocalId, NilLocalId, StringLocalId, ValueType};
     use crate::planner::dsl::{
-        bool_, bool_case_int_function, bool_function_ref, function, int, int_function_ref,
-        let_bool_function_step, let_int_function_step, let_nil_function_step,
-        let_string_function_step, local_bool, local_int, local_nil, local_string, module,
-        nil_function_ref, string_function_ref,
+        bool_, bool_case_int_function, bool_function_ref, call_int_function, capture_int, function,
+        int, int_function_arg, int_function_call_arg, int_function_closure, int_function_ref,
+        int_return_tail_call, let_bool_function_step, let_int_function_step, let_nil_function_step,
+        let_string_function_step, local_bool, local_int, local_int_function, local_nil,
+        local_string, module, module_with_anonymous, nil_function_ref, string_function_ref,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, compile_minimal_module, dummy_span, expect_plan_error};
     use crate::planner::{
-        InvalidTypedAstReason, PlanError, UnsupportedAssignmentKind, UnsupportedPatternKind,
-        UnsupportedStatementKind,
+        InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
+        InvalidTypedAstReason, InvalidUseShapeReason, PlanError, UnsupportedArgumentReason,
+        UnsupportedAssignmentKind, UnsupportedPatternKind, UnsupportedStatementKind,
     };
     use gleam_core::analyse::Inferred;
     use gleam_core::ast::{
-        AssignName, AssignmentKind, BitArraySize, Pattern, Statement, TypedAssignment, TypedExpr,
+        AssignName, AssignmentKind, BitArraySize, CallArg, FunctionLiteralKind,
+        ImplicitCallArgOrigin, Pattern, Statement, TypedAssignment, TypedExpr, TypedModule,
+        TypedUse, UseAssignment,
     };
     use gleam_core::exhaustiveness::CompiledCase;
     use gleam_core::parse::LiteralFloatValue;
@@ -331,23 +370,6 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_tuple_pattern() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  let #(a, b) = #(1, 2)
-  a
-}
-"#,
-            ),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::Tuple,
-            },
-        );
-    }
-
-    #[test]
     fn reject_profile_final_statement_positions() {
         assert_eq!(
             expect_plan_error(
@@ -377,10 +399,9 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_use_syntax() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+    fn plan_use_syntax() {
+        let actual = plan_module(compile(
+            r#"
 pub fn main() {
   use <- pair
   1
@@ -390,11 +411,285 @@ fn pair(callback: fn() -> Int) {
   callback()
 }
 "#,
+        ))
+        .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                int_return_tail_call(
+                    1,
+                    [int_function_arg(
+                        0,
+                        int_function_ref(2, Vec::<LocalId>::new()),
+                    )],
+                ),
             ),
-            PlanError::UnsupportedStatement {
-                kind: UnsupportedStatementKind::Use,
-            },
+            [function(
+                "pair",
+                call_int_function(
+                    local_int_function(0, "callback", Vec::<ValueType>::new()),
+                    [],
+                ),
+            )
+            .param_int_function(0, "callback", Vec::<ValueType>::new())],
+            [function("<anonymous:0>", int(1))],
         );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_use_syntax_with_assignment_and_capture() {
+        let actual = plan_module(compile(
+            r#"
+fn with_value(continue: fn(Int) -> Int) {
+  continue(32)
+}
+
+pub fn main() {
+  let base = 10
+  use value <- with_value
+  value + base
+}
+"#,
+        ))
+        .expect("source should plan");
+        let callback = int_function_closure(
+            2,
+            [LocalId::Int(IntLocalId(0))],
+            [capture_int(1, local_int(0, "base"))],
+        );
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                int_return_tail_call(1, [int_function_arg(0, callback)]),
+            )
+            .let_int(0, "base", int(10)),
+            [function(
+                "with_value",
+                call_int_function(
+                    local_int_function(0, "continue", [ValueType::Int]),
+                    [int_function_call_arg(0, int(32))],
+                ),
+            )
+            .param_int_function(0, "continue", [ValueType::Int])],
+            [function(
+                "<anonymous:0>",
+                local_int(0, "value").add_int(local_int(1, "base")),
+            )
+            .param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_profile_use_assignment_patterns() {
+        let cases = [
+            (
+                r#"
+fn with_value(continue: fn(Int) -> Int) {
+  continue(1)
+}
+
+pub fn main() {
+  use _ <- with_value
+  1
+}
+"#,
+                PlanError::UnsupportedArgument {
+                    function: "<anonymous:0>".into(),
+                    reason: UnsupportedArgumentReason::Discard,
+                },
+            ),
+            (
+                r#"
+fn with_value(continue: fn(Int) -> Int) {
+  continue(1)
+}
+
+pub fn main() {
+  use value as alias <- with_value
+  alias
+}
+"#,
+                PlanError::UnsupportedPattern {
+                    kind: UnsupportedPatternKind::Assign,
+                },
+            ),
+        ];
+
+        for (src, expected) in cases {
+            assert_eq!(expect_plan_error(src), expected);
+        }
+    }
+
+    #[test]
+    fn reject_margin_use_call_shapes() {
+        let mut non_call_rhs = compile_minimal_module();
+        non_call_rhs.definitions.functions[0].body = vec![Statement::Use(gleam_core::ast::Use {
+            call: Box::new(typed_int_expr(1)),
+            location: dummy_span(),
+            right_hand_side_location: dummy_span(),
+            assignments_location: dummy_span(),
+            assignments: Vec::new(),
+        })];
+        assert_eq!(
+            plan_module(non_call_rhs),
+            Err(invalid_use_shape(InvalidUseShapeReason::NonCallRhs)),
+        );
+
+        let mut missing_callback = compile_use_module();
+        expect_use_call_arguments_mut(&mut missing_callback).pop();
+        assert_eq!(
+            plan_module(missing_callback),
+            Err(invalid_use_shape(InvalidUseShapeReason::MissingCallback)),
+        );
+
+        let mut unexpected_assignment = compile_use_module();
+        expect_final_use_mut(&mut unexpected_assignment)
+            .assignments
+            .push(UseAssignment {
+                location: dummy_span(),
+                pattern: Pattern::Variable {
+                    location: dummy_span(),
+                    name: "value".into(),
+                    type_: type_::int(),
+                    origin: VariableOrigin::generated(),
+                },
+                annotation: None,
+            });
+        assert_eq!(
+            plan_module(unexpected_assignment),
+            Err(invalid_use_shape(
+                InvalidUseShapeReason::UnexpectedVariableAssignment
+            )),
+        );
+
+        let mut labelled_argument = compile_use_with_argument_module();
+        let arguments = expect_use_call_arguments_mut(&mut labelled_argument);
+        arguments[0].label = Some("value".into());
+        assert_eq!(
+            plan_module(labelled_argument),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: crate::planner::InvalidCallShapeReason::LabelledArguments,
+                },
+            }),
+        );
+
+        let mut multiple_callbacks = compile_use_module();
+        let arguments = expect_use_call_arguments_mut(&mut multiple_callbacks);
+        let callback = arguments
+            .last()
+            .expect("use call should have callback")
+            .clone();
+        arguments.push(callback);
+        assert_eq!(
+            plan_module(multiple_callbacks),
+            Err(invalid_use_shape(InvalidUseShapeReason::MultipleCallbacks)),
+        );
+
+        let mut callback_not_last = compile_use_with_argument_module();
+        let arguments = expect_use_call_arguments_mut(&mut callback_not_last);
+        arguments.swap(0, 1);
+        assert_eq!(
+            plan_module(callback_not_last),
+            Err(invalid_use_shape(InvalidUseShapeReason::CallbackNotLast)),
+        );
+
+        let mut unsupported_implicit = compile_use_module();
+        let callback = expect_use_callback_argument_mut(&mut unsupported_implicit);
+        callback.implicit = Some(ImplicitCallArgOrigin::IncorrectArityUse);
+        assert_eq!(
+            plan_module(unsupported_implicit),
+            Err(invalid_use_shape(
+                InvalidUseShapeReason::UnsupportedImplicitArgument
+            )),
+        );
+
+        let mut callback_not_function = compile_use_module();
+        expect_use_callback_argument_mut(&mut callback_not_function).value = typed_int_expr(1);
+        assert_eq!(
+            plan_module(callback_not_function),
+            Err(invalid_use_shape(
+                InvalidUseShapeReason::CallbackNotFunctionLiteral
+            )),
+        );
+
+        let mut callback_literal_kind = compile_use_module();
+        let (_, kind, _) = expect_use_callback_function_mut(&mut callback_literal_kind);
+        *kind = FunctionLiteralKind::Anonymous { head: dummy_span() };
+        assert_eq!(
+            plan_module(callback_literal_kind),
+            Err(invalid_use_shape(
+                InvalidUseShapeReason::CallbackLiteralKindNotUse
+            )),
+        );
+
+        let mut callback_non_function_type = compile_use_module();
+        let (type_, _, _) = expect_use_callback_function_mut(&mut callback_non_function_type);
+        *type_ = type_::int();
+        assert_eq!(
+            plan_module(callback_non_function_type),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Function,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+
+        let mut callback_unsupported_function_type = compile_use_module();
+        let (type_, _, _) =
+            expect_use_callback_function_mut(&mut callback_unsupported_function_type);
+        *type_ = type_::list(type_::int());
+        assert_eq!(
+            plan_module(callback_unsupported_function_type),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+
+        let mut callback_argument_type = compile_use_module();
+        let (_, _, arguments) = expect_use_callback_function_mut(&mut callback_argument_type);
+        arguments[0].type_ = type_::string();
+        assert_eq!(
+            plan_module(callback_argument_type),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::FunctionShape {
+                    name: "<anonymous:0>".into(),
+                    reason: InvalidFunctionShapeReason::ArgumentTypeMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "expected final use statement")]
+    fn expect_final_use_mut_panics_on_expression() {
+        let mut module = compile_minimal_module();
+        expect_final_use_mut(&mut module);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected use call expression")]
+    fn expect_use_call_arguments_mut_panics_on_non_call_rhs() {
+        let mut module = compile_use_module();
+        *expect_final_use_mut(&mut module).call = typed_int_expr(1);
+        expect_use_call_arguments_mut(&mut module);
+    }
+
+    #[test]
+    #[should_panic(expected = "use callback should be a function literal")]
+    fn expect_use_callback_function_mut_panics_on_non_function() {
+        let mut module = compile_use_module();
+        expect_use_callback_argument_mut(&mut module).value = typed_int_expr(1);
+        expect_use_callback_function_mut(&mut module);
     }
 
     #[test]
@@ -516,7 +811,7 @@ pub fn main() {
 
         assert_eq!(plan_variable_pattern(variable("x")), Ok("x".into()));
 
-        let patterns = vec![
+        let patterns = [
             Pattern::Int {
                 location: dummy_span(),
                 value: "1".into(),
@@ -542,6 +837,10 @@ pub fn main() {
                 tail: None,
                 type_: type_::list(type_::int()),
             },
+            Pattern::BitArray {
+                location: dummy_span(),
+                segments: Vec::new(),
+            },
             Pattern::Constructor {
                 location: dummy_span(),
                 name_location: dummy_span(),
@@ -551,10 +850,6 @@ pub fn main() {
                 constructor: Inferred::Unknown,
                 spread: None,
                 type_: type_::int(),
-            },
-            Pattern::BitArray {
-                location: dummy_span(),
-                segments: Vec::new(),
             },
             Pattern::StringPrefix {
                 location: dummy_span(),
@@ -586,6 +881,89 @@ pub fn main() {
             type_: type_::int(),
             value: value.to_string().into(),
             int_value: BigInt::from(value),
+        }
+    }
+
+    fn compile_use_module() -> TypedModule {
+        compile(
+            r#"
+fn with_value(continue: fn(Int) -> Int) {
+  continue(1)
+}
+
+pub fn main() {
+  use value <- with_value
+  value
+}
+"#,
+        )
+    }
+
+    fn compile_use_with_argument_module() -> TypedModule {
+        compile(
+            r#"
+fn with_value(value: Int, continue: fn(Int) -> Int) {
+  continue(value)
+}
+
+pub fn main() {
+  use value <- with_value(1)
+  value
+}
+"#,
+        )
+    }
+
+    fn expect_final_use_mut(module: &mut TypedModule) -> &mut TypedUse {
+        let main = module
+            .definitions
+            .functions
+            .iter_mut()
+            .find(|function| function.name.as_ref().is_some_and(|name| name.1 == "main"))
+            .expect("module should have main");
+        let [Statement::Use(use_)] = main.body.as_mut_slice() else {
+            panic!("expected final use statement");
+        };
+        use_
+    }
+
+    fn expect_use_call_arguments_mut(module: &mut TypedModule) -> &mut Vec<CallArg<TypedExpr>> {
+        let use_ = expect_final_use_mut(module);
+        let TypedExpr::Call { arguments, .. } = use_.call.as_mut() else {
+            panic!("expected use call expression");
+        };
+        arguments
+    }
+
+    fn expect_use_callback_argument_mut(module: &mut TypedModule) -> &mut CallArg<TypedExpr> {
+        expect_use_call_arguments_mut(module)
+            .last_mut()
+            .expect("use call should have callback")
+    }
+
+    fn expect_use_callback_function_mut(
+        module: &mut TypedModule,
+    ) -> (
+        &mut std::sync::Arc<gleam_core::type_::Type>,
+        &mut FunctionLiteralKind,
+        &mut Vec<gleam_core::ast::TypedArg>,
+    ) {
+        let callback = expect_use_callback_argument_mut(module);
+        let TypedExpr::Fn {
+            type_,
+            kind,
+            arguments,
+            ..
+        } = &mut callback.value
+        else {
+            panic!("use callback should be a function literal");
+        };
+        (type_, kind, arguments)
+    }
+
+    fn invalid_use_shape(reason: InvalidUseShapeReason) -> PlanError {
+        PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::UseShape { reason },
         }
     }
 }

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -142,6 +142,19 @@ mod functions {
             capturing_closure_return_shapes,
         );
     }
+
+    mod use_syntax {
+        execution_cases!("functions/use";
+            use_no_assignment,
+            use_value,
+            use_multiple_assignments,
+            use_nested,
+            use_capture,
+            use_block_scope,
+            use_function_value_provider,
+            use_inside_anonymous_function,
+        );
+    }
 }
 
 mod rejection {
@@ -182,10 +195,16 @@ mod rejection {
     mod anonymous {
         rejection_cases!("anonymous";
             anonymous_discard_argument,
+            anonymous_assert_statement,
             anonymous_unsupported_body,
             anonymous_unsupported_return_type,
             function_capture_literal,
-            use_literal,
+        );
+    }
+
+    mod use_syntax {
+        rejection_cases!("use";
+            use_discard_assignment,
         );
     }
 }

--- a/tests/fixtures/execution/functions/use/use_block_scope.gleam
+++ b/tests/fixtures/execution/functions/use/use_block_scope.gleam
@@ -1,0 +1,13 @@
+fn with_value(continue: fn(Int) -> Int) {
+  continue(40)
+}
+
+pub fn main() {
+  {
+    let base = 2
+    use value <- with_value
+    value + base
+  }
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/use/use_capture.gleam
+++ b/tests/fixtures/execution/functions/use/use_capture.gleam
@@ -1,8 +1,11 @@
 fn with_value(continue: fn(Int) -> Int) {
-  continue(41)
+  continue(32)
 }
 
 pub fn main() {
+  let base = 10
   use value <- with_value
-  value + 1
+  value + base
 }
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/use/use_function_value_provider.gleam
+++ b/tests/fixtures/execution/functions/use/use_function_value_provider.gleam
@@ -1,0 +1,11 @@
+fn with_value(continue: fn(Int) -> Int) {
+  continue(41)
+}
+
+pub fn main() {
+  let provider = with_value
+  use value <- provider
+  value + 1
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/use/use_inside_anonymous_function.gleam
+++ b/tests/fixtures/execution/functions/use/use_inside_anonymous_function.gleam
@@ -1,0 +1,15 @@
+fn with_value(continue: fn(Int) -> Int) {
+  continue(32)
+}
+
+pub fn main() {
+  let base = 10
+  let run = fn() {
+    use value <- with_value
+    value + base
+  }
+
+  run()
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/use/use_multiple_assignments.gleam
+++ b/tests/fixtures/execution/functions/use/use_multiple_assignments.gleam
@@ -1,0 +1,10 @@
+fn with_pair(continue: fn(Int, Int) -> Int) {
+  continue(20, 22)
+}
+
+pub fn main() {
+  use left, right <- with_pair
+  left + right
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/use/use_nested.gleam
+++ b/tests/fixtures/execution/functions/use/use_nested.gleam
@@ -1,0 +1,11 @@
+fn with_value(value: Int, continue: fn(Int) -> Int) {
+  continue(value)
+}
+
+pub fn main() {
+  use left <- with_value(20)
+  use right <- with_value(22)
+  left + right
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/use/use_no_assignment.gleam
+++ b/tests/fixtures/execution/functions/use/use_no_assignment.gleam
@@ -1,0 +1,10 @@
+fn run(continue: fn() -> Int) {
+  continue()
+}
+
+pub fn main() {
+  use <- run
+  42
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/use/use_value.gleam
+++ b/tests/fixtures/execution/functions/use/use_value.gleam
@@ -1,0 +1,10 @@
+fn with_value(continue: fn(Int) -> Int) {
+  continue(41)
+}
+
+pub fn main() {
+  use value <- with_value
+  value + 1
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/rejection/anonymous/anonymous_assert_statement.gleam
+++ b/tests/fixtures/rejection/anonymous/anonymous_assert_statement.gleam
@@ -1,0 +1,7 @@
+pub fn main() {
+  fn() {
+    assert True
+    1
+  }
+  1
+}

--- a/tests/fixtures/rejection/use/use_discard_assignment.gleam
+++ b/tests/fixtures/rejection/use/use_discard_assignment.gleam
@@ -1,0 +1,8 @@
+fn with_value(continue: fn(Int) -> Int) {
+  continue(41)
+}
+
+pub fn main() {
+  use _ <- with_value
+  42
+}


### PR DESCRIPTION
- Lower final use statements through the existing call and anonymous function paths.
- Accept use callbacks with variable assignments, captures, nested use, and function-value providers.
- Keep standalone use literals and malformed typed-AST use shapes rejected at the planner boundary.
- Add execution and rejection fixtures for use syntax behavior.
