### PR TITLE
Split planner call lowering

### DIFF
--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -119,6 +119,12 @@ Errors make boundaries visible:
 Do not use wildcard imports or re-exports anywhere. The only exception is a
 parent facade module re-exporting child modules as its intentional surface.
 
+## Module Split Rules
+
+Child modules must not become shared utility surfaces for sibling modules. If
+sibling modules need a helper, keep it in the parent facade or in a child module
+that owns that helper's domain.
+
 ## Test Rules
 
 Planner test names must identify the source of the case:

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -1,21 +1,18 @@
-use super::{invalid_expression_type, invalid_expression_type_for_value, plan_expr};
-use crate::plan::{
-    BoolExpr, CallArg, Expr, FunctionExpr, FunctionFunctionExpr, IntExpr, NilExpr, ParamLocal,
-    RuntimeFunctionId, StringExpr, ValueType,
-};
-use crate::planner::context::{FunctionInfo, FunctionParam, PlanContext};
+mod argument;
+mod direct;
+mod function_value;
+mod implicit;
+
+use crate::plan::Expr;
+use crate::planner::context::PlanContext;
 use crate::planner::error::{
-    InvalidCallShapeReason, InvalidExpressionType, InvalidPipelineShapeReason,
-    InvalidTypedAstReason, InvalidUseShapeReason, PlanError, UnsupportedPipelineReason,
+    InvalidCallShapeReason, InvalidTypedAstReason, InvalidUseShapeReason, PlanError,
+    UnsupportedPipelineReason,
 };
 use ecow::EcoString;
-use gleam_core::ast::{
-    CallArg as GleamCallArg, FunctionLiteralKind, ImplicitCallArgOrigin, Statement, TypedArg,
-    TypedExpr, TypedStatement,
-};
+use gleam_core::ast::{CallArg as GleamCallArg, TypedExpr};
 use gleam_core::type_::{Type, ValueConstructorVariant};
 use std::sync::Arc;
-use vec1::Vec1;
 
 pub(super) fn plan_call(
     type_: Arc<Type>,
@@ -54,26 +51,7 @@ pub(super) fn plan_use_call(
     call: TypedExpr,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    match call {
-        TypedExpr::Call {
-            type_,
-            fun,
-            arguments,
-            ..
-        } => {
-            validate_use_call_arguments(&arguments)?;
-            plan_call_expression(
-                type_,
-                *fun,
-                arguments,
-                context,
-                None,
-                CallArgumentMode::Use,
-                FunctionValueCallMode::Allow,
-            )
-        }
-        _ => Err(invalid_use_shape(InvalidUseShapeReason::NonCallRhs)),
-    }
+    implicit::plan_use_call(call, context)
 }
 
 pub(super) fn plan_pipeline_direct_call(
@@ -82,17 +60,7 @@ pub(super) fn plan_pipeline_direct_call(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    pipe_argument(&arguments)?;
-
-    plan_call_expression(
-        type_,
-        fun,
-        arguments,
-        context,
-        None,
-        CallArgumentMode::Normal,
-        FunctionValueCallMode::Reject,
-    )
+    implicit::plan_pipeline_direct_call(type_, fun, arguments, context)
 }
 
 pub(super) fn plan_pipeline_hole_call(
@@ -101,119 +69,7 @@ pub(super) fn plan_pipeline_hole_call(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let pipe_value = plan_expr(pipe_argument(&arguments)?.clone(), context)?;
-
-    let (kind, capture_args, body) = pipeline_capture_function_parts(fun)?;
-    if !matches!(kind, FunctionLiteralKind::Capture { .. }) {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::InvalidHoleCapture,
-            },
-        });
-    }
-    let capture_arg = single_capture_argument(&capture_args)?;
-    let capture_name = match capture_arg.names.get_variable_name().cloned() {
-        Some(capture_name) => capture_name,
-        None => {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::PipelineShape {
-                    reason: InvalidPipelineShapeReason::InvalidHoleCapture,
-                },
-            });
-        }
-    };
-
-    let mut body = body.into_iter();
-    let (fun, arguments) = pipeline_hole_body_call(body.next())?;
-    if body.next().is_some() {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::InvalidHoleCapture,
-            },
-        });
-    }
-    if arguments.iter().any(|argument| argument.label.is_some()) {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::LabelledArguments,
-            },
-        });
-    }
-    if arguments.iter().any(|argument| argument.implicit.is_some()) {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::UnsupportedImplicitArgument,
-            },
-        });
-    }
-    if count_capture_arguments(&arguments, &capture_name) != 1 {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::InvalidHoleCapture,
-            },
-        });
-    }
-
-    plan_call_expression(
-        type_,
-        *fun,
-        arguments,
-        context,
-        Some(&CaptureSubstitution {
-            name: capture_name,
-            value: pipe_value,
-        }),
-        CallArgumentMode::Normal,
-        FunctionValueCallMode::Reject,
-    )
-}
-
-fn pipeline_capture_function_parts(
-    fun: TypedExpr,
-) -> Result<(FunctionLiteralKind, Vec<TypedArg>, Vec1<TypedStatement>), PlanError> {
-    match fun {
-        TypedExpr::Fn {
-            kind,
-            arguments,
-            body,
-            ..
-        } => Ok((kind, arguments, body)),
-        _ => Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::InvalidHoleCapture,
-            },
-        }),
-    }
-}
-
-fn single_capture_argument(capture_args: &[TypedArg]) -> Result<&TypedArg, PlanError> {
-    if capture_args.len() == 1 {
-        Ok(&capture_args[0])
-    } else {
-        Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::InvalidHoleCapture,
-            },
-        })
-    }
-}
-
-fn pipeline_hole_body_call(
-    statement: Option<TypedStatement>,
-) -> Result<(Box<TypedExpr>, Vec<GleamCallArg<TypedExpr>>), PlanError> {
-    match statement {
-        Some(Statement::Expression(TypedExpr::Call { fun, arguments, .. })) => Ok((fun, arguments)),
-        _ => Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::NonCallStep,
-            },
-        }),
-    }
-}
-
-struct CaptureSubstitution {
-    name: EcoString,
-    value: Expr,
+    implicit::plan_pipeline_hole_call(type_, fun, arguments, context)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -226,6 +82,32 @@ enum FunctionValueCallMode {
 enum CallArgumentMode {
     Normal,
     Use,
+}
+
+struct CaptureSubstitution {
+    name: EcoString,
+    value: Expr,
+}
+
+fn invalid_use_shape(reason: InvalidUseShapeReason) -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::UseShape { reason },
+    }
+}
+
+fn is_capture_local(expression: &TypedExpr, capture_name: &EcoString) -> bool {
+    matches!(
+        expression,
+        TypedExpr::Var {
+            name,
+            constructor,
+            ..
+        } if name == capture_name
+            && matches!(
+                constructor.variant,
+                ValueConstructorVariant::LocalVariable { .. }
+            )
+    )
 }
 
 fn plan_call_expression(
@@ -256,7 +138,7 @@ fn plan_call_expression(
                             reason: InvalidCallShapeReason::MissingCurrentModuleFunction,
                         },
                     })?;
-                return plan_direct_function_call(
+                return direct::plan_direct_function_call(
                     type_,
                     function,
                     arguments,
@@ -296,1448 +178,100 @@ fn plan_call_expression(
         });
     }
 
