### PR TITLE
Support discard pattern bindings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub mod runtime;
 pub use frontend::{FrontendError, compile_typed_module};
 pub use plan::{
     BoolExpr, BoolLocalId, ExecutionPlan, Expr, FunctionId, FunctionPlan, FunctionType,
-    FunctionValue, IntExpr, IntLocalId, LocalId, NilExpr, NilLocalId, Param, Step, StringExpr,
-    StringLocalId, Value, ValueType,
+    FunctionValue, IntExpr, IntLocalId, LocalId, NilExpr, NilLocalId, Param, ParamBinding, Step,
+    StringExpr, StringLocalId, Value, ValueType,
 };
 pub use planner::{PlanError, plan_module};
 pub use runtime::{ExecutionError, run_main};

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -25,7 +25,7 @@ pub(crate) use function::{
     NilFunctionReturn, NilReturn, ParamLocal, ReturnBody, ReturnBodyKind, ReturnExprKind,
     RuntimeFunction, StringFunctionReturn, StringReturn,
 };
-pub use function::{FunctionPlan, Param, ReturnExpr};
+pub use function::{FunctionPlan, Param, ParamBinding, ReturnExpr};
 pub use id::{
     BoolFunctionFunctionId, BoolFunctionId, BoolFunctionLocalId, BoolLocalId,
     FunctionFunctionFunctionId, FunctionFunctionLocalId, FunctionId, IntFunctionFunctionId,

--- a/src/plan/function.rs
+++ b/src/plan/function.rs
@@ -25,7 +25,13 @@ pub struct FunctionPlan {
 #[derive(Debug, PartialEq)]
 pub struct Param {
     local: ParamLocal,
-    name: EcoString,
+    binding: ParamBinding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParamBinding {
+    Named(EcoString),
+    Discard,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -487,12 +493,29 @@ impl<Return> RuntimeFunction<Return> {
 }
 
 impl Param {
-    pub(crate) fn new(local: ParamLocal, name: EcoString) -> Self {
-        Self { local, name }
+    pub(crate) fn named(local: ParamLocal, name: EcoString) -> Self {
+        Self {
+            local,
+            binding: ParamBinding::Named(name),
+        }
     }
 
-    pub fn name(&self) -> &EcoString {
-        &self.name
+    pub(crate) fn discard(local: ParamLocal) -> Self {
+        Self {
+            local,
+            binding: ParamBinding::Discard,
+        }
+    }
+
+    pub fn name(&self) -> Option<&EcoString> {
+        match &self.binding {
+            ParamBinding::Named(name) => Some(name),
+            ParamBinding::Discard => None,
+        }
+    }
+
+    pub fn binding(&self) -> &ParamBinding {
+        &self.binding
     }
 
     pub(crate) fn local(&self) -> &ParamLocal {
@@ -554,7 +577,7 @@ impl ParamLocal {
 
 #[cfg(test)]
 mod tests {
-    use super::{FunctionPlan, Param, ParamLocal, ReturnExpr, RuntimeFunction};
+    use super::{FunctionPlan, Param, ParamBinding, ParamLocal, ReturnExpr, RuntimeFunction};
     use crate::plan::{
         BoolExpr, BoolFunctionExpr, BoolFunctionFunctionId, BoolFunctionId, BoolFunctionLocalId,
         BoolFunctionValue, BoolLocalId, FrameLayout, FunctionFunctionExpr,
@@ -569,7 +592,7 @@ mod tests {
 
     #[test]
     fn function_plan_accessors() {
-        let param = Param::new(ParamLocal::int(IntLocalId(0)), "x".into());
+        let param = Param::named(ParamLocal::int(IntLocalId(0)), "x".into());
         let return_ = ReturnExpr::int(IntFunctionId(0), IntExpr::value(BigInt::from(1)));
         let function = FunctionPlan::new(
             FunctionId::new(0),
@@ -582,7 +605,7 @@ mod tests {
         assert_eq!(function.id(), FunctionId::new(0));
         assert_eq!(function.name(), "main");
         assert_eq!(function.params().len(), 1);
-        assert_eq!(function.params()[0].name(), "x");
+        assert_eq!(function.params()[0].name(), Some(&"x".into()));
         assert_eq!(function.steps(), &[]);
         assert_eq!(
             function.return_(),
@@ -667,10 +690,14 @@ mod tests {
     }
 
     #[test]
-    fn param_name_accessor() {
-        let param = Param::new(ParamLocal::int(IntLocalId(0)), "x".into());
+    fn param_binding_accessors() {
+        let named = Param::named(ParamLocal::int(IntLocalId(0)), "x".into());
+        let discard = Param::discard(ParamLocal::int(IntLocalId(1)));
 
-        assert_eq!(param.name(), "x");
+        assert_eq!(named.name(), Some(&"x".into()));
+        assert_eq!(named.binding(), &ParamBinding::Named("x".into()));
+        assert_eq!(discard.name(), None);
+        assert_eq!(discard.binding(), &ParamBinding::Discard);
     }
 
     #[test]

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -4,8 +4,8 @@ use crate::plan::{
     FunctionFunctionLocalId, FunctionId, FunctionPlan, FunctionType, FunctionValue, IntExpr,
     IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId,
     NilExpr, NilFunctionExpr, NilFunctionFunctionId, NilFunctionId, NilFunctionLocalId, NilLocalId,
-    ParamLocal, RuntimeFunctionId, StringExpr, StringFunctionExpr, StringFunctionFunctionId,
-    StringFunctionId, StringFunctionLocalId, StringLocalId, ValueType,
+    ParamBinding, ParamLocal, RuntimeFunctionId, StringExpr, StringFunctionExpr,
+    StringFunctionFunctionId, StringFunctionId, StringFunctionLocalId, StringLocalId, ValueType,
 };
 use crate::planner::error::{InvalidTypedAstReason, PlanError};
 use ecow::EcoString;
@@ -23,7 +23,7 @@ pub(super) struct FunctionInfo {
 #[derive(Clone)]
 pub(super) struct FunctionParam {
     pub(super) local: ParamLocal,
-    pub(super) name: EcoString,
+    pub(super) binding: ParamBinding,
 }
 
 pub(super) struct PlanContext<'a> {

--- a/src/planner/dsl/function.rs
+++ b/src/planner/dsl/function.rs
@@ -65,13 +65,21 @@ pub(crate) fn function(
 
 impl FunctionDsl {
     pub(crate) fn param_int(mut self, local: usize, name: impl Into<EcoString>) -> Self {
+        self.params.push(Param::named(
+            ParamLocal::int(IntLocalId(local)),
+            name.into(),
+        ));
+        self
+    }
+
+    pub(crate) fn discard_int_param(mut self, local: usize) -> Self {
         self.params
-            .push(Param::new(ParamLocal::int(IntLocalId(local)), name.into()));
+            .push(Param::discard(ParamLocal::int(IntLocalId(local))));
         self
     }
 
     pub(crate) fn param_string(mut self, local: usize, name: impl Into<EcoString>) -> Self {
-        self.params.push(Param::new(
+        self.params.push(Param::named(
             ParamLocal::string(StringLocalId(local)),
             name.into(),
         ));
@@ -79,7 +87,7 @@ impl FunctionDsl {
     }
 
     pub(crate) fn param_bool(mut self, local: usize, name: impl Into<EcoString>) -> Self {
-        self.params.push(Param::new(
+        self.params.push(Param::named(
             ParamLocal::bool(BoolLocalId(local)),
             name.into(),
         ));
@@ -87,8 +95,10 @@ impl FunctionDsl {
     }
 
     pub(crate) fn param_nil(mut self, local: usize, name: impl Into<EcoString>) -> Self {
-        self.params
-            .push(Param::new(ParamLocal::nil(NilLocalId(local)), name.into()));
+        self.params.push(Param::named(
+            ParamLocal::nil(NilLocalId(local)),
+            name.into(),
+        ));
         self
     }
 
@@ -98,7 +108,7 @@ impl FunctionDsl {
         name: impl Into<EcoString>,
         arguments: impl IntoIterator<Item = ValueType>,
     ) -> Self {
-        self.params.push(Param::new(
+        self.params.push(Param::named(
             ParamLocal::int_function(
                 IntFunctionLocalId(local),
                 FunctionType::new(arguments.into_iter().collect(), ValueType::Int),
@@ -114,7 +124,7 @@ impl FunctionDsl {
         name: impl Into<EcoString>,
         arguments: impl IntoIterator<Item = ValueType>,
     ) -> Self {
-        self.params.push(Param::new(
+        self.params.push(Param::named(
             ParamLocal::string_function(
                 StringFunctionLocalId(local),
                 FunctionType::new(arguments.into_iter().collect(), ValueType::String),
@@ -130,7 +140,7 @@ impl FunctionDsl {
         name: impl Into<EcoString>,
         arguments: impl IntoIterator<Item = ValueType>,
     ) -> Self {
-        self.params.push(Param::new(
+        self.params.push(Param::named(
             ParamLocal::bool_function(
                 BoolFunctionLocalId(local),
                 FunctionType::new(arguments.into_iter().collect(), ValueType::Bool),
@@ -146,7 +156,7 @@ impl FunctionDsl {
         name: impl Into<EcoString>,
         arguments: impl IntoIterator<Item = ValueType>,
     ) -> Self {
-        self.params.push(Param::new(
+        self.params.push(Param::named(
             ParamLocal::nil_function(
                 NilFunctionLocalId(local),
                 FunctionType::new(arguments.into_iter().collect(), ValueType::Nil),
@@ -162,7 +172,7 @@ impl FunctionDsl {
         name: impl Into<EcoString>,
         type_: FunctionType,
     ) -> Self {
-        self.params.push(Param::new(
+        self.params.push(Param::named(
             ParamLocal::function_function(FunctionFunctionLocalId(local), type_),
             name.into(),
         ));

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -26,8 +26,6 @@ pub enum UnsupportedFunctionReason {
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedArgumentReason {
-    #[error("discard arguments are not supported")]
-    Discard,
     #[error("labelled arguments are not supported")]
     Labelled,
     #[error("argument type is not supported")]
@@ -54,8 +52,6 @@ pub enum UnsupportedAssignmentKind {
 pub enum UnsupportedPatternKind {
     #[error("assign")]
     Assign,
-    #[error("discard")]
-    Discard,
     #[error("tuple")]
     Tuple,
 }

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -424,8 +424,8 @@ mod tests {
     };
     use crate::planner::error::{
         InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
-        InvalidPipelineShapeReason, InvalidTypedAstReason, PlanError, UnsupportedArgumentReason,
-        UnsupportedAssignmentKind, UnsupportedExpressionKind, UnsupportedStatementKind,
+        InvalidPipelineShapeReason, InvalidTypedAstReason, PlanError, UnsupportedAssignmentKind,
+        UnsupportedExpressionKind, UnsupportedStatementKind,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, dummy_span};
@@ -462,6 +462,27 @@ pub fn main() {
                 function("<anonymous:0>", local_int(0, "value").add_int(int(1)))
                     .param_int(0, "value"),
             ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_anonymous_function_discard_argument() {
+        let actual = plan_module(compile(
+            r#"
+pub fn main() {
+  fn(_: Int) { 1 }
+  42
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function("main", int(42)).evaluate(int_function_ref(1, [LocalId::Int(IntLocalId(0))])),
+            [],
+            [function("<anonymous:0>", int(1)).discard_int_param(0)],
         );
 
         assert_eq!(actual, expected);
@@ -656,24 +677,6 @@ pub fn main() {
             )),
             Err(PlanError::UnsupportedExpression {
                 kind: UnsupportedExpressionKind::FunctionCaptureLiteral,
-            }),
-        );
-    }
-
-    #[test]
-    fn reject_profile_anonymous_function_discard_argument() {
-        assert_eq!(
-            plan_module(compile(
-                r#"
-pub fn main() {
-  fn(_: Int) { 1 }
-  1
-}
-"#,
-            )),
-            Err(PlanError::UnsupportedArgument {
-                function: "<anonymous:0>".into(),
-                reason: UnsupportedArgumentReason::Discard,
             }),
         );
     }

--- a/src/planner/function.rs
+++ b/src/planner/function.rs
@@ -3,7 +3,7 @@ use crate::plan::{
     Expr, ExprKind, FunctionFunctionExpr, FunctionFunctionExprKind, FunctionFunctionId,
     FunctionFunctionReturn, FunctionPlan, IntExpr, IntExprKind, IntFunctionExpr,
     IntFunctionExprKind, IntFunctionReturn, IntReturn, NilExpr, NilExprKind, NilFunctionExpr,
-    NilFunctionExprKind, NilFunctionReturn, NilReturn, Param, ReturnBody, ReturnExpr,
+    NilFunctionExprKind, NilFunctionReturn, NilReturn, Param, ParamBinding, ReturnBody, ReturnExpr,
     RuntimeFunctionId, Step, StringExpr, StringExprKind, StringFunctionExpr,
     StringFunctionExprKind, StringFunctionReturn, StringReturn, ValueType,
 };
@@ -107,9 +107,12 @@ pub(super) fn anonymous_function_plan(
 fn define_params(params: &[FunctionParam], context: &mut PlanContext<'_>) -> Vec<Param> {
     params
         .iter()
-        .map(|param| {
-            context.define_existing_param(param.name.clone(), &param.local);
-            Param::new(param.local.clone(), param.name.clone())
+        .map(|param| match &param.binding {
+            ParamBinding::Named(name) => {
+                context.define_existing_param(name.clone(), &param.local);
+                Param::named(param.local.clone(), name.clone())
+            }
+            ParamBinding::Discard => Param::discard(param.local.clone()),
         })
         .collect()
 }
@@ -1678,24 +1681,6 @@ pub fn main() -> Int
             PlanError::UnsupportedFunction {
                 name: "main".into(),
                 reason: UnsupportedFunctionReason::External,
-            },
-        );
-
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn helper(_: Int) {
-  1
-}
-
-pub fn main() {
-  helper(1)
-}
-"#,
-            ),
-            PlanError::UnsupportedArgument {
-                function: "helper".into(),
-                reason: UnsupportedArgumentReason::Discard,
             },
         );
 

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -1,6 +1,6 @@
 use crate::plan::{
     ExecutionPlan, FunctionFunctionLocalId, FunctionId, FunctionType, IntFunctionLocalId,
-    ParamLocal, ValueType,
+    ParamBinding, ParamLocal, ValueType,
 };
 use crate::planner::context::{
     AnonymousFunctions, FunctionInfo, FunctionParam, FunctionRuntimeIds,
@@ -223,19 +223,16 @@ pub(super) fn function_params(
     arguments
         .iter()
         .map(|argument| {
-            let Some(name) = argument.names.get_variable_name().cloned() else {
-                return Err(PlanError::UnsupportedArgument {
-                    function: function_name.clone(),
-                    reason: UnsupportedArgumentReason::Discard,
-                });
+            let binding = match &argument.names {
+                ArgNames::Named { name, .. } => ParamBinding::Named(name.clone()),
+                ArgNames::Discard { .. } => ParamBinding::Discard,
+                ArgNames::LabelledDiscard { .. } | ArgNames::NamedLabelled { .. } => {
+                    return Err(PlanError::UnsupportedArgument {
+                        function: function_name.clone(),
+                        reason: UnsupportedArgumentReason::Labelled,
+                    });
+                }
             };
-
-            if !matches!(argument.names, ArgNames::Named { .. }) {
-                return Err(PlanError::UnsupportedArgument {
-                    function: function_name.clone(),
-                    reason: UnsupportedArgumentReason::Labelled,
-                });
-            }
 
             let Some(type_) = ValueType::from_gleam(&argument.type_) else {
                 return Err(PlanError::UnsupportedArgument {
@@ -273,7 +270,7 @@ pub(super) fn function_params(
                     &mut next_function_function,
                 ),
             };
-            Ok(FunctionParam { local, name })
+            Ok(FunctionParam { local, binding })
         })
         .collect()
 }
@@ -347,7 +344,8 @@ mod tests {
         LocalId, ParamLocal, RuntimeFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        call_int_returning_function, function, function_ref, int, local_int, module,
+        call_int_returning_function, function, function_ref, int, int_arg, int_return_tail_call,
+        local_int, module,
     };
     use crate::planner::support::{compile, expect_plan_error};
     use crate::planner::{
@@ -635,6 +633,34 @@ fn getter(callback: fn() -> fn(Int) -> Int) {
     }
 
     #[test]
+    fn plan_discard_function_argument_slots() {
+        let actual = plan_module(compile(
+            r#"
+fn pick(_: Int, value: Int) {
+  value
+}
+
+pub fn main() {
+  pick(1, 42)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_tail_call(1, [int_arg(0, int(1)), int_arg(1, int(42))]),
+            ),
+            [function("pick", local_int(1, "value"))
+                .discard_int_param(0)
+                .param_int(1, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn reject_profile_unsupported_function_argument_type() {
         assert_eq!(
             expect_plan_error(
@@ -656,25 +682,7 @@ fn count(values: List(Int)) {
     }
 
     #[test]
-    fn reject_profile_function_argument_name_shape() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn helper(_: Int) {
-  1
-}
-
-pub fn main() {
-  helper(1)
-}
-"#,
-            ),
-            PlanError::UnsupportedArgument {
-                function: "helper".into(),
-                reason: UnsupportedArgumentReason::Discard,
-            },
-        );
-
+    fn reject_profile_labelled_function_argument() {
         assert_eq!(
             expect_plan_error(
                 r#"

--- a/src/planner/statement.rs
+++ b/src/planner/statement.rs
@@ -107,9 +107,18 @@ fn plan_assignment(
         }
     }
 
-    let name = plan_variable_pattern(assignment.pattern)?;
+    let pattern = plan_binding_pattern(assignment.pattern)?;
     let value = plan_expr(assignment.value, context)?;
-    plan_variable_runtime_step(name, value, context)
+    match pattern {
+        BindingPattern::Named(name) => plan_variable_runtime_step(name, value, context),
+        BindingPattern::Discard => Ok(Step::evaluate(value)),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum BindingPattern {
+    Named(EcoString),
+    Discard,
 }
 
 pub(in crate::planner) fn plan_variable_runtime_step(
@@ -161,9 +170,10 @@ pub(in crate::planner) fn plan_variable_runtime_step(
     }
 }
 
-fn plan_variable_pattern(pattern: TypedPattern) -> Result<EcoString, PlanError> {
+fn plan_binding_pattern(pattern: TypedPattern) -> Result<BindingPattern, PlanError> {
     match pattern {
-        Pattern::Variable { name, .. } => Ok(name),
+        Pattern::Variable { name, .. } => Ok(BindingPattern::Named(name)),
+        Pattern::Discard { .. } => Ok(BindingPattern::Discard),
         pattern => Err(non_variable_pattern_error(&pattern)),
     }
 }
@@ -189,9 +199,6 @@ fn non_variable_pattern_error(pattern: &TypedPattern) -> PlanError {
         Pattern::Assign { .. } => PlanError::UnsupportedPattern {
             kind: UnsupportedPatternKind::Assign,
         },
-        Pattern::Discard { .. } => PlanError::UnsupportedPattern {
-            kind: UnsupportedPatternKind::Discard,
-        },
         Pattern::Tuple { .. } => PlanError::UnsupportedPattern {
             kind: UnsupportedPatternKind::Tuple,
         },
@@ -204,6 +211,7 @@ fn non_variable_pattern_error(pattern: &TypedPattern) -> PlanError {
         | Pattern::Constructor { .. }
         | Pattern::StringPrefix { .. }
         | Pattern::Invalid { .. }
+        | Pattern::Discard { .. }
         | Pattern::Variable { .. } => PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::InvalidPattern,
         },
@@ -218,7 +226,7 @@ fn invalid_use_shape(reason: InvalidUseShapeReason) -> PlanError {
 
 #[cfg(test)]
 mod tests {
-    use super::plan_variable_pattern;
+    use super::{BindingPattern, plan_binding_pattern};
     use crate::plan::{BoolLocalId, IntLocalId, LocalId, NilLocalId, StringLocalId, ValueType};
     use crate::planner::dsl::{
         bool_, bool_case_int_function, bool_function_ref, call_int_function, capture_int, function,
@@ -231,8 +239,8 @@ mod tests {
     use crate::planner::support::{compile, compile_minimal_module, dummy_span, expect_plan_error};
     use crate::planner::{
         InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
-        InvalidTypedAstReason, InvalidUseShapeReason, PlanError, UnsupportedArgumentReason,
-        UnsupportedAssignmentKind, UnsupportedPatternKind, UnsupportedStatementKind,
+        InvalidTypedAstReason, InvalidUseShapeReason, PlanError, UnsupportedAssignmentKind,
+        UnsupportedExpressionKind, UnsupportedPatternKind, UnsupportedStatementKind,
     };
     use gleam_core::analyse::Inferred;
     use gleam_core::ast::{
@@ -263,6 +271,39 @@ pub fn main() {
         );
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_discard_assignment_evaluates_value() {
+        let actual = plan_module(compile(
+            r#"
+pub fn main() {
+  let _ = 1
+  42
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module("main", function("main", int(42)).evaluate(int(1)), []);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_profile_discard_assignment_value_is_validated() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  let _ = panic
+  42
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Panic,
+            },
+        );
     }
 
     #[test]
@@ -440,6 +481,69 @@ fn pair(callback: fn() -> Int) {
     }
 
     #[test]
+    fn plan_use_syntax_with_discard_assignment() {
+        let actual = plan_module(compile(
+            r#"
+fn with_value(continue: fn(Int) -> Int) {
+  continue(1)
+}
+
+pub fn main() {
+  use _ <- with_value
+  42
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                int_return_tail_call(
+                    1,
+                    [int_function_arg(
+                        0,
+                        int_function_ref(2, [LocalId::Int(IntLocalId(0))]),
+                    )],
+                ),
+            ),
+            [function(
+                "with_value",
+                call_int_function(
+                    local_int_function(0, "continue", [ValueType::Int]),
+                    [int_function_call_arg(0, int(1))],
+                ),
+            )
+            .param_int_function(0, "continue", [ValueType::Int])],
+            [function("<anonymous:0>", int(42)).discard_int_param(0)],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_profile_use_discard_callback_body_is_validated() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+fn with_value(continue: fn(Int) -> Int) {
+  continue(1)
+}
+
+pub fn main() {
+  use _ <- with_value
+  todo
+  42
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Todo,
+            },
+        );
+    }
+
+    #[test]
     fn plan_use_syntax_with_assignment_and_capture() {
         let actual = plan_module(compile(
             r#"
@@ -487,24 +591,8 @@ pub fn main() {
 
     #[test]
     fn reject_profile_use_assignment_patterns() {
-        let cases = [
-            (
-                r#"
-fn with_value(continue: fn(Int) -> Int) {
-  continue(1)
-}
-
-pub fn main() {
-  use _ <- with_value
-  1
-}
-"#,
-                PlanError::UnsupportedArgument {
-                    function: "<anonymous:0>".into(),
-                    reason: UnsupportedArgumentReason::Discard,
-                },
-            ),
-            (
+        assert_eq!(
+            expect_plan_error(
                 r#"
 fn with_value(continue: fn(Int) -> Int) {
   continue(1)
@@ -515,15 +603,11 @@ pub fn main() {
   alias
 }
 "#,
-                PlanError::UnsupportedPattern {
-                    kind: UnsupportedPatternKind::Assign,
-                },
             ),
-        ];
-
-        for (src, expected) in cases {
-            assert_eq!(expect_plan_error(src), expected);
-        }
+            PlanError::UnsupportedPattern {
+                kind: UnsupportedPatternKind::Assign,
+            },
+        );
     }
 
     #[test]
@@ -763,17 +847,6 @@ pub fn main() {
             (
                 r#"
 pub fn main() {
-  let _ = 1
-  1
-}
-"#,
-                PlanError::UnsupportedPattern {
-                    kind: UnsupportedPatternKind::Discard,
-                },
-            ),
-            (
-                r#"
-pub fn main() {
   let #(a, b) = #(1, 2)
   a
 }
@@ -809,7 +882,18 @@ pub fn main() {
             origin: VariableOrigin::generated(),
         };
 
-        assert_eq!(plan_variable_pattern(variable("x")), Ok("x".into()));
+        assert_eq!(
+            plan_binding_pattern(variable("x")),
+            Ok(BindingPattern::Named("x".into())),
+        );
+        assert_eq!(
+            plan_binding_pattern(Pattern::Discard {
+                location: dummy_span(),
+                name: "_".into(),
+                type_: type_::int(),
+            }),
+            Ok(BindingPattern::Discard),
+        );
 
         let patterns = [
             Pattern::Int {
@@ -867,7 +951,7 @@ pub fn main() {
 
         for pattern in patterns {
             assert_eq!(
-                plan_variable_pattern(pattern),
+                plan_binding_pattern(pattern),
                 Err(PlanError::InvalidTypedAst {
                     reason: InvalidTypedAstReason::InvalidPattern,
                 }),

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -34,6 +34,7 @@ mod values {
 mod bindings {
     execution_cases!("bindings";
         let_binding,
+        let_discard_binding,
         string_let_binding,
         bool_let_binding,
         nil_let_binding,
@@ -95,7 +96,10 @@ mod functions {
 
     mod argument {
         execution_cases!("functions/argument";
+            discard_argument,
+            discard_mixed_arguments,
             function_value_argument_callback,
+            function_value_argument_discard,
             function_value_argument_higher_order_alias,
             function_value_argument_higher_order_return_shapes,
             function_value_argument_input_shapes,
@@ -128,6 +132,7 @@ mod functions {
 
     mod anonymous {
         execution_cases!("functions/anonymous";
+            anonymous_discard_argument,
             anonymous_function_local_call,
             anonymous_function_immediate_call,
             anonymous_function_argument,
@@ -147,6 +152,7 @@ mod functions {
         execution_cases!("functions/use";
             use_no_assignment,
             use_value,
+            use_discard_assignment,
             use_multiple_assignments,
             use_nested,
             use_capture,
@@ -186,7 +192,6 @@ mod rejection {
 
     mod argument {
         rejection_cases!("argument";
-            argument_discard,
             argument_labelled,
             argument_unsupported_type,
         );
@@ -194,17 +199,10 @@ mod rejection {
 
     mod anonymous {
         rejection_cases!("anonymous";
-            anonymous_discard_argument,
             anonymous_assert_statement,
             anonymous_unsupported_body,
             anonymous_unsupported_return_type,
             function_capture_literal,
-        );
-    }
-
-    mod use_syntax {
-        rejection_cases!("use";
-            use_discard_assignment,
         );
     }
 }

--- a/tests/fixtures/execution/bindings/let_discard_binding.gleam
+++ b/tests/fixtures/execution/bindings/let_discard_binding.gleam
@@ -1,0 +1,6 @@
+pub fn main() {
+  let _ = 1
+  42
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/anonymous/anonymous_discard_argument.gleam
+++ b/tests/fixtures/execution/functions/anonymous/anonymous_discard_argument.gleam
@@ -1,0 +1,6 @@
+pub fn main() {
+  let run = fn(_: Int) { 42 }
+  run(1)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/argument/discard_argument.gleam
+++ b/tests/fixtures/execution/functions/argument/discard_argument.gleam
@@ -1,7 +1,9 @@
 fn helper(_: Int) {
-  1
+  42
 }
 
 pub fn main() {
   helper(1)
 }
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/argument/discard_mixed_arguments.gleam
+++ b/tests/fixtures/execution/functions/argument/discard_mixed_arguments.gleam
@@ -1,0 +1,9 @@
+fn pick(_: Int, value: Int) {
+  value
+}
+
+pub fn main() {
+  pick(1, 42)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/argument/function_value_argument_discard.gleam
+++ b/tests/fixtures/execution/functions/argument/function_value_argument_discard.gleam
@@ -1,0 +1,13 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn ignore(_: fn(Int) -> Int) {
+  42
+}
+
+pub fn main() {
+  ignore(add_one)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/use/use_discard_assignment.gleam
+++ b/tests/fixtures/execution/functions/use/use_discard_assignment.gleam
@@ -6,3 +6,5 @@ pub fn main() {
   use _ <- with_value
   42
 }
+
+// geam:expect Int(42)

--- a/tests/fixtures/rejection/anonymous/anonymous_discard_argument.gleam
+++ b/tests/fixtures/rejection/anonymous/anonymous_discard_argument.gleam
@@ -1,4 +1,0 @@
-pub fn main() {
-  fn(_: Int) { 1 }
-  1
-}


### PR DESCRIPTION
- Represent function parameter bindings as named or discard while preserving local slots.
- Accept discard function arguments, anonymous function arguments, use assignments, and let bindings.
- Lower let discard bindings to evaluated steps without introducing name bindings.
- Move discard fixtures from rejection to execution coverage and keep unsupported discarded expressions validated.