-    plan_function_value_call(type_, fun, arguments, context, capture, call_argument_mode)
-}
-
-fn plan_direct_function_call(
-    type_: Arc<Type>,
-    function: FunctionInfo,
-    arguments: Vec<GleamCallArg<TypedExpr>>,
-    context: &mut PlanContext<'_>,
-    capture: Option<&CaptureSubstitution>,
-    call_argument_mode: CallArgumentMode,
-) -> Result<Expr, PlanError> {
-    if function.arity() != arguments.len() {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CallShape {
-                reason: InvalidCallShapeReason::LocalFunctionCallArityMismatch,
-            },
-        });
-    }
-    let function_return_type = function.return_type();
-    let function_id = function.runtime_id;
-    let return_type = ValueType::from_gleam(type_.as_ref()).ok_or(PlanError::InvalidTypedAst {
-        reason: InvalidTypedAstReason::CallShape {
-            reason: InvalidCallShapeReason::LocalFunctionCallUnsupportedReturnType,
-        },
-    })?;
-    if return_type != function_return_type {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CallShape {
-                reason: InvalidCallShapeReason::LocalFunctionCallReturnTypeMismatch,
-            },
-        });
-    }
-    let args = plan_call_args(
+    function_value::plan_function_value_call(
+        type_,
+        fun,
         arguments,
-        &function.params,
         context,
         capture,
         call_argument_mode,
-    )?;
-
-    Ok(call_expr(function_id, args))
-}
-
-fn plan_function_value_call(
-    type_: Arc<Type>,
-    fun: TypedExpr,
-    arguments: Vec<GleamCallArg<TypedExpr>>,
-    context: &mut PlanContext<'_>,
-    capture: Option<&CaptureSubstitution>,
-    call_argument_mode: CallArgumentMode,
-) -> Result<Expr, PlanError> {
-    let function = {
-        let expression = plan_expr(fun, context)?;
-        let actual = super::expression_type(&expression);
-        match expression.into_function() {
-            Some(function) => function,
-            None => {
-                return Err(invalid_expression_type(
-                    InvalidExpressionType::Function,
-                    actual,
-                ));
-            }
-        }
-    };
-    let function_type = function.type_().clone();
-    let return_type = ValueType::from_gleam(type_.as_ref()).ok_or(PlanError::InvalidTypedAst {
-        reason: InvalidTypedAstReason::CallShape {
-            reason: InvalidCallShapeReason::FunctionCallUnsupportedReturnType,
-        },
-    })?;
-    if &return_type != function_type.return_() {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CallShape {
-                reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-            },
-        });
-    }
-    if arguments.len() != function_type.argument_types().len() {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CallShape {
-                reason: InvalidCallShapeReason::FunctionCallArityMismatch,
-            },
-        });
-    }
-
-    let args = plan_function_call_args(
-        arguments,
-        function_type.argument_types(),
-        context,
-        capture,
-        call_argument_mode,
-    )?;
-
-    function_call_expr(function, args, return_type)
-}
-
-fn plan_call_args(
-    arguments: Vec<GleamCallArg<TypedExpr>>,
-    params: &[FunctionParam],
-    context: &mut PlanContext<'_>,
-    capture: Option<&CaptureSubstitution>,
-    call_argument_mode: CallArgumentMode,
-) -> Result<Vec<CallArg>, PlanError> {
-    let mut args = Vec::with_capacity(arguments.len());
-    for (argument, param) in arguments.into_iter().zip(params) {
-        let expression = plan_argument_value(argument, capture, context, call_argument_mode)?;
-        let actual = expression.value_type();
-        let arg = match expression.into_call_arg(&param.local) {
-            Some(arg) => arg,
-            None => return Err(call_arg_type_mismatch(param.local.value_type(), actual)),
-        };
-        args.push(arg);
-    }
-    Ok(args)
-}
-
-fn plan_function_call_args(
-    arguments: Vec<GleamCallArg<TypedExpr>>,
-    params: &[ValueType],
-    context: &mut PlanContext<'_>,
-    capture: Option<&CaptureSubstitution>,
-    call_argument_mode: CallArgumentMode,
-) -> Result<Vec<CallArg>, PlanError> {
-    let locals = function_call_param_locals(params);
-    let mut args = Vec::with_capacity(arguments.len());
-    for (argument, local) in arguments.into_iter().zip(&locals) {
-        let expression = plan_argument_value(argument, capture, context, call_argument_mode)?;
-        let actual = expression.value_type();
-        let arg = match expression.into_call_arg(local) {
-            Some(arg) => arg,
-            None => return Err(call_arg_type_mismatch(local.value_type(), actual)),
-        };
-        args.push(arg);
-    }
-    Ok(args)
-}
-
-fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
-    let mut next_int = 0;
-    let mut next_string = 0;
-    let mut next_bool = 0;
-    let mut next_nil = 0;
-    let mut next_int_function = 0;
-    let mut next_string_function = 0;
-    let mut next_bool_function = 0;
-    let mut next_nil_function = 0;
-    let mut next_function_function = 0;
-
-    params
-        .iter()
-        .map(|type_| match type_ {
-            ValueType::Int => {
-                let local = ParamLocal::int(crate::plan::IntLocalId(next_int));
-                next_int += 1;
-                local
-            }
-            ValueType::String => {
-                let local = ParamLocal::string(crate::plan::StringLocalId(next_string));
-                next_string += 1;
-                local
-            }
-            ValueType::Bool => {
-                let local = ParamLocal::bool(crate::plan::BoolLocalId(next_bool));
-                next_bool += 1;
-                local
-            }
-            ValueType::Nil => {
-                let local = ParamLocal::nil(crate::plan::NilLocalId(next_nil));
-                next_nil += 1;
-                local
-            }
-            ValueType::Function(type_) => match type_.return_() {
-                ValueType::Int => {
-                    let local = ParamLocal::int_function(
-                        crate::plan::IntFunctionLocalId(next_int_function),
-                        type_.as_ref().clone(),
-                    );
-                    next_int_function += 1;
-                    local
-                }
-                ValueType::String => {
-                    let local = ParamLocal::string_function(
-                        crate::plan::StringFunctionLocalId(next_string_function),
-                        type_.as_ref().clone(),
-                    );
-                    next_string_function += 1;
-                    local
-                }
-                ValueType::Bool => {
-                    let local = ParamLocal::bool_function(
-                        crate::plan::BoolFunctionLocalId(next_bool_function),
-                        type_.as_ref().clone(),
-                    );
-                    next_bool_function += 1;
-                    local
-                }
-                ValueType::Nil => {
-                    let local = ParamLocal::nil_function(
-                        crate::plan::NilFunctionLocalId(next_nil_function),
-                        type_.as_ref().clone(),
-                    );
-                    next_nil_function += 1;
-                    local
-                }
-                ValueType::Function(_) => {
-                    let local = ParamLocal::function_function(
-                        crate::plan::FunctionFunctionLocalId(next_function_function),
-                        type_.as_ref().clone(),
-                    );
-                    next_function_function += 1;
-                    local
-                }
-            },
-        })
-        .collect()
-}
-
-fn call_arg_type_mismatch(expected: ValueType, actual: ValueType) -> PlanError {
-    if matches!(expected, ValueType::Function(_)) && matches!(actual, ValueType::Function(_)) {
-        PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CallShape {
-                reason: InvalidCallShapeReason::FunctionCallArgumentTypeMismatch,
-            },
-        }
-    } else {
-        invalid_expression_type_for_value(expected, actual)
-    }
-}
-
-fn plan_argument_value(
-    argument: GleamCallArg<TypedExpr>,
-    capture: Option<&CaptureSubstitution>,
-    context: &mut PlanContext<'_>,
-    call_argument_mode: CallArgumentMode,
-) -> Result<Expr, PlanError> {
-    if matches!(call_argument_mode, CallArgumentMode::Use)
-        && matches!(argument.implicit, Some(ImplicitCallArgOrigin::Use))
-    {
-        return plan_use_callback_argument(argument.value, context);
-    }
-
-    if let Some(capture) = capture
-        && is_capture_local(&argument.value, &capture.name)
-    {
-        return Ok(capture.value.clone());
-    }
-
-    plan_expr(argument.value, context)
-}
-
-fn plan_use_callback_argument(
-    argument: TypedExpr,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    match argument {
-        TypedExpr::Fn {
-            type_,
-            kind: FunctionLiteralKind::Use { .. },
-            arguments,
-            body,
-            ..
-        } => super::function::plan_use_callback(type_, arguments, body, context),
-        TypedExpr::Fn { .. } => Err(invalid_use_shape(
-            InvalidUseShapeReason::CallbackLiteralKindNotUse,
-        )),
-        _ => Err(invalid_use_shape(
-            InvalidUseShapeReason::CallbackNotFunctionLiteral,
-        )),
-    }
-}
-
-fn validate_use_call_arguments(arguments: &[GleamCallArg<TypedExpr>]) -> Result<(), PlanError> {
-    if arguments.iter().any(|argument| argument.label.is_some()) {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CallShape {
-                reason: InvalidCallShapeReason::LabelledArguments,
-            },
-        });
-    }
-
-    let mut callback_index = None;
-    for (index, argument) in arguments.iter().enumerate() {
-        match argument.implicit {
-            None => {}
-            Some(ImplicitCallArgOrigin::Use) => {
-                if callback_index.replace(index).is_some() {
-                    return Err(invalid_use_shape(InvalidUseShapeReason::MultipleCallbacks));
-                }
-            }
-            Some(
-                ImplicitCallArgOrigin::Pipe
-                | ImplicitCallArgOrigin::PatternFieldSpread
-                | ImplicitCallArgOrigin::IncorrectArityUse
-                | ImplicitCallArgOrigin::RecordUpdate,
-            ) => {
-                return Err(invalid_use_shape(
-                    InvalidUseShapeReason::UnsupportedImplicitArgument,
-                ));
-            }
-        }
-    }
-
-    match callback_index {
-        Some(index) if index + 1 == arguments.len() => Ok(()),
-        Some(_) => Err(invalid_use_shape(InvalidUseShapeReason::CallbackNotLast)),
-        None => Err(invalid_use_shape(InvalidUseShapeReason::MissingCallback)),
-    }
-}
-
-fn invalid_use_shape(reason: InvalidUseShapeReason) -> PlanError {
-    PlanError::InvalidTypedAst {
-        reason: InvalidTypedAstReason::UseShape { reason },
-    }
-}
-
-fn count_capture_arguments(
-    arguments: &[GleamCallArg<TypedExpr>],
-    capture_name: &EcoString,
-) -> usize {
-    arguments
-        .iter()
-        .filter(|argument| is_capture_local(&argument.value, capture_name))
-        .count()
-}
-
-fn pipe_argument(arguments: &[GleamCallArg<TypedExpr>]) -> Result<&TypedExpr, PlanError> {
-    if arguments.iter().any(|argument| argument.label.is_some()) {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::LabelledArguments,
-            },
-        });
-    }
-
-    let mut pipe_argument = None;
-    for argument in arguments {
-        match argument.implicit {
-            None => {}
-            Some(ImplicitCallArgOrigin::Pipe) => {
-                if pipe_argument.replace(&argument.value).is_some() {
-                    return Err(PlanError::InvalidTypedAst {
-                        reason: InvalidTypedAstReason::PipelineShape {
-                            reason: InvalidPipelineShapeReason::MultiplePipeArguments,
-                        },
-                    });
-                }
-            }
-            Some(
-                ImplicitCallArgOrigin::Use
-                | ImplicitCallArgOrigin::PatternFieldSpread
-                | ImplicitCallArgOrigin::IncorrectArityUse
-                | ImplicitCallArgOrigin::RecordUpdate,
-            ) => {
-                return Err(PlanError::InvalidTypedAst {
-                    reason: InvalidTypedAstReason::PipelineShape {
-                        reason: InvalidPipelineShapeReason::UnsupportedImplicitArgument,
-                    },
-                });
-            }
-        }
-    }
-
-    match pipe_argument {
-        Some(pipe_argument) => Ok(pipe_argument),
-        None => Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::MissingPipeArgument,
-            },
-        }),
-    }
-}
-
-fn is_capture_local(expression: &TypedExpr, capture_name: &ecow::EcoString) -> bool {
-    matches!(
-        expression,
-        TypedExpr::Var {
-            name,
-            constructor,
-            ..
-        } if name == capture_name
-            && matches!(
-                constructor.variant,
-                ValueConstructorVariant::LocalVariable { .. }
-            )
     )
 }
 
-fn call_expr(function: RuntimeFunctionId, args: Vec<CallArg>) -> Expr {
-    match function {
-        RuntimeFunctionId::Int(function) => Expr::int(IntExpr::call(function, args)),
-        RuntimeFunctionId::String(function) => Expr::string(StringExpr::call(function, args)),
-        RuntimeFunctionId::Bool(function) => Expr::bool(BoolExpr::call(function, args)),
-        RuntimeFunctionId::Nil(function) => Expr::nil(NilExpr::call(function, args)),
-        RuntimeFunctionId::Function { id, return_type } => {
-            function_returning_function_call_expr(id, args, return_type)
+#[cfg(test)]
+mod support {
+    use crate::planner::support::compile;
+    use gleam_core::ast::{CallArg, Statement, TypedExpr, TypedStatement};
+    use gleam_core::type_::{self, ValueConstructor};
+
+    pub(super) fn expect_call_statement_mut(
+        statement: &mut TypedStatement,
+    ) -> (
+        &mut std::sync::Arc<type_::Type>,
+        &mut TypedExpr,
+        &mut Vec<CallArg<TypedExpr>>,
+    ) {
+        match statement {
+            Statement::Expression(expression) => expect_call_expression_mut(expression),
+            _ => panic!("expected call expression statement"),
         }
     }
-}
 
-fn function_returning_function_call_expr(
-    function: crate::plan::FunctionFunctionId,
-    args: Vec<CallArg>,
-    return_type: crate::plan::FunctionType,
-) -> Expr {
-    match function {
-        crate::plan::FunctionFunctionId::Int(function) => Expr::function(FunctionExpr::int(
-            crate::plan::IntFunctionExpr::call(function, args, return_type),
-        )),
-        crate::plan::FunctionFunctionId::String(function) => Expr::function(FunctionExpr::string(
-            crate::plan::StringFunctionExpr::call(function, args, return_type),
-        )),
-        crate::plan::FunctionFunctionId::Bool(function) => Expr::function(FunctionExpr::bool(
-            crate::plan::BoolFunctionExpr::call(function, args, return_type),
-        )),
-        crate::plan::FunctionFunctionId::Nil(function) => Expr::function(FunctionExpr::nil(
-            crate::plan::NilFunctionExpr::call(function, args, return_type),
-        )),
-        crate::plan::FunctionFunctionId::Function(function) => Expr::function(
-            FunctionExpr::function(FunctionFunctionExpr::call(function, args, return_type)),
-        ),
+    pub(super) fn expect_call_expression_mut(
+        expression: &mut TypedExpr,
+    ) -> (
+        &mut std::sync::Arc<type_::Type>,
+        &mut TypedExpr,
+        &mut Vec<CallArg<TypedExpr>>,
+    ) {
+        match expression {
+            TypedExpr::Call {
+                type_,
+                fun,
+                arguments,
+                ..
+            } => (type_, fun.as_mut(), arguments),
+            _ => panic!("expected call expression statement"),
+        }
     }
-}
 
-fn function_call_expr(
-    function: FunctionExpr,
-    args: Vec<CallArg>,
-    return_type: ValueType,
-) -> Result<Expr, PlanError> {
-    match return_type {
-        ValueType::Int => match function.into_int() {
-            Some(function) => Ok(Expr::int(IntExpr::function_call(function, args))),
-            None => Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            }),
-        },
-        ValueType::String => match function.into_string() {
-            Some(function) => Ok(Expr::string(StringExpr::function_call(function, args))),
-            None => Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            }),
-        },
-        ValueType::Bool => match function.into_bool() {
-            Some(function) => Ok(Expr::bool(crate::plan::BoolExpr::function_call(
-                function, args,
-            ))),
-            None => Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            }),
-        },
-        ValueType::Nil => match function.into_nil() {
-            Some(function) => Ok(Expr::nil(NilExpr::function_call(function, args))),
-            None => Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            }),
-        },
-        ValueType::Function(return_type) => match function.into_function() {
-            Some(function) => Ok(function_returning_function_value_call_expr(
-                function,
-                args,
-                *return_type,
-            )),
-            None => Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            }),
-        },
+    pub(super) fn expect_var_constructor_mut(expression: &mut TypedExpr) -> &mut ValueConstructor {
+        match expression {
+            TypedExpr::Var { constructor, .. } => constructor,
+            _ => panic!("expected variable expression"),
+        }
     }
-}
 
-fn function_returning_function_value_call_expr(
-    function: FunctionFunctionExpr,
-    args: Vec<CallArg>,
-    return_type: crate::plan::FunctionType,
-) -> Expr {
-    match return_type.return_() {
-        ValueType::Int => Expr::function(FunctionExpr::int(
-            crate::plan::IntFunctionExpr::function_call(function, args, return_type),
-        )),
-        ValueType::String => Expr::function(FunctionExpr::string(
-            crate::plan::StringFunctionExpr::function_call(function, args, return_type),
-        )),
-        ValueType::Bool => Expr::function(FunctionExpr::bool(
-            crate::plan::BoolFunctionExpr::function_call(function, args, return_type),
-        )),
-        ValueType::Nil => Expr::function(FunctionExpr::nil(
-            crate::plan::NilFunctionExpr::function_call(function, args, return_type),
-        )),
-        ValueType::Function(_) => Expr::function(FunctionExpr::function(
-            FunctionFunctionExpr::function_call(function, args, return_type),
-        )),
+    #[test]
+    #[should_panic(expected = "expected call expression statement")]
+    fn expect_call_statement_mut_panics_on_expression() {
+        let mut module = crate::planner::support::compile_minimal_module();
+
+        expect_call_statement_mut(&mut module.definitions.functions[0].body[0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected call expression statement")]
+    fn expect_call_statement_mut_panics_on_assignment() {
+        let mut module = compile(
+            r#"
+pub fn main() {
+  let x = 1
+  x
+}
+"#,
+        );
+
+        expect_call_statement_mut(&mut module.definitions.functions[0].body[0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected variable expression")]
+    fn expect_var_constructor_mut_panics_on_int() {
+        let mut expression = super::super::typed_int_expr(1);
+
+        expect_var_constructor_mut(&mut expression);
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::super::{typed_int_expr, typed_string_expr};
-    use crate::plan::{
-        BoolFunctionFunctionId, BoolFunctionId, FunctionExpr, FunctionFunctionExpr,
-        FunctionFunctionFunctionId, FunctionFunctionId, FunctionType, IntFunctionFunctionId,
-        IntLocalId, LocalId, NilFunctionFunctionId, NilFunctionId, ParamLocal, RuntimeFunctionId,
-        StringFunctionFunctionId, StringFunctionId, ValueType,
-    };
-    use crate::planner::dsl::{
-        block_int_function, bool_, bool_case_int_function, call_int_function, function,
-        function_function_ref, function_ref, int, int_arg, int_case_int_function, int_function_arg,
-        int_function_call_arg, int_function_ref, int_return_tail_call, let_int_function_step,
-        local_int, local_int_function, module, module_with_anonymous,
-    };
+    use super::support::{expect_call_statement_mut, expect_var_constructor_mut};
     use crate::planner::plan_module;
-    use crate::planner::support::{compile, compile_minimal_module, dummy_span};
-    use crate::planner::{
-        InvalidCallShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
-        UnsupportedExpressionKind,
-    };
-    use gleam_core::ast::{
-        CallArg, ImplicitCallArgOrigin, Statement, TypedExpr, TypedModule, TypedStatement,
-    };
-    use gleam_core::type_::{
-        self, ValueConstructor, ValueConstructorVariant, error::VariableOrigin,
-    };
-
-    #[test]
-    fn plan_immediate_anonymous_function_call() {
-        let actual = plan_module(compile(r#"pub fn main() { fn(x) { x + 1 }(41) }"#))
-            .expect("source should plan");
-        let expected = module_with_anonymous(
-            "main",
-            function(
-                "main",
-                call_int_function(
-                    int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
-                    [int_function_call_arg(0, int(41))],
-                ),
-            ),
-            [],
-            [function("<anonymous:0>", local_int(0, "x").add_int(int(1))).param_int(0, "x")],
-        );
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn reject_profile_function_call_argument_expression() {
-        assert_eq!(
-            plan_module(compile(
-                r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  let function = add_one
-  function(todo)
-}
-"#,
-            )),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::Todo,
-            }),
-        );
-    }
-
-    #[test]
-    fn plan_function_value_assignment_before_call() {
-        let actual = plan_module(compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  let function = add_one
-  function(1)
-}
-"#,
-        ))
-        .expect("source should plan");
-        let expected = module(
-            "main",
-            function(
-                "main",
-                call_int_function(
-                    local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
-                    [int_function_call_arg(0, int(1))],
-                ),
-            )
-            .step(let_int_function_step(
-                0,
-                "function",
-                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
-            )),
-            [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
-        );
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn plan_function_value_argument_direct_call() {
-        let actual = plan_module(compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-fn apply(function: fn(Int) -> Int, value: Int) {
-  function(value)
-}
-
-pub fn main() {
-  apply(add_one, 41)
-}
-"#,
-        ))
-        .expect("source should plan");
-        let expected = module(
-            "main",
-            function(
-                "main",
-                int_return_tail_call(
-                    2,
-                    [
-                        int_function_arg(0, int_function_ref(1, [LocalId::Int(IntLocalId(0))])),
-                        int_arg(0, int(41)),
-                    ],
-                ),
-            ),
-            [
-                function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value"),
-                function(
-                    "apply",
-                    call_int_function(
-                        local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
-                        [int_function_call_arg(0, local_int(0, "value"))],
-                    ),
-                )
-                .param_int_function(0, "function", [ValueType::Int])
-                .param_int(0, "value"),
-            ],
-        );
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn plan_local_function_value_argument_direct_call() {
-        let actual = plan_module(compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-fn apply(function: fn(Int) -> Int, value: Int) {
-  function(value)
-}
-
-pub fn main() {
-  let add = add_one
-  apply(add, 41)
-}
-"#,
-        ))
-        .expect("source should plan");
-        let expected = module(
-            "main",
-            function(
-                "main",
-                int_return_tail_call(
-                    2,
-                    [
-                        int_function_arg(
-                            0,
-                            local_int_function(0, "add", [LocalId::Int(IntLocalId(0))]),
-                        ),
-                        int_arg(0, int(41)),
-                    ],
-                ),
-            )
-            .step(let_int_function_step(
-                0,
-                "add",
-                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
-            )),
-            [
-                function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value"),
-                function(
-                    "apply",
-                    call_int_function(
-                        local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
-                        [int_function_call_arg(0, local_int(0, "value"))],
-                    ),
-                )
-                .param_int_function(0, "function", [ValueType::Int])
-                .param_int(0, "value"),
-            ],
-        );
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn plan_function_value_and_primitive_shadowing_bindings() {
-        let actual = plan_module(compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  let function = 1
-  let function = add_one
-  function(1)
-}
-
-pub fn primitive_shadow() {
-  let function = add_one
-  let function = 1
-  function + 1
-}
-"#,
-        ))
-        .expect("source should plan");
-        let add_one =
-            function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value");
-        let expected = module(
-            "main",
-            function(
-                "main",
-                call_int_function(
-                    local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
-                    [int_function_call_arg(0, int(1))],
-                ),
-            )
-            .let_int(0, "function", int(1))
-            .step(let_int_function_step(
-                0,
-                "function",
-                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
-            )),
-            [
-                add_one,
-                function("primitive_shadow", local_int(0, "function").add_int(int(1)))
-                    .step(let_int_function_step(
-                        0,
-                        "function",
-                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
-                    ))
-                    .let_int(0, "function", int(1)),
-            ],
-        );
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn plan_function_valued_block_callee() {
-        let actual = plan_module(compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  { add_one }(1)
-}
-"#,
-        ))
-        .expect("source should plan");
-        let expected = module(
-            "main",
-            function(
-                "main",
-                call_int_function(
-                    block_int_function([], int_function_ref(1, [LocalId::Int(IntLocalId(0))])),
-                    [int_function_call_arg(0, int(1))],
-                ),
-            ),
-            [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
-        );
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn plan_function_valued_case_callee() {
-        let actual = plan_module(compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-fn add_ten(value: Int) {
-  value + 10
-}
-
-pub fn main() {
-  let bool_result = case True {
-    True -> add_one
-    False -> add_ten
-  }(1)
-  let int_result = case 0 {
-    0 -> add_ten
-    _ -> add_one
-  }(1)
-  bool_result + int_result
-}
-"#,
-        ))
-        .expect("source should plan");
-        let add_one =
-            function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value");
-        let add_ten =
-            function("add_ten", local_int(0, "value").add_int(int(10))).param_int(0, "value");
-        let expected = module(
-            "main",
-            function(
-                "main",
-                local_int(0, "bool_result").add_int(local_int(1, "int_result")),
-            )
-            .let_int(
-                0,
-                "bool_result",
-                call_int_function(
-                    bool_case_int_function(
-                        bool_(true),
-                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
-                        int_function_ref(2, [LocalId::Int(IntLocalId(0))]),
-                    ),
-                    [int_function_call_arg(0, int(1))],
-                ),
-            )
-            .let_int(
-                1,
-                "int_result",
-                call_int_function(
-                    int_case_int_function(
-                        int(0),
-                        [(0, int_function_ref(2, [LocalId::Int(IntLocalId(0))]))],
-                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
-                    ),
-                    [int_function_call_arg(0, int(1))],
-                ),
-            ),
-            [add_one, add_ten],
-        );
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn reject_margin_function_value_call_shapes() {
-        let mut arity_mismatch_case_call = compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  case True {
-    True -> add_one
-    False -> add_one
-  }(1)
-}
-"#,
-        );
-        let (_, _, arguments) = expect_call_statement_mut(
-            &mut arity_mismatch_case_call.definitions.functions[1].body[0],
-        );
-        let mut extra_argument = arguments[0].clone();
-        extra_argument.value = typed_int_expr(2);
-        arguments.push(extra_argument);
-        assert_eq!(arguments.len(), 2);
-        assert_eq!(
-            plan_module(arity_mismatch_case_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallArityMismatch,
-                },
-            }),
-        );
-
-        let mut non_function_callee = compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  let function = add_one
-  function(1)
-}
-"#,
-        );
-        let (_, fun, _) =
-            expect_call_statement_mut(&mut non_function_callee.definitions.functions[1].body[1]);
-        *fun = typed_int_expr(1);
-        assert_eq!(
-            plan_module(non_function_callee),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionType {
-                    expected: InvalidExpressionType::Function,
-                    actual: InvalidExpressionType::Int,
-                },
-            }),
-        );
-
-        let mut unsupported_return_type_call = compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  let function = add_one
-  function(1)
-}
-"#,
-        );
-        let (type_, _, _) = expect_call_statement_mut(
-            &mut unsupported_return_type_call.definitions.functions[1].body[1],
-        );
-        *type_ = type_::list(type_::int());
-        assert_eq!(
-            plan_module(unsupported_return_type_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallUnsupportedReturnType,
-                },
-            }),
-        );
-
-        let mut return_type_mismatch_call = compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  let function = add_one
-  function(1)
-}
-"#,
-        );
-        let (type_, _, _) = expect_call_statement_mut(
-            &mut return_type_mismatch_call.definitions.functions[1].body[1],
-        );
-        *type_ = type_::bool();
-        assert_eq!(
-            plan_module(return_type_mismatch_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-                },
-            }),
-        );
-
-        let mut argument_type_mismatch_call = compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  let function = add_one
-  function(1)
-}
-"#,
-        );
-        let (_, _, arguments) = expect_call_statement_mut(
-            &mut argument_type_mismatch_call.definitions.functions[1].body[1],
-        );
-        arguments[0].value = typed_string_expr("wrong");
-        assert_eq!(
-            plan_module(argument_type_mismatch_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionType {
-                    expected: InvalidExpressionType::Int,
-                    actual: InvalidExpressionType::String,
-                },
-            }),
-        );
-
-        let mut arity_mismatch_call = compile(
-            r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  let function = add_one
-  function(1)
-}
-"#,
-        );
-        let (_, _, arguments) =
-            expect_call_statement_mut(&mut arity_mismatch_call.definitions.functions[1].body[1]);
-        arguments.clear();
-        assert_eq!(
-            plan_module(arity_mismatch_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallArityMismatch,
-                },
-            }),
-        );
-    }
-
-    #[test]
-    fn reject_margin_function_call_argument_function_shapes() {
-        let mut function_mismatch_call = compile(
-            r#"
-fn apply(function: fn(Int) -> Int) {
-  function(1)
-}
-
-fn add_one(value: Int) {
-  value + 1
-}
-
-fn string_identity(value: String) {
-  value
-}
-
-fn accept_string(function: fn(String) -> String) {
-  function("ok")
-}
-
-pub fn main() {
-  accept_string(string_identity)
-  apply(add_one)
-}
-"#,
-        );
-        let wrong_function = {
-            let (_, _, arguments) = expect_call_statement_mut(
-                &mut function_mismatch_call.definitions.functions[4].body[0],
-            );
-            arguments[0].value.clone()
-        };
-        let (_, _, arguments) =
-            expect_call_statement_mut(&mut function_mismatch_call.definitions.functions[4].body[1]);
-        arguments[0].value = wrong_function;
-        assert_eq!(
-            plan_module(function_mismatch_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallArgumentTypeMismatch,
-                },
-            }),
-        );
-
-        let mut non_function_call = compile(
-            r#"
-fn apply(function: fn(Int) -> Int) {
-  function(1)
-}
-
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  apply(add_one)
-}
-"#,
-        );
-        let (_, _, arguments) =
-            expect_call_statement_mut(&mut non_function_call.definitions.functions[2].body[0]);
-        arguments[0].value = typed_int_expr(1);
-        assert_eq!(
-            plan_module(non_function_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionType {
-                    expected: InvalidExpressionType::Function,
-                    actual: InvalidExpressionType::Int,
-                },
-            }),
-        );
-    }
-
-    #[test]
-    fn reject_margin_function_value_call_argument_type_shapes() {
-        let mut function_mismatch_call = compile(
-            r#"
-fn apply(function: fn(Int) -> Int) {
-  function(1)
-}
-
-fn add_one(value: Int) {
-  value + 1
-}
-
-fn string_identity(value: String) {
-  value
-}
-
-fn accept_string(function: fn(String) -> String) {
-  function("ok")
-}
-
-pub fn main() {
-  accept_string(string_identity)
-  let apply_value = apply
-  apply_value(add_one)
-}
-"#,
-        );
-        let wrong_function = {
-            let (_, _, arguments) = expect_call_statement_mut(
-                &mut function_mismatch_call.definitions.functions[4].body[0],
-            );
-            arguments[0].value.clone()
-        };
-        let (_, _, arguments) =
-            expect_call_statement_mut(&mut function_mismatch_call.definitions.functions[4].body[2]);
-        arguments[0].value = wrong_function;
-        assert_eq!(
-            plan_module(function_mismatch_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::FunctionCallArgumentTypeMismatch,
-                },
-            }),
-        );
-
-        let mut non_function_call = compile(
-            r#"
-fn apply(function: fn(Int) -> Int) {
-  function(1)
-}
-
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  let apply_value = apply
-  apply_value(add_one)
-}
-"#,
-        );
-        let (_, _, arguments) =
-            expect_call_statement_mut(&mut non_function_call.definitions.functions[2].body[1]);
-        arguments[0].value = typed_int_expr(1);
-        assert_eq!(
-            plan_module(non_function_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionType {
-                    expected: InvalidExpressionType::Function,
-                    actual: InvalidExpressionType::Int,
-                },
-            }),
-        );
-
-        assert_function_value_argument_type_mismatch(
-            r#"
-fn identity(value: String) {
-  value
-}
-
-pub fn main() {
-  let function = identity
-  function("ok")
-}
-"#,
-            typed_int_expr(1),
-            InvalidExpressionType::String,
-            InvalidExpressionType::Int,
-        );
-        assert_function_value_argument_type_mismatch(
-            r#"
-fn identity(value: Bool) {
-  value
-}
-
-pub fn main() {
-  let function = identity
-  function(True)
-}
-"#,
-            typed_int_expr(1),
-            InvalidExpressionType::Bool,
-            InvalidExpressionType::Int,
-        );
-        assert_function_value_argument_type_mismatch(
-            r#"
-fn identity(value: Nil) {
-  value
-}
-
-pub fn main() {
-  let function = identity
-  function(Nil)
-}
-"#,
-            typed_int_expr(1),
-            InvalidExpressionType::Nil,
-            InvalidExpressionType::Int,
-        );
-    }
-
-    #[test]
-    fn function_call_expr_preserves_return_family() {
-        assert_eq!(
-            super::function_call_expr(
-                FunctionExpr::from(function_ref(
-                    RuntimeFunctionId::String(StringFunctionId(0)),
-                    Vec::<ParamLocal>::new(),
-                )),
-                Vec::new(),
-                ValueType::String,
-            )
-            .expect("string function call")
-            .value_type(),
-            ValueType::String,
-        );
-        assert_eq!(
-            super::function_call_expr(
-                FunctionExpr::from(function_ref(
-                    RuntimeFunctionId::Bool(BoolFunctionId(0)),
-                    Vec::<ParamLocal>::new(),
-                )),
-                Vec::new(),
-                ValueType::Bool,
-            )
-            .expect("bool function call")
-            .value_type(),
-            ValueType::Bool,
-        );
-        assert_eq!(
-            super::function_call_expr(
-                FunctionExpr::from(function_ref(
-                    RuntimeFunctionId::Nil(NilFunctionId(0)),
-                    Vec::<ParamLocal>::new(),
-                )),
-                Vec::new(),
-                ValueType::Nil,
-            )
-            .expect("nil function call")
-            .value_type(),
-            ValueType::Nil,
-        );
-
-        let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
-        assert_eq!(
-            super::function_call_expr(
-                FunctionExpr::from(function_function_ref(
-                    FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),
-                    Vec::<ParamLocal>::new(),
-                    returned_function_type.clone(),
-                )),
-                Vec::new(),
-                ValueType::Function(Box::new(returned_function_type.clone())),
-            )
-            .expect("function-returning function call")
-            .value_type(),
-            ValueType::Function(Box::new(returned_function_type)),
-        );
-    }
-
-    #[test]
-    fn function_returning_function_call_expr_preserves_return_family() {
-        let cases = [
-            (
-                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
-                FunctionType::new(vec![ValueType::Int], ValueType::Int),
-            ),
-            (
-                FunctionFunctionId::String(StringFunctionFunctionId(0)),
-                FunctionType::new(vec![ValueType::String], ValueType::String),
-            ),
-            (
-                FunctionFunctionId::Bool(BoolFunctionFunctionId(0)),
-                FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
-            ),
-            (
-                FunctionFunctionId::Nil(NilFunctionFunctionId(0)),
-                FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
-            ),
-            (
-                FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),
-                FunctionType::new(
-                    Vec::new(),
-                    ValueType::Function(Box::new(FunctionType::new(
-                        vec![ValueType::Int],
-                        ValueType::Int,
-                    ))),
-                ),
-            ),
-        ];
-
-        for (function, returned_function_type) in cases {
-            assert_eq!(
-                super::function_returning_function_call_expr(
-                    function,
-                    Vec::new(),
-                    returned_function_type.clone(),
-                )
-                .value_type(),
-                ValueType::Function(Box::new(returned_function_type)),
-            );
-        }
-    }
-
-    #[test]
-    fn function_returning_function_value_call_expr_preserves_return_family() {
-        let cases = [
-            (
-                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
-                FunctionType::new(vec![ValueType::Int], ValueType::Int),
-            ),
-            (
-                FunctionFunctionId::String(StringFunctionFunctionId(0)),
-                FunctionType::new(vec![ValueType::String], ValueType::String),
-            ),
-            (
-                FunctionFunctionId::Bool(BoolFunctionFunctionId(0)),
-                FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
-            ),
-            (
-                FunctionFunctionId::Nil(NilFunctionFunctionId(0)),
-                FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
-            ),
-            (
-                FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),
-                FunctionType::new(
-                    Vec::new(),
-                    ValueType::Function(Box::new(FunctionType::new(
-                        vec![ValueType::Int],
-                        ValueType::Int,
-                    ))),
-                ),
-            ),
-        ];
-
-        for (runtime_id, returned_function_type) in cases {
-            let function = FunctionFunctionExpr::from(function_function_ref(
-                runtime_id,
-                Vec::<ParamLocal>::new(),
-                returned_function_type.clone(),
-            ));
-
-            assert_eq!(
-                super::function_returning_function_value_call_expr(
-                    function,
-                    Vec::new(),
-                    returned_function_type.clone(),
-                )
-                .value_type(),
-                ValueType::Function(Box::new(returned_function_type)),
-            );
-        }
-    }
-
-    #[test]
-    fn reject_margin_function_call_expr_return_family_mismatch() {
-        assert_eq!(
-            super::function_call_expr(
-                FunctionExpr::from(function_ref(
-                    RuntimeFunctionId::String(StringFunctionId(0)),
-                    Vec::<ParamLocal>::new(),
-                )),
-                Vec::new(),
-                ValueType::Int,
-            ),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::function_call_expr(
-                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
-                Vec::new(),
-                ValueType::String,
-            ),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::function_call_expr(
-                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
-                Vec::new(),
-                ValueType::Bool,
-            ),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::function_call_expr(
-                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
-                Vec::new(),
-                ValueType::Nil,
-            ),
-            Err(function_call_return_type_mismatch()),
-        );
-        assert_eq!(
-            super::function_call_expr(
-                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
-                Vec::new(),
-                ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
-            ),
-            Err(function_call_return_type_mismatch()),
-        );
-    }
-
-    fn function_call_return_type_mismatch() -> PlanError {
-        PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CallShape {
-                reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
-            },
-        }
-    }
-
-    fn reject_margin_module_constant_call(mut module_constant_call: TypedModule) {
-        module_constant_call.definitions.constants.clear();
-        let statement = module_constant_call.definitions.functions[0].body.remove(0);
-        let module_constant = match statement {
-            Statement::Expression(module_constant) => module_constant,
-            _ => panic!("expected expression statement"),
-        };
-        module_constant_call.definitions.functions[0].body =
-            vec![Statement::Expression(TypedExpr::Call {
-                location: dummy_span(),
-                type_: type_::int(),
-                fun: Box::new(module_constant),
-                arguments: Vec::new(),
-                open_parenthesis: Some(0),
-            })];
-        assert_eq!(
-            plan_module(module_constant_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::ModuleConstant,
-                },
-            }),
-        );
-    }
+    use crate::planner::support::{compile, dummy_span};
+    use crate::planner::{InvalidCallShapeReason, InvalidTypedAstReason, PlanError};
+    use gleam_core::ast::{ImplicitCallArgOrigin, Statement, TypedExpr, TypedModule};
+    use gleam_core::type_::{self, ValueConstructorVariant, error::VariableOrigin};
 
     #[test]
     fn reject_margin_module_constant_call_shape() {
@@ -1766,7 +300,7 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_margin_call_shapes() {
+    fn reject_margin_call_entry_and_callee_shapes() {
         let mut labelled_call = compile(
             r#"
 fn identity(value: Int) {
@@ -1840,141 +374,6 @@ pub fn main() {
             }),
         );
 
-        let mut arity_mismatch_call = compile(
-            r#"
-fn identity(value: Int) {
-  value
-}
-
-pub fn main() {
-  identity(1)
-}
-"#,
-        );
-        let (_, _, arguments) =
-            expect_call_statement_mut(&mut arity_mismatch_call.definitions.functions[1].body[0]);
-        arguments.clear();
-        assert_eq!(
-            plan_module(arity_mismatch_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::LocalFunctionCallArityMismatch,
-                },
-            }),
-        );
-
-        let mut unsupported_return_type_call = compile(
-            r#"
-fn identity(value: Int) {
-  value
-}
-
-pub fn main() {
-  identity(1)
-}
-"#,
-        );
-        let (type_, _, _) = expect_call_statement_mut(
-            &mut unsupported_return_type_call.definitions.functions[1].body[0],
-        );
-        *type_ = type_::tuple(vec![type_::int()]);
-        assert_eq!(
-            plan_module(unsupported_return_type_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::LocalFunctionCallUnsupportedReturnType,
-                },
-            }),
-        );
-
-        let mut return_type_mismatch_call = compile(
-            r#"
-fn identity(value: Int) {
-  value
-}
-
-pub fn main() {
-  identity(1)
-}
-"#,
-        );
-        let (type_, _, _) = expect_call_statement_mut(
-            &mut return_type_mismatch_call.definitions.functions[1].body[0],
-        );
-        *type_ = type_::bool();
-        assert_eq!(
-            plan_module(return_type_mismatch_call),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CallShape {
-                    reason: InvalidCallShapeReason::LocalFunctionCallReturnTypeMismatch,
-                },
-            }),
-        );
-
-        assert_call_argument_type_mismatch(
-            r#"
-fn identity(value: Int) {
-  value
-}
-
-pub fn main() {
-  identity(1)
-}
-"#,
-            1,
-            typed_string_expr("wrong"),
-            InvalidExpressionType::Int,
-            InvalidExpressionType::String,
-        );
-
-        assert_call_argument_type_mismatch(
-            r#"
-fn identity(value: String) {
-  value
-}
-
-pub fn main() {
-  identity("ok")
-}
-"#,
-            1,
-            typed_int_expr(1),
-            InvalidExpressionType::String,
-            InvalidExpressionType::Int,
-        );
-
-        assert_call_argument_type_mismatch(
-            r#"
-fn identity(value: Bool) {
-  value
-}
-
-pub fn main() {
-  identity(True)
-}
-"#,
-            1,
-            typed_int_expr(1),
-            InvalidExpressionType::Bool,
-            InvalidExpressionType::Int,
-        );
-
-        assert_call_argument_type_mismatch(
-            r#"
-fn identity(value: Nil) {
-  value
-}
-
-pub fn main() {
-  identity(Nil)
-}
-"#,
-            1,
-            typed_int_expr(1),
-            InvalidExpressionType::Nil,
-            InvalidExpressionType::Int,
-        );
-
         let mut missing_current_module_fn = compile(
             r#"
 fn identity(value: Int) {
@@ -1996,7 +395,7 @@ pub fn main() {
             }),
         );
 
-        let non_local_module_fn = compile(
+        reject_margin_non_local_module_fn_call(compile(
             r#"
 fn identity(value: Int) {
   value
@@ -2006,8 +405,7 @@ pub fn main() {
   identity(1)
 }
 "#,
-        );
-        reject_margin_non_local_module_fn_call(non_local_module_fn);
+        ));
 
         let mut record_constructor_call = compile(
             r#"
@@ -2032,41 +430,27 @@ pub fn main() {
         );
     }
 
-    fn assert_call_argument_type_mismatch(
-        src: &str,
-        function_index: usize,
-        value: TypedExpr,
-        expected: InvalidExpressionType,
-        actual: InvalidExpressionType,
-    ) {
-        let mut module = compile(src);
-        let (_, _, arguments) =
-            expect_call_statement_mut(&mut module.definitions.functions[function_index].body[0]);
-        arguments[0].value = value;
-
+    fn reject_margin_module_constant_call(mut module_constant_call: TypedModule) {
+        module_constant_call.definitions.constants.clear();
+        let statement = module_constant_call.definitions.functions[0].body.remove(0);
+        let module_constant = match statement {
+            Statement::Expression(module_constant) => module_constant,
+            _ => panic!("expected expression statement"),
+        };
+        module_constant_call.definitions.functions[0].body =
+            vec![Statement::Expression(TypedExpr::Call {
+                location: dummy_span(),
+                type_: type_::int(),
+                fun: Box::new(module_constant),
+                arguments: Vec::new(),
+                open_parenthesis: Some(0),
+            })];
         assert_eq!(
-            plan_module(module),
+            plan_module(module_constant_call),
             Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionType { expected, actual },
-            }),
-        );
-    }
-
-    fn assert_function_value_argument_type_mismatch(
-        src: &str,
-        value: TypedExpr,
-        expected: InvalidExpressionType,
-        actual: InvalidExpressionType,
-    ) {
-        let mut module = compile(src);
-        let (_, _, arguments) =
-            expect_call_statement_mut(&mut module.definitions.functions[1].body[1]);
-        arguments[0].value = value;
-
-        assert_eq!(
-            plan_module(module),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionType { expected, actual },
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::ModuleConstant,
+                },
             }),
         );
     }
@@ -2109,74 +493,5 @@ pub fn main() {
 "#,
         );
         reject_margin_non_local_module_fn_call(record_constructor_call);
-    }
-
-    fn expect_call_statement_mut(
-        statement: &mut TypedStatement,
-    ) -> (
-        &mut std::sync::Arc<type_::Type>,
-        &mut TypedExpr,
-        &mut Vec<CallArg<TypedExpr>>,
-    ) {
-        match statement {
-            Statement::Expression(expression) => expect_call_expression_mut(expression),
-            _ => panic!("expected call expression statement"),
-        }
-    }
-
-    fn expect_call_expression_mut(
-        expression: &mut TypedExpr,
-    ) -> (
-        &mut std::sync::Arc<type_::Type>,
-        &mut TypedExpr,
-        &mut Vec<CallArg<TypedExpr>>,
-    ) {
-        match expression {
-            TypedExpr::Call {
-                type_,
-                fun,
-                arguments,
-                ..
-            } => (type_, fun.as_mut(), arguments),
-            _ => panic!("expected call expression statement"),
-        }
-    }
-
-    #[test]
-    #[should_panic(expected = "expected call expression statement")]
-    fn expect_call_statement_mut_panics_on_expression() {
-        let mut module = compile_minimal_module();
-
-        expect_call_statement_mut(&mut module.definitions.functions[0].body[0]);
-    }
-
-    #[test]
-    #[should_panic(expected = "expected call expression statement")]
-    fn expect_call_statement_mut_panics_on_assignment() {
-        let mut module = compile(
-            r#"
-pub fn main() {
-  let x = 1
-  x
-}
-"#,
-        );
-
-        expect_call_statement_mut(&mut module.definitions.functions[0].body[0]);
-    }
-
-    fn expect_var_constructor_mut(expression: &mut TypedExpr) -> &mut ValueConstructor {
-        match expression {
-            TypedExpr::Var { constructor, .. } => constructor,
-            _ => panic!("expected variable expression"),
-        }
-    }
-
-    #[test]
-    #[should_panic(expected = "expected variable expression")]
-    fn expect_var_constructor_mut_panics_on_int() {
-        let mut expression = typed_int_expr(1);
-
-        expect_var_constructor_mut(&mut expression);
     }
 }

--- a/src/planner/expression/call/argument.rs
+++ b/src/planner/expression/call/argument.rs
@@ -1,0 +1,260 @@
+use super::{CallArgumentMode, CaptureSubstitution};
+use crate::plan::{CallArg, Expr, ParamLocal, ValueType};
+use crate::planner::context::{FunctionParam, PlanContext};
+use crate::planner::error::{
+    InvalidCallShapeReason, InvalidTypedAstReason, InvalidUseShapeReason, PlanError,
+};
+use gleam_core::ast::{
+    CallArg as GleamCallArg, FunctionLiteralKind, ImplicitCallArgOrigin, TypedExpr,
+};
+
+pub(super) fn plan_call_args(
+    arguments: Vec<GleamCallArg<TypedExpr>>,
+    params: &[FunctionParam],
+    context: &mut PlanContext<'_>,
+    capture: Option<&CaptureSubstitution>,
+    call_argument_mode: CallArgumentMode,
+) -> Result<Vec<CallArg>, PlanError> {
+    let mut args = Vec::with_capacity(arguments.len());
+    for (argument, param) in arguments.into_iter().zip(params) {
+        let expression = plan_argument_value(argument, capture, context, call_argument_mode)?;
+        let actual = expression.value_type();
+        let arg = match expression.into_call_arg(&param.local) {
+            Some(arg) => arg,
+            None => return Err(call_arg_type_mismatch(param.local.value_type(), actual)),
+        };
+        args.push(arg);
+    }
+    Ok(args)
+}
+
+pub(super) fn plan_function_call_args(
+    arguments: Vec<GleamCallArg<TypedExpr>>,
+    params: &[ValueType],
+    context: &mut PlanContext<'_>,
+    capture: Option<&CaptureSubstitution>,
+    call_argument_mode: CallArgumentMode,
+) -> Result<Vec<CallArg>, PlanError> {
+    let locals = function_call_param_locals(params);
+    let mut args = Vec::with_capacity(arguments.len());
+    for (argument, local) in arguments.into_iter().zip(&locals) {
+        let expression = plan_argument_value(argument, capture, context, call_argument_mode)?;
+        let actual = expression.value_type();
+        let arg = match expression.into_call_arg(local) {
+            Some(arg) => arg,
+            None => return Err(call_arg_type_mismatch(local.value_type(), actual)),
+        };
+        args.push(arg);
+    }
+    Ok(args)
+}
+
+fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
+    let mut next_int = 0;
+    let mut next_string = 0;
+    let mut next_bool = 0;
+    let mut next_nil = 0;
+    let mut next_int_function = 0;
+    let mut next_string_function = 0;
+    let mut next_bool_function = 0;
+    let mut next_nil_function = 0;
+    let mut next_function_function = 0;
+
+    params
+        .iter()
+        .map(|type_| match type_ {
+            ValueType::Int => {
+                let local = ParamLocal::int(crate::plan::IntLocalId(next_int));
+                next_int += 1;
+                local
+            }
+            ValueType::String => {
+                let local = ParamLocal::string(crate::plan::StringLocalId(next_string));
+                next_string += 1;
+                local
+            }
+            ValueType::Bool => {
+                let local = ParamLocal::bool(crate::plan::BoolLocalId(next_bool));
+                next_bool += 1;
+                local
+            }
+            ValueType::Nil => {
+                let local = ParamLocal::nil(crate::plan::NilLocalId(next_nil));
+                next_nil += 1;
+                local
+            }
+            ValueType::Function(type_) => match type_.return_() {
+                ValueType::Int => {
+                    let local = ParamLocal::int_function(
+                        crate::plan::IntFunctionLocalId(next_int_function),
+                        type_.as_ref().clone(),
+                    );
+                    next_int_function += 1;
+                    local
+                }
+                ValueType::String => {
+                    let local = ParamLocal::string_function(
+                        crate::plan::StringFunctionLocalId(next_string_function),
+                        type_.as_ref().clone(),
+                    );
+                    next_string_function += 1;
+                    local
+                }
+                ValueType::Bool => {
+                    let local = ParamLocal::bool_function(
+                        crate::plan::BoolFunctionLocalId(next_bool_function),
+                        type_.as_ref().clone(),
+                    );
+                    next_bool_function += 1;
+                    local
+                }
+                ValueType::Nil => {
+                    let local = ParamLocal::nil_function(
+                        crate::plan::NilFunctionLocalId(next_nil_function),
+                        type_.as_ref().clone(),
+                    );
+                    next_nil_function += 1;
+                    local
+                }
+                ValueType::Function(_) => {
+                    let local = ParamLocal::function_function(
+                        crate::plan::FunctionFunctionLocalId(next_function_function),
+                        type_.as_ref().clone(),
+                    );
+                    next_function_function += 1;
+                    local
+                }
+            },
+        })
+        .collect()
+}
+
+fn call_arg_type_mismatch(expected: ValueType, actual: ValueType) -> PlanError {
+    if matches!(expected, ValueType::Function(_)) && matches!(actual, ValueType::Function(_)) {
+        PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::FunctionCallArgumentTypeMismatch,
+            },
+        }
+    } else {
+        super::super::invalid_expression_type_for_value(expected, actual)
+    }
+}
+
+fn plan_argument_value(
+    argument: GleamCallArg<TypedExpr>,
+    capture: Option<&CaptureSubstitution>,
+    context: &mut PlanContext<'_>,
+    call_argument_mode: CallArgumentMode,
+) -> Result<Expr, PlanError> {
+    if matches!(call_argument_mode, CallArgumentMode::Use)
+        && matches!(argument.implicit, Some(ImplicitCallArgOrigin::Use))
+    {
+        return plan_use_callback_argument(argument.value, context);
+    }
+
+    if let Some(capture) = capture
+        && super::is_capture_local(&argument.value, &capture.name)
+    {
+        return Ok(capture.value.clone());
+    }
+
+    super::super::plan_expr(argument.value, context)
+}
+
+fn plan_use_callback_argument(
+    argument: TypedExpr,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    match argument {
+        TypedExpr::Fn {
+            type_,
+            kind: FunctionLiteralKind::Use { .. },
+            arguments,
+            body,
+            ..
+        } => super::super::function::plan_use_callback(type_, arguments, body, context),
+        TypedExpr::Fn { .. } => Err(super::invalid_use_shape(
+            InvalidUseShapeReason::CallbackLiteralKindNotUse,
+        )),
+        _ => Err(super::invalid_use_shape(
+            InvalidUseShapeReason::CallbackNotFunctionLiteral,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::function_call_param_locals;
+    use crate::plan::{FunctionType, ParamLocal, ValueType};
+
+    #[test]
+    fn function_call_param_locals_preserve_family_local_order() {
+        assert_eq!(
+            function_call_param_locals(&[
+                ValueType::Int,
+                ValueType::String,
+                ValueType::Bool,
+                ValueType::Nil,
+                ValueType::Int,
+                ValueType::Function(Box::new(FunctionType::new(
+                    vec![ValueType::Int],
+                    ValueType::Int,
+                ))),
+                ValueType::Function(Box::new(FunctionType::new(
+                    vec![ValueType::String],
+                    ValueType::String,
+                ))),
+                ValueType::Function(Box::new(FunctionType::new(
+                    vec![ValueType::Bool],
+                    ValueType::Bool,
+                ))),
+                ValueType::Function(Box::new(FunctionType::new(
+                    vec![ValueType::Nil],
+                    ValueType::Nil,
+                ))),
+                ValueType::Function(Box::new(FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int,))),
+                ))),
+            ]),
+            vec![
+                ParamLocal::int(crate::plan::IntLocalId(0)),
+                ParamLocal::string(crate::plan::StringLocalId(0)),
+                ParamLocal::bool(crate::plan::BoolLocalId(0)),
+                ParamLocal::nil(crate::plan::NilLocalId(0)),
+                ParamLocal::int(crate::plan::IntLocalId(1)),
+                ParamLocal::int_function(
+                    crate::plan::IntFunctionLocalId(0),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                ),
+                ParamLocal::string_function(
+                    crate::plan::StringFunctionLocalId(0),
+                    FunctionType::new(vec![ValueType::String], ValueType::String),
+                ),
+                ParamLocal::bool_function(
+                    crate::plan::BoolFunctionLocalId(0),
+                    FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
+                ),
+                ParamLocal::nil_function(
+                    crate::plan::NilFunctionLocalId(0),
+                    FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+                ),
+                ParamLocal::function_function(
+                    crate::plan::FunctionFunctionLocalId(0),
+                    FunctionType::new(
+                        Vec::new(),
+                        ValueType::Function(Box::new(FunctionType::new(
+                            Vec::new(),
+                            ValueType::Int,
+                        ))),
+                    ),
+                ),
+            ],
+        );
+        assert_eq!(
+            function_call_param_locals(&[ValueType::Int])[0],
+            ParamLocal::int(crate::plan::IntLocalId(0)),
+        );
+    }
+}

--- a/src/planner/expression/call/direct.rs
+++ b/src/planner/expression/call/direct.rs
@@ -1,0 +1,482 @@
+use super::{CallArgumentMode, CaptureSubstitution};
+use crate::plan::{
+    BoolExpr, CallArg, Expr, FunctionExpr, FunctionFunctionExpr, IntExpr, NilExpr,
+    RuntimeFunctionId, StringExpr, ValueType,
+};
+use crate::planner::context::{FunctionInfo, PlanContext};
+use crate::planner::error::{InvalidCallShapeReason, InvalidTypedAstReason, PlanError};
+use gleam_core::ast::{CallArg as GleamCallArg, TypedExpr};
+use gleam_core::type_::Type;
+use std::sync::Arc;
+
+pub(super) fn plan_direct_function_call(
+    type_: Arc<Type>,
+    function: FunctionInfo,
+    arguments: Vec<GleamCallArg<TypedExpr>>,
+    context: &mut PlanContext<'_>,
+    capture: Option<&CaptureSubstitution>,
+    call_argument_mode: CallArgumentMode,
+) -> Result<Expr, PlanError> {
+    if function.arity() != arguments.len() {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::LocalFunctionCallArityMismatch,
+            },
+        });
+    }
+    let function_return_type = function.return_type();
+    let function_id = function.runtime_id;
+    let return_type = ValueType::from_gleam(type_.as_ref()).ok_or(PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::CallShape {
+            reason: InvalidCallShapeReason::LocalFunctionCallUnsupportedReturnType,
+        },
+    })?;
+    if return_type != function_return_type {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::LocalFunctionCallReturnTypeMismatch,
+            },
+        });
+    }
+    let args = super::argument::plan_call_args(
+        arguments,
+        &function.params,
+        context,
+        capture,
+        call_argument_mode,
+    )?;
+
+    Ok(call_expr(function_id, args))
+}
+
+fn call_expr(function: RuntimeFunctionId, args: Vec<CallArg>) -> Expr {
+    match function {
+        RuntimeFunctionId::Int(function) => Expr::int(IntExpr::call(function, args)),
+        RuntimeFunctionId::String(function) => Expr::string(StringExpr::call(function, args)),
+        RuntimeFunctionId::Bool(function) => Expr::bool(BoolExpr::call(function, args)),
+        RuntimeFunctionId::Nil(function) => Expr::nil(NilExpr::call(function, args)),
+        RuntimeFunctionId::Function { id, return_type } => {
+            function_returning_function_call_expr(id, args, return_type)
+        }
+    }
+}
+
+fn function_returning_function_call_expr(
+    function: crate::plan::FunctionFunctionId,
+    args: Vec<CallArg>,
+    return_type: crate::plan::FunctionType,
+) -> Expr {
+    match function {
+        crate::plan::FunctionFunctionId::Int(function) => Expr::function(FunctionExpr::int(
+            crate::plan::IntFunctionExpr::call(function, args, return_type),
+        )),
+        crate::plan::FunctionFunctionId::String(function) => Expr::function(FunctionExpr::string(
+            crate::plan::StringFunctionExpr::call(function, args, return_type),
+        )),
+        crate::plan::FunctionFunctionId::Bool(function) => Expr::function(FunctionExpr::bool(
+            crate::plan::BoolFunctionExpr::call(function, args, return_type),
+        )),
+        crate::plan::FunctionFunctionId::Nil(function) => Expr::function(FunctionExpr::nil(
+            crate::plan::NilFunctionExpr::call(function, args, return_type),
+        )),
+        crate::plan::FunctionFunctionId::Function(function) => Expr::function(
+            FunctionExpr::function(FunctionFunctionExpr::call(function, args, return_type)),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::function_returning_function_call_expr;
+    use crate::plan::{
+        BoolFunctionFunctionId, FunctionFunctionFunctionId, FunctionFunctionId, FunctionType,
+        IntFunctionFunctionId, IntLocalId, LocalId, NilFunctionFunctionId,
+        StringFunctionFunctionId, ValueType,
+    };
+    use crate::planner::dsl::{
+        call_int_function, function, int, int_arg, int_function_arg, int_function_call_arg,
+        int_function_ref, int_return_tail_call, let_int_function_step, local_int,
+        local_int_function, module,
+    };
+    use crate::planner::expression::call::support::expect_call_statement_mut;
+    use crate::planner::expression::{typed_int_expr, typed_string_expr};
+    use crate::planner::plan_module;
+    use crate::planner::support::compile;
+    use crate::planner::{
+        InvalidCallShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
+    };
+    use gleam_core::type_;
+
+    #[test]
+    fn plan_function_value_argument_direct_call() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn apply(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  apply(add_one, 41)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_tail_call(
+                    2,
+                    [
+                        int_function_arg(0, int_function_ref(1, [LocalId::Int(IntLocalId(0))])),
+                        int_arg(0, int(41)),
+                    ],
+                ),
+            ),
+            [
+                function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value"),
+                function(
+                    "apply",
+                    call_int_function(
+                        local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
+                        [int_function_call_arg(0, local_int(0, "value"))],
+                    ),
+                )
+                .param_int_function(0, "function", [ValueType::Int])
+                .param_int(0, "value"),
+            ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_local_function_value_argument_direct_call() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn apply(function: fn(Int) -> Int, value: Int) {
+  function(value)
+}
+
+pub fn main() {
+  let add = add_one
+  apply(add, 41)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_tail_call(
+                    2,
+                    [
+                        int_function_arg(
+                            0,
+                            local_int_function(0, "add", [LocalId::Int(IntLocalId(0))]),
+                        ),
+                        int_arg(0, int(41)),
+                    ],
+                ),
+            )
+            .step(let_int_function_step(
+                0,
+                "add",
+                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+            )),
+            [
+                function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value"),
+                function(
+                    "apply",
+                    call_int_function(
+                        local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
+                        [int_function_call_arg(0, local_int(0, "value"))],
+                    ),
+                )
+                .param_int_function(0, "function", [ValueType::Int])
+                .param_int(0, "value"),
+            ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_margin_direct_local_function_call_shapes() {
+        let mut arity_mismatch_call = compile(
+            r#"
+fn identity(value: Int) {
+  value
+}
+
+pub fn main() {
+  identity(1)
+}
+"#,
+        );
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut arity_mismatch_call.definitions.functions[1].body[0]);
+        arguments.clear();
+        assert_eq!(
+            plan_module(arity_mismatch_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::LocalFunctionCallArityMismatch,
+                },
+            }),
+        );
+
+        let mut unsupported_return_type_call = compile(
+            r#"
+fn identity(value: Int) {
+  value
+}
+
+pub fn main() {
+  identity(1)
+}
+"#,
+        );
+        let (type_, _, _) = expect_call_statement_mut(
+            &mut unsupported_return_type_call.definitions.functions[1].body[0],
+        );
+        *type_ = type_::tuple(vec![type_::int()]);
+        assert_eq!(
+            plan_module(unsupported_return_type_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::LocalFunctionCallUnsupportedReturnType,
+                },
+            }),
+        );
+
+        let mut return_type_mismatch_call = compile(
+            r#"
+fn identity(value: Int) {
+  value
+}
+
+pub fn main() {
+  identity(1)
+}
+"#,
+        );
+        let (type_, _, _) = expect_call_statement_mut(
+            &mut return_type_mismatch_call.definitions.functions[1].body[0],
+        );
+        *type_ = type_::bool();
+        assert_eq!(
+            plan_module(return_type_mismatch_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::LocalFunctionCallReturnTypeMismatch,
+                },
+            }),
+        );
+
+        assert_call_argument_type_mismatch(
+            r#"
+fn identity(value: Int) {
+  value
+}
+
+pub fn main() {
+  identity(1)
+}
+"#,
+            typed_string_expr("wrong"),
+            InvalidExpressionType::Int,
+            InvalidExpressionType::String,
+        );
+
+        assert_call_argument_type_mismatch(
+            r#"
+fn identity(value: String) {
+  value
+}
+
+pub fn main() {
+  identity("ok")
+}
+"#,
+            typed_int_expr(1),
+            InvalidExpressionType::String,
+            InvalidExpressionType::Int,
+        );
+
+        assert_call_argument_type_mismatch(
+            r#"
+fn identity(value: Bool) {
+  value
+}
+
+pub fn main() {
+  identity(True)
+}
+"#,
+            typed_int_expr(1),
+            InvalidExpressionType::Bool,
+            InvalidExpressionType::Int,
+        );
+
+        assert_call_argument_type_mismatch(
+            r#"
+fn identity(value: Nil) {
+  value
+}
+
+pub fn main() {
+  identity(Nil)
+}
+"#,
+            typed_int_expr(1),
+            InvalidExpressionType::Nil,
+            InvalidExpressionType::Int,
+        );
+    }
+
+    #[test]
+    fn reject_margin_function_call_argument_function_shapes() {
+        let mut function_mismatch_call = compile(
+            r#"
+fn apply(function: fn(Int) -> Int) {
+  function(1)
+}
+
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn string_identity(value: String) {
+  value
+}
+
+fn accept_string(function: fn(String) -> String) {
+  function("ok")
+}
+
+pub fn main() {
+  accept_string(string_identity)
+  apply(add_one)
+}
+"#,
+        );
+        let wrong_function = {
+            let (_, _, arguments) = expect_call_statement_mut(
+                &mut function_mismatch_call.definitions.functions[4].body[0],
+            );
+            arguments[0].value.clone()
+        };
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut function_mismatch_call.definitions.functions[4].body[1]);
+        arguments[0].value = wrong_function;
+        assert_eq!(
+            plan_module(function_mismatch_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallArgumentTypeMismatch,
+                },
+            }),
+        );
+
+        let mut non_function_call = compile(
+            r#"
+fn apply(function: fn(Int) -> Int) {
+  function(1)
+}
+
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  apply(add_one)
+}
+"#,
+        );
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut non_function_call.definitions.functions[2].body[0]);
+        arguments[0].value = typed_int_expr(1);
+        assert_eq!(
+            plan_module(non_function_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Function,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+    }
+
+    fn assert_call_argument_type_mismatch(
+        src: &str,
+        value: gleam_core::ast::TypedExpr,
+        expected: InvalidExpressionType,
+        actual: InvalidExpressionType,
+    ) {
+        let mut module = compile(src);
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut module.definitions.functions[1].body[0]);
+        arguments[0].value = value;
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType { expected, actual },
+            }),
+        );
+    }
+
+    #[test]
+    fn function_returning_function_call_expr_preserves_return_family() {
+        let cases = [
+            (
+                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            ),
+            (
+                FunctionFunctionId::String(StringFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::String], ValueType::String),
+            ),
+            (
+                FunctionFunctionId::Bool(BoolFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
+            ),
+            (
+                FunctionFunctionId::Nil(NilFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+            ),
+            (
+                FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),
+                FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(FunctionType::new(
+                        vec![ValueType::Int],
+                        ValueType::Int,
+                    ))),
+                ),
+            ),
+        ];
+
+        for (function, returned_function_type) in cases {
+            assert_eq!(
+                function_returning_function_call_expr(
+                    function,
+                    Vec::new(),
+                    returned_function_type.clone(),
+                )
+                .value_type(),
+                ValueType::Function(Box::new(returned_function_type)),
+            );
+        }
+    }
+}

--- a/src/planner/expression/call/function_value.rs
+++ b/src/planner/expression/call/function_value.rs
@@ -1,0 +1,843 @@
+use super::{CallArgumentMode, CaptureSubstitution};
+use crate::plan::{CallArg, Expr, FunctionExpr, FunctionFunctionExpr, ValueType};
+use crate::planner::context::PlanContext;
+use crate::planner::error::{
+    InvalidCallShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
+};
+use gleam_core::ast::{CallArg as GleamCallArg, TypedExpr};
+use gleam_core::type_::Type;
+use std::sync::Arc;
+
+pub(super) fn plan_function_value_call(
+    type_: Arc<Type>,
+    fun: TypedExpr,
+    arguments: Vec<GleamCallArg<TypedExpr>>,
+    context: &mut PlanContext<'_>,
+    capture: Option<&CaptureSubstitution>,
+    call_argument_mode: CallArgumentMode,
+) -> Result<Expr, PlanError> {
+    let function = {
+        let expression = super::super::plan_expr(fun, context)?;
+        let actual = super::super::expression_type(&expression);
+        match expression.into_function() {
+            Some(function) => function,
+            None => {
+                return Err(super::super::invalid_expression_type(
+                    InvalidExpressionType::Function,
+                    actual,
+                ));
+            }
+        }
+    };
+    let function_type = function.type_().clone();
+    let return_type = ValueType::from_gleam(type_.as_ref()).ok_or(PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::CallShape {
+            reason: InvalidCallShapeReason::FunctionCallUnsupportedReturnType,
+        },
+    })?;
+    if &return_type != function_type.return_() {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
+            },
+        });
+    }
+    if arguments.len() != function_type.argument_types().len() {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::FunctionCallArityMismatch,
+            },
+        });
+    }
+
+    let args = super::argument::plan_function_call_args(
+        arguments,
+        function_type.argument_types(),
+        context,
+        capture,
+        call_argument_mode,
+    )?;
+
+    function_call_expr(function, args, return_type)
+}
+
+fn function_call_expr(
+    function: FunctionExpr,
+    args: Vec<CallArg>,
+    return_type: ValueType,
+) -> Result<Expr, PlanError> {
+    match return_type {
+        ValueType::Int => match function.into_int() {
+            Some(function) => Ok(Expr::int(crate::plan::IntExpr::function_call(
+                function, args,
+            ))),
+            None => Err(function_call_return_type_mismatch()),
+        },
+        ValueType::String => match function.into_string() {
+            Some(function) => Ok(Expr::string(crate::plan::StringExpr::function_call(
+                function, args,
+            ))),
+            None => Err(function_call_return_type_mismatch()),
+        },
+        ValueType::Bool => match function.into_bool() {
+            Some(function) => Ok(Expr::bool(crate::plan::BoolExpr::function_call(
+                function, args,
+            ))),
+            None => Err(function_call_return_type_mismatch()),
+        },
+        ValueType::Nil => match function.into_nil() {
+            Some(function) => Ok(Expr::nil(crate::plan::NilExpr::function_call(
+                function, args,
+            ))),
+            None => Err(function_call_return_type_mismatch()),
+        },
+        ValueType::Function(return_type) => match function.into_function() {
+            Some(function) => Ok(function_returning_function_value_call_expr(
+                function,
+                args,
+                *return_type,
+            )),
+            None => Err(function_call_return_type_mismatch()),
+        },
+    }
+}
+
+fn function_call_return_type_mismatch() -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::CallShape {
+            reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
+        },
+    }
+}
+
+fn function_returning_function_value_call_expr(
+    function: FunctionFunctionExpr,
+    args: Vec<CallArg>,
+    return_type: crate::plan::FunctionType,
+) -> Expr {
+    match return_type.return_() {
+        ValueType::Int => Expr::function(FunctionExpr::int(
+            crate::plan::IntFunctionExpr::function_call(function, args, return_type),
+        )),
+        ValueType::String => Expr::function(FunctionExpr::string(
+            crate::plan::StringFunctionExpr::function_call(function, args, return_type),
+        )),
+        ValueType::Bool => Expr::function(FunctionExpr::bool(
+            crate::plan::BoolFunctionExpr::function_call(function, args, return_type),
+        )),
+        ValueType::Nil => Expr::function(FunctionExpr::nil(
+            crate::plan::NilFunctionExpr::function_call(function, args, return_type),
+        )),
+        ValueType::Function(_) => Expr::function(FunctionExpr::function(
+            FunctionFunctionExpr::function_call(function, args, return_type),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        function_call_expr, function_call_return_type_mismatch,
+        function_returning_function_value_call_expr,
+    };
+    use crate::plan::{
+        BoolFunctionFunctionId, BoolFunctionId, FunctionExpr, FunctionFunctionExpr,
+        FunctionFunctionFunctionId, FunctionFunctionId, FunctionType, IntFunctionFunctionId,
+        IntLocalId, LocalId, NilFunctionFunctionId, NilFunctionId, ParamLocal, RuntimeFunctionId,
+        StringFunctionFunctionId, StringFunctionId, ValueType,
+    };
+    use crate::planner::dsl::{
+        block_int_function, bool_, bool_case_int_function, call_int_function, function,
+        function_function_ref, function_ref, int, int_case_int_function, int_function_call_arg,
+        int_function_ref, let_int_function_step, local_int, local_int_function, module,
+        module_with_anonymous,
+    };
+    use crate::planner::expression::call::support::expect_call_statement_mut;
+    use crate::planner::expression::{typed_int_expr, typed_string_expr};
+    use crate::planner::plan_module;
+    use crate::planner::support::compile;
+    use crate::planner::{
+        InvalidCallShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
+        UnsupportedExpressionKind,
+    };
+    use gleam_core::type_;
+
+    #[test]
+    fn plan_immediate_anonymous_function_call() {
+        let actual = plan_module(compile(r#"pub fn main() { fn(x) { x + 1 }(41) }"#))
+            .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                    [int_function_call_arg(0, int(41))],
+                ),
+            ),
+            [],
+            [function("<anonymous:0>", local_int(0, "x").add_int(int(1))).param_int(0, "x")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_profile_function_call_argument_expression() {
+        assert_eq!(
+            plan_module(compile(
+                r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let function = add_one
+  function(todo)
+}
+"#,
+            )),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Todo,
+            }),
+        );
+    }
+
+    #[test]
+    fn plan_function_value_assignment_before_call() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let function = add_one
+  function(1)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
+                    [int_function_call_arg(0, int(1))],
+                ),
+            )
+            .step(let_int_function_step(
+                0,
+                "function",
+                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+            )),
+            [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_function_value_and_primitive_shadowing_bindings() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let function = 1
+  let function = add_one
+  function(1)
+}
+
+pub fn primitive_shadow() {
+  let function = add_one
+  let function = 1
+  function + 1
+}
+"#,
+        ))
+        .expect("source should plan");
+        let add_one =
+            function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    local_int_function(0, "function", [LocalId::Int(IntLocalId(0))]),
+                    [int_function_call_arg(0, int(1))],
+                ),
+            )
+            .let_int(0, "function", int(1))
+            .step(let_int_function_step(
+                0,
+                "function",
+                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+            )),
+            [
+                add_one,
+                function("primitive_shadow", local_int(0, "function").add_int(int(1)))
+                    .step(let_int_function_step(
+                        0,
+                        "function",
+                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                    ))
+                    .let_int(0, "function", int(1)),
+            ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_function_valued_block_callee() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  { add_one }(1)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    block_int_function([], int_function_ref(1, [LocalId::Int(IntLocalId(0))])),
+                    [int_function_call_arg(0, int(1))],
+                ),
+            ),
+            [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_function_valued_case_callee() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn add_ten(value: Int) {
+  value + 10
+}
+
+pub fn main() {
+  let bool_result = case True {
+    True -> add_one
+    False -> add_ten
+  }(1)
+  let int_result = case 0 {
+    0 -> add_ten
+    _ -> add_one
+  }(1)
+  bool_result + int_result
+}
+"#,
+        ))
+        .expect("source should plan");
+        let add_one =
+            function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value");
+        let add_ten =
+            function("add_ten", local_int(0, "value").add_int(int(10))).param_int(0, "value");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                local_int(0, "bool_result").add_int(local_int(1, "int_result")),
+            )
+            .let_int(
+                0,
+                "bool_result",
+                call_int_function(
+                    bool_case_int_function(
+                        bool_(true),
+                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                        int_function_ref(2, [LocalId::Int(IntLocalId(0))]),
+                    ),
+                    [int_function_call_arg(0, int(1))],
+                ),
+            )
+            .let_int(
+                1,
+                "int_result",
+                call_int_function(
+                    int_case_int_function(
+                        int(0),
+                        [(0, int_function_ref(2, [LocalId::Int(IntLocalId(0))]))],
+                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                    ),
+                    [int_function_call_arg(0, int(1))],
+                ),
+            ),
+            [add_one, add_ten],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_margin_function_value_call_shapes() {
+        let mut arity_mismatch_case_call = compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  case True {
+    True -> add_one
+    False -> add_one
+  }(1)
+}
+"#,
+        );
+        let (_, _, arguments) = expect_call_statement_mut(
+            &mut arity_mismatch_case_call.definitions.functions[1].body[0],
+        );
+        let mut extra_argument = arguments[0].clone();
+        extra_argument.value = typed_int_expr(2);
+        arguments.push(extra_argument);
+        assert_eq!(arguments.len(), 2);
+        assert_eq!(
+            plan_module(arity_mismatch_case_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallArityMismatch,
+                },
+            }),
+        );
+
+        let mut non_function_callee = compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let function = add_one
+  function(1)
+}
+"#,
+        );
+        let (_, fun, _) =
+            expect_call_statement_mut(&mut non_function_callee.definitions.functions[1].body[1]);
+        *fun = typed_int_expr(1);
+        assert_eq!(
+            plan_module(non_function_callee),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Function,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+
+        let mut unsupported_return_type_call = compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let function = add_one
+  function(1)
+}
+"#,
+        );
+        let (type_, _, _) = expect_call_statement_mut(
+            &mut unsupported_return_type_call.definitions.functions[1].body[1],
+        );
+        *type_ = type_::list(type_::int());
+        assert_eq!(
+            plan_module(unsupported_return_type_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallUnsupportedReturnType,
+                },
+            }),
+        );
+
+        let mut return_type_mismatch_call = compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let function = add_one
+  function(1)
+}
+"#,
+        );
+        let (type_, _, _) = expect_call_statement_mut(
+            &mut return_type_mismatch_call.definitions.functions[1].body[1],
+        );
+        *type_ = type_::bool();
+        assert_eq!(
+            plan_module(return_type_mismatch_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallReturnTypeMismatch,
+                },
+            }),
+        );
+
+        let mut argument_type_mismatch_call = compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let function = add_one
+  function(1)
+}
+"#,
+        );
+        let (_, _, arguments) = expect_call_statement_mut(
+            &mut argument_type_mismatch_call.definitions.functions[1].body[1],
+        );
+        arguments[0].value = typed_string_expr("wrong");
+        assert_eq!(
+            plan_module(argument_type_mismatch_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Int,
+                    actual: InvalidExpressionType::String,
+                },
+            }),
+        );
+
+        let mut arity_mismatch_call = compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let function = add_one
+  function(1)
+}
+"#,
+        );
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut arity_mismatch_call.definitions.functions[1].body[1]);
+        arguments.clear();
+        assert_eq!(
+            plan_module(arity_mismatch_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallArityMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_function_value_call_argument_type_shapes() {
+        let mut function_mismatch_call = compile(
+            r#"
+fn apply(function: fn(Int) -> Int) {
+  function(1)
+}
+
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn string_identity(value: String) {
+  value
+}
+
+fn accept_string(function: fn(String) -> String) {
+  function("ok")
+}
+
+pub fn main() {
+  accept_string(string_identity)
+  let apply_value = apply
+  apply_value(add_one)
+}
+"#,
+        );
+        let wrong_function = {
+            let (_, _, arguments) = expect_call_statement_mut(
+                &mut function_mismatch_call.definitions.functions[4].body[0],
+            );
+            arguments[0].value.clone()
+        };
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut function_mismatch_call.definitions.functions[4].body[2]);
+        arguments[0].value = wrong_function;
+        assert_eq!(
+            plan_module(function_mismatch_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::FunctionCallArgumentTypeMismatch,
+                },
+            }),
+        );
+
+        let mut non_function_call = compile(
+            r#"
+fn apply(function: fn(Int) -> Int) {
+  function(1)
+}
+
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let apply_value = apply
+  apply_value(add_one)
+}
+"#,
+        );
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut non_function_call.definitions.functions[2].body[1]);
+        arguments[0].value = typed_int_expr(1);
+        assert_eq!(
+            plan_module(non_function_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Function,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+
+        assert_function_value_argument_type_mismatch(
+            r#"
+fn identity(value: String) {
+  value
+}
+
+pub fn main() {
+  let function = identity
+  function("ok")
+}
+"#,
+            typed_int_expr(1),
+            InvalidExpressionType::String,
+            InvalidExpressionType::Int,
+        );
+        assert_function_value_argument_type_mismatch(
+            r#"
+fn identity(value: Bool) {
+  value
+}
+
+pub fn main() {
+  let function = identity
+  function(True)
+}
+"#,
+            typed_int_expr(1),
+            InvalidExpressionType::Bool,
+            InvalidExpressionType::Int,
+        );
+        assert_function_value_argument_type_mismatch(
+            r#"
+fn identity(value: Nil) {
+  value
+}
+
+pub fn main() {
+  let function = identity
+  function(Nil)
+}
+"#,
+            typed_int_expr(1),
+            InvalidExpressionType::Nil,
+            InvalidExpressionType::Int,
+        );
+    }
+
+    #[test]
+    fn function_call_expr_preserves_return_family() {
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::String(StringFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                )),
+                Vec::new(),
+                ValueType::String,
+            )
+            .expect("string function call")
+            .value_type(),
+            ValueType::String,
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Bool(BoolFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                )),
+                Vec::new(),
+                ValueType::Bool,
+            )
+            .expect("bool function call")
+            .value_type(),
+            ValueType::Bool,
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Nil(NilFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                )),
+                Vec::new(),
+                ValueType::Nil,
+            )
+            .expect("nil function call")
+            .value_type(),
+            ValueType::Nil,
+        );
+
+        let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(function_function_ref(
+                    FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                    returned_function_type.clone(),
+                )),
+                Vec::new(),
+                ValueType::Function(Box::new(returned_function_type.clone())),
+            )
+            .expect("function-returning function call")
+            .value_type(),
+            ValueType::Function(Box::new(returned_function_type)),
+        );
+    }
+
+    #[test]
+    fn function_returning_function_value_call_expr_preserves_return_family() {
+        let cases = [
+            (
+                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            ),
+            (
+                FunctionFunctionId::String(StringFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::String], ValueType::String),
+            ),
+            (
+                FunctionFunctionId::Bool(BoolFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
+            ),
+            (
+                FunctionFunctionId::Nil(NilFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+            ),
+            (
+                FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),
+                FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(FunctionType::new(
+                        vec![ValueType::Int],
+                        ValueType::Int,
+                    ))),
+                ),
+            ),
+        ];
+
+        for (runtime_id, returned_function_type) in cases {
+            let function = FunctionFunctionExpr::from(function_function_ref(
+                runtime_id,
+                Vec::<ParamLocal>::new(),
+                returned_function_type.clone(),
+            ));
+
+            assert_eq!(
+                function_returning_function_value_call_expr(
+                    function,
+                    Vec::new(),
+                    returned_function_type.clone(),
+                )
+                .value_type(),
+                ValueType::Function(Box::new(returned_function_type)),
+            );
+        }
+    }
+
+    #[test]
+    fn reject_margin_function_call_expr_return_family_mismatch() {
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::String(StringFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                )),
+                Vec::new(),
+                ValueType::Int,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
+                Vec::new(),
+                ValueType::String,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
+                Vec::new(),
+                ValueType::Bool,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
+                Vec::new(),
+                ValueType::Nil,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
+                Vec::new(),
+                ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+    }
+
+    fn assert_function_value_argument_type_mismatch(
+        src: &str,
+        value: gleam_core::ast::TypedExpr,
+        expected: InvalidExpressionType,
+        actual: InvalidExpressionType,
+    ) {
+        let mut module = compile(src);
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut module.definitions.functions[1].body[1]);
+        arguments[0].value = value;
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType { expected, actual },
+            }),
+        );
+    }
+}

--- a/src/planner/expression/call/implicit.rs
+++ b/src/planner/expression/call/implicit.rs
@@ -1,0 +1,257 @@
+use super::{CallArgumentMode, CaptureSubstitution, FunctionValueCallMode};
+use crate::plan::Expr;
+use crate::planner::context::PlanContext;
+use crate::planner::error::{
+    InvalidCallShapeReason, InvalidPipelineShapeReason, InvalidTypedAstReason,
+    InvalidUseShapeReason, PlanError,
+};
+use ecow::EcoString;
+use gleam_core::ast::{
+    CallArg as GleamCallArg, FunctionLiteralKind, ImplicitCallArgOrigin, Statement, TypedArg,
+    TypedExpr, TypedStatement,
+};
+use vec1::Vec1;
+
+pub(super) fn plan_use_call(
+    call: TypedExpr,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    match call {
+        TypedExpr::Call {
+            type_,
+            fun,
+            arguments,
+            ..
+        } => {
+            validate_use_call_arguments(&arguments)?;
+            super::plan_call_expression(
+                type_,
+                *fun,
+                arguments,
+                context,
+                None,
+                CallArgumentMode::Use,
+                FunctionValueCallMode::Allow,
+            )
+        }
+        _ => Err(super::invalid_use_shape(InvalidUseShapeReason::NonCallRhs)),
+    }
+}
+
+pub(super) fn plan_pipeline_direct_call(
+    type_: std::sync::Arc<gleam_core::type_::Type>,
+    fun: TypedExpr,
+    arguments: Vec<GleamCallArg<TypedExpr>>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    pipe_argument(&arguments)?;
+
+    super::plan_call_expression(
+        type_,
+        fun,
+        arguments,
+        context,
+        None,
+        CallArgumentMode::Normal,
+        FunctionValueCallMode::Reject,
+    )
+}
+
+pub(super) fn plan_pipeline_hole_call(
+    type_: std::sync::Arc<gleam_core::type_::Type>,
+    fun: TypedExpr,
+    arguments: Vec<GleamCallArg<TypedExpr>>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let pipe_value = super::super::plan_expr(pipe_argument(&arguments)?.clone(), context)?;
+
+    let (kind, capture_args, body) = pipeline_capture_function_parts(fun)?;
+    if !matches!(kind, FunctionLiteralKind::Capture { .. }) {
+        return Err(invalid_hole_capture());
+    }
+    let capture_arg = single_capture_argument(&capture_args)?;
+    let capture_name = match capture_arg.names.get_variable_name().cloned() {
+        Some(capture_name) => capture_name,
+        None => return Err(invalid_hole_capture()),
+    };
+
+    let mut body = body.into_iter();
+    let (fun, arguments) = pipeline_hole_body_call(body.next())?;
+    if body.next().is_some() {
+        return Err(invalid_hole_capture());
+    }
+    if arguments.iter().any(|argument| argument.label.is_some()) {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::PipelineShape {
+                reason: InvalidPipelineShapeReason::LabelledArguments,
+            },
+        });
+    }
+    if arguments.iter().any(|argument| argument.implicit.is_some()) {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::PipelineShape {
+                reason: InvalidPipelineShapeReason::UnsupportedImplicitArgument,
+            },
+        });
+    }
+    if count_capture_arguments(&arguments, &capture_name) != 1 {
+        return Err(invalid_hole_capture());
+    }
+
+    super::plan_call_expression(
+        type_,
+        *fun,
+        arguments,
+        context,
+        Some(&CaptureSubstitution {
+            name: capture_name,
+            value: pipe_value,
+        }),
+        CallArgumentMode::Normal,
+        FunctionValueCallMode::Reject,
+    )
+}
+
+fn pipeline_capture_function_parts(
+    fun: TypedExpr,
+) -> Result<(FunctionLiteralKind, Vec<TypedArg>, Vec1<TypedStatement>), PlanError> {
+    match fun {
+        TypedExpr::Fn {
+            kind,
+            arguments,
+            body,
+            ..
+        } => Ok((kind, arguments, body)),
+        _ => Err(invalid_hole_capture()),
+    }
+}
+
+fn single_capture_argument(capture_args: &[TypedArg]) -> Result<&TypedArg, PlanError> {
+    if capture_args.len() == 1 {
+        Ok(&capture_args[0])
+    } else {
+        Err(invalid_hole_capture())
+    }
+}
+
+fn pipeline_hole_body_call(
+    statement: Option<TypedStatement>,
+) -> Result<(Box<TypedExpr>, Vec<GleamCallArg<TypedExpr>>), PlanError> {
+    match statement {
+        Some(Statement::Expression(TypedExpr::Call { fun, arguments, .. })) => Ok((fun, arguments)),
+        _ => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::PipelineShape {
+                reason: InvalidPipelineShapeReason::NonCallStep,
+            },
+        }),
+    }
+}
+
+fn validate_use_call_arguments(arguments: &[GleamCallArg<TypedExpr>]) -> Result<(), PlanError> {
+    if arguments.iter().any(|argument| argument.label.is_some()) {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::LabelledArguments,
+            },
+        });
+    }
+
+    let mut callback_index = None;
+    for (index, argument) in arguments.iter().enumerate() {
+        match argument.implicit {
+            None => {}
+            Some(ImplicitCallArgOrigin::Use) => {
+                if callback_index.replace(index).is_some() {
+                    return Err(super::invalid_use_shape(
+                        InvalidUseShapeReason::MultipleCallbacks,
+                    ));
+                }
+            }
+            Some(
+                ImplicitCallArgOrigin::Pipe
+                | ImplicitCallArgOrigin::PatternFieldSpread
+                | ImplicitCallArgOrigin::IncorrectArityUse
+                | ImplicitCallArgOrigin::RecordUpdate,
+            ) => {
+                return Err(super::invalid_use_shape(
+                    InvalidUseShapeReason::UnsupportedImplicitArgument,
+                ));
+            }
+        }
+    }
+
+    match callback_index {
+        Some(index) if index + 1 == arguments.len() => Ok(()),
+        Some(_) => Err(super::invalid_use_shape(
+            InvalidUseShapeReason::CallbackNotLast,
+        )),
+        None => Err(super::invalid_use_shape(
+            InvalidUseShapeReason::MissingCallback,
+        )),
+    }
+}
+
+fn count_capture_arguments(
+    arguments: &[GleamCallArg<TypedExpr>],
+    capture_name: &EcoString,
+) -> usize {
+    arguments
+        .iter()
+        .filter(|argument| super::is_capture_local(&argument.value, capture_name))
+        .count()
+}
+
+fn pipe_argument(arguments: &[GleamCallArg<TypedExpr>]) -> Result<&TypedExpr, PlanError> {
+    if arguments.iter().any(|argument| argument.label.is_some()) {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::PipelineShape {
+                reason: InvalidPipelineShapeReason::LabelledArguments,
+            },
+        });
+    }
+
+    let mut pipe_argument = None;
+    for argument in arguments {
+        match argument.implicit {
+            None => {}
+            Some(ImplicitCallArgOrigin::Pipe) => {
+                if pipe_argument.replace(&argument.value).is_some() {
+                    return Err(PlanError::InvalidTypedAst {
+                        reason: InvalidTypedAstReason::PipelineShape {
+                            reason: InvalidPipelineShapeReason::MultiplePipeArguments,
+                        },
+                    });
+                }
+            }
+            Some(
+                ImplicitCallArgOrigin::Use
+                | ImplicitCallArgOrigin::PatternFieldSpread
+                | ImplicitCallArgOrigin::IncorrectArityUse
+                | ImplicitCallArgOrigin::RecordUpdate,
+            ) => {
+                return Err(PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::PipelineShape {
+                        reason: InvalidPipelineShapeReason::UnsupportedImplicitArgument,
+                    },
+                });
+            }
+        }
+    }
+
+    match pipe_argument {
+        Some(pipe_argument) => Ok(pipe_argument),
+        None => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::PipelineShape {
+                reason: InvalidPipelineShapeReason::MissingPipeArgument,
+            },
+        }),
+    }
+}
+
+fn invalid_hole_capture() -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::PipelineShape {
+            reason: InvalidPipelineShapeReason::InvalidHoleCapture,
+        },
+    }
+}


### PR DESCRIPTION
- Move direct calls, function-value calls, implicit call handling, and argument lowering into focused child modules.
- Keep planner::expression::call as the facade for dispatch and shared call-shape helpers.
- Colocate call lowering tests with the module that owns each behavior.
- Add a review-policy rule that keeps shared split-module helpers in the parent facade or an owning child module.
