### PR TITLE
Support Tuple value family

### DIFF
--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -36,9 +36,11 @@ behavior, or a source-visible semantic difference.
 cannot encode in the current plan shape. Adding a new `ExecutionError`
 constructor or invariant kind requires explicit design review.
 
-Tuple element projection may add a narrow `ExecutionError` invariant only after
-the planner preserves the tuple element types in the plan and selects a typed
-expression family for the projected result.
+Tuple projection has one approved execution invariant:
+`ExecutionError::tuple_index_family_mismatch`. It is only for typed tuple-index
+plan evaluation when the runtime tuple value lacks the planner-selected element
+or that element has a different value family. Tuple index validation, profile
+boundaries, and typed-AST margins remain planner responsibilities.
 
 ## Plan Construction Rules
 

--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -36,6 +36,10 @@ behavior, or a source-visible semantic difference.
 cannot encode in the current plan shape. Adding a new `ExecutionError`
 constructor or invariant kind requires explicit design review.
 
+Tuple element projection may add a narrow `ExecutionError` invariant only after
+the planner preserves the tuple element types in the plan and selects a typed
+expression family for the projected result.
+
 ## Plan Construction Rules
 
 Plan construction is not a validation layer. Reaching an `ExecutionPlan` or plan

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -14,18 +14,20 @@ pub(crate) use expression::{
     BoolCaseBranches, BoolExprKind, BoolFunctionExprKind, CallArgKind, CaptureArg, CaptureArgKind,
     ExprKind, FloatCaseBranches, FloatExprKind, FloatFunctionExprKind, FunctionExprKind,
     FunctionFunctionExprKind, IntCaseBranches, IntExprKind, IntFunctionExprKind, NilExprKind,
-    NilFunctionExprKind, StringCaseBranches, StringExprKind, StringFunctionExprKind,
+    NilFunctionExprKind, StringCaseBranches, StringExprKind, StringFunctionExprKind, TupleExprKind,
+    TupleFunctionExprKind,
 };
 pub use expression::{
     BoolExpr, BoolFunctionExpr, CallArg, Expr, FloatExpr, FloatFunctionExpr, FunctionExpr,
     FunctionFunctionExpr, IntExpr, IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr,
-    StringFunctionExpr,
+    StringFunctionExpr, TupleExpr, TupleFunctionExpr,
 };
 pub(crate) use frame::FrameLayout;
 pub(crate) use function::{
     BoolFunctionReturn, BoolReturn, FloatFunctionReturn, FloatReturn, FunctionFunctionReturn,
     IntFunctionReturn, IntReturn, NilFunctionReturn, NilReturn, ParamLocal, ReturnBody,
     ReturnBodyKind, ReturnExprKind, RuntimeFunction, StringFunctionReturn, StringReturn,
+    TupleFunctionReturn, TupleReturn,
 };
 pub use function::{FunctionPlan, Param, ParamBinding, ReturnExpr};
 pub use id::{
@@ -34,14 +36,15 @@ pub use id::{
     FunctionFunctionFunctionId, FunctionFunctionLocalId, FunctionId, IntFunctionFunctionId,
     IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId, NilFunctionFunctionId, NilFunctionId,
     NilFunctionLocalId, NilLocalId, StringFunctionFunctionId, StringFunctionId,
-    StringFunctionLocalId, StringLocalId,
+    StringFunctionLocalId, StringLocalId, TupleFunctionFunctionId, TupleFunctionId,
+    TupleFunctionLocalId, TupleLocalId,
 };
 pub(crate) use id::{FunctionFunctionId, FunctionReturnFamily, RuntimeFunctionId};
 pub use step::Step;
 pub(crate) use step::StepKind;
 pub(crate) use value::{
     BoolFunctionValue, CaptureValue, CaptureValueKind, FloatFunctionValue, FunctionFunctionValue,
-    FunctionValueKind, IntFunctionValue, NilFunctionValue, StringFunctionValue,
+    FunctionValueKind, IntFunctionValue, NilFunctionValue, StringFunctionValue, TupleFunctionValue,
 };
 pub use value::{FunctionType, FunctionValue, Value, ValueType};
 
@@ -117,6 +120,10 @@ impl ExecutionPlan {
         self.runtime.nil_function(id)
     }
 
+    pub(crate) fn tuple_function(&self, id: TupleFunctionId) -> &RuntimeFunction<TupleReturn> {
+        self.runtime.tuple_function(id)
+    }
+
     pub(crate) fn int_function_function(
         &self,
         id: IntFunctionFunctionId,
@@ -150,6 +157,13 @@ impl ExecutionPlan {
         id: NilFunctionFunctionId,
     ) -> &RuntimeFunction<NilFunctionReturn> {
         self.runtime.nil_function_function(id)
+    }
+
+    pub(crate) fn tuple_function_function(
+        &self,
+        id: TupleFunctionFunctionId,
+    ) -> &RuntimeFunction<TupleFunctionReturn> {
+        self.runtime.tuple_function_function(id)
     }
 
     pub(crate) fn function_function_function(

--- a/src/plan/expression.rs
+++ b/src/plan/expression.rs
@@ -5,12 +5,13 @@ mod function;
 mod int;
 mod nil;
 mod string;
+mod tuple;
 
 use super::function::ParamLocal;
 use super::id::{
     BoolFunctionLocalId, BoolLocalId, FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId,
     IntFunctionLocalId, IntLocalId, NilFunctionLocalId, NilLocalId, StringFunctionLocalId,
-    StringLocalId,
+    StringLocalId, TupleFunctionLocalId, TupleLocalId,
 };
 use super::value::{Value, ValueType};
 
@@ -22,22 +23,24 @@ pub use self::{
     float::FloatExpr,
     function::{
         BoolFunctionExpr, FloatFunctionExpr, FunctionExpr, FunctionFunctionExpr, IntFunctionExpr,
-        NilFunctionExpr, StringFunctionExpr,
+        NilFunctionExpr, StringFunctionExpr, TupleFunctionExpr,
     },
     int::IntExpr,
     nil::NilExpr,
     string::StringExpr,
+    tuple::TupleExpr,
 };
 pub(crate) use self::{
     bool::BoolExprKind,
     float::FloatExprKind,
     function::{
         BoolFunctionExprKind, FloatFunctionExprKind, FunctionExprKind, FunctionFunctionExprKind,
-        IntFunctionExprKind, NilFunctionExprKind, StringFunctionExprKind,
+        IntFunctionExprKind, NilFunctionExprKind, StringFunctionExprKind, TupleFunctionExprKind,
     },
     int::IntExprKind,
     nil::NilExprKind,
     string::StringExprKind,
+    tuple::TupleExprKind,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -52,6 +55,7 @@ pub(crate) enum ExprKind {
     Float(FloatExpr),
     Bool(BoolExpr),
     Nil(NilExpr),
+    Tuple(TupleExpr),
     Function(FunctionExpr),
 }
 
@@ -82,6 +86,10 @@ pub(crate) enum CallArgKind {
         local: NilLocalId,
         value: NilExpr,
     },
+    Tuple {
+        local: TupleLocalId,
+        value: TupleExpr,
+    },
     IntFunction {
         local: IntFunctionLocalId,
         value: IntFunctionExpr,
@@ -101,6 +109,10 @@ pub(crate) enum CallArgKind {
     NilFunction {
         local: NilFunctionLocalId,
         value: NilFunctionExpr,
+    },
+    TupleFunction {
+        local: TupleFunctionLocalId,
+        value: TupleFunctionExpr,
     },
     FunctionFunction {
         local: FunctionFunctionLocalId,
@@ -135,6 +147,10 @@ pub(crate) enum CaptureArgKind {
         local: NilLocalId,
         value: NilExpr,
     },
+    Tuple {
+        local: TupleLocalId,
+        value: TupleExpr,
+    },
     IntFunction {
         local: IntFunctionLocalId,
         value: IntFunctionExpr,
@@ -154,6 +170,10 @@ pub(crate) enum CaptureArgKind {
     NilFunction {
         local: NilFunctionLocalId,
         value: NilFunctionExpr,
+    },
+    TupleFunction {
+        local: TupleFunctionLocalId,
+        value: TupleFunctionExpr,
     },
     FunctionFunction {
         local: FunctionFunctionLocalId,
@@ -192,6 +212,12 @@ impl Expr {
         }
     }
 
+    pub(crate) fn tuple(expression: TupleExpr) -> Self {
+        Self {
+            kind: ExprKind::Tuple(expression),
+        }
+    }
+
     pub(crate) fn function(expression: FunctionExpr) -> Self {
         Self {
             kind: ExprKind::Function(expression),
@@ -215,6 +241,9 @@ impl Expr {
             BoolCaseBranches::Nil { true_, false_ } => {
                 Self::nil(NilExpr::bool_case(subject, true_, false_))
             }
+            BoolCaseBranches::Tuple { true_, false_ } => {
+                Self::tuple(TupleExpr::bool_case(subject, true_, false_))
+            }
             BoolCaseBranches::IntFunction { true_, false_ } => Self::function(FunctionExpr::int(
                 IntFunctionExpr::bool_case(subject, true_, false_),
             )),
@@ -230,6 +259,9 @@ impl Expr {
             BoolCaseBranches::NilFunction { true_, false_ } => Self::function(FunctionExpr::nil(
                 NilFunctionExpr::bool_case(subject, true_, false_),
             )),
+            BoolCaseBranches::TupleFunction { true_, false_ } => Self::function(
+                FunctionExpr::tuple(TupleFunctionExpr::bool_case(subject, true_, false_)),
+            ),
             BoolCaseBranches::FunctionFunction { true_, false_ } => Self::function(
                 FunctionExpr::function(FunctionFunctionExpr::bool_case(subject, true_, false_)),
             ),
@@ -253,6 +285,9 @@ impl Expr {
             IntCaseBranches::Nil { clauses, fallback } => {
                 Self::nil(NilExpr::int_case(subject, clauses, fallback))
             }
+            IntCaseBranches::Tuple { clauses, fallback } => {
+                Self::tuple(TupleExpr::int_case(subject, clauses, fallback))
+            }
             IntCaseBranches::IntFunction { clauses, fallback } => Self::function(
                 FunctionExpr::int(IntFunctionExpr::int_case(subject, clauses, fallback)),
             ),
@@ -267,6 +302,9 @@ impl Expr {
             ),
             IntCaseBranches::NilFunction { clauses, fallback } => Self::function(
                 FunctionExpr::nil(NilFunctionExpr::int_case(subject, clauses, fallback)),
+            ),
+            IntCaseBranches::TupleFunction { clauses, fallback } => Self::function(
+                FunctionExpr::tuple(TupleFunctionExpr::int_case(subject, clauses, fallback)),
             ),
             IntCaseBranches::FunctionFunction { clauses, fallback } => Self::function(
                 FunctionExpr::function(FunctionFunctionExpr::int_case(subject, clauses, fallback)),
@@ -291,6 +329,9 @@ impl Expr {
             StringCaseBranches::Nil { clauses, fallback } => {
                 Self::nil(NilExpr::string_case(subject, clauses, fallback))
             }
+            StringCaseBranches::Tuple { clauses, fallback } => {
+                Self::tuple(TupleExpr::string_case(subject, clauses, fallback))
+            }
             StringCaseBranches::IntFunction { clauses, fallback } => Self::function(
                 FunctionExpr::int(IntFunctionExpr::string_case(subject, clauses, fallback)),
             ),
@@ -305,6 +346,9 @@ impl Expr {
             ),
             StringCaseBranches::NilFunction { clauses, fallback } => Self::function(
                 FunctionExpr::nil(NilFunctionExpr::string_case(subject, clauses, fallback)),
+            ),
+            StringCaseBranches::TupleFunction { clauses, fallback } => Self::function(
+                FunctionExpr::tuple(TupleFunctionExpr::string_case(subject, clauses, fallback)),
             ),
             StringCaseBranches::FunctionFunction { clauses, fallback } => {
                 Self::function(FunctionExpr::function(FunctionFunctionExpr::string_case(
@@ -331,6 +375,9 @@ impl Expr {
             FloatCaseBranches::Nil { clauses, fallback } => {
                 Self::nil(NilExpr::float_case(subject, clauses, fallback))
             }
+            FloatCaseBranches::Tuple { clauses, fallback } => {
+                Self::tuple(TupleExpr::float_case(subject, clauses, fallback))
+            }
             FloatCaseBranches::IntFunction { clauses, fallback } => Self::function(
                 FunctionExpr::int(IntFunctionExpr::float_case(subject, clauses, fallback)),
             ),
@@ -345,6 +392,9 @@ impl Expr {
             ),
             FloatCaseBranches::NilFunction { clauses, fallback } => Self::function(
                 FunctionExpr::nil(NilFunctionExpr::float_case(subject, clauses, fallback)),
+            ),
+            FloatCaseBranches::TupleFunction { clauses, fallback } => Self::function(
+                FunctionExpr::tuple(TupleFunctionExpr::float_case(subject, clauses, fallback)),
             ),
             FloatCaseBranches::FunctionFunction { clauses, fallback } => {
                 Self::function(FunctionExpr::function(FunctionFunctionExpr::float_case(
@@ -390,6 +440,13 @@ impl Expr {
         }
     }
 
+    pub(crate) fn into_tuple(self) -> Option<TupleExpr> {
+        match self.kind {
+            ExprKind::Tuple(expression) => Some(expression),
+            _ => None,
+        }
+    }
+
     pub(crate) fn into_function(self) -> Option<FunctionExpr> {
         match self.kind {
             ExprKind::Function(expression) => Some(expression),
@@ -412,6 +469,7 @@ impl Expr {
             ExprKind::Float(_) => ValueType::Float,
             ExprKind::Bool(_) => ValueType::Bool,
             ExprKind::Nil(_) => ValueType::Nil,
+            ExprKind::Tuple(expression) => ValueType::Tuple(expression.type_().to_vec()),
             ExprKind::Function(expression) => {
                 ValueType::Function(Box::new(expression.type_().clone()))
             }
@@ -429,6 +487,13 @@ impl Expr {
             }
             (ParamLocal::Bool(local), ExprKind::Bool(value)) => Some(CallArg::bool(*local, value)),
             (ParamLocal::Nil(local), ExprKind::Nil(value)) => Some(CallArg::nil(*local, value)),
+            (
+                ParamLocal::Tuple {
+                    local,
+                    type_: expected,
+                },
+                ExprKind::Tuple(value),
+            ) if value.type_() == expected => Some(CallArg::tuple(*local, value)),
             (
                 ParamLocal::IntFunction {
                     local,
@@ -475,6 +540,15 @@ impl Expr {
                 .into_nil()
                 .map(|value| CallArg::nil_function(*local, value)),
             (
+                ParamLocal::TupleFunction {
+                    local,
+                    type_: expected,
+                },
+                ExprKind::Function(value),
+            ) if value.type_() == expected => value
+                .into_tuple()
+                .map(|value| CallArg::tuple_function(*local, value)),
+            (
                 ParamLocal::FunctionFunction {
                     local,
                     type_: expected,
@@ -519,6 +593,12 @@ impl CallArg {
         }
     }
 
+    pub(crate) fn tuple(local: TupleLocalId, value: TupleExpr) -> Self {
+        Self {
+            kind: CallArgKind::Tuple { local, value },
+        }
+    }
+
     pub(crate) fn int_function(local: IntFunctionLocalId, value: IntFunctionExpr) -> Self {
         Self {
             kind: CallArgKind::IntFunction { local, value },
@@ -546,6 +626,12 @@ impl CallArg {
     pub(crate) fn nil_function(local: NilFunctionLocalId, value: NilFunctionExpr) -> Self {
         Self {
             kind: CallArgKind::NilFunction { local, value },
+        }
+    }
+
+    pub(crate) fn tuple_function(local: TupleFunctionLocalId, value: TupleFunctionExpr) -> Self {
+        Self {
+            kind: CallArgKind::TupleFunction { local, value },
         }
     }
 
@@ -594,6 +680,12 @@ impl CaptureArg {
         }
     }
 
+    pub(crate) fn tuple(local: TupleLocalId, value: TupleExpr) -> Self {
+        Self {
+            kind: CaptureArgKind::Tuple { local, value },
+        }
+    }
+
     pub(crate) fn int_function(local: IntFunctionLocalId, value: IntFunctionExpr) -> Self {
         Self {
             kind: CaptureArgKind::IntFunction { local, value },
@@ -624,6 +716,12 @@ impl CaptureArg {
         }
     }
 
+    pub(crate) fn tuple_function(local: TupleFunctionLocalId, value: TupleFunctionExpr) -> Self {
+        Self {
+            kind: CaptureArgKind::TupleFunction { local, value },
+        }
+    }
+
     pub(crate) fn function_function(
         local: FunctionFunctionLocalId,
         value: FunctionFunctionExpr,
@@ -646,6 +744,10 @@ impl From<Value> for Expr {
             Value::Float(value) => Self::float(FloatExpr::value(value)),
             Value::Bool(value) => Self::bool(BoolExpr::value(value)),
             Value::Nil => Self::nil(NilExpr::value()),
+            Value::Tuple(value) => Self::tuple(TupleExpr::value(
+                value.iter().cloned().map(Self::from).collect(),
+                value.iter().map(Value::value_type).collect(),
+            )),
             Value::Function(value) => Self::function(FunctionExpr::value(value)),
         }
     }
@@ -657,14 +759,15 @@ mod tests {
         BoolCaseBranches, BoolExpr, BoolFunctionExpr, CallArg, Expr, FloatCaseBranches, FloatExpr,
         FloatFunctionExpr, FunctionExpr, FunctionFunctionExpr, IntCaseBranches, IntExpr,
         IntFunctionExpr, NilExpr, NilFunctionExpr, StringCaseBranches, StringExpr,
-        StringFunctionExpr,
+        StringFunctionExpr, TupleExpr, TupleFunctionExpr,
     };
     use crate::plan::{
         BoolFunctionId, BoolFunctionValue, BoolLocalId, FloatFunctionId, FloatFunctionLocalId,
         FloatFunctionValue, FloatLocalId, FunctionFunctionId, FunctionFunctionValue, FunctionType,
         FunctionValue, IntFunctionFunctionId, IntFunctionId, IntFunctionValue, IntLocalId,
         NilFunctionId, NilFunctionValue, NilLocalId, ParamLocal, RuntimeFunctionId,
-        StringFunctionId, StringFunctionValue, StringLocalId, Value, ValueType,
+        StringFunctionId, StringFunctionValue, StringLocalId, TupleFunctionId,
+        TupleFunctionLocalId, TupleFunctionValue, TupleLocalId, Value, ValueType,
     };
     use num_bigint::BigInt;
 
@@ -687,6 +790,13 @@ mod tests {
             Expr::from(Value::Bool(true))
         );
         assert_eq!(Expr::nil(NilExpr::value()), Expr::from(Value::Nil));
+        assert_eq!(
+            Expr::tuple(TupleExpr::value(
+                vec![Expr::int(IntExpr::value(BigInt::from(1)))],
+                vec![ValueType::Int],
+            )),
+            Expr::from(Value::Tuple(vec![Value::Int(BigInt::from(1))])),
+        );
         assert_eq!(
             Expr::function(FunctionExpr::value(function_value())),
             Expr::from(Value::Function(function_value())),
@@ -1185,6 +1295,10 @@ mod tests {
         assert_eq!(Expr::from(Value::Bool(true)).value_type(), ValueType::Bool);
         assert_eq!(Expr::from(Value::Nil).value_type(), ValueType::Nil);
         assert_eq!(
+            Expr::from(Value::Tuple(vec![Value::Int(BigInt::from(1))])).value_type(),
+            ValueType::Tuple(vec![ValueType::Int]),
+        );
+        assert_eq!(
             Expr::from(Value::Function(function_value())).value_type(),
             ValueType::Function(Box::new(function_type())),
         );
@@ -1210,6 +1324,13 @@ mod tests {
             Some(BoolExpr::value(true)),
         );
         assert_eq!(Expr::from(Value::Nil).into_nil(), Some(NilExpr::value()));
+        assert_eq!(
+            Expr::from(Value::Tuple(vec![Value::Int(BigInt::from(1))])).into_tuple(),
+            Some(TupleExpr::value(
+                vec![Expr::int(IntExpr::value(BigInt::from(1)))],
+                vec![ValueType::Int],
+            )),
+        );
         assert_eq!(Expr::from(Value::Nil).into_int(), None);
         assert_eq!(Expr::from(Value::Int(BigInt::from(1))).into_nil(), None);
         assert_eq!(
@@ -1248,6 +1369,16 @@ mod tests {
         assert_eq!(
             Expr::nil(NilExpr::value()).into_call_arg(&ParamLocal::nil(NilLocalId(0))),
             Some(CallArg::nil(NilLocalId(0), NilExpr::value())),
+        );
+        assert_eq!(
+            tuple_expr().into_call_arg(&ParamLocal::tuple(TupleLocalId(0), vec![ValueType::Int])),
+            Some(CallArg::tuple(
+                TupleLocalId(0),
+                TupleExpr::value(
+                    vec![Expr::int(IntExpr::value(BigInt::from(1)))],
+                    vec![ValueType::Int],
+                ),
+            )),
         );
         assert_eq!(
             Expr::function(FunctionExpr::value(function_value())).into_call_arg(
@@ -1307,6 +1438,15 @@ mod tests {
             Some(CallArg::nil_function(
                 crate::plan::NilFunctionLocalId(0),
                 nil_function_expr(),
+            )),
+        );
+        assert_eq!(
+            Expr::function(FunctionExpr::tuple(tuple_function_expr())).into_call_arg(
+                &ParamLocal::tuple_function(TupleFunctionLocalId(0), tuple_function_type())
+            ),
+            Some(CallArg::tuple_function(
+                TupleFunctionLocalId(0),
+                tuple_function_expr(),
             )),
         );
         assert_eq!(
@@ -1372,6 +1512,16 @@ mod tests {
             None,
         );
         assert_eq!(
+            Expr::function(FunctionExpr::string(malformed_string_function_expr(
+                tuple_function_type(),
+            )))
+            .into_call_arg(&ParamLocal::tuple_function(
+                TupleFunctionLocalId(0),
+                tuple_function_type(),
+            )),
+            None,
+        );
+        assert_eq!(
             Expr::function(FunctionExpr::value(function_value()))
                 .into_call_arg(&ParamLocal::int(IntLocalId(0))),
             None,
@@ -1425,6 +1575,21 @@ mod tests {
         ))
     }
 
+    fn tuple_expr() -> Expr {
+        Expr::tuple(TupleExpr::value(
+            vec![Expr::int(IntExpr::value(BigInt::from(1)))],
+            vec![ValueType::Int],
+        ))
+    }
+
+    fn tuple_function_expr() -> TupleFunctionExpr {
+        TupleFunctionExpr::value(TupleFunctionValue::new(
+            TupleFunctionId(0),
+            vec![ParamLocal::tuple(TupleLocalId(0), vec![ValueType::Int])],
+            vec![ValueType::Int],
+        ))
+    }
+
     fn function_function_expr() -> FunctionFunctionExpr {
         FunctionFunctionExpr::value(FunctionFunctionValue::new(
             FunctionFunctionId::Int(IntFunctionFunctionId(0)),
@@ -1463,6 +1628,13 @@ mod tests {
 
     fn nil_function_type() -> FunctionType {
         FunctionType::new(vec![ValueType::Nil], ValueType::Nil)
+    }
+
+    fn tuple_function_type() -> FunctionType {
+        FunctionType::new(
+            vec![ValueType::Tuple(vec![ValueType::Int])],
+            ValueType::Tuple(vec![ValueType::Int]),
+        )
     }
 
     fn function_function_type() -> FunctionType {

--- a/src/plan/expression/bool.rs
+++ b/src/plan/expression/bool.rs
@@ -1,4 +1,4 @@
-use super::{BoolFunctionExpr, CallArg, Expr, FloatExpr, IntExpr, StringExpr};
+use super::{BoolFunctionExpr, CallArg, Expr, FloatExpr, IntExpr, StringExpr, TupleExpr};
 use crate::plan::{BoolFunctionId, BoolLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -22,6 +22,10 @@ pub(crate) enum BoolExprKind {
     FunctionCall {
         function: Box<BoolFunctionExpr>,
         args: Vec<CallArg>,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
     },
     Not(Box<BoolExpr>),
     LtInt {
@@ -122,6 +126,15 @@ impl BoolExpr {
             kind: BoolExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize) -> Self {
+        Self {
+            kind: BoolExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
             },
         }
     }
@@ -329,6 +342,17 @@ mod tests {
         assert!(matches!(
             BoolExpr::function_call(function_expr(), Vec::new()).kind(),
             BoolExprKind::FunctionCall { .. }
+        ));
+        assert!(matches!(
+            BoolExpr::tuple_index(
+                crate::plan::TupleExpr::value(
+                    vec![Expr::bool(BoolExpr::value(true))],
+                    vec![crate::plan::ValueType::Bool],
+                ),
+                0,
+            )
+            .kind(),
+            BoolExprKind::TupleIndex { .. }
         ));
         assert!(matches!(
             BoolExpr::int_case(

--- a/src/plan/expression/case.rs
+++ b/src/plan/expression/case.rs
@@ -1,6 +1,7 @@
 use super::{
     BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr, FunctionFunctionExpr, IntExpr,
-    IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr,
+    IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr,
+    TupleFunctionExpr,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -27,6 +28,10 @@ pub(crate) enum BoolCaseBranches {
         true_: NilExpr,
         false_: NilExpr,
     },
+    Tuple {
+        true_: TupleExpr,
+        false_: TupleExpr,
+    },
     IntFunction {
         true_: IntFunctionExpr,
         false_: IntFunctionExpr,
@@ -46,6 +51,10 @@ pub(crate) enum BoolCaseBranches {
     NilFunction {
         true_: NilFunctionExpr,
         false_: NilFunctionExpr,
+    },
+    TupleFunction {
+        true_: TupleFunctionExpr,
+        false_: TupleFunctionExpr,
     },
     FunctionFunction {
         true_: FunctionFunctionExpr,
@@ -75,6 +84,10 @@ pub(crate) enum IntCaseBranches {
         clauses: Vec<(BigInt, NilExpr)>,
         fallback: NilExpr,
     },
+    Tuple {
+        clauses: Vec<(BigInt, TupleExpr)>,
+        fallback: TupleExpr,
+    },
     IntFunction {
         clauses: Vec<(BigInt, IntFunctionExpr)>,
         fallback: IntFunctionExpr,
@@ -94,6 +107,10 @@ pub(crate) enum IntCaseBranches {
     NilFunction {
         clauses: Vec<(BigInt, NilFunctionExpr)>,
         fallback: NilFunctionExpr,
+    },
+    TupleFunction {
+        clauses: Vec<(BigInt, TupleFunctionExpr)>,
+        fallback: TupleFunctionExpr,
     },
     FunctionFunction {
         clauses: Vec<(BigInt, FunctionFunctionExpr)>,
@@ -123,6 +140,10 @@ pub(crate) enum StringCaseBranches {
         clauses: Vec<(EcoString, NilExpr)>,
         fallback: NilExpr,
     },
+    Tuple {
+        clauses: Vec<(EcoString, TupleExpr)>,
+        fallback: TupleExpr,
+    },
     IntFunction {
         clauses: Vec<(EcoString, IntFunctionExpr)>,
         fallback: IntFunctionExpr,
@@ -142,6 +163,10 @@ pub(crate) enum StringCaseBranches {
     NilFunction {
         clauses: Vec<(EcoString, NilFunctionExpr)>,
         fallback: NilFunctionExpr,
+    },
+    TupleFunction {
+        clauses: Vec<(EcoString, TupleFunctionExpr)>,
+        fallback: TupleFunctionExpr,
     },
     FunctionFunction {
         clauses: Vec<(EcoString, FunctionFunctionExpr)>,
@@ -171,6 +196,10 @@ pub(crate) enum FloatCaseBranches {
         clauses: Vec<(f64, NilExpr)>,
         fallback: NilExpr,
     },
+    Tuple {
+        clauses: Vec<(f64, TupleExpr)>,
+        fallback: TupleExpr,
+    },
     IntFunction {
         clauses: Vec<(f64, IntFunctionExpr)>,
         fallback: IntFunctionExpr,
@@ -190,6 +219,10 @@ pub(crate) enum FloatCaseBranches {
     NilFunction {
         clauses: Vec<(f64, NilFunctionExpr)>,
         fallback: NilFunctionExpr,
+    },
+    TupleFunction {
+        clauses: Vec<(f64, TupleFunctionExpr)>,
+        fallback: TupleFunctionExpr,
     },
     FunctionFunction {
         clauses: Vec<(f64, FunctionFunctionExpr)>,

--- a/src/plan/expression/float.rs
+++ b/src/plan/expression/float.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg, FloatFunctionExpr, IntExpr, StringExpr};
+use super::{BoolExpr, CallArg, FloatFunctionExpr, IntExpr, StringExpr, TupleExpr};
 use crate::plan::{FloatFunctionId, FloatLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -22,6 +22,10 @@ pub(crate) enum FloatExprKind {
     FunctionCall {
         function: Box<FloatFunctionExpr>,
         args: Vec<CallArg>,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
     },
     Add {
         left: Box<FloatExpr>,
@@ -89,6 +93,15 @@ impl FloatExpr {
             kind: FloatExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize) -> Self {
+        Self {
+            kind: FloatExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
             },
         }
     }
@@ -218,6 +231,17 @@ mod tests {
         assert!(matches!(
             FloatExpr::function_call(function_expr(), Vec::new()).kind(),
             FloatExprKind::FunctionCall { .. }
+        ));
+        assert!(matches!(
+            FloatExpr::tuple_index(
+                crate::plan::TupleExpr::value(
+                    vec![Expr::float(FloatExpr::value(1.0))],
+                    vec![crate::plan::ValueType::Float],
+                ),
+                0,
+            )
+            .kind(),
+            FloatExprKind::TupleIndex { .. }
         ));
         assert!(matches!(
             FloatExpr::float_case(

--- a/src/plan/expression/function.rs
+++ b/src/plan/expression/function.rs
@@ -4,17 +4,18 @@ mod int;
 mod nil;
 mod returning_function;
 mod string;
+mod tuple;
 
 use crate::plan::{FunctionType, FunctionValue, FunctionValueKind};
 
 pub use self::{
     bool::BoolFunctionExpr, float::FloatFunctionExpr, int::IntFunctionExpr, nil::NilFunctionExpr,
-    returning_function::FunctionFunctionExpr, string::StringFunctionExpr,
+    returning_function::FunctionFunctionExpr, string::StringFunctionExpr, tuple::TupleFunctionExpr,
 };
 pub(crate) use self::{
     bool::BoolFunctionExprKind, float::FloatFunctionExprKind, int::IntFunctionExprKind,
     nil::NilFunctionExprKind, returning_function::FunctionFunctionExprKind,
-    string::StringFunctionExprKind,
+    string::StringFunctionExprKind, tuple::TupleFunctionExprKind,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -29,6 +30,7 @@ pub(crate) enum FunctionExprKind {
     Float(FloatFunctionExpr),
     Bool(BoolFunctionExpr),
     Nil(NilFunctionExpr),
+    Tuple(TupleFunctionExpr),
     Function(FunctionFunctionExpr),
 }
 
@@ -42,6 +44,7 @@ impl FunctionExpr {
             FunctionValueKind::Float(value) => Self::float(FloatFunctionExpr::value(value.clone())),
             FunctionValueKind::Bool(value) => Self::bool(BoolFunctionExpr::value(value.clone())),
             FunctionValueKind::Nil(value) => Self::nil(NilFunctionExpr::value(value.clone())),
+            FunctionValueKind::Tuple(value) => Self::tuple(TupleFunctionExpr::value(value.clone())),
             FunctionValueKind::Function(value) => {
                 Self::function(FunctionFunctionExpr::value(value.clone()))
             }
@@ -78,6 +81,12 @@ impl FunctionExpr {
         }
     }
 
+    pub(crate) fn tuple(expression: TupleFunctionExpr) -> Self {
+        Self {
+            kind: FunctionExprKind::Tuple(expression),
+        }
+    }
+
     pub(crate) fn function(expression: FunctionFunctionExpr) -> Self {
         Self {
             kind: FunctionExprKind::Function(expression),
@@ -91,6 +100,7 @@ impl FunctionExpr {
             FunctionExprKind::Float(expression) => expression.type_(),
             FunctionExprKind::Bool(expression) => expression.type_(),
             FunctionExprKind::Nil(expression) => expression.type_(),
+            FunctionExprKind::Tuple(expression) => expression.type_(),
             FunctionExprKind::Function(expression) => expression.type_(),
         }
     }
@@ -138,6 +148,13 @@ impl FunctionExpr {
         }
     }
 
+    pub(crate) fn into_tuple(self) -> Option<TupleFunctionExpr> {
+        match self.kind {
+            FunctionExprKind::Tuple(expression) => Some(expression),
+            _ => None,
+        }
+    }
+
     pub(crate) fn into_function(self) -> Option<FunctionFunctionExpr> {
         match self.kind {
             FunctionExprKind::Function(expression) => Some(expression),
@@ -176,6 +193,12 @@ impl From<NilFunctionExpr> for FunctionExpr {
     }
 }
 
+impl From<TupleFunctionExpr> for FunctionExpr {
+    fn from(expression: TupleFunctionExpr) -> Self {
+        Self::tuple(expression)
+    }
+}
+
 impl From<FunctionFunctionExpr> for FunctionExpr {
     fn from(expression: FunctionFunctionExpr) -> Self {
         Self::function(expression)
@@ -186,13 +209,13 @@ impl From<FunctionFunctionExpr> for FunctionExpr {
 mod tests {
     use super::{
         BoolFunctionExpr, FloatFunctionExpr, FunctionExpr, FunctionExprKind, FunctionFunctionExpr,
-        IntFunctionExpr, NilFunctionExpr, StringFunctionExpr,
+        IntFunctionExpr, NilFunctionExpr, StringFunctionExpr, TupleFunctionExpr,
     };
     use crate::plan::{
         BoolFunctionId, BoolFunctionValue, FloatFunctionId, FloatFunctionValue, FunctionFunctionId,
         FunctionFunctionValue, FunctionType, FunctionValue, IntFunctionFunctionId, IntFunctionId,
         IntFunctionValue, NilFunctionId, NilFunctionValue, ParamLocal, RuntimeFunctionId,
-        StringFunctionId, StringFunctionValue, ValueType,
+        StringFunctionId, StringFunctionValue, TupleFunctionId, TupleFunctionValue, ValueType,
     };
 
     #[test]
@@ -222,6 +245,10 @@ mod tests {
             FunctionExprKind::Nil(_)
         ));
         assert!(matches!(
+            FunctionExpr::tuple(tuple_function_value()).kind(),
+            FunctionExprKind::Tuple(_)
+        ));
+        assert!(matches!(
             FunctionExpr::function(function_function_value()).kind(),
             FunctionExprKind::Function(_)
         ));
@@ -246,6 +273,11 @@ mod tests {
                 .is_some()
         );
         assert!(FunctionExpr::nil(nil_function_value()).into_nil().is_some());
+        assert!(
+            FunctionExpr::tuple(tuple_function_value())
+                .into_tuple()
+                .is_some()
+        );
 
         assert!(
             FunctionExpr::int(int_function_value())
@@ -263,6 +295,11 @@ mod tests {
                 .is_none()
         );
         assert!(FunctionExpr::int(int_function_value()).into_nil().is_none());
+        assert!(
+            FunctionExpr::int(int_function_value())
+                .into_tuple()
+                .is_none()
+        );
 
         assert!(matches!(
             FunctionExpr::from(int_function_value()).kind(),
@@ -283,6 +320,10 @@ mod tests {
         assert!(matches!(
             FunctionExpr::from(nil_function_value()).kind(),
             FunctionExprKind::Nil(_),
+        ));
+        assert!(matches!(
+            FunctionExpr::from(tuple_function_value()).kind(),
+            FunctionExprKind::Tuple(_),
         ));
         assert!(matches!(
             FunctionExpr::from(function_function_value()).kind(),
@@ -329,6 +370,17 @@ mod tests {
         NilFunctionExpr::value(NilFunctionValue::new(
             NilFunctionId(0),
             vec![ParamLocal::nil(crate::plan::NilLocalId(0))],
+        ))
+    }
+
+    fn tuple_function_value() -> TupleFunctionExpr {
+        TupleFunctionExpr::value(TupleFunctionValue::new(
+            TupleFunctionId(0),
+            vec![ParamLocal::tuple(
+                crate::plan::TupleLocalId(0),
+                vec![ValueType::Int],
+            )],
+            vec![ValueType::Int],
         ))
     }
 

--- a/src/plan/expression/function/bool.rs
+++ b/src/plan/expression/function/bool.rs
@@ -1,7 +1,7 @@
 use crate::plan::{
     BoolExpr, BoolFunctionFunctionId, BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue,
     CaptureArg, FloatExpr, FunctionFunctionExpr, FunctionType, IntExpr, ParamLocal, Step,
-    StringExpr,
+    StringExpr, TupleExpr,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -32,6 +32,11 @@ pub(crate) enum BoolFunctionExprKind {
     FunctionCall {
         function: Box<FunctionFunctionExpr>,
         args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
         type_: FunctionType,
     },
     BoolCase {
@@ -120,6 +125,17 @@ impl BoolFunctionExpr {
             kind: BoolFunctionExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize, type_: FunctionType) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: BoolFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
                 type_,
             },
         }
@@ -229,6 +245,10 @@ mod tests {
             BoolFunctionExprKind::FunctionCall { .. },
         ));
         assert!(matches!(
+            BoolFunctionExpr::tuple_index(tuple_expr(), 0, function_type()).kind(),
+            BoolFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
             BoolFunctionExpr::bool_case(BoolExpr::value(true), function_value(), function_value(),)
                 .kind(),
             BoolFunctionExprKind::BoolCase { .. },
@@ -283,5 +303,14 @@ mod tests {
             Vec::new(),
             function_type(),
         ))
+    }
+
+    fn tuple_expr() -> crate::plan::TupleExpr {
+        crate::plan::TupleExpr::value(
+            vec![Expr::function(crate::plan::FunctionExpr::bool(
+                function_value(),
+            ))],
+            vec![ValueType::Function(Box::new(function_type()))],
+        )
     }
 }

--- a/src/plan/expression/function/float.rs
+++ b/src/plan/expression/function/float.rs
@@ -1,7 +1,7 @@
 use crate::plan::{
     BoolExpr, CaptureArg, FloatExpr, FloatFunctionFunctionId, FloatFunctionId,
     FloatFunctionLocalId, FloatFunctionValue, FunctionFunctionExpr, FunctionType, IntExpr,
-    ParamLocal, Step, StringExpr,
+    ParamLocal, Step, StringExpr, TupleExpr,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -32,6 +32,11 @@ pub(crate) enum FloatFunctionExprKind {
     FunctionCall {
         function: Box<FunctionFunctionExpr>,
         args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
         type_: FunctionType,
     },
     BoolCase {
@@ -120,6 +125,17 @@ impl FloatFunctionExpr {
             kind: FloatFunctionExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize, type_: FunctionType) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: FloatFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
                 type_,
             },
         }
@@ -247,6 +263,10 @@ mod tests {
             FloatFunctionExprKind::FunctionCall { .. }
         ));
         assert!(matches!(
+            FloatFunctionExpr::tuple_index(tuple_expr(), 0, float_function_type()).kind(),
+            FloatFunctionExprKind::TupleIndex { .. }
+        ));
+        assert!(matches!(
             FloatFunctionExpr::float_case(
                 FloatExpr::value(1.0),
                 vec![(1.0, float_function_value())],
@@ -309,5 +329,14 @@ mod tests {
             Vec::new(),
             float_function_type(),
         ))
+    }
+
+    fn tuple_expr() -> crate::plan::TupleExpr {
+        crate::plan::TupleExpr::value(
+            vec![Expr::function(crate::plan::FunctionExpr::float(
+                float_function_value(),
+            ))],
+            vec![ValueType::Function(Box::new(float_function_type()))],
+        )
     }
 }

--- a/src/plan/expression/function/int.rs
+++ b/src/plan/expression/function/int.rs
@@ -1,7 +1,7 @@
 use crate::plan::{
     BoolExpr, CaptureArg, FloatExpr, FunctionFunctionExpr, FunctionType, IntExpr,
     IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId, IntFunctionValue, ParamLocal, Step,
-    StringExpr,
+    StringExpr, TupleExpr,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -32,6 +32,11 @@ pub(crate) enum IntFunctionExprKind {
     FunctionCall {
         function: Box<FunctionFunctionExpr>,
         args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
         type_: FunctionType,
     },
     BoolCase {
@@ -120,6 +125,17 @@ impl IntFunctionExpr {
             kind: IntFunctionExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize, type_: FunctionType) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: IntFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
                 type_,
             },
         }
@@ -238,6 +254,10 @@ mod tests {
             IntFunctionExprKind::FunctionCall { .. }
         ));
         assert!(matches!(
+            IntFunctionExpr::tuple_index(tuple_expr(), 0, int_function_type()).kind(),
+            IntFunctionExprKind::TupleIndex { .. }
+        ));
+        assert!(matches!(
             IntFunctionExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), int_function_value())],
@@ -309,5 +329,14 @@ mod tests {
             Vec::new(),
             int_function_type(),
         ))
+    }
+
+    fn tuple_expr() -> crate::plan::TupleExpr {
+        crate::plan::TupleExpr::value(
+            vec![Expr::function(crate::plan::FunctionExpr::int(
+                int_function_value(),
+            ))],
+            vec![ValueType::Function(Box::new(int_function_type()))],
+        )
     }
 }

--- a/src/plan/expression/function/nil.rs
+++ b/src/plan/expression/function/nil.rs
@@ -1,7 +1,7 @@
 use crate::plan::{
     BoolExpr, CaptureArg, FloatExpr, FunctionFunctionExpr, FunctionType, IntExpr,
     NilFunctionFunctionId, NilFunctionId, NilFunctionLocalId, NilFunctionValue, ParamLocal, Step,
-    StringExpr,
+    StringExpr, TupleExpr,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -32,6 +32,11 @@ pub(crate) enum NilFunctionExprKind {
     FunctionCall {
         function: Box<FunctionFunctionExpr>,
         args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
         type_: FunctionType,
     },
     BoolCase {
@@ -120,6 +125,17 @@ impl NilFunctionExpr {
             kind: NilFunctionExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize, type_: FunctionType) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: NilFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
                 type_,
             },
         }
@@ -229,6 +245,10 @@ mod tests {
             NilFunctionExprKind::FunctionCall { .. },
         ));
         assert!(matches!(
+            NilFunctionExpr::tuple_index(tuple_expr(), 0, function_type()).kind(),
+            NilFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
             NilFunctionExpr::bool_case(BoolExpr::value(true), function_value(), function_value(),)
                 .kind(),
             NilFunctionExprKind::BoolCase { .. },
@@ -283,5 +303,14 @@ mod tests {
             Vec::new(),
             function_type(),
         ))
+    }
+
+    fn tuple_expr() -> crate::plan::TupleExpr {
+        crate::plan::TupleExpr::value(
+            vec![Expr::function(crate::plan::FunctionExpr::nil(
+                function_value(),
+            ))],
+            vec![ValueType::Function(Box::new(function_type()))],
+        )
     }
 }

--- a/src/plan/expression/function/returning_function.rs
+++ b/src/plan/expression/function/returning_function.rs
@@ -1,7 +1,7 @@
 use crate::plan::{
     BoolExpr, CaptureArg, FloatExpr, FunctionFunctionFunctionId, FunctionFunctionId,
     FunctionFunctionLocalId, FunctionFunctionValue, FunctionType, IntExpr, ParamLocal, Step,
-    StringExpr,
+    StringExpr, TupleExpr,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -34,6 +34,11 @@ pub(crate) enum FunctionFunctionExprKind {
     FunctionCall {
         function: Box<FunctionFunctionExpr>,
         args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
         type_: FunctionType,
     },
     BoolCase {
@@ -124,6 +129,17 @@ impl FunctionFunctionExpr {
             kind: FunctionFunctionExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize, type_: FunctionType) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: FunctionFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
                 type_,
             },
         }
@@ -242,6 +258,10 @@ mod tests {
             FunctionFunctionExprKind::FunctionCall { .. },
         ));
         assert!(matches!(
+            FunctionFunctionExpr::tuple_index(tuple_expr(), 0, function_type()).kind(),
+            FunctionFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
             FunctionFunctionExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), function_value())],
@@ -298,6 +318,15 @@ mod tests {
                 vec![ValueType::Int],
                 ValueType::Int,
             ))),
+        )
+    }
+
+    fn tuple_expr() -> crate::plan::TupleExpr {
+        crate::plan::TupleExpr::value(
+            vec![Expr::function(crate::plan::FunctionExpr::function(
+                function_value(),
+            ))],
+            vec![ValueType::Function(Box::new(function_type()))],
         )
     }
 }

--- a/src/plan/expression/function/string.rs
+++ b/src/plan/expression/function/string.rs
@@ -1,7 +1,7 @@
 use crate::plan::{
     BoolExpr, CaptureArg, FloatExpr, FunctionFunctionExpr, FunctionType, IntExpr, ParamLocal, Step,
     StringExpr, StringFunctionFunctionId, StringFunctionId, StringFunctionLocalId,
-    StringFunctionValue,
+    StringFunctionValue, TupleExpr,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -32,6 +32,11 @@ pub(crate) enum StringFunctionExprKind {
     FunctionCall {
         function: Box<FunctionFunctionExpr>,
         args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
         type_: FunctionType,
     },
     BoolCase {
@@ -120,6 +125,17 @@ impl StringFunctionExpr {
             kind: StringFunctionExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize, type_: FunctionType) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: StringFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
                 type_,
             },
         }
@@ -235,6 +251,10 @@ mod tests {
             StringFunctionExprKind::FunctionCall { .. },
         ));
         assert!(matches!(
+            StringFunctionExpr::tuple_index(tuple_expr(), 0, function_type()).kind(),
+            StringFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
             StringFunctionExpr::bool_case(
                 BoolExpr::value(true),
                 function_value(),
@@ -293,5 +313,14 @@ mod tests {
             Vec::new(),
             function_type(),
         ))
+    }
+
+    fn tuple_expr() -> crate::plan::TupleExpr {
+        crate::plan::TupleExpr::value(
+            vec![Expr::function(crate::plan::FunctionExpr::string(
+                function_value(),
+            ))],
+            vec![ValueType::Function(Box::new(function_type()))],
+        )
     }
 }

--- a/src/plan/expression/function/tuple.rs
+++ b/src/plan/expression/function/tuple.rs
@@ -1,0 +1,397 @@
+use crate::plan::{
+    BoolExpr, CaptureArg, FloatExpr, FunctionFunctionExpr, FunctionType, IntExpr, ParamLocal, Step,
+    StringExpr, TupleExpr, TupleFunctionFunctionId, TupleFunctionId, TupleFunctionLocalId,
+    TupleFunctionValue, ValueType,
+};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TupleFunctionExpr {
+    type_: FunctionType,
+    kind: TupleFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum TupleFunctionExprKind {
+    Value(TupleFunctionValue),
+    Closure {
+        runtime_id: TupleFunctionId,
+        params: Vec<ParamLocal>,
+        captures: Vec<CaptureArg>,
+        return_type: Vec<ValueType>,
+    },
+    LocalGet {
+        local: TupleFunctionLocalId,
+        name: EcoString,
+    },
+    Call {
+        function: TupleFunctionFunctionId,
+        args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    FunctionCall {
+        function: Box<FunctionFunctionExpr>,
+        args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
+        type_: FunctionType,
+    },
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<TupleFunctionExpr>,
+        false_: Box<TupleFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, TupleFunctionExpr)>,
+        fallback: Box<TupleFunctionExpr>,
+    },
+    StringCase {
+        subject: Box<StringExpr>,
+        clauses: Vec<(EcoString, TupleFunctionExpr)>,
+        fallback: Box<TupleFunctionExpr>,
+    },
+    FloatCase {
+        subject: Box<FloatExpr>,
+        clauses: Vec<(f64, TupleFunctionExpr)>,
+        fallback: Box<TupleFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<TupleFunctionExpr>,
+    },
+}
+
+impl TupleFunctionExpr {
+    pub(crate) fn value(value: TupleFunctionValue) -> Self {
+        Self {
+            type_: value.type_(),
+            kind: TupleFunctionExprKind::Value(value),
+        }
+    }
+
+    pub(crate) fn closure(
+        runtime_id: TupleFunctionId,
+        params: Vec<ParamLocal>,
+        captures: Vec<CaptureArg>,
+        type_: FunctionType,
+        return_type: Vec<ValueType>,
+    ) -> Self {
+        Self {
+            type_,
+            kind: TupleFunctionExprKind::Closure {
+                runtime_id,
+                params,
+                captures,
+                return_type,
+            },
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: TupleFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: TupleFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn call(
+        function: TupleFunctionFunctionId,
+        args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: TupleFunctionExprKind::Call {
+                function,
+                args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn function_call(
+        function: FunctionFunctionExpr,
+        args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: TupleFunctionExprKind::FunctionCall {
+                function: Box::new(function),
+                args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize, type_: FunctionType) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: TupleFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: TupleFunctionExpr,
+        false_: TupleFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: TupleFunctionExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, TupleFunctionExpr)>,
+        fallback: TupleFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: TupleFunctionExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn string_case(
+        subject: StringExpr,
+        clauses: Vec<(EcoString, TupleFunctionExpr)>,
+        fallback: TupleFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: TupleFunctionExprKind::StringCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn float_case(
+        subject: FloatExpr,
+        clauses: Vec<(f64, TupleFunctionExpr)>,
+        fallback: TupleFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: TupleFunctionExprKind::FloatCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: TupleFunctionExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: TupleFunctionExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &TupleFunctionExprKind {
+        &self.kind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TupleFunctionExpr, TupleFunctionExprKind};
+    use crate::plan::{
+        BoolExpr, Expr, FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionValue,
+        FunctionType, IntExpr, ParamLocal, Step, TupleExpr, TupleFunctionFunctionId,
+        TupleFunctionId, TupleFunctionLocalId, TupleFunctionValue, ValueType,
+    };
+
+    #[test]
+    fn tuple_function_expr_kind_accessors() {
+        assert!(matches!(
+            tuple_function_value().kind(),
+            TupleFunctionExprKind::Value(_)
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::closure(
+                TupleFunctionId(0),
+                Vec::new(),
+                Vec::new(),
+                tuple_function_type(),
+                tuple_type(),
+            )
+            .kind(),
+            TupleFunctionExprKind::Closure { .. }
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::local_get(
+                TupleFunctionLocalId(0),
+                "f".into(),
+                tuple_function_type(),
+            )
+            .kind(),
+            TupleFunctionExprKind::LocalGet { .. }
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::call(
+                TupleFunctionFunctionId(0),
+                Vec::new(),
+                tuple_function_type(),
+            )
+            .kind(),
+            TupleFunctionExprKind::Call { .. }
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::function_call(
+                function_function_value(),
+                Vec::new(),
+                tuple_function_type(),
+            )
+            .kind(),
+            TupleFunctionExprKind::FunctionCall { .. }
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::tuple_index(tuple_expr(), 0, tuple_function_type()).kind(),
+            TupleFunctionExprKind::TupleIndex { .. }
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                tuple_function_value(),
+                tuple_function_value(),
+            )
+            .kind(),
+            TupleFunctionExprKind::BoolCase { .. }
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), tuple_function_value())],
+                tuple_function_value(),
+            )
+            .kind(),
+            TupleFunctionExprKind::IntCase { .. }
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::string_case(
+                crate::plan::StringExpr::value("one".into()),
+                vec![("one".into(), tuple_function_value())],
+                tuple_function_value(),
+            )
+            .kind(),
+            TupleFunctionExprKind::StringCase { .. }
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::float_case(
+                crate::plan::FloatExpr::value(1.0),
+                vec![(1.0, tuple_function_value())],
+                tuple_function_value(),
+            )
+            .kind(),
+            TupleFunctionExprKind::FloatCase { .. }
+        ));
+        assert!(matches!(
+            TupleFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                tuple_function_value(),
+            )
+            .kind(),
+            TupleFunctionExprKind::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn tuple_function_expr_type() {
+        assert_eq!(tuple_function_value().type_(), &tuple_function_type());
+        assert_eq!(
+            TupleFunctionExpr::closure(
+                TupleFunctionId(0),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                Vec::new(),
+                tuple_function_type(),
+                tuple_type(),
+            )
+            .type_(),
+            &tuple_function_type(),
+        );
+        assert_eq!(
+            TupleFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                tuple_function_value(),
+                tuple_function_value(),
+            )
+            .type_(),
+            &tuple_function_type(),
+        );
+        assert_eq!(
+            TupleFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), tuple_function_value())],
+                tuple_function_value(),
+            )
+            .type_(),
+            &tuple_function_type(),
+        );
+        assert_eq!(
+            TupleFunctionExpr::block(Vec::new(), tuple_function_value()).type_(),
+            &tuple_function_type(),
+        );
+    }
+
+    fn tuple_function_value() -> TupleFunctionExpr {
+        TupleFunctionExpr::value(TupleFunctionValue::new(
+            TupleFunctionId(0),
+            vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+            tuple_type(),
+        ))
+    }
+
+    fn tuple_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Int], ValueType::Tuple(tuple_type()))
+    }
+
+    fn tuple_type() -> Vec<ValueType> {
+        vec![ValueType::Int]
+    }
+
+    fn tuple_expr() -> TupleExpr {
+        TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Function(Box::new(tuple_function_type()))],
+        )
+    }
+
+    fn function_function_value() -> FunctionFunctionExpr {
+        FunctionFunctionExpr::value(FunctionFunctionValue::new(
+            FunctionFunctionId::Tuple(TupleFunctionFunctionId(0)),
+            Vec::new(),
+            tuple_function_type(),
+        ))
+    }
+}

--- a/src/plan/expression/int.rs
+++ b/src/plan/expression/int.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg, FloatExpr, IntFunctionExpr, StringExpr};
+use super::{BoolExpr, CallArg, FloatExpr, IntFunctionExpr, StringExpr, TupleExpr};
 use crate::plan::{IntFunctionId, IntLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -22,6 +22,10 @@ pub(crate) enum IntExprKind {
     FunctionCall {
         function: Box<IntFunctionExpr>,
         args: Vec<CallArg>,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
     },
     Add {
         left: Box<IntExpr>,
@@ -94,6 +98,15 @@ impl IntExpr {
             kind: IntExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize) -> Self {
+        Self {
+            kind: IntExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
             },
         }
     }
@@ -238,6 +251,17 @@ mod tests {
         assert!(matches!(
             IntExpr::function_call(function_expr(), Vec::new()).kind(),
             IntExprKind::FunctionCall { .. }
+        ));
+        assert!(matches!(
+            IntExpr::tuple_index(
+                crate::plan::TupleExpr::value(
+                    vec![Expr::int(IntExpr::value(1.into()))],
+                    vec![crate::plan::ValueType::Int],
+                ),
+                0,
+            )
+            .kind(),
+            IntExprKind::TupleIndex { .. }
         ));
         assert!(matches!(
             IntExpr::int_case(

--- a/src/plan/expression/nil.rs
+++ b/src/plan/expression/nil.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg, FloatExpr, IntExpr, NilFunctionExpr, StringExpr};
+use super::{BoolExpr, CallArg, FloatExpr, IntExpr, NilFunctionExpr, StringExpr, TupleExpr};
 use crate::plan::{NilFunctionId, NilLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -22,6 +22,10 @@ pub(crate) enum NilExprKind {
     FunctionCall {
         function: Box<NilFunctionExpr>,
         args: Vec<CallArg>,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
     },
     BoolCase {
         subject: Box<BoolExpr>,
@@ -73,6 +77,15 @@ impl NilExpr {
             kind: NilExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize) -> Self {
+        Self {
+            kind: NilExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
             },
         }
     }
@@ -154,6 +167,17 @@ mod tests {
         assert!(matches!(
             NilExpr::function_call(function_expr(), Vec::new()).kind(),
             NilExprKind::FunctionCall { .. }
+        ));
+        assert!(matches!(
+            NilExpr::tuple_index(
+                crate::plan::TupleExpr::value(
+                    vec![Expr::nil(NilExpr::value())],
+                    vec![crate::plan::ValueType::Nil],
+                ),
+                0,
+            )
+            .kind(),
+            NilExprKind::TupleIndex { .. }
         ));
         assert!(matches!(
             NilExpr::bool_case(BoolExpr::value(true), NilExpr::value(), NilExpr::value()).kind(),

--- a/src/plan/expression/string.rs
+++ b/src/plan/expression/string.rs
@@ -1,4 +1,4 @@
-use super::{BoolExpr, CallArg, FloatExpr, IntExpr, StringFunctionExpr};
+use super::{BoolExpr, CallArg, FloatExpr, IntExpr, StringFunctionExpr, TupleExpr};
 use crate::plan::{Step, StringFunctionId, StringLocalId};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -22,6 +22,10 @@ pub(crate) enum StringExprKind {
     FunctionCall {
         function: Box<StringFunctionExpr>,
         args: Vec<CallArg>,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
     },
     Concatenate {
         left: Box<StringExpr>,
@@ -77,6 +81,15 @@ impl StringExpr {
             kind: StringExprKind::FunctionCall {
                 function: Box::new(function),
                 args,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize) -> Self {
+        Self {
+            kind: StringExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
             },
         }
     }
@@ -179,6 +192,17 @@ mod tests {
         assert!(matches!(
             StringExpr::function_call(function_expr(), Vec::new()).kind(),
             StringExprKind::FunctionCall { .. }
+        ));
+        assert!(matches!(
+            StringExpr::tuple_index(
+                crate::plan::TupleExpr::value(
+                    vec![Expr::string(StringExpr::value("geam".into()))],
+                    vec![crate::plan::ValueType::String],
+                ),
+                0,
+            )
+            .kind(),
+            StringExprKind::TupleIndex { .. }
         ));
         assert!(matches!(
             StringExpr::int_case(

--- a/src/plan/expression/tuple.rs
+++ b/src/plan/expression/tuple.rs
@@ -1,0 +1,316 @@
+use super::{BoolExpr, CallArg, FloatExpr, IntExpr, StringExpr, TupleFunctionExpr};
+use crate::plan::{Step, TupleFunctionId, TupleLocalId, ValueType};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TupleExpr {
+    type_: Vec<ValueType>,
+    kind: TupleExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum TupleExprKind {
+    Value(Vec<super::Expr>),
+    LocalGet {
+        local: TupleLocalId,
+        name: EcoString,
+    },
+    Call {
+        function: TupleFunctionId,
+        args: Vec<CallArg>,
+    },
+    FunctionCall {
+        function: Box<TupleFunctionExpr>,
+        args: Vec<CallArg>,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
+    },
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<TupleExpr>,
+        false_: Box<TupleExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, TupleExpr)>,
+        fallback: Box<TupleExpr>,
+    },
+    StringCase {
+        subject: Box<StringExpr>,
+        clauses: Vec<(EcoString, TupleExpr)>,
+        fallback: Box<TupleExpr>,
+    },
+    FloatCase {
+        subject: Box<FloatExpr>,
+        clauses: Vec<(f64, TupleExpr)>,
+        fallback: Box<TupleExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<TupleExpr>,
+    },
+}
+
+impl TupleExpr {
+    pub(crate) fn value(elements: Vec<super::Expr>, type_: Vec<ValueType>) -> Self {
+        Self {
+            type_,
+            kind: TupleExprKind::Value(elements),
+        }
+    }
+
+    pub(crate) fn local_get(local: TupleLocalId, name: EcoString, type_: Vec<ValueType>) -> Self {
+        Self {
+            type_,
+            kind: TupleExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn call(
+        function: TupleFunctionId,
+        args: Vec<CallArg>,
+        type_: Vec<ValueType>,
+    ) -> Self {
+        Self {
+            type_,
+            kind: TupleExprKind::Call { function, args },
+        }
+    }
+
+    pub(crate) fn function_call(
+        function: TupleFunctionExpr,
+        args: Vec<CallArg>,
+        type_: Vec<ValueType>,
+    ) -> Self {
+        Self {
+            type_,
+            kind: TupleExprKind::FunctionCall {
+                function: Box::new(function),
+                args,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize, type_: Vec<ValueType>) -> Self {
+        Self {
+            type_,
+            kind: TupleExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
+            },
+        }
+    }
+
+    pub(crate) fn bool_case(subject: BoolExpr, true_: TupleExpr, false_: TupleExpr) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: TupleExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, TupleExpr)>,
+        fallback: TupleExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: TupleExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn string_case(
+        subject: StringExpr,
+        clauses: Vec<(EcoString, TupleExpr)>,
+        fallback: TupleExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: TupleExprKind::StringCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn float_case(
+        subject: FloatExpr,
+        clauses: Vec<(f64, TupleExpr)>,
+        fallback: TupleExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: TupleExprKind::FloatCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: TupleExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: TupleExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &[ValueType] {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &TupleExprKind {
+        &self.kind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TupleExpr, TupleExprKind};
+    use crate::plan::{
+        BoolExpr, Expr, FunctionType, IntExpr, Step, TupleFunctionExpr, TupleFunctionId,
+        TupleFunctionValue, TupleLocalId, ValueType,
+    };
+
+    #[test]
+    fn tuple_expr_kind_accessors() {
+        assert!(matches!(tuple_value().kind(), TupleExprKind::Value(_)));
+        assert!(matches!(
+            TupleExpr::local_get(TupleLocalId(0), "pair".into(), tuple_type()).kind(),
+            TupleExprKind::LocalGet { .. }
+        ));
+        assert!(matches!(
+            TupleExpr::call(TupleFunctionId(0), Vec::new(), tuple_type()).kind(),
+            TupleExprKind::Call { .. }
+        ));
+        assert!(matches!(
+            TupleExpr::function_call(tuple_function_expr(), Vec::new(), tuple_type()).kind(),
+            TupleExprKind::FunctionCall { .. }
+        ));
+        assert!(matches!(
+            TupleExpr::tuple_index(tuple_value(), 0, tuple_type()).kind(),
+            TupleExprKind::TupleIndex { .. }
+        ));
+        assert!(matches!(
+            TupleExpr::bool_case(BoolExpr::value(true), tuple_value(), tuple_value()).kind(),
+            TupleExprKind::BoolCase { .. }
+        ));
+        assert!(matches!(
+            TupleExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), tuple_value())],
+                tuple_value(),
+            )
+            .kind(),
+            TupleExprKind::IntCase { .. }
+        ));
+        assert!(matches!(
+            TupleExpr::string_case(
+                crate::plan::StringExpr::value("one".into()),
+                vec![("one".into(), tuple_value())],
+                tuple_value(),
+            )
+            .kind(),
+            TupleExprKind::StringCase { .. }
+        ));
+        assert!(matches!(
+            TupleExpr::float_case(
+                crate::plan::FloatExpr::value(1.0),
+                vec![(1.0, tuple_value())],
+                tuple_value(),
+            )
+            .kind(),
+            TupleExprKind::FloatCase { .. }
+        ));
+        assert!(matches!(
+            TupleExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                tuple_value(),
+            )
+            .kind(),
+            TupleExprKind::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn tuple_expr_type() {
+        assert_eq!(tuple_value().type_(), tuple_type());
+        assert_eq!(
+            TupleExpr::bool_case(BoolExpr::value(true), tuple_value(), tuple_value()).type_(),
+            tuple_type(),
+        );
+        assert_eq!(
+            TupleExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), tuple_value())],
+                tuple_value(),
+            )
+            .type_(),
+            tuple_type(),
+        );
+        assert_eq!(
+            TupleExpr::string_case(
+                crate::plan::StringExpr::value("one".into()),
+                vec![("one".into(), tuple_value())],
+                tuple_value(),
+            )
+            .type_(),
+            tuple_type(),
+        );
+        assert_eq!(
+            TupleExpr::float_case(
+                crate::plan::FloatExpr::value(1.0),
+                vec![(1.0, tuple_value())],
+                tuple_value(),
+            )
+            .type_(),
+            tuple_type(),
+        );
+        assert_eq!(
+            TupleExpr::block(Vec::new(), tuple_value()).type_(),
+            tuple_type(),
+        );
+    }
+
+    fn tuple_value() -> TupleExpr {
+        TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        )
+    }
+
+    fn tuple_type() -> Vec<ValueType> {
+        vec![ValueType::Int]
+    }
+
+    fn tuple_function_expr() -> TupleFunctionExpr {
+        TupleFunctionExpr::value(TupleFunctionValue::new(
+            TupleFunctionId(0),
+            Vec::new(),
+            tuple_type(),
+        ))
+    }
+
+    #[test]
+    fn tuple_function_value_type_fixture() {
+        assert_eq!(
+            tuple_function_expr().type_(),
+            &FunctionType::new(Vec::new(), ValueType::Tuple(tuple_type())),
+        );
+    }
+}

--- a/src/plan/frame.rs
+++ b/src/plan/frame.rs
@@ -8,7 +8,7 @@ use super::function::{Param, ParamLocal, ReturnExpr};
 use super::id::{
     BoolFunctionLocalId, BoolLocalId, FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId,
     IntFunctionLocalId, IntLocalId, NilFunctionLocalId, NilLocalId, StringFunctionLocalId,
-    StringLocalId,
+    StringLocalId, TupleFunctionLocalId, TupleLocalId,
 };
 use super::step::Step;
 
@@ -19,11 +19,13 @@ pub(crate) struct FrameLayout {
     strings: usize,
     bools: usize,
     nils: usize,
+    tuples: usize,
     int_functions: usize,
     float_functions: usize,
     string_functions: usize,
     bool_functions: usize,
     nil_functions: usize,
+    tuple_functions: usize,
     function_functions: usize,
 }
 
@@ -51,11 +53,13 @@ impl FrameLayout {
             ParamLocal::String(local) => self.include_string(*local),
             ParamLocal::Bool(local) => self.include_bool(*local),
             ParamLocal::Nil(local) => self.include_nil(*local),
+            ParamLocal::Tuple { local, .. } => self.include_tuple(*local),
             ParamLocal::IntFunction { local, .. } => self.include_int_function(*local),
             ParamLocal::FloatFunction { local, .. } => self.include_float_function(*local),
             ParamLocal::StringFunction { local, .. } => self.include_string_function(*local),
             ParamLocal::BoolFunction { local, .. } => self.include_bool_function(*local),
             ParamLocal::NilFunction { local, .. } => self.include_nil_function(*local),
+            ParamLocal::TupleFunction { local, .. } => self.include_tuple_function(*local),
             ParamLocal::FunctionFunction { local, .. } => self.include_function_function(*local),
         }
     }
@@ -80,6 +84,10 @@ impl FrameLayout {
         self.nils = self.nils.max(local.0 + 1);
     }
 
+    pub(crate) fn include_tuple(&mut self, local: TupleLocalId) {
+        self.tuples = self.tuples.max(local.0 + 1);
+    }
+
     pub(crate) fn include_int_function(&mut self, local: IntFunctionLocalId) {
         self.int_functions = self.int_functions.max(local.0 + 1);
     }
@@ -98,6 +106,10 @@ impl FrameLayout {
 
     pub(crate) fn include_nil_function(&mut self, local: NilFunctionLocalId) {
         self.nil_functions = self.nil_functions.max(local.0 + 1);
+    }
+
+    pub(crate) fn include_tuple_function(&mut self, local: TupleFunctionLocalId) {
+        self.tuple_functions = self.tuple_functions.max(local.0 + 1);
     }
 
     pub(crate) fn include_function_function(&mut self, local: FunctionFunctionLocalId) {
@@ -125,6 +137,10 @@ impl FrameLayout {
         self.nils
     }
 
+    pub(crate) fn tuples(self) -> usize {
+        self.tuples
+    }
+
     pub(crate) fn int_functions(self) -> usize {
         self.int_functions
     }
@@ -143,6 +159,10 @@ impl FrameLayout {
 
     pub(crate) fn nil_functions(self) -> usize {
         self.nil_functions
+    }
+
+    pub(crate) fn tuple_functions(self) -> usize {
+        self.tuple_functions
     }
 
     pub(crate) fn function_functions(self) -> usize {
@@ -208,7 +228,8 @@ mod tests {
     use super::FrameLayout;
     use crate::plan::{
         BoolLocalId, FloatFunctionLocalId, FloatLocalId, IntFunctionLocalId, IntLocalId,
-        NilFunctionLocalId, NilLocalId, ParamLocal, StringLocalId,
+        NilFunctionLocalId, NilLocalId, ParamLocal, StringLocalId, TupleFunctionLocalId,
+        TupleLocalId, ValueType,
     };
 
     #[test]
@@ -219,7 +240,7 @@ mod tests {
         assert_eq!(layout, cloned);
         assert_eq!(
             format!("{layout:?}"),
-            "FrameLayout { ints: 0, floats: 0, strings: 0, bools: 0, nils: 0, int_functions: 0, float_functions: 0, string_functions: 0, bool_functions: 0, nil_functions: 0, function_functions: 0 }",
+            "FrameLayout { ints: 0, floats: 0, strings: 0, bools: 0, nils: 0, tuples: 0, int_functions: 0, float_functions: 0, string_functions: 0, bool_functions: 0, nil_functions: 0, tuple_functions: 0, function_functions: 0 }",
         );
     }
 
@@ -236,17 +257,24 @@ mod tests {
         layout.include_local(&ParamLocal::string(StringLocalId(2)));
         layout.include_local(&ParamLocal::bool(BoolLocalId(3)));
         layout.include_local(&ParamLocal::nil(NilLocalId(4)));
+        layout.include_local(&ParamLocal::tuple(TupleLocalId(5), vec![ValueType::Int]));
         layout.include_int_function(IntFunctionLocalId(5));
         layout.include_float_function(FloatFunctionLocalId(6));
         layout.include_nil_function(NilFunctionLocalId(7));
+        layout.include_local(&ParamLocal::tuple_function(
+            TupleFunctionLocalId(8),
+            crate::plan::FunctionType::new(Vec::new(), ValueType::Tuple(vec![ValueType::Int])),
+        ));
 
         assert_eq!(layout.ints(), 2);
         assert_eq!(layout.floats(), 3);
         assert_eq!(layout.strings(), 3);
         assert_eq!(layout.bools(), 4);
         assert_eq!(layout.nils(), 5);
+        assert_eq!(layout.tuples(), 6);
         assert_eq!(layout.int_functions(), 6);
         assert_eq!(layout.float_functions(), 7);
         assert_eq!(layout.nil_functions(), 8);
+        assert_eq!(layout.tuple_functions(), 9);
     }
 }

--- a/src/plan/frame/args.rs
+++ b/src/plan/frame/args.rs
@@ -10,6 +10,7 @@ impl FrameLayout {
                 CallArgKind::Float { value, .. } => self.include_float_expr(value),
                 CallArgKind::Bool { value, .. } => self.include_bool_expr(value),
                 CallArgKind::Nil { value, .. } => self.include_nil_expr(value),
+                CallArgKind::Tuple { value, .. } => self.include_tuple_expr(value),
                 CallArgKind::IntFunction { value, .. } => self.include_int_function_expr(value),
                 CallArgKind::StringFunction { value, .. } => {
                     self.include_string_function_expr(value);
@@ -19,6 +20,9 @@ impl FrameLayout {
                 }
                 CallArgKind::BoolFunction { value, .. } => self.include_bool_function_expr(value),
                 CallArgKind::NilFunction { value, .. } => self.include_nil_function_expr(value),
+                CallArgKind::TupleFunction { value, .. } => {
+                    self.include_tuple_function_expr(value);
+                }
                 CallArgKind::FunctionFunction { value, .. } => {
                     self.include_function_function_expr(value);
                 }
@@ -34,6 +38,7 @@ impl FrameLayout {
                 CaptureArgKind::Float { value, .. } => self.include_float_expr(value),
                 CaptureArgKind::Bool { value, .. } => self.include_bool_expr(value),
                 CaptureArgKind::Nil { value, .. } => self.include_nil_expr(value),
+                CaptureArgKind::Tuple { value, .. } => self.include_tuple_expr(value),
                 CaptureArgKind::IntFunction { value, .. } => self.include_int_function_expr(value),
                 CaptureArgKind::StringFunction { value, .. } => {
                     self.include_string_function_expr(value);
@@ -45,6 +50,9 @@ impl FrameLayout {
                     self.include_bool_function_expr(value)
                 }
                 CaptureArgKind::NilFunction { value, .. } => self.include_nil_function_expr(value),
+                CaptureArgKind::TupleFunction { value, .. } => {
+                    self.include_tuple_function_expr(value);
+                }
                 CaptureArgKind::FunctionFunction { value, .. } => {
                     self.include_function_function_expr(value);
                 }
@@ -61,7 +69,8 @@ mod tests {
         FloatFunctionExpr, FloatFunctionLocalId, FloatLocalId, FunctionExpr, FunctionFunctionExpr,
         FunctionFunctionId, FunctionFunctionLocalId, IntExpr, IntFunctionFunctionId, IntFunctionId,
         IntFunctionLocalId, ReturnExpr, Step, StringExpr, StringFunctionExpr,
-        StringFunctionLocalId, StringLocalId,
+        StringFunctionLocalId, StringLocalId, TupleExpr, TupleFunctionExpr, TupleFunctionLocalId,
+        TupleLocalId, ValueType,
     };
 
     #[test]
@@ -115,6 +124,18 @@ mod tests {
                                 .clone(),
                         ),
                     ),
+                    CallArg::tuple(
+                        TupleLocalId(1),
+                        TupleExpr::local_get(TupleLocalId(1), "tuple_arg".into(), tuple_type()),
+                    ),
+                    CallArg::tuple_function(
+                        TupleFunctionLocalId(1),
+                        TupleFunctionExpr::local_get(
+                            TupleFunctionLocalId(1),
+                            "tuple_function_arg".into(),
+                            tuple_function_type(),
+                        ),
+                    ),
                     CallArg::function_function(
                         FunctionFunctionLocalId(1),
                         FunctionFunctionExpr::local_get(
@@ -150,6 +171,14 @@ mod tests {
                             crate::plan::NilExpr::local_get(
                                 crate::plan::NilLocalId(17),
                                 "nil_capture".into(),
+                            ),
+                        ),
+                        CaptureArg::tuple(
+                            TupleLocalId(2),
+                            TupleExpr::local_get(
+                                TupleLocalId(2),
+                                "tuple_capture".into(),
+                                tuple_type(),
                             ),
                         ),
                         CaptureArg::int_function(
@@ -200,6 +229,14 @@ mod tests {
                                     .clone(),
                             ),
                         ),
+                        CaptureArg::tuple_function(
+                            TupleFunctionLocalId(2),
+                            TupleFunctionExpr::local_get(
+                                TupleFunctionLocalId(2),
+                                "tuple_function_capture".into(),
+                                tuple_function_type(),
+                            ),
+                        ),
                         CaptureArg::function_function(
                             FunctionFunctionLocalId(2),
                             FunctionFunctionExpr::local_get(
@@ -228,5 +265,18 @@ mod tests {
         assert_eq!(layout.int_functions(), 19);
         assert_eq!(layout.float_functions(), 22);
         assert_eq!(layout.floats(), 21);
+        assert_eq!(layout.tuples(), 3);
+        assert_eq!(layout.tuple_functions(), 3);
+    }
+
+    fn tuple_type() -> Vec<ValueType> {
+        vec![ValueType::Int]
+    }
+
+    fn tuple_function_type() -> crate::plan::FunctionType {
+        crate::plan::FunctionType::new(
+            vec![ValueType::Tuple(tuple_type())],
+            ValueType::Tuple(tuple_type()),
+        )
     }
 }

--- a/src/plan/frame/expression.rs
+++ b/src/plan/frame/expression.rs
@@ -1,7 +1,7 @@
 use super::FrameLayout;
 use crate::plan::{
     BoolExpr, BoolExprKind, Expr, ExprKind, FloatExpr, FloatExprKind, IntExpr, IntExprKind,
-    NilExpr, NilExprKind, StringExpr, StringExprKind,
+    NilExpr, NilExprKind, StringExpr, StringExprKind, TupleExpr, TupleExprKind,
 };
 
 impl FrameLayout {
@@ -12,6 +12,7 @@ impl FrameLayout {
             ExprKind::Float(expression) => self.include_float_expr(expression),
             ExprKind::Bool(expression) => self.include_bool_expr(expression),
             ExprKind::Nil(expression) => self.include_nil_expr(expression),
+            ExprKind::Tuple(expression) => self.include_tuple_expr(expression),
             ExprKind::Function(expression) => self.include_function_expr(expression),
         }
     }
@@ -25,6 +26,7 @@ impl FrameLayout {
                 self.include_int_function_expr(function);
                 self.include_call_args(args);
             }
+            IntExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             IntExprKind::Add { left, right }
             | IntExprKind::Sub { left, right }
             | IntExprKind::Mult { left, right }
@@ -92,6 +94,7 @@ impl FrameLayout {
                 self.include_string_function_expr(function);
                 self.include_call_args(args);
             }
+            StringExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             StringExprKind::Concatenate { left, right } => {
                 self.include_string_expr(left);
                 self.include_string_expr(right);
@@ -154,6 +157,7 @@ impl FrameLayout {
                 self.include_bool_function_expr(function);
                 self.include_call_args(args);
             }
+            BoolExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             BoolExprKind::Not(value) => self.include_bool_expr(value),
             BoolExprKind::LtInt { left, right } => self.include_int_binary_expr(left, right),
             BoolExprKind::LtEqInt { left, right } => self.include_int_binary_expr(left, right),
@@ -245,6 +249,7 @@ impl FrameLayout {
                 self.include_nil_function_expr(function);
                 self.include_call_args(args);
             }
+            NilExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             NilExprKind::BoolCase {
                 subject,
                 true_,
@@ -303,6 +308,7 @@ impl FrameLayout {
                 self.include_float_function_expr(function);
                 self.include_call_args(args);
             }
+            FloatExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             FloatExprKind::Add { left, right }
             | FloatExprKind::Sub { left, right }
             | FloatExprKind::Mult { left, right }
@@ -358,6 +364,69 @@ impl FrameLayout {
             }
         }
     }
+
+    pub(in crate::plan::frame) fn include_tuple_expr(&mut self, expression: &TupleExpr) {
+        match expression.kind() {
+            TupleExprKind::Value(elements) => {
+                for element in elements {
+                    self.include_expr(element);
+                }
+            }
+            TupleExprKind::LocalGet { local, .. } => self.include_tuple(*local),
+            TupleExprKind::Call { args, .. } => self.include_call_args(args),
+            TupleExprKind::FunctionCall { function, args } => {
+                self.include_tuple_function_expr(function);
+                self.include_call_args(args);
+            }
+            TupleExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
+            TupleExprKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_tuple_expr(true_);
+                self.include_tuple_expr(false_);
+            }
+            TupleExprKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_expr(branch);
+                }
+                self.include_tuple_expr(fallback);
+            }
+            TupleExprKind::StringCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_string_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_expr(branch);
+                }
+                self.include_tuple_expr(fallback);
+            }
+            TupleExprKind::FloatCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_float_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_expr(branch);
+                }
+                self.include_tuple_expr(fallback);
+            }
+            TupleExprKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_tuple_expr(return_);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -365,8 +434,9 @@ mod tests {
     use super::FrameLayout;
     use crate::plan::{
         BoolExpr, BoolLocalId, CallArg, Expr, FloatExpr, FloatFunctionId, FloatFunctionLocalId,
-        FloatLocalId, IntExpr, IntFunctionId, IntLocalId, NilExpr, NilLocalId, ReturnExpr, Step,
-        StringExpr, StringLocalId,
+        FloatLocalId, FunctionType, IntExpr, IntFunctionId, IntLocalId, NilExpr, NilLocalId,
+        ReturnExpr, Step, StringExpr, StringLocalId, TupleExpr, TupleFunctionExpr, TupleFunctionId,
+        TupleFunctionLocalId, TupleLocalId, ValueType,
     };
 
     #[test]
@@ -638,6 +708,136 @@ mod tests {
                 )))],
                 FloatExpr::local_get(FloatLocalId(38), "float_block_return".into()),
             ))),
+            Step::evaluate(Expr::int(IntExpr::tuple_index(
+                TupleExpr::value(
+                    vec![Expr::int(IntExpr::local_get(
+                        IntLocalId(25),
+                        "int_tuple_index_value".into(),
+                    ))],
+                    vec![ValueType::Int],
+                ),
+                0,
+            ))),
+            Step::evaluate(Expr::string(StringExpr::tuple_index(
+                TupleExpr::value(
+                    vec![Expr::string(StringExpr::local_get(
+                        StringLocalId(18),
+                        "string_tuple_index_value".into(),
+                    ))],
+                    vec![ValueType::String],
+                ),
+                0,
+            ))),
+            Step::evaluate(Expr::float(FloatExpr::tuple_index(
+                TupleExpr::value(
+                    vec![Expr::float(FloatExpr::local_get(
+                        FloatLocalId(40),
+                        "float_tuple_index_value".into(),
+                    ))],
+                    vec![ValueType::Float],
+                ),
+                0,
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::value(
+                vec![
+                    Expr::int(IntExpr::local_get(IntLocalId(22), "tuple_int".into())),
+                    Expr::string(StringExpr::local_get(
+                        StringLocalId(16),
+                        "tuple_string".into(),
+                    )),
+                ],
+                vec![ValueType::Int, ValueType::String],
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::local_get(
+                TupleLocalId(0),
+                "tuple_local".into(),
+                vec![ValueType::Int],
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::call(
+                TupleFunctionId(0),
+                vec![CallArg::tuple(
+                    TupleLocalId(1),
+                    TupleExpr::local_get(TupleLocalId(2), "tuple_call_arg".into(), tuple_type()),
+                )],
+                tuple_type(),
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::function_call(
+                TupleFunctionExpr::local_get(
+                    TupleFunctionLocalId(0),
+                    "tuple_function".into(),
+                    tuple_function_type(),
+                ),
+                vec![CallArg::tuple(
+                    TupleLocalId(3),
+                    TupleExpr::local_get(
+                        TupleLocalId(4),
+                        "tuple_function_call_arg".into(),
+                        tuple_type(),
+                    ),
+                )],
+                tuple_type(),
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::tuple_index(
+                TupleExpr::local_get(
+                    TupleLocalId(5),
+                    "tuple_index_subject".into(),
+                    vec![ValueType::Tuple(tuple_type())],
+                ),
+                0,
+                tuple_type(),
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::bool_case(
+                BoolExpr::local_get(BoolLocalId(14), "tuple_bool_case_subject".into()),
+                TupleExpr::local_get(TupleLocalId(6), "tuple_bool_true".into(), tuple_type()),
+                TupleExpr::local_get(TupleLocalId(7), "tuple_bool_false".into(), tuple_type()),
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::int_case(
+                IntExpr::local_get(IntLocalId(23), "tuple_int_case_subject".into()),
+                vec![(
+                    1.into(),
+                    TupleExpr::local_get(TupleLocalId(8), "tuple_int_branch".into(), tuple_type()),
+                )],
+                TupleExpr::local_get(TupleLocalId(9), "tuple_int_fallback".into(), tuple_type()),
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::string_case(
+                StringExpr::local_get(StringLocalId(17), "tuple_string_case_subject".into()),
+                vec![(
+                    "one".into(),
+                    TupleExpr::local_get(
+                        TupleLocalId(10),
+                        "tuple_string_branch".into(),
+                        tuple_type(),
+                    ),
+                )],
+                TupleExpr::local_get(
+                    TupleLocalId(11),
+                    "tuple_string_fallback".into(),
+                    tuple_type(),
+                ),
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::float_case(
+                FloatExpr::local_get(FloatLocalId(39), "tuple_float_case_subject".into()),
+                vec![(
+                    1.0,
+                    TupleExpr::local_get(
+                        TupleLocalId(12),
+                        "tuple_float_branch".into(),
+                        tuple_type(),
+                    ),
+                )],
+                TupleExpr::local_get(
+                    TupleLocalId(13),
+                    "tuple_float_fallback".into(),
+                    tuple_type(),
+                ),
+            ))),
+            Step::evaluate(Expr::tuple(TupleExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::local_get(
+                    IntLocalId(24),
+                    "tuple_block_step".into(),
+                )))],
+                TupleExpr::local_get(TupleLocalId(14), "tuple_block_return".into(), tuple_type()),
+            ))),
             Step::evaluate(Expr::nil(NilExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::local_get(
                     IntLocalId(6),
@@ -650,11 +850,24 @@ mod tests {
 
         let layout = FrameLayout::from_function_parts(&[], &steps, &return_);
 
-        assert_eq!(layout.ints(), 22);
-        assert_eq!(layout.floats(), 39);
-        assert_eq!(layout.strings(), 16);
-        assert_eq!(layout.bools(), 14);
+        assert_eq!(layout.ints(), 26);
+        assert_eq!(layout.floats(), 41);
+        assert_eq!(layout.strings(), 19);
+        assert_eq!(layout.bools(), 15);
         assert_eq!(layout.nils(), 11);
+        assert_eq!(layout.tuples(), 15);
         assert_eq!(layout.float_functions(), 1);
+        assert_eq!(layout.tuple_functions(), 1);
+    }
+
+    fn tuple_type() -> Vec<ValueType> {
+        vec![ValueType::Int]
+    }
+
+    fn tuple_function_type() -> FunctionType {
+        FunctionType::new(
+            vec![ValueType::Tuple(tuple_type())],
+            ValueType::Tuple(tuple_type()),
+        )
     }
 }

--- a/src/plan/frame/function.rs
+++ b/src/plan/frame/function.rs
@@ -3,7 +3,7 @@ use crate::plan::{
     BoolFunctionExpr, BoolFunctionExprKind, FloatFunctionExpr, FloatFunctionExprKind, FunctionExpr,
     FunctionExprKind, FunctionFunctionExpr, FunctionFunctionExprKind, IntFunctionExpr,
     IntFunctionExprKind, NilFunctionExpr, NilFunctionExprKind, StringFunctionExpr,
-    StringFunctionExprKind,
+    StringFunctionExprKind, TupleFunctionExpr, TupleFunctionExprKind,
 };
 
 impl FrameLayout {
@@ -14,6 +14,7 @@ impl FrameLayout {
             FunctionExprKind::Float(expression) => self.include_float_function_expr(expression),
             FunctionExprKind::Bool(expression) => self.include_bool_function_expr(expression),
             FunctionExprKind::Nil(expression) => self.include_nil_function_expr(expression),
+            FunctionExprKind::Tuple(expression) => self.include_tuple_function_expr(expression),
             FunctionExprKind::Function(expression) => {
                 self.include_function_function_expr(expression);
             }
@@ -33,6 +34,7 @@ impl FrameLayout {
                 self.include_function_function_expr(function);
                 self.include_call_args(args);
             }
+            IntFunctionExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             IntFunctionExprKind::BoolCase {
                 subject,
                 true_,
@@ -95,6 +97,7 @@ impl FrameLayout {
                 self.include_function_function_expr(function);
                 self.include_call_args(args);
             }
+            FloatFunctionExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             FloatFunctionExprKind::BoolCase {
                 subject,
                 true_,
@@ -159,6 +162,7 @@ impl FrameLayout {
                 self.include_function_function_expr(function);
                 self.include_call_args(args);
             }
+            StringFunctionExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             StringFunctionExprKind::BoolCase {
                 subject,
                 true_,
@@ -221,6 +225,7 @@ impl FrameLayout {
                 self.include_function_function_expr(function);
                 self.include_call_args(args);
             }
+            BoolFunctionExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             BoolFunctionExprKind::BoolCase {
                 subject,
                 true_,
@@ -283,6 +288,7 @@ impl FrameLayout {
                 self.include_function_function_expr(function);
                 self.include_call_args(args);
             }
+            NilFunctionExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             NilFunctionExprKind::BoolCase {
                 subject,
                 true_,
@@ -349,6 +355,7 @@ impl FrameLayout {
                 self.include_function_function_expr(function);
                 self.include_call_args(args);
             }
+            FunctionFunctionExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
             FunctionFunctionExprKind::BoolCase {
                 subject,
                 true_,
@@ -397,6 +404,69 @@ impl FrameLayout {
             }
         }
     }
+
+    pub(in crate::plan::frame) fn include_tuple_function_expr(
+        &mut self,
+        expression: &TupleFunctionExpr,
+    ) {
+        match expression.kind() {
+            TupleFunctionExprKind::Value(_) => {}
+            TupleFunctionExprKind::Closure { captures, .. } => self.include_capture_args(captures),
+            TupleFunctionExprKind::LocalGet { local, .. } => self.include_tuple_function(*local),
+            TupleFunctionExprKind::Call { args, .. } => self.include_call_args(args),
+            TupleFunctionExprKind::FunctionCall { function, args, .. } => {
+                self.include_function_function_expr(function);
+                self.include_call_args(args);
+            }
+            TupleFunctionExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
+            TupleFunctionExprKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_tuple_function_expr(true_);
+                self.include_tuple_function_expr(false_);
+            }
+            TupleFunctionExprKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_function_expr(branch);
+                }
+                self.include_tuple_function_expr(fallback);
+            }
+            TupleFunctionExprKind::StringCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_string_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_function_expr(branch);
+                }
+                self.include_tuple_function_expr(fallback);
+            }
+            TupleFunctionExprKind::FloatCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_float_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_function_expr(branch);
+                }
+                self.include_tuple_function_expr(fallback);
+            }
+            TupleFunctionExprKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_tuple_function_expr(return_);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -408,7 +478,8 @@ mod tests {
         FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionLocalId, FunctionType, IntExpr,
         IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId, IntLocalId,
         NilFunctionExpr, NilFunctionId, NilFunctionLocalId, ReturnExpr, Step, StringExpr,
-        StringFunctionExpr, StringFunctionId, StringFunctionLocalId, ValueType,
+        StringFunctionExpr, StringFunctionId, StringFunctionLocalId, TupleExpr, TupleFunctionExpr,
+        TupleFunctionFunctionId, TupleFunctionId, TupleFunctionLocalId, TupleLocalId, ValueType,
     };
 
     #[test]
@@ -702,6 +773,161 @@ mod tests {
     }
 
     #[test]
+    fn frame_layout_includes_tuple_function_expression_families() {
+        let tuple_function_type = tuple_function_type();
+        let tuple_function_callee_type = FunctionType::new(
+            vec![ValueType::Int],
+            ValueType::Function(Box::new(tuple_function_type.clone())),
+        );
+        let tuple_type = tuple_type();
+        let steps = vec![
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::closure(
+                    TupleFunctionId(1),
+                    Vec::new(),
+                    vec![CaptureArg::int(
+                        IntLocalId(10),
+                        IntExpr::local_get(IntLocalId(10), "closure_capture".into()),
+                    )],
+                    tuple_function_type.clone(),
+                    tuple_type.clone(),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::local_get(
+                    TupleFunctionLocalId(2),
+                    "local_function".into(),
+                    tuple_function_type.clone(),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::call(
+                    TupleFunctionFunctionId(0),
+                    vec![CallArg::int(
+                        IntLocalId(0),
+                        IntExpr::local_get(IntLocalId(11), "direct_arg".into()),
+                    )],
+                    tuple_function_type.clone(),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::function_call(
+                    FunctionFunctionExpr::local_get(
+                        FunctionFunctionLocalId(3),
+                        "callee".into(),
+                        tuple_function_callee_type,
+                    ),
+                    vec![CallArg::int(
+                        IntLocalId(0),
+                        IntExpr::local_get(IntLocalId(12), "function_arg".into()),
+                    )],
+                    tuple_function_type.clone(),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::tuple_index(
+                    TupleExpr::local_get(TupleLocalId(1), "tuple".into(), tuple_type.clone()),
+                    0,
+                    tuple_function_type.clone(),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::bool_case(
+                    BoolExpr::local_get(crate::plan::BoolLocalId(4), "flag".into()),
+                    TupleFunctionExpr::local_get(
+                        TupleFunctionLocalId(5),
+                        "true_branch".into(),
+                        tuple_function_type.clone(),
+                    ),
+                    TupleFunctionExpr::local_get(
+                        TupleFunctionLocalId(6),
+                        "false_branch".into(),
+                        tuple_function_type.clone(),
+                    ),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::int_case(
+                    IntExpr::local_get(IntLocalId(13), "int_subject".into()),
+                    vec![(
+                        1.into(),
+                        TupleFunctionExpr::local_get(
+                            TupleFunctionLocalId(7),
+                            "int_branch".into(),
+                            tuple_function_type.clone(),
+                        ),
+                    )],
+                    TupleFunctionExpr::local_get(
+                        TupleFunctionLocalId(8),
+                        "int_fallback".into(),
+                        tuple_function_type.clone(),
+                    ),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::string_case(
+                    StringExpr::local_get(crate::plan::StringLocalId(9), "string_subject".into()),
+                    vec![(
+                        "hit".into(),
+                        TupleFunctionExpr::local_get(
+                            TupleFunctionLocalId(10),
+                            "string_branch".into(),
+                            tuple_function_type.clone(),
+                        ),
+                    )],
+                    TupleFunctionExpr::local_get(
+                        TupleFunctionLocalId(11),
+                        "string_fallback".into(),
+                        tuple_function_type.clone(),
+                    ),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::float_case(
+                    FloatExpr::local_get(crate::plan::FloatLocalId(2), "float_subject".into()),
+                    vec![(
+                        1.0,
+                        TupleFunctionExpr::local_get(
+                            TupleFunctionLocalId(12),
+                            "float_branch".into(),
+                            tuple_function_type.clone(),
+                        ),
+                    )],
+                    TupleFunctionExpr::local_get(
+                        TupleFunctionLocalId(13),
+                        "float_fallback".into(),
+                        tuple_function_type.clone(),
+                    ),
+                ),
+            ))),
+            Step::evaluate(Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::local_get(
+                        IntLocalId(14),
+                        "block_step".into(),
+                    )))],
+                    TupleFunctionExpr::local_get(
+                        TupleFunctionLocalId(14),
+                        "block_return".into(),
+                        tuple_function_type,
+                    ),
+                ),
+            ))),
+        ];
+        let return_ = ReturnExpr::int(IntFunctionId(0), IntExpr::value(0.into()));
+
+        let layout = FrameLayout::from_function_parts(&[], &steps, &return_);
+
+        assert_eq!(layout.ints(), 15);
+        assert_eq!(layout.floats(), 3);
+        assert_eq!(layout.strings(), 10);
+        assert_eq!(layout.bools(), 5);
+        assert_eq!(layout.tuples(), 2);
+        assert_eq!(layout.function_functions(), 4);
+        assert_eq!(layout.tuple_functions(), 15);
+    }
+
+    #[test]
     fn frame_layout_includes_function_expression_float_case_families() {
         let int_function_type = super::super::test_helpers::int_function_expr()
             .type_()
@@ -911,5 +1137,13 @@ mod tests {
         assert_eq!(layout.ints(), 6);
         assert_eq!(layout.strings(), 7);
         assert_eq!(layout.float_functions(), 14);
+    }
+
+    fn tuple_type() -> Vec<ValueType> {
+        vec![ValueType::Int, ValueType::String]
+    }
+
+    fn tuple_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Int], ValueType::Tuple(tuple_type()))
     }
 }

--- a/src/plan/frame/return_.rs
+++ b/src/plan/frame/return_.rs
@@ -12,6 +12,7 @@ impl FrameLayout {
             ReturnExprKind::String { body, .. } => self.include_string_return(body),
             ReturnExprKind::Bool { body, .. } => self.include_bool_return(body),
             ReturnExprKind::Nil { body, .. } => self.include_nil_return(body),
+            ReturnExprKind::Tuple { body, .. } => self.include_tuple_return(body),
             ReturnExprKind::IntFunction { body, .. } => {
                 self.include_int_function_return(body);
             }
@@ -26,6 +27,9 @@ impl FrameLayout {
             }
             ReturnExprKind::NilFunction { body, .. } => {
                 self.include_nil_function_return(body);
+            }
+            ReturnExprKind::TupleFunction { body, .. } => {
+                self.include_tuple_function_return(body);
             }
             ReturnExprKind::FunctionFunction { body, .. } => {
                 self.include_function_function_return(body);

--- a/src/plan/frame/return_/function.rs
+++ b/src/plan/frame/return_/function.rs
@@ -281,6 +281,62 @@ impl FrameLayout {
         }
     }
 
+    pub(in crate::plan::frame) fn include_tuple_function_return(
+        &mut self,
+        body: &crate::plan::TupleFunctionReturn,
+    ) {
+        match body.kind() {
+            ReturnBodyKind::Expr(expression) => self.include_tuple_function_expr(expression),
+            ReturnBodyKind::TailCall { args, .. } => self.include_call_args(args),
+            ReturnBodyKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_tuple_function_return(true_);
+                self.include_tuple_function_return(false_);
+            }
+            ReturnBodyKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_function_return(branch);
+                }
+                self.include_tuple_function_return(fallback);
+            }
+            ReturnBodyKind::FloatCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_float_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_function_return(branch);
+                }
+                self.include_tuple_function_return(fallback);
+            }
+            ReturnBodyKind::StringCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_string_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_function_return(branch);
+                }
+                self.include_tuple_function_return(fallback);
+            }
+            ReturnBodyKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_tuple_function_return(return_);
+            }
+        }
+    }
+
     pub(in crate::plan::frame) fn include_function_function_return(
         &mut self,
         body: &crate::plan::FunctionFunctionReturn,

--- a/src/plan/frame/return_/primitive.rs
+++ b/src/plan/frame/return_/primitive.rs
@@ -268,6 +268,59 @@ impl FrameLayout {
             }
         }
     }
+
+    pub(in crate::plan::frame) fn include_tuple_return(&mut self, body: &crate::plan::TupleReturn) {
+        match body.kind() {
+            ReturnBodyKind::Expr(expression) => self.include_tuple_expr(expression),
+            ReturnBodyKind::TailCall { args, .. } => self.include_call_args(args),
+            ReturnBodyKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_tuple_return(true_);
+                self.include_tuple_return(false_);
+            }
+            ReturnBodyKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_return(branch);
+                }
+                self.include_tuple_return(fallback);
+            }
+            ReturnBodyKind::FloatCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_float_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_return(branch);
+                }
+                self.include_tuple_return(fallback);
+            }
+            ReturnBodyKind::StringCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_string_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_tuple_return(branch);
+                }
+                self.include_tuple_return(fallback);
+            }
+            ReturnBodyKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_tuple_return(return_);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/plan/frame/step.rs
+++ b/src/plan/frame/step.rs
@@ -30,6 +30,10 @@ impl FrameLayout {
                 self.include_nil_expr(value);
                 self.include_nil(*local);
             }
+            StepKind::LetTuple { local, value, .. } => {
+                self.include_tuple_expr(value);
+                self.include_tuple(*local);
+            }
             StepKind::LetIntFunction { local, value, .. } => {
                 self.include_int_function_expr(value);
                 self.include_int_function(*local);
@@ -49,6 +53,10 @@ impl FrameLayout {
             StepKind::LetNilFunction { local, value, .. } => {
                 self.include_nil_function_expr(value);
                 self.include_nil_function(*local);
+            }
+            StepKind::LetTupleFunction { local, value, .. } => {
+                self.include_tuple_function_expr(value);
+                self.include_tuple_function(*local);
             }
             StepKind::LetFunctionFunction { local, value, .. } => {
                 self.include_function_function_expr(value);

--- a/src/plan/function.rs
+++ b/src/plan/function.rs
@@ -1,12 +1,13 @@
 use super::FrameLayout;
-use super::expression::{BoolExpr, CallArg, FloatExpr, IntExpr, NilExpr, StringExpr};
+use super::expression::{BoolExpr, CallArg, FloatExpr, IntExpr, NilExpr, StringExpr, TupleExpr};
 use super::id::{
     BoolFunctionFunctionId, BoolFunctionId, BoolFunctionLocalId, BoolLocalId,
     FloatFunctionFunctionId, FloatFunctionId, FloatFunctionLocalId, FloatLocalId,
     FunctionFunctionFunctionId, FunctionFunctionId, FunctionFunctionLocalId, FunctionId,
     IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId, IntLocalId, NilFunctionFunctionId,
     NilFunctionId, NilFunctionLocalId, NilLocalId, RuntimeFunctionId, StringFunctionFunctionId,
-    StringFunctionId, StringFunctionLocalId, StringLocalId,
+    StringFunctionId, StringFunctionLocalId, StringLocalId, TupleFunctionFunctionId,
+    TupleFunctionId, TupleFunctionLocalId, TupleLocalId,
 };
 use super::step::Step;
 use super::value::{FunctionType, ValueType};
@@ -42,6 +43,10 @@ pub(crate) enum ParamLocal {
     String(StringLocalId),
     Bool(BoolLocalId),
     Nil(NilLocalId),
+    Tuple {
+        local: TupleLocalId,
+        type_: Vec<ValueType>,
+    },
     IntFunction {
         local: IntFunctionLocalId,
         type_: FunctionType,
@@ -62,6 +67,10 @@ pub(crate) enum ParamLocal {
         local: NilFunctionLocalId,
         type_: FunctionType,
     },
+    TupleFunction {
+        local: TupleFunctionLocalId,
+        type_: FunctionType,
+    },
     FunctionFunction {
         local: FunctionFunctionLocalId,
         type_: FunctionType,
@@ -79,12 +88,14 @@ pub(crate) type FloatReturn = ReturnBody<FloatExpr, FloatFunctionId>;
 pub(crate) type StringReturn = ReturnBody<StringExpr, StringFunctionId>;
 pub(crate) type BoolReturn = ReturnBody<BoolExpr, BoolFunctionId>;
 pub(crate) type NilReturn = ReturnBody<NilExpr, NilFunctionId>;
+pub(crate) type TupleReturn = ReturnBody<TupleExpr, TupleFunctionId>;
 pub(crate) type IntFunctionReturn = ReturnBody<super::IntFunctionExpr, IntFunctionFunctionId>;
 pub(crate) type FloatFunctionReturn = ReturnBody<super::FloatFunctionExpr, FloatFunctionFunctionId>;
 pub(crate) type StringFunctionReturn =
     ReturnBody<super::StringFunctionExpr, StringFunctionFunctionId>;
 pub(crate) type BoolFunctionReturn = ReturnBody<super::BoolFunctionExpr, BoolFunctionFunctionId>;
 pub(crate) type NilFunctionReturn = ReturnBody<super::NilFunctionExpr, NilFunctionFunctionId>;
+pub(crate) type TupleFunctionReturn = ReturnBody<super::TupleFunctionExpr, TupleFunctionFunctionId>;
 pub(crate) type FunctionFunctionReturn =
     ReturnBody<super::FunctionFunctionExpr, FunctionFunctionFunctionId>;
 
@@ -153,6 +164,11 @@ pub(crate) enum ReturnExprKind {
         runtime_id: NilFunctionId,
         body: NilReturn,
     },
+    Tuple {
+        runtime_id: TupleFunctionId,
+        type_: Vec<ValueType>,
+        body: TupleReturn,
+    },
     IntFunction {
         runtime_id: IntFunctionFunctionId,
         type_: FunctionType,
@@ -177,6 +193,11 @@ pub(crate) enum ReturnExprKind {
         runtime_id: NilFunctionFunctionId,
         type_: FunctionType,
         body: NilFunctionReturn,
+    },
+    TupleFunction {
+        runtime_id: TupleFunctionFunctionId,
+        type_: FunctionType,
+        body: TupleFunctionReturn,
     },
     FunctionFunction {
         runtime_id: FunctionFunctionFunctionId,
@@ -283,6 +304,26 @@ impl ReturnExpr {
     pub(crate) fn nil_body(runtime_id: NilFunctionId, body: NilReturn) -> Self {
         Self {
             kind: ReturnExprKind::Nil { runtime_id, body },
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tuple(runtime_id: TupleFunctionId, expression: TupleExpr) -> Self {
+        let type_ = expression.type_().to_vec();
+        Self::tuple_body(runtime_id, type_, ReturnBody::expr(expression))
+    }
+
+    pub(crate) fn tuple_body(
+        runtime_id: TupleFunctionId,
+        type_: Vec<ValueType>,
+        body: TupleReturn,
+    ) -> Self {
+        Self {
+            kind: ReturnExprKind::Tuple {
+                runtime_id,
+                type_,
+                body,
+            },
         }
     }
 
@@ -402,6 +443,29 @@ impl ReturnExpr {
     }
 
     #[cfg(test)]
+    pub(crate) fn tuple_function(
+        runtime_id: TupleFunctionFunctionId,
+        expression: super::TupleFunctionExpr,
+    ) -> Self {
+        let type_ = expression.type_().clone();
+        Self::tuple_function_body(runtime_id, type_, ReturnBody::expr(expression))
+    }
+
+    pub(crate) fn tuple_function_body(
+        runtime_id: TupleFunctionFunctionId,
+        type_: FunctionType,
+        body: TupleFunctionReturn,
+    ) -> Self {
+        Self {
+            kind: ReturnExprKind::TupleFunction {
+                runtime_id,
+                type_,
+                body,
+            },
+        }
+    }
+
+    #[cfg(test)]
     pub(crate) fn function_function(
         runtime_id: FunctionFunctionFunctionId,
         expression: super::FunctionFunctionExpr,
@@ -435,11 +499,13 @@ impl ReturnExpr {
             ReturnExprKind::String { .. } => ValueType::String,
             ReturnExprKind::Bool { .. } => ValueType::Bool,
             ReturnExprKind::Nil { .. } => ValueType::Nil,
+            ReturnExprKind::Tuple { type_, .. } => ValueType::Tuple(type_.clone()),
             ReturnExprKind::IntFunction { type_, .. }
             | ReturnExprKind::FloatFunction { type_, .. }
             | ReturnExprKind::StringFunction { type_, .. }
             | ReturnExprKind::BoolFunction { type_, .. }
             | ReturnExprKind::NilFunction { type_, .. }
+            | ReturnExprKind::TupleFunction { type_, .. }
             | ReturnExprKind::FunctionFunction { type_, .. } => {
                 ValueType::Function(Box::new(type_.clone()))
             }
@@ -453,6 +519,12 @@ impl ReturnExpr {
             ReturnExprKind::String { runtime_id, .. } => RuntimeFunctionId::String(*runtime_id),
             ReturnExprKind::Bool { runtime_id, .. } => RuntimeFunctionId::Bool(*runtime_id),
             ReturnExprKind::Nil { runtime_id, .. } => RuntimeFunctionId::Nil(*runtime_id),
+            ReturnExprKind::Tuple {
+                runtime_id, type_, ..
+            } => RuntimeFunctionId::Tuple {
+                id: *runtime_id,
+                return_type: type_.clone(),
+            },
             ReturnExprKind::IntFunction {
                 runtime_id, type_, ..
             } => RuntimeFunctionId::Function {
@@ -481,6 +553,12 @@ impl ReturnExpr {
                 runtime_id, type_, ..
             } => RuntimeFunctionId::Function {
                 id: FunctionFunctionId::Nil(*runtime_id),
+                return_type: type_.clone(),
+            },
+            ReturnExprKind::TupleFunction {
+                runtime_id, type_, ..
+            } => RuntimeFunctionId::Function {
+                id: FunctionFunctionId::Tuple(*runtime_id),
                 return_type: type_.clone(),
             },
             ReturnExprKind::FunctionFunction {
@@ -642,6 +720,10 @@ impl ParamLocal {
         Self::Nil(local)
     }
 
+    pub(crate) fn tuple(local: TupleLocalId, type_: Vec<ValueType>) -> Self {
+        Self::Tuple { local, type_ }
+    }
+
     pub(crate) fn int_function(local: IntFunctionLocalId, type_: FunctionType) -> Self {
         Self::IntFunction { local, type_ }
     }
@@ -662,6 +744,10 @@ impl ParamLocal {
         Self::NilFunction { local, type_ }
     }
 
+    pub(crate) fn tuple_function(local: TupleFunctionLocalId, type_: FunctionType) -> Self {
+        Self::TupleFunction { local, type_ }
+    }
+
     pub(crate) fn function_function(local: FunctionFunctionLocalId, type_: FunctionType) -> Self {
         Self::FunctionFunction { local, type_ }
     }
@@ -673,11 +759,13 @@ impl ParamLocal {
             Self::String(_) => ValueType::String,
             Self::Bool(_) => ValueType::Bool,
             Self::Nil(_) => ValueType::Nil,
+            Self::Tuple { type_, .. } => ValueType::Tuple(type_.clone()),
             Self::IntFunction { type_, .. }
             | Self::FloatFunction { type_, .. }
             | Self::StringFunction { type_, .. }
             | Self::BoolFunction { type_, .. }
             | Self::NilFunction { type_, .. }
+            | Self::TupleFunction { type_, .. }
             | Self::FunctionFunction { type_, .. } => ValueType::Function(Box::new(type_.clone())),
         }
     }
@@ -695,7 +783,9 @@ mod tests {
         IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId,
         NilExpr, NilFunctionExpr, NilFunctionFunctionId, NilFunctionId, NilFunctionLocalId,
         NilFunctionValue, StringExpr, StringFunctionExpr, StringFunctionFunctionId,
-        StringFunctionId, StringFunctionLocalId, StringFunctionValue, ValueType,
+        StringFunctionId, StringFunctionLocalId, StringFunctionValue, TupleExpr, TupleFunctionExpr,
+        TupleFunctionFunctionId, TupleFunctionId, TupleFunctionLocalId, TupleFunctionValue,
+        ValueType,
     };
     use num_bigint::BigInt;
 
@@ -750,6 +840,17 @@ mod tests {
             ValueType::Nil,
         );
         assert_eq!(
+            ReturnExpr::tuple(
+                TupleFunctionId(0),
+                TupleExpr::value(
+                    vec![crate::plan::Expr::int(IntExpr::value(BigInt::from(1)))],
+                    vec![ValueType::Int],
+                ),
+            )
+            .value_type(),
+            ValueType::Tuple(vec![ValueType::Int]),
+        );
+        assert_eq!(
             ReturnExpr::int_function(
                 IntFunctionFunctionId(0),
                 IntFunctionExpr::value(IntFunctionValue::new(IntFunctionId(0), Vec::new())),
@@ -791,6 +892,21 @@ mod tests {
             )
             .value_type(),
             ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Nil))),
+        );
+        assert_eq!(
+            ReturnExpr::tuple_function(
+                TupleFunctionFunctionId(0),
+                TupleFunctionExpr::value(TupleFunctionValue::new(
+                    TupleFunctionId(0),
+                    Vec::new(),
+                    vec![ValueType::Int],
+                )),
+            )
+            .value_type(),
+            ValueType::Function(Box::new(FunctionType::new(
+                Vec::new(),
+                ValueType::Tuple(vec![ValueType::Int]),
+            ))),
         );
         let return_type = FunctionType::new(Vec::new(), ValueType::Int);
         assert_eq!(
@@ -893,6 +1009,20 @@ mod tests {
             ValueType::Function(Box::new(FunctionType::new(
                 vec![ValueType::Nil],
                 ValueType::Nil,
+            ))),
+        );
+        assert_eq!(
+            ParamLocal::tuple_function(
+                TupleFunctionLocalId(0),
+                FunctionType::new(
+                    vec![ValueType::Tuple(vec![ValueType::Int])],
+                    ValueType::Tuple(vec![ValueType::String]),
+                ),
+            )
+            .value_type(),
+            ValueType::Function(Box::new(FunctionType::new(
+                vec![ValueType::Tuple(vec![ValueType::Int])],
+                ValueType::Tuple(vec![ValueType::String]),
             ))),
         );
     }

--- a/src/plan/id.rs
+++ b/src/plan/id.rs
@@ -22,6 +22,9 @@ pub struct BoolLocalId(pub(crate) usize);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NilLocalId(pub(crate) usize);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TupleLocalId(pub(crate) usize);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct IntFunctionLocalId(pub(crate) usize);
 
@@ -38,6 +41,9 @@ pub struct BoolFunctionLocalId(pub(crate) usize);
 pub struct NilFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TupleFunctionLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FunctionFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,6 +56,10 @@ pub(crate) enum RuntimeFunctionId {
     String(StringFunctionId),
     Bool(BoolFunctionId),
     Nil(NilFunctionId),
+    Tuple {
+        id: TupleFunctionId,
+        return_type: Vec<crate::plan::ValueType>,
+    },
     Function {
         id: FunctionFunctionId,
         return_type: crate::plan::FunctionType,
@@ -72,12 +82,16 @@ pub struct BoolFunctionId(pub(crate) usize);
 pub struct NilFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TupleFunctionId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FunctionFunctionId {
     Int(IntFunctionFunctionId),
     Float(FloatFunctionFunctionId),
     String(StringFunctionFunctionId),
     Bool(BoolFunctionFunctionId),
     Nil(NilFunctionFunctionId),
+    Tuple(TupleFunctionFunctionId),
     Function(FunctionFunctionFunctionId),
 }
 
@@ -88,6 +102,7 @@ pub(crate) enum FunctionReturnFamily {
     String,
     Bool,
     Nil,
+    Tuple,
     Function,
 }
 
@@ -105,6 +120,9 @@ pub struct BoolFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NilFunctionFunctionId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TupleFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FunctionFunctionFunctionId(pub(crate) usize);
@@ -140,6 +158,7 @@ impl FunctionFunctionId {
             Self::String(_) => FunctionReturnFamily::String,
             Self::Bool(_) => FunctionReturnFamily::Bool,
             Self::Nil(_) => FunctionReturnFamily::Nil,
+            Self::Tuple(_) => FunctionReturnFamily::Tuple,
             Self::Function(_) => FunctionReturnFamily::Function,
         }
     }
@@ -179,6 +198,13 @@ impl FunctionFunctionId {
         }
     }
 
+    pub(crate) fn tuple(self) -> Option<TupleFunctionFunctionId> {
+        match self {
+            Self::Tuple(id) => Some(id),
+            _ => None,
+        }
+    }
+
     pub(crate) fn function(self) -> Option<FunctionFunctionFunctionId> {
         match self {
             Self::Function(id) => Some(id),
@@ -195,6 +221,7 @@ impl std::fmt::Display for FunctionReturnFamily {
             Self::String => f.write_str("String"),
             Self::Bool => f.write_str("Bool"),
             Self::Nil => f.write_str("Nil"),
+            Self::Tuple => f.write_str("Tuple"),
             Self::Function => f.write_str("Function"),
         }
     }
@@ -206,7 +233,8 @@ mod tests {
         BoolFunctionFunctionId, BoolFunctionLocalId, FloatFunctionFunctionId, FloatFunctionLocalId,
         FunctionFunctionFunctionId, FunctionFunctionId, FunctionFunctionLocalId, FunctionId,
         IntFunctionFunctionId, IntFunctionLocalId, NilFunctionFunctionId, NilFunctionLocalId,
-        StringFunctionFunctionId, StringFunctionLocalId,
+        StringFunctionFunctionId, StringFunctionLocalId, TupleFunctionFunctionId,
+        TupleFunctionLocalId,
     };
 
     #[test]
@@ -237,6 +265,10 @@ mod tests {
             "NilFunctionLocalId(3)"
         );
         assert_eq!(
+            format!("{:?}", TupleFunctionLocalId(3)),
+            "TupleFunctionLocalId(3)"
+        );
+        assert_eq!(
             format!("{:?}", FunctionFunctionLocalId(3)),
             "FunctionFunctionLocalId(3)"
         );
@@ -265,8 +297,12 @@ mod tests {
             Some(NilFunctionFunctionId(4)),
         );
         assert_eq!(
-            FunctionFunctionId::Function(FunctionFunctionFunctionId(5)).function(),
-            Some(FunctionFunctionFunctionId(5)),
+            FunctionFunctionId::Tuple(TupleFunctionFunctionId(5)).tuple(),
+            Some(TupleFunctionFunctionId(5)),
+        );
+        assert_eq!(
+            FunctionFunctionId::Function(FunctionFunctionFunctionId(6)).function(),
+            Some(FunctionFunctionFunctionId(6)),
         );
     }
 
@@ -291,6 +327,10 @@ mod tests {
         assert_eq!(
             FunctionFunctionId::Int(IntFunctionFunctionId(1)).nil(),
             None
+        );
+        assert_eq!(
+            FunctionFunctionId::Int(IntFunctionFunctionId(1)).tuple(),
+            None,
         );
         assert_eq!(
             FunctionFunctionId::Int(IntFunctionFunctionId(1)).function(),
@@ -321,6 +361,10 @@ mod tests {
             super::FunctionReturnFamily::Nil,
         );
         assert_eq!(
+            FunctionFunctionId::Tuple(TupleFunctionFunctionId(1)).family(),
+            super::FunctionReturnFamily::Tuple,
+        );
+        assert_eq!(
             FunctionFunctionId::Function(FunctionFunctionFunctionId(1)).family(),
             super::FunctionReturnFamily::Function,
         );
@@ -333,6 +377,7 @@ mod tests {
         assert_eq!(super::FunctionReturnFamily::String.to_string(), "String");
         assert_eq!(super::FunctionReturnFamily::Bool.to_string(), "Bool");
         assert_eq!(super::FunctionReturnFamily::Nil.to_string(), "Nil");
+        assert_eq!(super::FunctionReturnFamily::Tuple.to_string(), "Tuple");
         assert_eq!(
             super::FunctionReturnFamily::Function.to_string(),
             "Function"

--- a/src/plan/runtime.rs
+++ b/src/plan/runtime.rs
@@ -4,7 +4,8 @@ use super::{
     FunctionFunctionFunctionId, FunctionFunctionReturn, FunctionPlan, IntFunctionFunctionId,
     IntFunctionId, IntFunctionReturn, IntReturn, NilFunctionFunctionId, NilFunctionId,
     NilFunctionReturn, NilReturn, RuntimeFunction, RuntimeFunctionId, StringFunctionFunctionId,
-    StringFunctionId, StringFunctionReturn, StringReturn,
+    StringFunctionId, StringFunctionReturn, StringReturn, TupleFunctionFunctionId, TupleFunctionId,
+    TupleFunctionReturn, TupleReturn,
 };
 use crate::plan::ReturnExprKind;
 
@@ -15,11 +16,13 @@ pub(super) struct RuntimePlan {
     string_functions: Vec<RuntimeFunction<StringReturn>>,
     bool_functions: Vec<RuntimeFunction<BoolReturn>>,
     nil_functions: Vec<RuntimeFunction<NilReturn>>,
+    tuple_functions: Vec<RuntimeFunction<TupleReturn>>,
     int_function_functions: Vec<RuntimeFunction<IntFunctionReturn>>,
     float_function_functions: Vec<RuntimeFunction<FloatFunctionReturn>>,
     string_function_functions: Vec<RuntimeFunction<StringFunctionReturn>>,
     bool_function_functions: Vec<RuntimeFunction<BoolFunctionReturn>>,
     nil_function_functions: Vec<RuntimeFunction<NilFunctionReturn>>,
+    tuple_function_functions: Vec<RuntimeFunction<TupleFunctionReturn>>,
     function_function_functions: Vec<RuntimeFunction<FunctionFunctionReturn>>,
 }
 
@@ -67,6 +70,10 @@ impl RuntimePlan {
         &self.nil_functions[id.0]
     }
 
+    pub(super) fn tuple_function(&self, id: TupleFunctionId) -> &RuntimeFunction<TupleReturn> {
+        &self.tuple_functions[id.0]
+    }
+
     pub(super) fn int_function_function(
         &self,
         id: IntFunctionFunctionId,
@@ -102,6 +109,13 @@ impl RuntimePlan {
         &self.nil_function_functions[id.0]
     }
 
+    pub(super) fn tuple_function_function(
+        &self,
+        id: TupleFunctionFunctionId,
+    ) -> &RuntimeFunction<TupleFunctionReturn> {
+        &self.tuple_function_functions[id.0]
+    }
+
     pub(super) fn function_function_function(
         &self,
         id: FunctionFunctionFunctionId,
@@ -117,11 +131,13 @@ struct RuntimePlanBuilder {
     string_functions: Vec<(usize, RuntimeFunction<StringReturn>)>,
     bool_functions: Vec<(usize, RuntimeFunction<BoolReturn>)>,
     nil_functions: Vec<(usize, RuntimeFunction<NilReturn>)>,
+    tuple_functions: Vec<(usize, RuntimeFunction<TupleReturn>)>,
     int_function_functions: Vec<(usize, RuntimeFunction<IntFunctionReturn>)>,
     float_function_functions: Vec<(usize, RuntimeFunction<FloatFunctionReturn>)>,
     string_function_functions: Vec<(usize, RuntimeFunction<StringFunctionReturn>)>,
     bool_function_functions: Vec<(usize, RuntimeFunction<BoolFunctionReturn>)>,
     nil_function_functions: Vec<(usize, RuntimeFunction<NilFunctionReturn>)>,
+    tuple_function_functions: Vec<(usize, RuntimeFunction<TupleFunctionReturn>)>,
     function_function_functions: Vec<(usize, RuntimeFunction<FunctionFunctionReturn>)>,
 }
 
@@ -138,11 +154,13 @@ impl RuntimePlanBuilder {
             string_functions: sort_functions(self.string_functions),
             bool_functions: sort_functions(self.bool_functions),
             nil_functions: sort_functions(self.nil_functions),
+            tuple_functions: sort_functions(self.tuple_functions),
             int_function_functions: sort_functions(self.int_function_functions),
             float_function_functions: sort_functions(self.float_function_functions),
             string_function_functions: sort_functions(self.string_function_functions),
             bool_function_functions: sort_functions(self.bool_function_functions),
             nil_function_functions: sort_functions(self.nil_function_functions),
+            tuple_function_functions: sort_functions(self.tuple_function_functions),
             function_function_functions: sort_functions(self.function_function_functions),
         }
     }
@@ -192,6 +210,18 @@ fn runtime_function(function: &FunctionPlan, runtime_functions: &mut RuntimePlan
         }
         ReturnExprKind::Nil { runtime_id, body } => {
             runtime_functions.nil_functions.push((
+                runtime_id.0,
+                RuntimeFunction::new(
+                    function.frame_layout(),
+                    function.steps().to_vec(),
+                    body.clone(),
+                ),
+            ));
+        }
+        ReturnExprKind::Tuple {
+            runtime_id, body, ..
+        } => {
+            runtime_functions.tuple_functions.push((
                 runtime_id.0,
                 RuntimeFunction::new(
                     function.frame_layout(),
@@ -252,6 +282,18 @@ fn runtime_function(function: &FunctionPlan, runtime_functions: &mut RuntimePlan
             runtime_id, body, ..
         } => {
             runtime_functions.nil_function_functions.push((
+                runtime_id.0,
+                RuntimeFunction::new(
+                    function.frame_layout(),
+                    function.steps().to_vec(),
+                    body.clone(),
+                ),
+            ));
+        }
+        ReturnExprKind::TupleFunction {
+            runtime_id, body, ..
+        } => {
+            runtime_functions.tuple_function_functions.push((
                 runtime_id.0,
                 RuntimeFunction::new(
                     function.frame_layout(),

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -1,11 +1,12 @@
 use super::expression::{
     BoolExpr, BoolFunctionExpr, Expr, FloatExpr, FloatFunctionExpr, FunctionFunctionExpr, IntExpr,
-    IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr,
+    IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr,
+    TupleFunctionExpr,
 };
 use super::id::{
     BoolFunctionLocalId, BoolLocalId, FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId,
     IntFunctionLocalId, IntLocalId, NilFunctionLocalId, NilLocalId, StringFunctionLocalId,
-    StringLocalId,
+    StringLocalId, TupleFunctionLocalId, TupleLocalId,
 };
 use ecow::EcoString;
 
@@ -41,6 +42,11 @@ pub(crate) enum StepKind {
         name: EcoString,
         value: NilExpr,
     },
+    LetTuple {
+        local: TupleLocalId,
+        name: EcoString,
+        value: TupleExpr,
+    },
     LetIntFunction {
         local: IntFunctionLocalId,
         name: EcoString,
@@ -65,6 +71,11 @@ pub(crate) enum StepKind {
         local: NilFunctionLocalId,
         name: EcoString,
         value: NilFunctionExpr,
+    },
+    LetTupleFunction {
+        local: TupleFunctionLocalId,
+        name: EcoString,
+        value: TupleFunctionExpr,
     },
     LetFunctionFunction {
         local: FunctionFunctionLocalId,
@@ -102,6 +113,12 @@ impl Step {
     pub(crate) fn let_nil(local: NilLocalId, name: EcoString, value: NilExpr) -> Self {
         Self {
             kind: StepKind::LetNil { local, name, value },
+        }
+    }
+
+    pub(crate) fn let_tuple(local: TupleLocalId, name: EcoString, value: TupleExpr) -> Self {
+        Self {
+            kind: StepKind::LetTuple { local, name, value },
         }
     }
 
@@ -152,6 +169,16 @@ impl Step {
     ) -> Self {
         Self {
             kind: StepKind::LetNilFunction { local, name, value },
+        }
+    }
+
+    pub(crate) fn let_tuple_function(
+        local: TupleFunctionLocalId,
+        name: EcoString,
+        value: TupleFunctionExpr,
+    ) -> Self {
+        Self {
+            kind: StepKind::LetTupleFunction { local, name, value },
         }
     }
 

--- a/src/plan/value.rs
+++ b/src/plan/value.rs
@@ -5,7 +5,8 @@ use super::{
     BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FloatFunctionId, FloatFunctionLocalId,
     FloatLocalId, FunctionFunctionId, FunctionFunctionLocalId, IntFunctionId, IntFunctionLocalId,
     IntLocalId, NilFunctionId, NilFunctionLocalId, NilLocalId, ParamLocal, RuntimeFunctionId,
-    StringFunctionId, StringFunctionLocalId, StringLocalId,
+    StringFunctionId, StringFunctionLocalId, StringLocalId, TupleFunctionId, TupleFunctionLocalId,
+    TupleLocalId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,6 +16,7 @@ pub enum ValueType {
     String,
     Bool,
     Nil,
+    Tuple(Vec<ValueType>),
     Function(Box<FunctionType>),
 }
 
@@ -36,6 +38,7 @@ pub(crate) enum FunctionValueKind {
     String(StringFunctionValue),
     Bool(BoolFunctionValue),
     Nil(NilFunctionValue),
+    Tuple(TupleFunctionValue),
     Function(FunctionFunctionValue),
 }
 
@@ -75,6 +78,14 @@ pub(crate) struct NilFunctionValue {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TupleFunctionValue {
+    runtime_id: TupleFunctionId,
+    params: Vec<ParamLocal>,
+    captures: Vec<CaptureValue>,
+    return_type: Vec<ValueType>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct FunctionFunctionValue {
     runtime_id: FunctionFunctionId,
     params: Vec<ParamLocal>,
@@ -108,6 +119,10 @@ pub(crate) enum CaptureValueKind {
     Nil {
         local: NilLocalId,
     },
+    Tuple {
+        local: TupleLocalId,
+        value: Vec<Value>,
+    },
     IntFunction {
         local: IntFunctionLocalId,
         value: IntFunctionValue,
@@ -128,6 +143,10 @@ pub(crate) enum CaptureValueKind {
         local: NilFunctionLocalId,
         value: NilFunctionValue,
     },
+    TupleFunction {
+        local: TupleFunctionLocalId,
+        value: TupleFunctionValue,
+    },
     FunctionFunction {
         local: FunctionFunctionLocalId,
         value: FunctionFunctionValue,
@@ -141,7 +160,22 @@ pub enum Value {
     String(EcoString),
     Bool(bool),
     Nil,
+    Tuple(Vec<Value>),
     Function(FunctionValue),
+}
+
+impl Value {
+    pub fn value_type(&self) -> ValueType {
+        match self {
+            Self::Int(_) => ValueType::Int,
+            Self::Float(_) => ValueType::Float,
+            Self::String(_) => ValueType::String,
+            Self::Bool(_) => ValueType::Bool,
+            Self::Nil => ValueType::Nil,
+            Self::Tuple(values) => ValueType::Tuple(values.iter().map(Self::value_type).collect()),
+            Self::Function(value) => ValueType::Function(Box::new(value.type_())),
+        }
+    }
 }
 
 impl FunctionType {
@@ -191,6 +225,9 @@ impl FunctionValue {
             RuntimeFunctionId::Nil(runtime_id) => FunctionValueKind::Nil(
                 NilFunctionValue::new_with_captures(runtime_id, params, captures),
             ),
+            RuntimeFunctionId::Tuple { id, return_type } => FunctionValueKind::Tuple(
+                TupleFunctionValue::new_with_captures(id, params, captures, return_type),
+            ),
             RuntimeFunctionId::Function { id, return_type } => FunctionValueKind::Function(
                 FunctionFunctionValue::new_with_captures(id, params, captures, return_type),
             ),
@@ -206,6 +243,7 @@ impl FunctionValue {
             FunctionValueKind::String(value) => value.type_(),
             FunctionValueKind::Bool(value) => value.type_(),
             FunctionValueKind::Nil(value) => value.type_(),
+            FunctionValueKind::Tuple(value) => value.type_(),
             FunctionValueKind::Function(value) => value.type_(),
         }
     }
@@ -222,6 +260,7 @@ impl FunctionValue {
             FunctionValueKind::String(value) => value.params(),
             FunctionValueKind::Bool(value) => value.params(),
             FunctionValueKind::Nil(value) => value.params(),
+            FunctionValueKind::Tuple(value) => value.params(),
             FunctionValueKind::Function(value) => value.params(),
         }
     }
@@ -407,6 +446,48 @@ impl NilFunctionValue {
     }
 }
 
+impl TupleFunctionValue {
+    #[cfg(test)]
+    pub(crate) fn new(
+        runtime_id: TupleFunctionId,
+        params: Vec<ParamLocal>,
+        return_type: Vec<ValueType>,
+    ) -> Self {
+        Self::new_with_captures(runtime_id, params, Vec::new(), return_type)
+    }
+
+    pub(crate) fn new_with_captures(
+        runtime_id: TupleFunctionId,
+        params: Vec<ParamLocal>,
+        captures: Vec<CaptureValue>,
+        return_type: Vec<ValueType>,
+    ) -> Self {
+        Self {
+            runtime_id,
+            params,
+            captures,
+            return_type,
+        }
+    }
+
+    pub(crate) fn type_(&self) -> FunctionType {
+        FunctionType::from_params(&self.params, ValueType::Tuple(self.return_type.clone()))
+    }
+
+    pub(crate) fn runtime_id(&self) -> TupleFunctionId {
+        self.runtime_id
+    }
+
+    pub(crate) fn captures(&self) -> &[CaptureValue] {
+        &self.captures
+    }
+
+    #[cfg(test)]
+    pub(crate) fn params(&self) -> &[ParamLocal] {
+        &self.params
+    }
+}
+
 impl FunctionFunctionValue {
     #[cfg(test)]
     pub(crate) fn new(
@@ -483,6 +564,12 @@ impl CaptureValue {
         }
     }
 
+    pub(crate) fn tuple(local: TupleLocalId, value: Vec<Value>) -> Self {
+        Self {
+            kind: CaptureValueKind::Tuple { local, value },
+        }
+    }
+
     pub(crate) fn int_function(local: IntFunctionLocalId, value: IntFunctionValue) -> Self {
         Self {
             kind: CaptureValueKind::IntFunction { local, value },
@@ -513,6 +600,12 @@ impl CaptureValue {
     pub(crate) fn nil_function(local: NilFunctionLocalId, value: NilFunctionValue) -> Self {
         Self {
             kind: CaptureValueKind::NilFunction { local, value },
+        }
+    }
+
+    pub(crate) fn tuple_function(local: TupleFunctionLocalId, value: TupleFunctionValue) -> Self {
+        Self {
+            kind: CaptureValueKind::TupleFunction { local, value },
         }
     }
 
@@ -570,6 +663,14 @@ impl From<NilFunctionValue> for FunctionValue {
     }
 }
 
+impl From<TupleFunctionValue> for FunctionValue {
+    fn from(value: TupleFunctionValue) -> Self {
+        Self {
+            kind: FunctionValueKind::Tuple(value),
+        }
+    }
+}
+
 impl From<FunctionFunctionValue> for FunctionValue {
     fn from(value: FunctionFunctionValue) -> Self {
         Self {
@@ -583,14 +684,26 @@ mod tests {
     use super::{
         BoolFunctionValue, CaptureValue, CaptureValueKind, FloatFunctionValue,
         FunctionFunctionValue, FunctionType, FunctionValue, IntFunctionValue, NilFunctionValue,
-        StringFunctionValue, ValueType,
+        StringFunctionValue, TupleFunctionValue, Value, ValueType,
     };
     use crate::plan::{
         BoolFunctionId, BoolFunctionLocalId, BoolLocalId, FloatFunctionId, FloatFunctionLocalId,
         FloatLocalId, FunctionFunctionId, FunctionValueKind, IntFunctionFunctionId, IntFunctionId,
         IntLocalId, NilFunctionId, NilLocalId, ParamLocal, RuntimeFunctionId, StringFunctionId,
-        StringLocalId,
+        StringLocalId, TupleFunctionId, TupleFunctionLocalId, TupleLocalId,
     };
+
+    #[test]
+    fn value_type_preserves_tuple_element_families() {
+        assert_eq!(Value::Float(1.0).value_type(), ValueType::Float);
+        assert_eq!(Value::String("one".into()).value_type(), ValueType::String);
+        assert_eq!(Value::Bool(true).value_type(), ValueType::Bool);
+        assert_eq!(Value::Nil.value_type(), ValueType::Nil);
+        assert_eq!(
+            Value::Tuple(vec![Value::Int(1.into()), Value::String("one".into())]).value_type(),
+            ValueType::Tuple(vec![ValueType::Int, ValueType::String]),
+        );
+    }
 
     #[test]
     fn function_value_accepts_matching_shape() {
@@ -623,6 +736,8 @@ mod tests {
             StringFunctionValue::new(StringFunctionId(0), Vec::new()).into();
         let bool: FunctionValue = BoolFunctionValue::new(BoolFunctionId(0), Vec::new()).into();
         let nil: FunctionValue = NilFunctionValue::new(NilFunctionId(0), Vec::new()).into();
+        let tuple: FunctionValue =
+            TupleFunctionValue::new(TupleFunctionId(0), Vec::new(), vec![ValueType::Int]).into();
         let function: FunctionValue = FunctionFunctionValue::new(
             FunctionFunctionId::Int(IntFunctionFunctionId(0)),
             Vec::new(),
@@ -635,6 +750,10 @@ mod tests {
         assert_eq!(string.type_().return_(), &ValueType::String);
         assert_eq!(bool.type_().return_(), &ValueType::Bool);
         assert_eq!(nil.type_().return_(), &ValueType::Nil);
+        assert_eq!(
+            tuple.type_().return_(),
+            &ValueType::Tuple(vec![ValueType::Int])
+        );
         assert!(matches!(function.type_().return_(), ValueType::Function(_)));
     }
 
@@ -649,7 +768,9 @@ mod tests {
                 string_param(0),
                 bool_param(0),
                 nil_param(0),
+                tuple_param(0),
                 ParamLocal::float_function(FloatFunctionLocalId(0), argument_function.clone()),
+                ParamLocal::tuple_function(TupleFunctionLocalId(0), argument_function.clone()),
                 ParamLocal::bool_function(BoolFunctionLocalId(0), argument_function.clone()),
             ],
         );
@@ -663,6 +784,8 @@ mod tests {
                     ValueType::String,
                     ValueType::Bool,
                     ValueType::Nil,
+                    ValueType::Tuple(vec![ValueType::Int]),
+                    ValueType::Function(Box::new(argument_function.clone())),
                     ValueType::Function(Box::new(argument_function.clone())),
                     ValueType::Function(Box::new(argument_function)),
                 ],
@@ -703,6 +826,13 @@ mod tests {
         );
         let bool = FunctionValue::new(RuntimeFunctionId::Bool(BoolFunctionId(0)), params.clone());
         let nil = FunctionValue::new(RuntimeFunctionId::Nil(NilFunctionId(0)), params.clone());
+        let tuple = FunctionValue::new(
+            RuntimeFunctionId::Tuple {
+                id: TupleFunctionId(0),
+                return_type: vec![ValueType::Int],
+            },
+            params.clone(),
+        );
         let function = FunctionValue::new(
             RuntimeFunctionId::Function {
                 id: FunctionFunctionId::Int(IntFunctionFunctionId(0)),
@@ -716,6 +846,7 @@ mod tests {
         assert_eq!(string.params(), params);
         assert_eq!(bool.params(), params);
         assert_eq!(nil.params(), params);
+        assert_eq!(tuple.params(), params);
         assert_eq!(function.params(), params);
         assert!(matches!(int.kind(), FunctionValueKind::Int(_)));
     }
@@ -730,6 +861,25 @@ mod tests {
         assert!(matches!(
             value.kind(),
             CaptureValueKind::FloatFunction { .. }
+        ));
+    }
+
+    #[test]
+    fn capture_value_preserves_tuple_shapes() {
+        let tuple = CaptureValue::tuple(TupleLocalId(0), vec![Value::Int(1.into())]);
+        assert!(matches!(tuple.kind(), CaptureValueKind::Tuple { .. }));
+
+        let function = CaptureValue::tuple_function(
+            TupleFunctionLocalId(0),
+            TupleFunctionValue::new(
+                TupleFunctionId(0),
+                vec![tuple_param(0)],
+                vec![ValueType::Int],
+            ),
+        );
+        assert!(matches!(
+            function.kind(),
+            CaptureValueKind::TupleFunction { .. }
         ));
     }
 
@@ -751,5 +901,9 @@ mod tests {
 
     fn nil_param(index: usize) -> ParamLocal {
         ParamLocal::nil(NilLocalId(index))
+    }
+
+    fn tuple_param(index: usize) -> ParamLocal {
+        ParamLocal::tuple(TupleLocalId(index), vec![ValueType::Int])
     }
 }

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -7,7 +7,8 @@ use crate::plan::{
     IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId, NilExpr, NilFunctionExpr,
     NilFunctionFunctionId, NilFunctionId, NilFunctionLocalId, NilLocalId, ParamBinding, ParamLocal,
     RuntimeFunctionId, StringExpr, StringFunctionExpr, StringFunctionFunctionId, StringFunctionId,
-    StringFunctionLocalId, StringLocalId, ValueType,
+    StringFunctionLocalId, StringLocalId, TupleExpr, TupleFunctionExpr, TupleFunctionFunctionId,
+    TupleFunctionId, TupleFunctionLocalId, TupleLocalId, ValueType,
 };
 use crate::planner::error::{InvalidTypedAstReason, PlanError};
 use ecow::EcoString;
@@ -38,17 +39,23 @@ pub(super) struct PlanContext<'a> {
     next_string_local: usize,
     next_bool_local: usize,
     next_nil_local: usize,
+    next_tuple_local: usize,
     next_int_function_local: usize,
     next_float_function_local: usize,
     next_string_function_local: usize,
     next_bool_function_local: usize,
     next_nil_function_local: usize,
+    next_tuple_function_local: usize,
     next_function_function_local: usize,
 }
 
 #[derive(Clone)]
 enum LocalBinding {
     Primitive(LocalId),
+    Tuple {
+        local: TupleLocalId,
+        type_: Vec<ValueType>,
+    },
     Function(FunctionLocalBinding),
 }
 
@@ -79,6 +86,10 @@ pub(super) enum FunctionLocalBinding {
         local: NilFunctionLocalId,
         type_: FunctionType,
     },
+    Tuple {
+        local: TupleFunctionLocalId,
+        type_: FunctionType,
+    },
     Function {
         local: FunctionFunctionLocalId,
         type_: FunctionType,
@@ -101,11 +112,13 @@ impl<'a> PlanContext<'a> {
             next_string_local: 0,
             next_bool_local: 0,
             next_nil_local: 0,
+            next_tuple_local: 0,
             next_int_function_local: 0,
             next_float_function_local: 0,
             next_string_function_local: 0,
             next_bool_function_local: 0,
             next_nil_function_local: 0,
+            next_tuple_function_local: 0,
             next_function_function_local: 0,
         }
     }
@@ -147,6 +160,16 @@ impl<'a> PlanContext<'a> {
             }
             ParamLocal::Nil(local) => {
                 self.define_existing_local(name, LocalId::Nil(*local));
+            }
+            ParamLocal::Tuple { local, type_ } => {
+                self.next_tuple_local = self.next_tuple_local.max(local.0 + 1);
+                self.bindings.insert(
+                    name,
+                    LocalBinding::Tuple {
+                        local: *local,
+                        type_: type_.clone(),
+                    },
+                );
             }
             ParamLocal::IntFunction { local, type_ } => {
                 self.next_int_function_local = self.next_int_function_local.max(local.0 + 1);
@@ -193,6 +216,16 @@ impl<'a> PlanContext<'a> {
                 self.bindings.insert(
                     name,
                     LocalBinding::Function(FunctionLocalBinding::Nil {
+                        local: *local,
+                        type_: type_.clone(),
+                    }),
+                );
+            }
+            ParamLocal::TupleFunction { local, type_ } => {
+                self.next_tuple_function_local = self.next_tuple_function_local.max(local.0 + 1);
+                self.bindings.insert(
+                    name,
+                    LocalBinding::Function(FunctionLocalBinding::Tuple {
                         local: *local,
                         type_: type_.clone(),
                     }),
@@ -282,6 +315,20 @@ impl<'a> PlanContext<'a> {
         local
     }
 
+    pub(super) fn define_tuple_function_local(
+        &mut self,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> TupleFunctionLocalId {
+        let local = TupleFunctionLocalId(self.next_tuple_function_local);
+        self.next_tuple_function_local += 1;
+        self.bindings.insert(
+            name,
+            LocalBinding::Function(FunctionLocalBinding::Tuple { local, type_ }),
+        );
+        local
+    }
+
     pub(super) fn define_function_function_local(
         &mut self,
         name: EcoString,
@@ -336,10 +383,33 @@ impl<'a> PlanContext<'a> {
         local
     }
 
+    pub(super) fn define_tuple_local(
+        &mut self,
+        name: EcoString,
+        type_: Vec<ValueType>,
+    ) -> TupleLocalId {
+        let local = TupleLocalId(self.next_tuple_local);
+        self.next_tuple_local += 1;
+        self.bindings
+            .insert(name, LocalBinding::Tuple { local, type_ });
+        local
+    }
+
     pub(super) fn lookup_local(&self, name: &EcoString) -> Option<(LocalId, ValueType)> {
         match self.bindings.get(name)? {
             LocalBinding::Primitive(local) => Some((*local, local.value_type())),
+            LocalBinding::Tuple { .. } => None,
             LocalBinding::Function(_) => None,
+        }
+    }
+
+    pub(super) fn lookup_tuple_local(
+        &self,
+        name: &EcoString,
+    ) -> Option<(TupleLocalId, Vec<ValueType>)> {
+        match self.bindings.get(name)? {
+            LocalBinding::Tuple { local, type_ } => Some((*local, type_.clone())),
+            LocalBinding::Primitive(_) | LocalBinding::Function(_) => None,
         }
     }
 
@@ -350,7 +420,7 @@ impl<'a> PlanContext<'a> {
     pub(super) fn lookup_function_local(&self, name: &EcoString) -> Option<FunctionLocalBinding> {
         match self.bindings.get(name)? {
             LocalBinding::Function(binding) => Some(binding.clone()),
-            LocalBinding::Primitive(_) => None,
+            LocalBinding::Primitive(_) | LocalBinding::Tuple { .. } => None,
         }
     }
 
@@ -390,11 +460,13 @@ impl<'a> PlanContext<'a> {
             next_string_local: 0,
             next_bool_local: 0,
             next_nil_local: 0,
+            next_tuple_local: 0,
             next_int_function_local: 0,
             next_float_function_local: 0,
             next_string_function_local: 0,
             next_bool_function_local: 0,
             next_nil_function_local: 0,
+            next_tuple_function_local: 0,
             next_function_function_local: 0,
         }
     }
@@ -479,6 +551,13 @@ impl<'a> PlanContext<'a> {
                     NilExpr::local_get(local, capture.name),
                 ))
             }
+            LocalBinding::Tuple { local, type_ } => {
+                let target = self.define_tuple_local(capture.name.clone(), type_.clone());
+                Ok(CaptureArg::tuple(
+                    target,
+                    TupleExpr::local_get(local, capture.name, type_),
+                ))
+            }
             LocalBinding::Function(FunctionLocalBinding::Int { local, type_ }) => {
                 let target = self.define_int_function_local(capture.name.clone(), type_.clone());
                 Ok(CaptureArg::int_function(
@@ -512,6 +591,13 @@ impl<'a> PlanContext<'a> {
                 Ok(CaptureArg::nil_function(
                     target,
                     NilFunctionExpr::local_get(local, capture.name, type_),
+                ))
+            }
+            LocalBinding::Function(FunctionLocalBinding::Tuple { local, type_ }) => {
+                let target = self.define_tuple_function_local(capture.name.clone(), type_.clone());
+                Ok(CaptureArg::tuple_function(
+                    target,
+                    TupleFunctionExpr::local_get(local, capture.name, type_),
                 ))
             }
             LocalBinding::Function(FunctionLocalBinding::Function { local, type_ }) => {
@@ -615,11 +701,13 @@ pub(in crate::planner) struct FunctionRuntimeIds {
     next_string: usize,
     next_bool: usize,
     next_nil: usize,
+    next_tuple: usize,
     next_int_function: usize,
     next_float_function: usize,
     next_string_function: usize,
     next_bool_function: usize,
     next_nil_function: usize,
+    next_tuple_function: usize,
     next_function_function: usize,
 }
 
@@ -631,6 +719,10 @@ impl FunctionRuntimeIds {
             ValueType::String => RuntimeFunctionId::String(self.next_string_id()),
             ValueType::Bool => RuntimeFunctionId::Bool(self.next_bool_id()),
             ValueType::Nil => RuntimeFunctionId::Nil(self.next_nil_id()),
+            ValueType::Tuple(return_type) => RuntimeFunctionId::Tuple {
+                id: self.next_tuple_id(),
+                return_type: return_type.clone(),
+            },
             ValueType::Function(return_type) => self.next_function(return_type.as_ref().clone()),
         }
     }
@@ -642,6 +734,7 @@ impl FunctionRuntimeIds {
             ValueType::String => FunctionFunctionId::String(self.next_string_function_id()),
             ValueType::Bool => FunctionFunctionId::Bool(self.next_bool_function_id()),
             ValueType::Nil => FunctionFunctionId::Nil(self.next_nil_function_id()),
+            ValueType::Tuple(_) => FunctionFunctionId::Tuple(self.next_tuple_function_id()),
             ValueType::Function(_) => {
                 FunctionFunctionId::Function(self.next_function_function_id())
             }
@@ -680,6 +773,12 @@ impl FunctionRuntimeIds {
         id
     }
 
+    pub(in crate::planner) fn next_tuple_id(&mut self) -> TupleFunctionId {
+        let id = TupleFunctionId(self.next_tuple);
+        self.next_tuple += 1;
+        id
+    }
+
     pub(in crate::planner) fn next_int_function_id(&mut self) -> IntFunctionFunctionId {
         let id = IntFunctionFunctionId(self.next_int_function);
         self.next_int_function += 1;
@@ -710,6 +809,12 @@ impl FunctionRuntimeIds {
         id
     }
 
+    pub(in crate::planner) fn next_tuple_function_id(&mut self) -> TupleFunctionFunctionId {
+        let id = TupleFunctionFunctionId(self.next_tuple_function);
+        self.next_tuple_function += 1;
+        id
+    }
+
     pub(in crate::planner) fn next_function_function_id(&mut self) -> FunctionFunctionFunctionId {
         let id = FunctionFunctionFunctionId(self.next_function_function);
         self.next_function_function += 1;
@@ -729,6 +834,12 @@ impl ValueType {
             Some(Self::Bool)
         } else if type_.is_nil() {
             Some(Self::Nil)
+        } else if let Some(elements) = type_.tuple_types() {
+            let elements = elements
+                .iter()
+                .map(|element| Self::from_gleam(element.as_ref()))
+                .collect::<Option<Vec<_>>>()?;
+            Some(Self::Tuple(elements))
         } else if let Some((arguments, return_)) = type_.fn_types() {
             let arguments = arguments
                 .iter()
@@ -749,10 +860,14 @@ mod tests {
     use super::FunctionLocalBinding;
     use super::{AnonymousFunctions, FunctionInfo, FunctionRuntimeIds, PlanContext};
     use crate::plan::{
-        CaptureArgKind, FloatFunctionId, FloatFunctionLocalId, FunctionType, FunctionValue,
-        IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId, RuntimeFunctionId, ValueType,
+        BoolFunctionExpr, BoolFunctionLocalId, CaptureArg, FloatFunctionExpr, FloatFunctionId,
+        FloatFunctionLocalId, FunctionFunctionExpr, FunctionFunctionLocalId, FunctionType,
+        FunctionValue, IntFunctionId, IntFunctionLocalId, IntLocalId, LocalId, NilFunctionExpr,
+        NilFunctionLocalId, ParamLocal, RuntimeFunctionId, StringFunctionExpr,
+        StringFunctionLocalId, TupleFunctionExpr, TupleFunctionLocalId, TupleLocalId, ValueType,
     };
     use ecow::EcoString;
+    use gleam_core::type_;
     use std::collections::HashMap;
 
     #[test]
@@ -794,6 +909,148 @@ mod tests {
             })
         );
         assert_eq!(context.lookup_local(&"f".into()), None);
+    }
+
+    #[test]
+    fn define_existing_param_records_tuple_function_binding() {
+        let module = EcoString::from("main");
+        let functions = HashMap::<EcoString, FunctionInfo>::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        let type_ = FunctionType::new(vec![ValueType::Int], ValueType::Tuple(vec![ValueType::Int]));
+
+        context.define_existing_param(
+            "f".into(),
+            &ParamLocal::tuple_function(TupleFunctionLocalId(2), type_.clone()),
+        );
+
+        assert_eq!(
+            context.lookup_function_local(&"f".into()),
+            Some(FunctionLocalBinding::Tuple {
+                local: TupleFunctionLocalId(2),
+                type_: type_.clone(),
+            }),
+        );
+        assert_eq!(context.define_tuple_function_local("g".into(), type_).0, 3);
+    }
+
+    #[test]
+    fn define_existing_param_records_tuple_and_function_family_bindings() {
+        let module = EcoString::from("main");
+        let functions = HashMap::<EcoString, FunctionInfo>::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        let tuple_type = vec![ValueType::Int];
+        let string_type = FunctionType::new(Vec::new(), ValueType::String);
+        let float_type = FunctionType::new(Vec::new(), ValueType::Float);
+        let bool_type = FunctionType::new(Vec::new(), ValueType::Bool);
+        let nil_type = FunctionType::new(Vec::new(), ValueType::Nil);
+        let function_type = FunctionType::new(
+            Vec::new(),
+            ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+        );
+
+        context.define_existing_param(
+            "tuple".into(),
+            &ParamLocal::tuple(TupleLocalId(2), tuple_type.clone()),
+        );
+        context.define_existing_param(
+            "string_fn".into(),
+            &ParamLocal::string_function(StringFunctionLocalId(3), string_type.clone()),
+        );
+        context.define_existing_param(
+            "float_fn".into(),
+            &ParamLocal::float_function(FloatFunctionLocalId(4), float_type.clone()),
+        );
+        context.define_existing_param(
+            "bool_fn".into(),
+            &ParamLocal::bool_function(BoolFunctionLocalId(5), bool_type.clone()),
+        );
+        context.define_existing_param(
+            "nil_fn".into(),
+            &ParamLocal::nil_function(NilFunctionLocalId(6), nil_type.clone()),
+        );
+        context.define_existing_param(
+            "function_fn".into(),
+            &ParamLocal::function_function(FunctionFunctionLocalId(7), function_type.clone()),
+        );
+
+        assert_eq!(
+            context.lookup_tuple_local(&"tuple".into()),
+            Some((TupleLocalId(2), tuple_type.clone())),
+        );
+        assert_eq!(
+            context.lookup_function_local(&"string_fn".into()),
+            Some(FunctionLocalBinding::String {
+                local: StringFunctionLocalId(3),
+                type_: string_type.clone(),
+            }),
+        );
+        assert_eq!(
+            context.lookup_function_local(&"float_fn".into()),
+            Some(FunctionLocalBinding::Float {
+                local: FloatFunctionLocalId(4),
+                type_: float_type.clone(),
+            }),
+        );
+        assert_eq!(
+            context.lookup_function_local(&"bool_fn".into()),
+            Some(FunctionLocalBinding::Bool {
+                local: BoolFunctionLocalId(5),
+                type_: bool_type.clone(),
+            }),
+        );
+        assert_eq!(
+            context.lookup_function_local(&"nil_fn".into()),
+            Some(FunctionLocalBinding::Nil {
+                local: NilFunctionLocalId(6),
+                type_: nil_type.clone(),
+            }),
+        );
+        assert_eq!(
+            context.lookup_function_local(&"function_fn".into()),
+            Some(FunctionLocalBinding::Function {
+                local: FunctionFunctionLocalId(7),
+                type_: function_type.clone(),
+            }),
+        );
+
+        assert_eq!(
+            context
+                .define_tuple_local("next_tuple".into(), tuple_type)
+                .0,
+            3
+        );
+        assert_eq!(
+            context
+                .define_string_function_local("next_string_fn".into(), string_type)
+                .0,
+            4,
+        );
+        assert_eq!(
+            context
+                .define_float_function_local("next_float_fn".into(), float_type)
+                .0,
+            5,
+        );
+        assert_eq!(
+            context
+                .define_bool_function_local("next_bool_fn".into(), bool_type)
+                .0,
+            6,
+        );
+        assert_eq!(
+            context
+                .define_nil_function_local("next_nil_fn".into(), nil_type)
+                .0,
+            7,
+        );
+        assert_eq!(
+            context
+                .define_function_function_local("next_function_fn".into(), function_type)
+                .0,
+            8,
+        );
     }
 
     #[test]
@@ -842,17 +1099,119 @@ mod tests {
         let mut context = PlanContext::new(&module, &functions, &mut anonymous);
         let type_ = FunctionType::new(vec![ValueType::Float], ValueType::Float);
 
-        context.define_float_function_local("f".into(), type_);
+        context.define_float_function_local("f".into(), type_.clone());
         let captures = context.capture_bindings(&[EcoString::from("f")]).unwrap();
         let captures = context.define_captures(captures).unwrap();
 
-        assert!(matches!(
-            captures[0].kind(),
-            CaptureArgKind::FloatFunction {
-                local: FloatFunctionLocalId(1),
-                ..
-            },
-        ));
+        assert_eq!(
+            captures[0],
+            CaptureArg::float_function(
+                FloatFunctionLocalId(1),
+                FloatFunctionExpr::local_get(FloatFunctionLocalId(0), "f".into(), type_),
+            ),
+        );
+    }
+
+    #[test]
+    fn define_captures_records_tuple_function_binding() {
+        let module = EcoString::from("main");
+        let functions = HashMap::<EcoString, FunctionInfo>::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        let type_ = FunctionType::new(vec![ValueType::Int], ValueType::Tuple(vec![ValueType::Int]));
+
+        context.define_tuple_function_local("f".into(), type_.clone());
+        let captures = context.capture_bindings(&[EcoString::from("f")]).unwrap();
+        let captures = context.define_captures(captures).unwrap();
+
+        assert_eq!(
+            captures[0],
+            CaptureArg::tuple_function(
+                TupleFunctionLocalId(1),
+                TupleFunctionExpr::local_get(TupleFunctionLocalId(0), "f".into(), type_),
+            ),
+        );
+    }
+
+    #[test]
+    fn define_captures_records_remaining_function_families() {
+        let module = EcoString::from("main");
+        let functions = HashMap::<EcoString, FunctionInfo>::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        let string_type = FunctionType::new(Vec::new(), ValueType::String);
+        let bool_type = FunctionType::new(Vec::new(), ValueType::Bool);
+        let nil_type = FunctionType::new(Vec::new(), ValueType::Nil);
+        let function_type = FunctionType::new(
+            Vec::new(),
+            ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+        );
+
+        context.define_string_function_local("string_fn".into(), string_type.clone());
+        context.define_bool_function_local("bool_fn".into(), bool_type.clone());
+        context.define_nil_function_local("nil_fn".into(), nil_type.clone());
+        context.define_function_function_local("function_fn".into(), function_type.clone());
+        let captures = context
+            .capture_bindings(&[
+                "string_fn".into(),
+                "bool_fn".into(),
+                "nil_fn".into(),
+                "function_fn".into(),
+            ])
+            .unwrap();
+        let captures = context.define_captures(captures).unwrap();
+
+        assert_eq!(
+            captures,
+            vec![
+                CaptureArg::string_function(
+                    StringFunctionLocalId(1),
+                    StringFunctionExpr::local_get(
+                        StringFunctionLocalId(0),
+                        "string_fn".into(),
+                        string_type,
+                    ),
+                ),
+                CaptureArg::bool_function(
+                    BoolFunctionLocalId(1),
+                    BoolFunctionExpr::local_get(
+                        BoolFunctionLocalId(0),
+                        "bool_fn".into(),
+                        bool_type
+                    ),
+                ),
+                CaptureArg::nil_function(
+                    NilFunctionLocalId(1),
+                    NilFunctionExpr::local_get(NilFunctionLocalId(0), "nil_fn".into(), nil_type),
+                ),
+                CaptureArg::function_function(
+                    FunctionFunctionLocalId(1),
+                    FunctionFunctionExpr::local_get(
+                        FunctionFunctionLocalId(0),
+                        "function_fn".into(),
+                        function_type,
+                    ),
+                ),
+            ],
+        );
+    }
+
+    #[test]
+    fn value_type_rejects_function_with_unsupported_return_type() {
+        assert_eq!(
+            ValueType::from_gleam(type_::fn_(Vec::new(), type_::list(type_::int())).as_ref()),
+            None,
+        );
+        assert_eq!(
+            ValueType::from_gleam(
+                type_::fn_(vec![type_::list(type_::int())], type_::int()).as_ref()
+            ),
+            None,
+        );
+        assert_eq!(
+            ValueType::from_gleam(type_::tuple(vec![type_::list(type_::int())]).as_ref()),
+            None,
+        );
     }
 
     #[test]

--- a/src/planner/dsl.rs
+++ b/src/planner/dsl.rs
@@ -5,13 +5,14 @@ mod module;
 pub(crate) use expression::{
     block_function, block_int, block_int_function, bool_, bool_arg, bool_case_int_function,
     bool_function_ref, call_bool, call_int, call_int_function, call_int_returning_function,
-    capture_int, equal, evaluate_step, float, function_function_closure, function_function_ref,
-    function_ref, int, int_arg, int_case_int_function, int_function_arg, int_function_call_arg,
-    int_function_closure, int_function_ref, let_bool_function_step, let_bool_step,
-    let_int_function_step, let_int_step, let_nil_function_step, let_nil_step,
-    let_string_function_step, let_string_step, local_bool, local_float, local_int,
-    local_int_function, local_nil, local_string, nil, nil_arg, nil_function_ref, not_equal, string,
-    string_arg, string_function_ref,
+    capture_int, capture_tuple, equal, evaluate_step, float, function_function_closure,
+    function_function_ref, function_ref, int, int_arg, int_case_int_function, int_function_arg,
+    int_function_call_arg, int_function_closure, int_function_ref, let_bool_function_step,
+    let_bool_step, let_int_function_step, let_int_step, let_nil_function_step, let_nil_step,
+    let_string_function_step, let_string_step, let_tuple_step, local_bool, local_float, local_int,
+    local_int_function, local_nil, local_string, local_tuple, nil, nil_arg, nil_function_ref,
+    not_equal, string, string_arg, string_function_ref, tuple, tuple_arg, tuple_function_closure,
+    tuple_function_ref,
 };
 pub(crate) use function::{
     bool_function_return_block, bool_function_return_bool_case, bool_function_return_expr,

--- a/src/planner/dsl.rs
+++ b/src/planner/dsl.rs
@@ -5,14 +5,14 @@ mod module;
 pub(crate) use expression::{
     block_function, block_int, block_int_function, bool_, bool_arg, bool_case_int_function,
     bool_function_ref, call_bool, call_int, call_int_function, call_int_returning_function,
-    capture_int, capture_tuple, equal, evaluate_step, float, function_function_closure,
-    function_function_ref, function_ref, int, int_arg, int_case_int_function, int_function_arg,
-    int_function_call_arg, int_function_closure, int_function_ref, let_bool_function_step,
-    let_bool_step, let_int_function_step, let_int_step, let_nil_function_step, let_nil_step,
-    let_string_function_step, let_string_step, let_tuple_step, local_bool, local_float, local_int,
-    local_int_function, local_nil, local_string, local_tuple, nil, nil_arg, nil_function_ref,
-    not_equal, string, string_arg, string_function_ref, tuple, tuple_arg, tuple_function_closure,
-    tuple_function_ref,
+    capture_int, capture_tuple, equal, evaluate_step, float, float_function_ref,
+    function_function_closure, function_function_ref, function_ref, int, int_arg,
+    int_case_int_function, int_function_arg, int_function_call_arg, int_function_closure,
+    int_function_ref, let_bool_function_step, let_bool_step, let_int_function_step, let_int_step,
+    let_nil_function_step, let_nil_step, let_string_function_step, let_string_step, let_tuple_step,
+    local_bool, local_float, local_int, local_int_function, local_nil, local_string, local_tuple,
+    nil, nil_arg, nil_function_ref, not_equal, string, string_arg, string_function_ref, tuple,
+    tuple_arg, tuple_function_closure, tuple_function_ref,
 };
 pub(crate) use function::{
     bool_function_return_block, bool_function_return_bool_case, bool_function_return_expr,

--- a/src/planner/dsl/expression.rs
+++ b/src/planner/dsl/expression.rs
@@ -22,7 +22,7 @@ pub(crate) use value::*;
 use crate::plan::{
     BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr, FunctionExpr, FunctionFunctionExpr,
     IntExpr, IntFunctionExpr, NilExpr, NilFunctionExpr, ParamLocal, StringExpr, StringFunctionExpr,
-    ValueType,
+    TupleExpr, TupleFunctionExpr, ValueType,
 };
 
 pub(crate) struct Int(IntExpr);
@@ -35,6 +35,8 @@ pub(crate) struct Bool(BoolExpr);
 
 pub(crate) struct Nil(NilExpr);
 
+pub(crate) struct Tuple(TupleExpr);
+
 pub(crate) struct Function(FunctionExpr);
 
 pub(crate) struct IntFunction(IntFunctionExpr);
@@ -46,6 +48,8 @@ pub(crate) struct FloatFunction(FloatFunctionExpr);
 pub(crate) struct BoolFunction(BoolFunctionExpr);
 
 pub(crate) struct NilFunction(NilFunctionExpr);
+
+pub(crate) struct TupleFunction(TupleFunctionExpr);
 
 pub(crate) struct FunctionFunction(FunctionFunctionExpr);
 

--- a/src/planner/dsl/expression/arg.rs
+++ b/src/planner/dsl/expression/arg.rs
@@ -1,11 +1,11 @@
 use super::{
     Bool, BoolFunction, Float, FloatFunction, Int, IntFunction, Nil, NilFunction, String,
-    StringFunction,
+    StringFunction, Tuple, TupleFunction,
 };
 use crate::plan::{
     BoolFunctionLocalId, BoolLocalId, CallArg, CaptureArg, FloatFunctionLocalId, FloatLocalId,
     IntFunctionLocalId, IntLocalId, NilFunctionLocalId, NilLocalId, StringFunctionLocalId,
-    StringLocalId,
+    StringLocalId, TupleFunctionLocalId, TupleLocalId,
 };
 
 pub(crate) fn int_arg(local: usize, value: Int) -> CallArg {
@@ -60,16 +60,29 @@ pub(crate) fn nil_function_arg(local: usize, value: NilFunction) -> CallArg {
     CallArg::nil_function(NilFunctionLocalId(local), value.into())
 }
 
+pub(crate) fn tuple_arg(local: usize, value: Tuple) -> CallArg {
+    CallArg::tuple(TupleLocalId(local), value.into())
+}
+
+pub(crate) fn capture_tuple(local: usize, value: Tuple) -> CaptureArg {
+    CaptureArg::tuple(TupleLocalId(local), value.into())
+}
+
+pub(crate) fn tuple_function_arg(local: usize, value: TupleFunction) -> CallArg {
+    CallArg::tuple_function(TupleFunctionLocalId(local), value.into())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        bool_arg, bool_function_arg, float_arg, float_function_arg, int_arg, int_function_arg,
-        int_function_call_arg, nil_arg, nil_function_arg, string_arg, string_function_arg,
+        bool_arg, bool_function_arg, capture_tuple, float_arg, float_function_arg, int_arg,
+        int_function_arg, int_function_call_arg, nil_arg, nil_function_arg, string_arg,
+        string_function_arg, tuple_arg, tuple_function_arg,
     };
-    use crate::plan::{CallArgKind, ParamLocal};
+    use crate::plan::{CallArgKind, CaptureArgKind, Expr, ParamLocal};
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, int, int_function_ref, nil,
-        nil_function_ref, string, string_function_ref,
+        nil_function_ref, string, string_function_ref, tuple, tuple_function_ref,
     };
 
     #[test]
@@ -111,6 +124,22 @@ mod tests {
         assert!(matches!(
             nil_function_arg(0, nil_function_ref(0, Vec::<ParamLocal>::new())).kind(),
             CallArgKind::NilFunction { .. },
+        ));
+        assert!(matches!(
+            tuple_arg(0, tuple([Expr::from(int(1)), Expr::from(string("one"))])).kind(),
+            CallArgKind::Tuple { .. },
+        ));
+        assert!(matches!(
+            capture_tuple(0, tuple([Expr::from(int(1)), Expr::from(string("one"))])).kind(),
+            CaptureArgKind::Tuple { .. },
+        ));
+        assert!(matches!(
+            tuple_function_arg(
+                0,
+                tuple_function_ref(0, Vec::<ParamLocal>::new(), [crate::plan::ValueType::Int]),
+            )
+            .kind(),
+            CallArgKind::TupleFunction { .. },
         ));
     }
 }

--- a/src/planner/dsl/expression/block.rs
+++ b/src/planner/dsl/expression/block.rs
@@ -1,8 +1,10 @@
-use super::{Bool, Float, Function, FunctionFunction, Int, IntFunction, Nil, String};
+use super::{
+    Bool, Float, Function, FunctionFunction, Int, IntFunction, Nil, String, TupleFunction,
+};
 use crate::plan::{
     BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr, FunctionExpr, FunctionExprKind,
     FunctionFunctionExpr, IntExpr, IntFunctionExpr, NilExpr, NilFunctionExpr, Step, StringExpr,
-    StringFunctionExpr,
+    StringFunctionExpr, TupleFunctionExpr,
 };
 
 pub(crate) fn block_int(steps: impl IntoIterator<Item = Step>, return_: Int) -> Int {
@@ -44,10 +46,23 @@ pub(crate) fn block_function(steps: Vec<Step>, return_: Function) -> Function {
             FunctionExpr::bool(BoolFunctionExpr::block(steps, return_))
         }
         FunctionExprKind::Nil(return_) => FunctionExpr::nil(NilFunctionExpr::block(steps, return_)),
+        FunctionExprKind::Tuple(return_) => {
+            FunctionExpr::tuple(TupleFunctionExpr::block(steps, return_))
+        }
         FunctionExprKind::Function(return_) => {
             FunctionExpr::function(FunctionFunctionExpr::block(steps, return_))
         }
     })
+}
+
+pub(crate) fn block_tuple_function(
+    steps: impl IntoIterator<Item = Step>,
+    return_: TupleFunction,
+) -> TupleFunction {
+    TupleFunction(TupleFunctionExpr::block(
+        steps.into_iter().collect(),
+        return_.into(),
+    ))
 }
 
 pub(crate) fn block_function_function(
@@ -74,17 +89,17 @@ pub(crate) fn block_int_function(
 mod tests {
     use super::{
         block_bool, block_float, block_function, block_function_function, block_int,
-        block_int_function, block_nil, block_string,
+        block_int_function, block_nil, block_string, block_tuple_function,
     };
     use crate::plan::{
         BoolExprKind, FloatExprKind, FunctionExpr, FunctionExprKind, FunctionFunctionId,
         FunctionType, IntExprKind, IntFunctionExprKind, IntFunctionFunctionId, NilExprKind,
-        ParamLocal, RuntimeFunctionId, StringExprKind, ValueType,
+        ParamLocal, RuntimeFunctionId, StringExprKind, TupleFunctionExprKind, ValueType,
     };
     use crate::planner::dsl::expression::{
         Function, bool_, float, function_function_ref, function_ref, int, int_function_ref,
         let_bool_step, let_int_step, let_nil_step, let_string_step, local_bool, local_int,
-        local_nil, local_string, nil, string,
+        local_nil, local_string, nil, string, tuple_function_ref,
     };
 
     #[test]
@@ -176,6 +191,18 @@ mod tests {
             .kind(),
             FunctionExprKind::Nil(_),
         ));
+        assert!(matches!(
+            FunctionExpr::from(block_function(
+                vec![],
+                Function::from(tuple_function_ref(
+                    0,
+                    [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+                    [ValueType::Int, ValueType::String],
+                )),
+            ))
+            .kind(),
+            FunctionExprKind::Tuple(_),
+        ));
         let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
         assert!(matches!(
             FunctionExpr::from(block_function(
@@ -197,6 +224,19 @@ mod tests {
             .0
             .kind(),
             IntFunctionExprKind::Block { .. },
+        ));
+        assert!(matches!(
+            block_tuple_function(
+                [],
+                tuple_function_ref(
+                    0,
+                    [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+                    [ValueType::Int, ValueType::String],
+                ),
+            )
+            .0
+            .kind(),
+            TupleFunctionExprKind::Block { .. },
         ));
         assert_eq!(
             block_function_function(

--- a/src/planner/dsl/expression/conversion.rs
+++ b/src/planner/dsl/expression/conversion.rs
@@ -1,11 +1,11 @@
 use super::{
     Bool, BoolFunction, Float, FloatFunction, Function, FunctionFunction, Int, IntFunction,
-    IntoParamLocal, IntoValueType, Nil, NilFunction, String, StringFunction,
+    IntoParamLocal, IntoValueType, Nil, NilFunction, String, StringFunction, Tuple, TupleFunction,
 };
 use crate::plan::{
     BoolExpr, BoolFunctionExpr, Expr, FloatExpr, FloatFunctionExpr, FunctionExpr,
     FunctionFunctionExpr, IntExpr, IntFunctionExpr, LocalId, NilExpr, NilFunctionExpr, ParamLocal,
-    StringExpr, StringFunctionExpr, ValueType,
+    StringExpr, StringFunctionExpr, TupleExpr, TupleFunctionExpr, ValueType,
 };
 
 impl From<Int> for Expr {
@@ -35,6 +35,12 @@ impl From<Bool> for Expr {
 impl From<Nil> for Expr {
     fn from(value: Nil) -> Self {
         Self::nil(value.into())
+    }
+}
+
+impl From<Tuple> for Expr {
+    fn from(value: Tuple) -> Self {
+        Self::tuple(value.into())
     }
 }
 
@@ -70,6 +76,12 @@ impl From<Bool> for BoolExpr {
 
 impl From<Nil> for NilExpr {
     fn from(value: Nil) -> Self {
+        value.0
+    }
+}
+
+impl From<Tuple> for TupleExpr {
+    fn from(value: Tuple) -> Self {
         value.0
     }
 }
@@ -164,6 +176,30 @@ impl From<NilFunction> for Expr {
     }
 }
 
+impl From<TupleFunction> for TupleFunctionExpr {
+    fn from(value: TupleFunction) -> Self {
+        value.0
+    }
+}
+
+impl From<TupleFunction> for Function {
+    fn from(value: TupleFunction) -> Self {
+        Function(FunctionExpr::tuple(value.into()))
+    }
+}
+
+impl From<TupleFunction> for Expr {
+    fn from(value: TupleFunction) -> Self {
+        Self::function(FunctionExpr::tuple(value.into()))
+    }
+}
+
+impl From<TupleFunction> for FunctionExpr {
+    fn from(value: TupleFunction) -> Self {
+        FunctionExpr::tuple(value.into())
+    }
+}
+
 impl From<FunctionFunction> for Function {
     fn from(value: FunctionFunction) -> Self {
         Function(FunctionExpr::function(value.into()))
@@ -239,7 +275,7 @@ mod tests {
     };
     use crate::planner::dsl::expression::{
         Function, bool_, float, float_function_ref, function_function_ref, int, int_function_ref,
-        nil, string,
+        nil, string, tuple, tuple_function_ref,
     };
 
     #[test]
@@ -278,6 +314,10 @@ mod tests {
         assert!(matches!(Expr::from(bool_(true)).kind(), ExprKind::Bool(_)));
         assert!(matches!(Expr::from(nil()).kind(), ExprKind::Nil(_)));
         assert!(matches!(
+            Expr::from(tuple([Expr::from(int(1)), Expr::from(string("one"))])).kind(),
+            ExprKind::Tuple(_),
+        ));
+        assert!(matches!(
             Expr::from(int_function_ref(0, Vec::<ParamLocal>::new())).kind(),
             ExprKind::Function(_),
         ));
@@ -290,12 +330,30 @@ mod tests {
             FunctionExprKind::Float(_),
         ));
         assert!(matches!(
+            FunctionExpr::from(tuple_function_ref(
+                0,
+                Vec::<ParamLocal>::new(),
+                [ValueType::Int],
+            ))
+            .kind(),
+            FunctionExprKind::Tuple(_),
+        ));
+        assert!(matches!(
             FunctionExpr::from(Function::from(float_function_ref(
                 0,
                 Vec::<ParamLocal>::new()
             )))
             .kind(),
             FunctionExprKind::Float(_),
+        ));
+        assert!(matches!(
+            FunctionExpr::from(Function::from(tuple_function_ref(
+                0,
+                Vec::<ParamLocal>::new(),
+                [ValueType::Int],
+            )))
+            .kind(),
+            FunctionExprKind::Tuple(_),
         ));
         assert!(matches!(
             FunctionExpr::from(Function::from(function_function_ref(

--- a/src/planner/dsl/expression/function_value.rs
+++ b/src/planner/dsl/expression/function_value.rs
@@ -1,6 +1,6 @@
 use super::{
     BoolFunction, FloatFunction, Function, FunctionFunction, IntFunction, IntoParamLocal,
-    IntoValueType, NilFunction, StringFunction,
+    IntoValueType, NilFunction, StringFunction, TupleFunction,
 };
 use crate::plan::{
     BoolFunctionExpr, BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue, CaptureArg,
@@ -9,7 +9,8 @@ use crate::plan::{
     FunctionType, FunctionValue, IntFunctionExpr, IntFunctionId, IntFunctionLocalId,
     IntFunctionValue, NilFunctionExpr, NilFunctionId, NilFunctionLocalId, NilFunctionValue,
     RuntimeFunctionId, StringFunctionExpr, StringFunctionId, StringFunctionLocalId,
-    StringFunctionValue, ValueType,
+    StringFunctionValue, TupleFunctionExpr, TupleFunctionId, TupleFunctionLocalId,
+    TupleFunctionValue, ValueType,
 };
 use ecow::EcoString;
 
@@ -129,6 +130,49 @@ pub(crate) fn nil_function_ref(
     )))
 }
 
+pub(crate) fn tuple_function_ref(
+    runtime_id: usize,
+    params: impl IntoIterator<Item = impl IntoParamLocal>,
+    return_type: impl IntoIterator<Item = impl IntoValueType>,
+) -> TupleFunction {
+    TupleFunction(TupleFunctionExpr::value(TupleFunctionValue::new(
+        TupleFunctionId(runtime_id),
+        params
+            .into_iter()
+            .map(IntoParamLocal::into_param_local)
+            .collect(),
+        return_type
+            .into_iter()
+            .map(IntoValueType::into_value_type)
+            .collect(),
+    )))
+}
+
+pub(crate) fn tuple_function_closure(
+    runtime_id: usize,
+    params: impl IntoIterator<Item = impl IntoParamLocal>,
+    captures: impl IntoIterator<Item = CaptureArg>,
+    return_type: impl IntoIterator<Item = impl IntoValueType>,
+) -> TupleFunction {
+    let params = params
+        .into_iter()
+        .map(IntoParamLocal::into_param_local)
+        .collect::<Vec<_>>();
+    let return_type = return_type
+        .into_iter()
+        .map(IntoValueType::into_value_type)
+        .collect::<Vec<_>>();
+    let type_ = FunctionType::from_params(&params, ValueType::Tuple(return_type.clone()));
+
+    TupleFunction(TupleFunctionExpr::closure(
+        TupleFunctionId(runtime_id),
+        params,
+        captures.into_iter().collect(),
+        type_,
+        return_type,
+    ))
+}
+
 pub(crate) fn local_int_function(
     local: usize,
     name: impl Into<EcoString>,
@@ -226,6 +270,27 @@ pub(crate) fn local_nil_function(
     ))
 }
 
+pub(crate) fn local_tuple_function(
+    local: usize,
+    name: impl Into<EcoString>,
+    params: impl IntoIterator<Item = impl IntoValueType>,
+    return_type: impl IntoIterator<Item = impl IntoValueType>,
+) -> TupleFunction {
+    TupleFunction(TupleFunctionExpr::local_get(
+        TupleFunctionLocalId(local),
+        name.into(),
+        function_type(
+            params,
+            ValueType::Tuple(
+                return_type
+                    .into_iter()
+                    .map(IntoValueType::into_value_type)
+                    .collect(),
+            ),
+        ),
+    ))
+}
+
 pub(crate) fn local_function_function(
     local: usize,
     name: impl Into<EcoString>,
@@ -277,13 +342,14 @@ mod tests {
         bool_function_ref, float_function_closure, float_function_ref, function_function_closure,
         function_function_ref, function_ref, int_function_closure, int_function_ref,
         local_bool_function, local_float_function, local_function_function, local_int_function,
-        local_nil_function, local_string_function, nil_function_ref, string_function_ref,
+        local_nil_function, local_string_function, local_tuple_function, nil_function_ref,
+        string_function_ref, tuple_function_closure, tuple_function_ref,
     };
     use crate::plan::{
         BoolFunctionExprKind, Expr, ExprKind, FloatFunctionExprKind, FunctionExpr,
         FunctionExprKind, FunctionFunctionId, FunctionType, IntFunctionExprKind,
         IntFunctionFunctionId, NilFunctionExprKind, ParamLocal, RuntimeFunctionId,
-        StringFunctionExprKind, ValueType,
+        StringFunctionExprKind, TupleFunctionExprKind, ValueType,
     };
     use crate::planner::dsl::expression::{Function, float, int};
 
@@ -325,6 +391,15 @@ mod tests {
             Expr::from(nil_function_ref(
                 0,
                 [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))],
+            ))
+            .kind(),
+            ExprKind::Function(_),
+        ));
+        assert!(matches!(
+            Expr::from(tuple_function_ref(
+                0,
+                [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+                [ValueType::Int, ValueType::String],
             ))
             .kind(),
             ExprKind::Function(_),
@@ -399,6 +474,17 @@ mod tests {
             .kind(),
             NilFunctionExprKind::LocalGet { .. },
         ));
+        assert!(matches!(
+            local_tuple_function(
+                0,
+                "f",
+                [ValueType::Int],
+                [ValueType::Int, ValueType::String]
+            )
+            .0
+            .kind(),
+            TupleFunctionExprKind::LocalGet { .. },
+        ));
         assert_eq!(
             local_function_function(
                 0,
@@ -459,6 +545,20 @@ mod tests {
                     vec![ValueType::Int],
                     ValueType::Int,
                 ))),
+            ),
+        );
+        assert_eq!(
+            tuple_function_closure(
+                0,
+                [ParamLocal::int(crate::plan::IntLocalId(0))],
+                [crate::planner::dsl::expression::capture_int(0, int(1))],
+                [ValueType::Int, ValueType::String],
+            )
+            .0
+            .type_(),
+            &FunctionType::new(
+                vec![ValueType::Int],
+                ValueType::Tuple(vec![ValueType::Int, ValueType::String]),
             ),
         );
     }

--- a/src/planner/dsl/expression/local.rs
+++ b/src/planner/dsl/expression/local.rs
@@ -1,7 +1,7 @@
-use super::{Bool, Float, Int, Nil, String};
+use super::{Bool, Float, Int, Nil, String, Tuple};
 use crate::plan::{
     BoolExpr, BoolLocalId, FloatExpr, FloatLocalId, IntExpr, IntLocalId, NilExpr, NilLocalId,
-    StringExpr, StringLocalId,
+    StringExpr, StringLocalId, TupleExpr, TupleLocalId, ValueType,
 };
 use ecow::EcoString;
 
@@ -25,10 +25,25 @@ pub(crate) fn local_nil(index: usize, name: impl Into<EcoString>) -> Nil {
     Nil(NilExpr::local_get(NilLocalId(index), name.into()))
 }
 
+pub(crate) fn local_tuple(
+    index: usize,
+    name: impl Into<EcoString>,
+    type_: impl IntoIterator<Item = ValueType>,
+) -> Tuple {
+    Tuple(TupleExpr::local_get(
+        TupleLocalId(index),
+        name.into(),
+        type_.into_iter().collect(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{local_bool, local_float, local_int, local_nil, local_string};
-    use crate::plan::{BoolExprKind, FloatExprKind, IntExprKind, NilExprKind, StringExprKind};
+    use super::{local_bool, local_float, local_int, local_nil, local_string, local_tuple};
+    use crate::plan::{
+        BoolExprKind, FloatExprKind, IntExprKind, NilExprKind, StringExprKind, TupleExprKind,
+        ValueType,
+    };
 
     #[test]
     fn local_helpers_build_local_get_shapes() {
@@ -51,6 +66,10 @@ mod tests {
         assert!(matches!(
             local_nil(0, "x").0.kind(),
             NilExprKind::LocalGet { .. },
+        ));
+        assert!(matches!(
+            local_tuple(0, "x", [ValueType::Int]).0.kind(),
+            TupleExprKind::LocalGet { .. },
         ));
     }
 }

--- a/src/planner/dsl/expression/operator.rs
+++ b/src/planner/dsl/expression/operator.rs
@@ -1,5 +1,12 @@
-use super::{Bool, Float, Int, String, Tuple};
-use crate::plan::{BoolExpr, Expr, FloatExpr, IntExpr, StringExpr};
+use super::{
+    Bool, BoolFunction, Float, FloatFunction, FunctionFunction, Int, IntFunction, IntoValueType,
+    Nil, NilFunction, String, StringFunction, Tuple, TupleFunction,
+};
+use crate::plan::{
+    BoolExpr, BoolFunctionExpr, Expr, FloatExpr, FloatFunctionExpr, FunctionFunctionExpr,
+    FunctionType, IntExpr, IntFunctionExpr, NilExpr, NilFunctionExpr, StringExpr,
+    StringFunctionExpr, TupleExpr, TupleFunctionExpr, ValueType,
+};
 
 pub(crate) fn equal(left: impl Into<Expr>, right: impl Into<Expr>) -> Bool {
     Bool(BoolExpr::equal(left.into(), right.into()))
@@ -95,6 +102,153 @@ impl Tuple {
     pub(crate) fn index_int(self, index: usize) -> Int {
         Int(IntExpr::tuple_index(self.into(), index))
     }
+
+    pub(crate) fn index_string(self, index: usize) -> String {
+        String(StringExpr::tuple_index(self.into(), index))
+    }
+
+    pub(crate) fn index_float(self, index: usize) -> Float {
+        Float(FloatExpr::tuple_index(self.into(), index))
+    }
+
+    pub(crate) fn index_bool(self, index: usize) -> Bool {
+        Bool(BoolExpr::tuple_index(self.into(), index))
+    }
+
+    pub(crate) fn index_nil(self, index: usize) -> Nil {
+        Nil(NilExpr::tuple_index(self.into(), index))
+    }
+
+    pub(crate) fn index_tuple(
+        self,
+        index: usize,
+        type_: impl IntoIterator<Item = impl IntoValueType>,
+    ) -> Tuple {
+        Tuple(TupleExpr::tuple_index(
+            self.into(),
+            index,
+            type_
+                .into_iter()
+                .map(IntoValueType::into_value_type)
+                .collect(),
+        ))
+    }
+
+    pub(crate) fn index_int_function(
+        self,
+        index: usize,
+        params: impl IntoIterator<Item = impl IntoValueType>,
+    ) -> IntFunction {
+        IntFunction(IntFunctionExpr::tuple_index(
+            self.into(),
+            index,
+            primitive_function_type(params, ValueType::Int),
+        ))
+    }
+
+    pub(crate) fn index_string_function(
+        self,
+        index: usize,
+        params: impl IntoIterator<Item = impl IntoValueType>,
+    ) -> StringFunction {
+        StringFunction(StringFunctionExpr::tuple_index(
+            self.into(),
+            index,
+            primitive_function_type(params, ValueType::String),
+        ))
+    }
+
+    pub(crate) fn index_float_function(
+        self,
+        index: usize,
+        params: impl IntoIterator<Item = impl IntoValueType>,
+    ) -> FloatFunction {
+        FloatFunction(FloatFunctionExpr::tuple_index(
+            self.into(),
+            index,
+            primitive_function_type(params, ValueType::Float),
+        ))
+    }
+
+    pub(crate) fn index_bool_function(
+        self,
+        index: usize,
+        params: impl IntoIterator<Item = impl IntoValueType>,
+    ) -> BoolFunction {
+        BoolFunction(BoolFunctionExpr::tuple_index(
+            self.into(),
+            index,
+            primitive_function_type(params, ValueType::Bool),
+        ))
+    }
+
+    pub(crate) fn index_nil_function(
+        self,
+        index: usize,
+        params: impl IntoIterator<Item = impl IntoValueType>,
+    ) -> NilFunction {
+        NilFunction(NilFunctionExpr::tuple_index(
+            self.into(),
+            index,
+            primitive_function_type(params, ValueType::Nil),
+        ))
+    }
+
+    pub(crate) fn index_tuple_function(
+        self,
+        index: usize,
+        params: impl IntoIterator<Item = impl IntoValueType>,
+        return_type: impl IntoIterator<Item = impl IntoValueType>,
+    ) -> TupleFunction {
+        TupleFunction(TupleFunctionExpr::tuple_index(
+            self.into(),
+            index,
+            FunctionType::new(
+                params
+                    .into_iter()
+                    .map(IntoValueType::into_value_type)
+                    .collect(),
+                ValueType::Tuple(
+                    return_type
+                        .into_iter()
+                        .map(IntoValueType::into_value_type)
+                        .collect(),
+                ),
+            ),
+        ))
+    }
+
+    pub(crate) fn index_function_function(
+        self,
+        index: usize,
+        params: impl IntoIterator<Item = impl IntoValueType>,
+        return_type: FunctionType,
+    ) -> FunctionFunction {
+        FunctionFunction(FunctionFunctionExpr::tuple_index(
+            self.into(),
+            index,
+            FunctionType::new(
+                params
+                    .into_iter()
+                    .map(IntoValueType::into_value_type)
+                    .collect(),
+                ValueType::Function(Box::new(return_type)),
+            ),
+        ))
+    }
+}
+
+fn primitive_function_type(
+    params: impl IntoIterator<Item = impl IntoValueType>,
+    return_: ValueType,
+) -> FunctionType {
+    FunctionType::new(
+        params
+            .into_iter()
+            .map(IntoValueType::into_value_type)
+            .collect(),
+        return_,
+    )
 }
 
 impl Bool {
@@ -114,7 +268,12 @@ impl Bool {
 #[cfg(test)]
 mod tests {
     use super::{equal, not_equal};
-    use crate::plan::{BoolExprKind, FloatExprKind, IntExprKind, StringExprKind, ValueType};
+    use crate::plan::{
+        BoolExprKind, BoolFunctionExprKind, FloatExprKind, FloatFunctionExprKind,
+        FunctionFunctionExprKind, FunctionType, IntExprKind, IntFunctionExprKind, NilExprKind,
+        NilFunctionExprKind, StringExprKind, StringFunctionExprKind, TupleExprKind,
+        TupleFunctionExprKind, ValueType,
+    };
     use crate::planner::dsl::expression::{bool_, float, int, local_tuple, string};
 
     #[test]
@@ -238,5 +397,140 @@ mod tests {
                 .kind(),
             IntExprKind::TupleIndex { .. },
         ));
+        assert!(matches!(
+            local_tuple(0, "pair", [ValueType::String])
+                .index_string(0)
+                .0
+                .kind(),
+            StringExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(0, "pair", [ValueType::Float])
+                .index_float(0)
+                .0
+                .kind(),
+            FloatExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(0, "pair", [ValueType::Bool])
+                .index_bool(0)
+                .0
+                .kind(),
+            BoolExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(0, "pair", [ValueType::Nil])
+                .index_nil(0)
+                .0
+                .kind(),
+            NilExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(0, "pair", [ValueType::Tuple(vec![ValueType::Int])])
+                .index_tuple(0, [ValueType::Int])
+                .0
+                .kind(),
+            TupleExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(
+                0,
+                "pair",
+                [function_value_type([ValueType::Int], ValueType::Int)]
+            )
+            .index_int_function(0, [ValueType::Int])
+            .0
+            .kind(),
+            IntFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(
+                0,
+                "pair",
+                [function_value_type([ValueType::String], ValueType::String)]
+            )
+            .index_string_function(0, [ValueType::String])
+            .0
+            .kind(),
+            StringFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(
+                0,
+                "pair",
+                [function_value_type([ValueType::Float], ValueType::Float)]
+            )
+            .index_float_function(0, [ValueType::Float])
+            .0
+            .kind(),
+            FloatFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(
+                0,
+                "pair",
+                [function_value_type([ValueType::Bool], ValueType::Bool)]
+            )
+            .index_bool_function(0, [ValueType::Bool])
+            .0
+            .kind(),
+            BoolFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(
+                0,
+                "pair",
+                [function_value_type([ValueType::Nil], ValueType::Nil)]
+            )
+            .index_nil_function(0, [ValueType::Nil])
+            .0
+            .kind(),
+            NilFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(
+                0,
+                "pair",
+                [function_value_type(
+                    [ValueType::Int],
+                    ValueType::Tuple(vec![ValueType::Int])
+                )]
+            )
+            .index_tuple_function(0, [ValueType::Int], [ValueType::Int])
+            .0
+            .kind(),
+            TupleFunctionExprKind::TupleIndex { .. },
+        ));
+        assert!(matches!(
+            local_tuple(
+                0,
+                "pair",
+                [function_value_type(
+                    [ValueType::Int],
+                    ValueType::Function(Box::new(FunctionType::new(
+                        vec![ValueType::Int],
+                        ValueType::Int
+                    )))
+                )]
+            )
+            .index_function_function(
+                0,
+                [ValueType::Int],
+                FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            )
+            .0
+            .kind(),
+            FunctionFunctionExprKind::TupleIndex { .. },
+        ));
+    }
+
+    fn function_value_type(
+        params: impl IntoIterator<Item = ValueType>,
+        return_: ValueType,
+    ) -> ValueType {
+        ValueType::Function(Box::new(FunctionType::new(
+            params.into_iter().collect(),
+            return_,
+        )))
     }
 }

--- a/src/planner/dsl/expression/operator.rs
+++ b/src/planner/dsl/expression/operator.rs
@@ -1,4 +1,4 @@
-use super::{Bool, Float, Int, String};
+use super::{Bool, Float, Int, String, Tuple};
 use crate::plan::{BoolExpr, Expr, FloatExpr, IntExpr, StringExpr};
 
 pub(crate) fn equal(left: impl Into<Expr>, right: impl Into<Expr>) -> Bool {
@@ -91,6 +91,12 @@ impl String {
     }
 }
 
+impl Tuple {
+    pub(crate) fn index_int(self, index: usize) -> Int {
+        Int(IntExpr::tuple_index(self.into(), index))
+    }
+}
+
 impl Bool {
     pub(crate) fn and_bool(self, right: Self) -> Self {
         Self(BoolExpr::and(self.into(), right.into()))
@@ -108,8 +114,8 @@ impl Bool {
 #[cfg(test)]
 mod tests {
     use super::{equal, not_equal};
-    use crate::plan::{BoolExprKind, FloatExprKind, IntExprKind, StringExprKind};
-    use crate::planner::dsl::expression::{bool_, float, int, string};
+    use crate::plan::{BoolExprKind, FloatExprKind, IntExprKind, StringExprKind, ValueType};
+    use crate::planner::dsl::expression::{bool_, float, int, local_tuple, string};
 
     #[test]
     fn int_operator_helpers_build_operator_shapes() {
@@ -220,6 +226,17 @@ mod tests {
         assert!(matches!(
             string("a").concatenate(string("b")).0.kind(),
             StringExprKind::Concatenate { .. },
+        ));
+    }
+
+    #[test]
+    fn tuple_projection_helpers_build_projection_shapes() {
+        assert!(matches!(
+            local_tuple(0, "pair", [ValueType::Int])
+                .index_int(0)
+                .0
+                .kind(),
+            IntExprKind::TupleIndex { .. },
         ));
     }
 }

--- a/src/planner/dsl/expression/step.rs
+++ b/src/planner/dsl/expression/step.rs
@@ -1,10 +1,11 @@
 use super::{
     Bool, BoolFunction, Float, FloatFunction, Int, IntFunction, Nil, NilFunction, String,
-    StringFunction,
+    StringFunction, Tuple,
 };
 use crate::plan::{
     BoolFunctionLocalId, BoolLocalId, Expr, FloatFunctionLocalId, FloatLocalId, IntFunctionLocalId,
     IntLocalId, NilFunctionLocalId, NilLocalId, Step, StringFunctionLocalId, StringLocalId,
+    TupleLocalId,
 };
 use ecow::EcoString;
 
@@ -26,6 +27,10 @@ pub(crate) fn let_bool_step(local: usize, name: impl Into<EcoString>, value: Boo
 
 pub(crate) fn let_nil_step(local: usize, name: impl Into<EcoString>, value: Nil) -> Step {
     Step::let_nil(NilLocalId(local), name.into(), value.into())
+}
+
+pub(crate) fn let_tuple_step(local: usize, name: impl Into<EcoString>, value: Tuple) -> Step {
+    Step::let_tuple(TupleLocalId(local), name.into(), value.into())
 }
 
 pub(crate) fn let_int_function_step(
@@ -77,12 +82,13 @@ mod tests {
     use super::{
         evaluate_step, let_bool_function_step, let_bool_step, let_float_function_step,
         let_float_step, let_int_function_step, let_int_step, let_nil_function_step, let_nil_step,
-        let_string_function_step, let_string_step,
+        let_string_function_step, let_string_step, let_tuple_step,
     };
+    use crate::plan::Expr;
     use crate::plan::StepKind;
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, int, int_function_ref, nil,
-        nil_function_ref, string, string_function_ref,
+        nil_function_ref, string, string_function_ref, tuple,
     };
 
     #[test]
@@ -106,6 +112,15 @@ mod tests {
         assert!(matches!(
             let_nil_step(0, "x", nil()).kind(),
             StepKind::LetNil { .. },
+        ));
+        assert!(matches!(
+            let_tuple_step(
+                0,
+                "x",
+                tuple([Expr::from(int(1)), Expr::from(string("one"))])
+            )
+            .kind(),
+            StepKind::LetTuple { .. },
         ));
         assert!(matches!(
             let_int_function_step(

--- a/src/planner/dsl/expression/value.rs
+++ b/src/planner/dsl/expression/value.rs
@@ -1,5 +1,5 @@
-use super::{Bool, Float, Int, Nil, String};
-use crate::plan::{BoolExpr, FloatExpr, IntExpr, NilExpr, StringExpr};
+use super::{Bool, Float, Int, Nil, String, Tuple};
+use crate::plan::{BoolExpr, Expr, FloatExpr, IntExpr, NilExpr, StringExpr, TupleExpr};
 use ecow::EcoString;
 use num_bigint::BigInt;
 
@@ -23,9 +23,16 @@ pub(crate) fn nil() -> Nil {
     Nil(NilExpr::value())
 }
 
+pub(crate) fn tuple(elements: impl IntoIterator<Item = impl Into<Expr>>) -> Tuple {
+    let elements = elements.into_iter().map(Into::into).collect::<Vec<_>>();
+    let type_ = elements.iter().map(Expr::value_type).collect();
+
+    Tuple(TupleExpr::value(elements, type_))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{bool_, float, int, nil, string};
+    use super::{bool_, float, int, nil, string, tuple};
     use crate::plan::{Expr, ExprKind};
 
     #[test]
@@ -38,5 +45,9 @@ mod tests {
         assert!(matches!(Expr::from(float(1.0)).kind(), ExprKind::Float(_)));
         assert!(matches!(Expr::from(bool_(true)).kind(), ExprKind::Bool(_)));
         assert!(matches!(Expr::from(nil()).kind(), ExprKind::Nil(_)));
+        assert!(matches!(
+            Expr::from(tuple([Expr::from(int(1)), Expr::from(string("one"))])).kind(),
+            ExprKind::Tuple(_),
+        ));
     }
 }

--- a/src/planner/dsl/function/params.rs
+++ b/src/planner/dsl/function/params.rs
@@ -2,7 +2,8 @@ use super::FunctionDsl;
 use crate::plan::{
     BoolFunctionLocalId, BoolLocalId, FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId,
     FunctionType, IntFunctionLocalId, IntLocalId, NilFunctionLocalId, NilLocalId, Param,
-    ParamLocal, StringFunctionLocalId, StringLocalId, ValueType,
+    ParamLocal, StringFunctionLocalId, StringLocalId, TupleFunctionLocalId, TupleLocalId,
+    ValueType,
 };
 use ecow::EcoString;
 
@@ -48,6 +49,19 @@ impl FunctionDsl {
     pub(crate) fn param_nil(mut self, local: usize, name: impl Into<EcoString>) -> Self {
         self.params.push(Param::named(
             ParamLocal::nil(NilLocalId(local)),
+            name.into(),
+        ));
+        self
+    }
+
+    pub(crate) fn param_tuple(
+        mut self,
+        local: usize,
+        name: impl Into<EcoString>,
+        type_: impl IntoIterator<Item = ValueType>,
+    ) -> Self {
+        self.params.push(Param::named(
+            ParamLocal::tuple(TupleLocalId(local), type_.into_iter().collect()),
             name.into(),
         ));
         self
@@ -133,6 +147,26 @@ impl FunctionDsl {
         self
     }
 
+    pub(crate) fn param_tuple_function(
+        mut self,
+        local: usize,
+        name: impl Into<EcoString>,
+        arguments: impl IntoIterator<Item = ValueType>,
+        return_type: impl IntoIterator<Item = ValueType>,
+    ) -> Self {
+        self.params.push(Param::named(
+            ParamLocal::tuple_function(
+                TupleFunctionLocalId(local),
+                FunctionType::new(
+                    arguments.into_iter().collect(),
+                    ValueType::Tuple(return_type.into_iter().collect()),
+                ),
+            ),
+            name.into(),
+        ));
+        self
+    }
+
     pub(crate) fn param_function_function(
         mut self,
         local: usize,
@@ -149,14 +183,24 @@ impl FunctionDsl {
 
 #[cfg(test)]
 mod tests {
-    use crate::plan::{FloatFunctionLocalId, FloatLocalId, FunctionType, ParamLocal, ValueType};
+    use crate::plan::{
+        FloatFunctionLocalId, FloatLocalId, FunctionType, ParamLocal, TupleFunctionLocalId,
+        TupleLocalId, ValueType,
+    };
     use crate::planner::dsl::function;
 
     #[test]
     fn float_param_helpers_build_float_local_shapes() {
         let function = function("main", crate::planner::dsl::int(1))
             .param_float(0, "value")
-            .param_float_function(0, "callback", [ValueType::Float]);
+            .param_tuple(0, "pair", [ValueType::Int])
+            .param_float_function(0, "callback", [ValueType::Float])
+            .param_tuple_function(
+                0,
+                "tuple_callback",
+                [ValueType::Tuple(vec![ValueType::Int])],
+                [ValueType::String],
+            );
 
         assert_eq!(
             function.params[0].local(),
@@ -164,9 +208,23 @@ mod tests {
         );
         assert_eq!(
             function.params[1].local(),
+            &ParamLocal::tuple(TupleLocalId(0), vec![ValueType::Int]),
+        );
+        assert_eq!(
+            function.params[2].local(),
             &ParamLocal::float_function(
                 FloatFunctionLocalId(0),
                 FunctionType::new(vec![ValueType::Float], ValueType::Float),
+            ),
+        );
+        assert_eq!(
+            function.params[3].local(),
+            &ParamLocal::tuple_function(
+                TupleFunctionLocalId(0),
+                FunctionType::new(
+                    vec![ValueType::Tuple(vec![ValueType::Int])],
+                    ValueType::Tuple(vec![ValueType::String]),
+                ),
             ),
         );
     }

--- a/src/planner/dsl/function/return_body.rs
+++ b/src/planner/dsl/function/return_body.rs
@@ -5,7 +5,7 @@ mod primitive;
 use crate::plan::{
     BoolFunctionReturn, BoolReturn, FloatFunctionReturn, FloatReturn, FunctionFunctionReturn,
     FunctionType, IntFunctionReturn, IntReturn, NilFunctionReturn, NilReturn, ReturnExpr,
-    StringFunctionReturn, StringReturn,
+    StringFunctionReturn, StringReturn, TupleFunctionReturn, TupleReturn, ValueType,
 };
 use crate::planner::context::FunctionRuntimeIds;
 
@@ -18,6 +18,10 @@ pub(crate) enum FunctionReturn {
     Float(FloatReturn),
     Bool(BoolReturn),
     Nil(NilReturn),
+    Tuple {
+        type_: Vec<ValueType>,
+        body: TupleReturn,
+    },
     IntFunction {
         type_: FunctionType,
         body: IntFunctionReturn,
@@ -38,6 +42,10 @@ pub(crate) enum FunctionReturn {
         type_: FunctionType,
         body: NilFunctionReturn,
     },
+    TupleFunction {
+        type_: FunctionType,
+        body: TupleFunctionReturn,
+    },
     FunctionFunction {
         type_: FunctionType,
         body: FunctionFunctionReturn,
@@ -52,6 +60,9 @@ impl FunctionReturn {
             Self::Float(body) => ReturnExpr::float_body(runtime_ids.next_float_id(), body),
             Self::Bool(body) => ReturnExpr::bool_body(runtime_ids.next_bool_id(), body),
             Self::Nil(body) => ReturnExpr::nil_body(runtime_ids.next_nil_id(), body),
+            Self::Tuple { type_, body } => {
+                ReturnExpr::tuple_body(runtime_ids.next_tuple_id(), type_, body)
+            }
             Self::IntFunction { type_, body } => {
                 ReturnExpr::int_function_body(runtime_ids.next_int_function_id(), type_, body)
             }
@@ -67,6 +78,9 @@ impl FunctionReturn {
             Self::NilFunction { type_, body } => {
                 ReturnExpr::nil_function_body(runtime_ids.next_nil_function_id(), type_, body)
             }
+            Self::TupleFunction { type_, body } => {
+                ReturnExpr::tuple_function_body(runtime_ids.next_tuple_function_id(), type_, body)
+            }
             Self::FunctionFunction { type_, body } => ReturnExpr::function_function_body(
                 runtime_ids.next_function_function_id(),
                 type_,
@@ -80,15 +94,17 @@ impl FunctionReturn {
 mod tests {
     use super::FunctionReturn;
     use crate::plan::{
-        BoolFunctionFunctionId, BoolFunctionId, FloatFunctionFunctionId, FloatFunctionId,
+        BoolFunctionFunctionId, BoolFunctionId, Expr, FloatFunctionFunctionId, FloatFunctionId,
         FunctionFunctionFunctionId, FunctionFunctionId, FunctionType, IntFunctionFunctionId,
         IntFunctionId, NilFunctionFunctionId, NilFunctionId, ParamLocal, ReturnExprKind,
-        StringFunctionFunctionId, StringFunctionId, ValueType,
+        StringFunctionFunctionId, StringFunctionId, TupleFunctionFunctionId, TupleFunctionId,
+        ValueType,
     };
     use crate::planner::context::FunctionRuntimeIds;
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, function_function_ref, int,
-        int_function_ref, nil, nil_function_ref, string, string_function_ref,
+        int_function_ref, nil, nil_function_ref, string, string_function_ref, tuple,
+        tuple_function_ref,
     };
 
     #[test]
@@ -136,6 +152,15 @@ mod tests {
                 ..
             },
         ));
+        assert!(matches!(
+            FunctionReturn::from(tuple([Expr::from(int(1))]))
+                .build(&mut runtime_ids)
+                .kind(),
+            ReturnExprKind::Tuple {
+                runtime_id: TupleFunctionId(0),
+                ..
+            },
+        ));
 
         assert!(matches!(
             FunctionReturn::from(int_function_ref(0, Vec::<ParamLocal>::new()))
@@ -179,6 +204,19 @@ mod tests {
                 .kind(),
             ReturnExprKind::NilFunction {
                 runtime_id: NilFunctionFunctionId(0),
+                ..
+            },
+        ));
+        assert!(matches!(
+            FunctionReturn::from(tuple_function_ref(
+                0,
+                Vec::<ParamLocal>::new(),
+                [ValueType::Int],
+            ))
+            .build(&mut runtime_ids)
+            .kind(),
+            ReturnExprKind::TupleFunction {
+                runtime_id: TupleFunctionFunctionId(0),
                 ..
             },
         ));

--- a/src/planner/dsl/function/return_body/conversion.rs
+++ b/src/planner/dsl/function/return_body/conversion.rs
@@ -2,11 +2,11 @@ use super::FunctionReturn;
 use crate::plan::{
     BoolFunctionExpr, BoolReturn, FloatFunctionExpr, FloatReturn, FunctionExpr, FunctionExprKind,
     FunctionFunctionExpr, IntFunctionExpr, IntReturn, NilFunctionExpr, NilReturn, ReturnBody,
-    StringFunctionExpr, StringReturn,
+    StringFunctionExpr, StringReturn, TupleFunctionExpr, TupleReturn,
 };
 use crate::planner::dsl::expression::{
     Bool, BoolFunction, Float, FloatFunction, Function, FunctionFunction, Int, IntFunction, Nil,
-    NilFunction, String, StringFunction,
+    NilFunction, String, StringFunction, Tuple, TupleFunction,
 };
 
 impl From<Int> for FunctionReturn {
@@ -36,6 +36,16 @@ impl From<Bool> for FunctionReturn {
 impl From<Nil> for FunctionReturn {
     fn from(value: Nil) -> Self {
         Self::Nil(ReturnBody::expr(value.into()))
+    }
+}
+
+impl From<Tuple> for FunctionReturn {
+    fn from(value: Tuple) -> Self {
+        let expression = crate::plan::TupleExpr::from(value);
+        Self::Tuple {
+            type_: expression.type_().to_vec(),
+            body: TupleReturn::expr(expression),
+        }
     }
 }
 
@@ -89,6 +99,16 @@ impl From<NilFunction> for FunctionReturn {
     }
 }
 
+impl From<TupleFunction> for FunctionReturn {
+    fn from(value: TupleFunction) -> Self {
+        let expression = TupleFunctionExpr::from(value);
+        Self::TupleFunction {
+            type_: expression.type_().clone(),
+            body: ReturnBody::expr(expression),
+        }
+    }
+}
+
 impl From<FunctionFunction> for FunctionReturn {
     fn from(value: FunctionFunction) -> Self {
         let expression = FunctionFunctionExpr::from(value);
@@ -119,6 +139,10 @@ impl From<Function> for FunctionReturn {
                 body: ReturnBody::expr(expression),
             },
             FunctionExprKind::Nil(expression) => Self::NilFunction {
+                type_: expression.type_().clone(),
+                body: ReturnBody::expr(expression),
+            },
+            FunctionExprKind::Tuple(expression) => Self::TupleFunction {
                 type_: expression.type_().clone(),
                 body: ReturnBody::expr(expression),
             },
@@ -164,13 +188,13 @@ impl From<NilReturn> for FunctionReturn {
 mod tests {
     use super::FunctionReturn;
     use crate::plan::{
-        BoolFunctionId, BoolReturn, FunctionFunctionId, FunctionType, IntFunctionFunctionId,
+        BoolFunctionId, BoolReturn, Expr, FunctionFunctionId, FunctionType, IntFunctionFunctionId,
         IntFunctionId, IntReturn, NilFunctionId, NilReturn, ParamLocal, ReturnBodyKind,
-        RuntimeFunctionId, StringFunctionId, StringReturn, ValueType,
+        RuntimeFunctionId, StringFunctionId, StringReturn, TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, function_function_ref, function_ref, int, int_function_ref, nil,
-        nil_function_ref, string, string_function_ref,
+        nil_function_ref, string, string_function_ref, tuple, tuple_function_ref,
     };
 
     #[test]
@@ -191,6 +215,10 @@ mod tests {
             FunctionReturn::from(nil()),
             FunctionReturn::Nil(_),
         ));
+        assert!(matches!(
+            FunctionReturn::from(tuple([Expr::from(int(1))])),
+            FunctionReturn::Tuple { .. },
+        ));
     }
 
     #[test]
@@ -210,6 +238,14 @@ mod tests {
         assert!(matches!(
             FunctionReturn::from(nil_function_ref(0, Vec::<ParamLocal>::new())),
             FunctionReturn::NilFunction { .. },
+        ));
+        assert!(matches!(
+            FunctionReturn::from(tuple_function_ref(
+                0,
+                Vec::<ParamLocal>::new(),
+                [ValueType::Int],
+            )),
+            FunctionReturn::TupleFunction { .. },
         ));
         assert!(matches!(
             FunctionReturn::from(function_function_ref(
@@ -250,6 +286,16 @@ mod tests {
                 Vec::<ParamLocal>::new(),
             )),
             FunctionReturn::NilFunction { .. },
+        ));
+        assert!(matches!(
+            FunctionReturn::from(function_ref(
+                RuntimeFunctionId::Tuple {
+                    id: TupleFunctionId(0),
+                    return_type: vec![ValueType::Int],
+                },
+                Vec::<ParamLocal>::new(),
+            )),
+            FunctionReturn::TupleFunction { .. },
         ));
         assert!(matches!(
             FunctionReturn::from(function_ref(

--- a/src/planner/error/invalid.rs
+++ b/src/planner/error/invalid.rs
@@ -67,6 +67,8 @@ pub enum InvalidExpressionShapeKind {
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum InvalidExpressionType {
+    #[error("unsupported")]
+    Unsupported,
     #[error("Int")]
     Int,
     #[error("String")]
@@ -77,6 +79,8 @@ pub enum InvalidExpressionType {
     Bool,
     #[error("Nil")]
     Nil,
+    #[error("Tuple")]
+    Tuple,
     #[error("Function")]
     Function,
 }

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -70,10 +70,6 @@ pub enum UnsupportedExpressionKind {
     Panic,
     #[error("todo")]
     Todo,
-    #[error("tuple")]
-    Tuple,
-    #[error("tuple index")]
-    TupleIndex,
     #[error("function literal type is not supported")]
     UnsupportedFunctionLiteralType,
 }

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -408,9 +408,17 @@ mod tests {
         module_returning_typed_expr, typed_int_expr, typed_string_expr, typed_tuple_expr,
     };
     use crate::plan::{
-        Expr, FunctionExpr, FunctionValue, NilFunctionId, RuntimeFunctionId, ValueType,
+        BoolLocalId, Expr, FunctionExpr, FunctionFunctionId, FunctionType, FunctionValue,
+        IntFunctionFunctionId, IntLocalId, NilFunctionId, NilLocalId, ParamLocal,
+        RuntimeFunctionId, StringLocalId, ValueType,
     };
     use crate::planner::context::{AnonymousFunctions, PlanContext};
+    use crate::planner::dsl::{
+        bool_, bool_function_ref, float, float_function_ref, function, function_function_ref, int,
+        int_function_ref, let_tuple_step, local_bool, local_float, local_int, local_nil,
+        local_string, local_tuple, module, nil, nil_function_ref, string, string_function_ref,
+        tuple, tuple_function_ref,
+    };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, dummy_span, expect_plan_error};
     use crate::planner::{
@@ -605,6 +613,10 @@ pub fn main() {
         );
         assert_eq!(
             super::plan_float_expr(invalid_expr(type_::float()), &mut context),
+            Err(expected.clone()),
+        );
+        assert_eq!(
+            super::plan_bool_expr(invalid_expr(type_::bool()), &mut context),
             Err(expected),
         );
     }
@@ -638,7 +650,7 @@ pub fn main() {
 
     #[test]
     fn plan_tuple_index_result_families() {
-        let cases = [
+        assert_tuple_index_plan(
             r#"
 fn add_one(value: Int) {
   value + 1
@@ -649,6 +661,138 @@ pub fn main() {
   values.0
 }
 "#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(
+                        0,
+                        "values",
+                        [
+                            ValueType::Bool,
+                            ValueType::Nil,
+                            ValueType::Function(Box::new(int_to_int_type())),
+                        ],
+                    )
+                    .index_bool(0),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([
+                        Expr::from(bool_(true)),
+                        Expr::from(nil()),
+                        Expr::from(int_function_ref(0, [ParamLocal::int(IntLocalId(0))])),
+                    ]),
+                )),
+                [
+                    function("add_one", local_int(0, "value").add_int(int(1)))
+                        .param_int(0, "value"),
+                ],
+            ),
+        );
+
+        assert_tuple_index_plan(
+            r#"
+pub fn main() {
+  let values = #("ok")
+  values.0
+}
+"#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(0, "values", [ValueType::String]).index_string(0),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([Expr::from(string("ok"))]),
+                )),
+                [],
+            ),
+        );
+
+        assert_tuple_index_plan(
+            r#"
+pub fn main() {
+  let values = #(1.5)
+  values.0
+}
+"#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(0, "values", [ValueType::Float]).index_float(0),
+                )
+                .step(let_tuple_step(0, "values", tuple([Expr::from(float(1.5))]))),
+                [],
+            ),
+        );
+
+        assert_tuple_index_plan(
+            r#"
+pub fn main() {
+  let values = #(#(1))
+  values.0
+}
+"#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(0, "values", [ValueType::Tuple(vec![ValueType::Int])])
+                        .index_tuple(0, [ValueType::Int]),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([Expr::from(tuple([Expr::from(int(1))]))]),
+                )),
+                [],
+            ),
+        );
+
+        assert_tuple_index_plan(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let values = #(add_one)
+  values.0
+}
+"#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(
+                        0,
+                        "values",
+                        [ValueType::Function(Box::new(int_to_int_type()))],
+                    )
+                    .index_int_function(0, [ValueType::Int]),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([Expr::from(int_function_ref(
+                        0,
+                        [ParamLocal::int(IntLocalId(0))],
+                    ))]),
+                )),
+                [
+                    function("add_one", local_int(0, "value").add_int(int(1)))
+                        .param_int(0, "value"),
+                ],
+            ),
+        );
+
+        assert_tuple_index_plan(
             r#"
 fn text(value: String) {
   value
@@ -659,6 +803,30 @@ pub fn main() {
   values.0
 }
 "#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(
+                        0,
+                        "values",
+                        [ValueType::Function(Box::new(string_to_string_type()))],
+                    )
+                    .index_string_function(0, [ValueType::String]),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([Expr::from(string_function_ref(
+                        0,
+                        [ParamLocal::string(StringLocalId(0))],
+                    ))]),
+                )),
+                [function("text", local_string(0, "value")).param_string(0, "value")],
+            ),
+        );
+
+        assert_tuple_index_plan(
             r#"
 fn number(value: Float) {
   value
@@ -669,6 +837,30 @@ pub fn main() {
   values.0
 }
 "#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(
+                        0,
+                        "values",
+                        [ValueType::Function(Box::new(float_to_float_type()))],
+                    )
+                    .index_float_function(0, [ValueType::Float]),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([Expr::from(float_function_ref(
+                        0,
+                        [ParamLocal::float(crate::plan::FloatLocalId(0))],
+                    ))]),
+                )),
+                [function("number", local_float(0, "value")).param_float(0, "value")],
+            ),
+        );
+
+        assert_tuple_index_plan(
             r#"
 fn flag(value: Bool) {
   value
@@ -679,6 +871,30 @@ pub fn main() {
   values.0
 }
 "#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(
+                        0,
+                        "values",
+                        [ValueType::Function(Box::new(bool_to_bool_type()))],
+                    )
+                    .index_bool_function(0, [ValueType::Bool]),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([Expr::from(bool_function_ref(
+                        0,
+                        [ParamLocal::bool(BoolLocalId(0))],
+                    ))]),
+                )),
+                [function("flag", local_bool(0, "value")).param_bool(0, "value")],
+            ),
+        );
+
+        assert_tuple_index_plan(
             r#"
 fn unit(value: Nil) {
   value
@@ -689,6 +905,30 @@ pub fn main() {
   values.0
 }
 "#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(
+                        0,
+                        "values",
+                        [ValueType::Function(Box::new(nil_to_nil_type()))],
+                    )
+                    .index_nil_function(0, [ValueType::Nil]),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([Expr::from(nil_function_ref(
+                        0,
+                        [ParamLocal::nil(NilLocalId(0))],
+                    ))]),
+                )),
+                [function("unit", local_nil(0, "value")).param_nil(0, "value")],
+            ),
+        );
+
+        assert_tuple_index_plan(
             r#"
 fn tuple(value: Int) {
   #(value)
@@ -699,6 +939,38 @@ pub fn main() {
   values.0
 }
 "#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(
+                        0,
+                        "values",
+                        [ValueType::Function(Box::new(int_to_tuple_type()))],
+                    )
+                    .index_tuple_function(
+                        0,
+                        [ValueType::Int],
+                        [ValueType::Int],
+                    ),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([Expr::from(tuple_function_ref(
+                        0,
+                        [ParamLocal::int(IntLocalId(0))],
+                        [ValueType::Int],
+                    ))]),
+                )),
+                [
+                    function("tuple", tuple([Expr::from(local_int(0, "value"))]))
+                        .param_int(0, "value"),
+                ],
+            ),
+        );
+
+        assert_tuple_index_plan(
             r#"
 fn add_one(value: Int) {
   value + 1
@@ -713,17 +985,81 @@ pub fn main() {
   values.0
 }
 "#,
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(0, "values", [ValueType::Function(Box::new(getter_type()))])
+                        .index_function_function(0, Vec::<ValueType>::new(), int_to_int_type()),
+                )
+                .step(let_tuple_step(
+                    0,
+                    "values",
+                    tuple([Expr::from(function_function_ref(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                        Vec::<ParamLocal>::new(),
+                        int_to_int_type(),
+                    ))]),
+                )),
+                [
+                    function("add_one", local_int(0, "value").add_int(int(1)))
+                        .param_int(0, "value"),
+                    function("get", int_function_ref(0, [ParamLocal::int(IntLocalId(0))])),
+                ],
+            ),
+        );
+
+        assert_tuple_index_plan(
             r#"
 pub fn main() {
   let values = #(Nil)
   values.0
 }
 "#,
-        ];
+            module(
+                "main",
+                function(
+                    "main",
+                    local_tuple(0, "values", [ValueType::Nil]).index_nil(0),
+                )
+                .step(let_tuple_step(0, "values", tuple([Expr::from(nil())]))),
+                [],
+            ),
+        );
+    }
 
-        for src in cases {
-            assert!(plan_module(compile(src)).is_ok());
-        }
+    fn assert_tuple_index_plan(src: &str, expected: crate::plan::ExecutionPlan) {
+        let actual = plan_module(compile(src)).expect("source should plan");
+
+        assert_eq!(actual, expected);
+    }
+
+    fn int_to_int_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Int], ValueType::Int)
+    }
+
+    fn string_to_string_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::String], ValueType::String)
+    }
+
+    fn float_to_float_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Float], ValueType::Float)
+    }
+
+    fn bool_to_bool_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Bool], ValueType::Bool)
+    }
+
+    fn nil_to_nil_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Nil], ValueType::Nil)
+    }
+
+    fn int_to_tuple_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Int], ValueType::Tuple(vec![ValueType::Int]))
+    }
+
+    fn getter_type() -> FunctionType {
+        FunctionType::new(Vec::new(), ValueType::Function(Box::new(int_to_int_type())))
     }
 
     #[test]

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -6,7 +6,10 @@ mod operator;
 mod pipeline;
 mod var;
 
-use crate::plan::{BoolExpr, Expr, FloatExpr, IntExpr, StringExpr, ValueType};
+use crate::plan::{
+    BoolExpr, Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr, FunctionType, IntExpr,
+    StringExpr, TupleExpr, ValueType,
+};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
     InvalidExpressionShapeKind, InvalidExpressionType, InvalidTypedAstReason, PlanError,
@@ -42,6 +45,15 @@ pub(super) fn plan_expr(
         TypedExpr::NegateInt { value, .. } => operator::plan_negate_int(*value, context),
         TypedExpr::NegateBool { value, .. } => operator::plan_negate_bool(*value, context),
         TypedExpr::Block { statements, .. } => block::plan(statements, context),
+        TypedExpr::Tuple {
+            type_, elements, ..
+        } => plan_tuple(type_, elements, context),
+        TypedExpr::TupleIndex {
+            type_,
+            index,
+            tuple,
+            ..
+        } => plan_tuple_index(type_, index, *tuple, context),
         TypedExpr::Pipeline {
             first_value,
             assignments,
@@ -80,12 +92,6 @@ pub(super) fn plan_expr(
                 kind: InvalidExpressionShapeKind::ModuleSelect,
             },
         }),
-        TypedExpr::Tuple { .. } => Err(PlanError::UnsupportedExpression {
-            kind: UnsupportedExpressionKind::Tuple,
-        }),
-        TypedExpr::TupleIndex { .. } => Err(PlanError::UnsupportedExpression {
-            kind: UnsupportedExpressionKind::TupleIndex,
-        }),
         TypedExpr::Todo { .. } => Err(PlanError::UnsupportedExpression {
             kind: UnsupportedExpressionKind::Todo,
         }),
@@ -108,6 +114,126 @@ pub(super) fn plan_expr(
                 kind: InvalidExpressionShapeKind::Invalid,
             },
         }),
+    }
+}
+
+fn plan_tuple(
+    type_: std::sync::Arc<gleam_core::type_::Type>,
+    elements: Vec<TypedExpr>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let planned_elements = elements
+        .into_iter()
+        .map(|element| plan_expr(element, context))
+        .collect::<Result<Vec<_>, _>>()?;
+    let actual_type = planned_elements
+        .iter()
+        .map(Expr::value_type)
+        .collect::<Vec<_>>();
+    let expected_type = match ValueType::from_gleam(type_.as_ref()) {
+        Some(ValueType::Tuple(type_)) => type_,
+        Some(actual) => {
+            return Err(invalid_expression_type_for_value(
+                ValueType::Tuple(actual_type),
+                actual,
+            ));
+        }
+        None => {
+            return Err(invalid_expression_type(
+                InvalidExpressionType::Tuple,
+                InvalidExpressionType::Unsupported,
+            ));
+        }
+    };
+
+    if expected_type != actual_type {
+        return Err(invalid_expression_type_for_value(
+            ValueType::Tuple(expected_type),
+            ValueType::Tuple(actual_type),
+        ));
+    }
+
+    Ok(Expr::tuple(TupleExpr::value(
+        planned_elements,
+        expected_type,
+    )))
+}
+
+fn plan_tuple_index(
+    type_: std::sync::Arc<gleam_core::type_::Type>,
+    index: u64,
+    tuple: TypedExpr,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    #[cfg(target_pointer_width = "64")]
+    let index = index as usize;
+    #[cfg(not(target_pointer_width = "64"))]
+    let index = usize::try_from(index).map_err(|_| PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionType {
+            expected: InvalidExpressionType::Tuple,
+            actual: InvalidExpressionType::Tuple,
+        },
+    })?;
+    let tuple = plan_expr(tuple, context)?;
+    let actual = expression_type(&tuple);
+    let tuple = tuple
+        .into_tuple()
+        .ok_or_else(|| invalid_expression_type(InvalidExpressionType::Tuple, actual))?;
+    let expected = ValueType::from_gleam(type_.as_ref()).ok_or_else(|| {
+        invalid_expression_type(
+            InvalidExpressionType::Unsupported,
+            InvalidExpressionType::Tuple,
+        )
+    })?;
+    let actual = tuple.type_().get(index).cloned().ok_or_else(|| {
+        invalid_expression_type_for_value(expected.clone(), ValueType::Tuple(vec![]))
+    })?;
+    if actual != expected {
+        return Err(invalid_expression_type_for_value(expected.clone(), actual));
+    }
+
+    tuple_index_expr(tuple, index, expected)
+}
+
+fn tuple_index_expr(
+    tuple: TupleExpr,
+    index: usize,
+    return_type: ValueType,
+) -> Result<Expr, PlanError> {
+    match return_type {
+        ValueType::Int => Ok(Expr::int(IntExpr::tuple_index(tuple, index))),
+        ValueType::String => Ok(Expr::string(StringExpr::tuple_index(tuple, index))),
+        ValueType::Float => Ok(Expr::float(FloatExpr::tuple_index(tuple, index))),
+        ValueType::Bool => Ok(Expr::bool(BoolExpr::tuple_index(tuple, index))),
+        ValueType::Nil => Ok(Expr::nil(crate::plan::NilExpr::tuple_index(tuple, index))),
+        ValueType::Tuple(type_) => Ok(Expr::tuple(TupleExpr::tuple_index(tuple, index, type_))),
+        ValueType::Function(type_) => Ok(tuple_index_function_expr(tuple, index, *type_)),
+    }
+}
+
+fn tuple_index_function_expr(tuple: TupleExpr, index: usize, type_: FunctionType) -> Expr {
+    match type_.return_() {
+        ValueType::Int => Expr::function(FunctionExpr::int(
+            crate::plan::IntFunctionExpr::tuple_index(tuple, index, type_),
+        )),
+        ValueType::String => Expr::function(FunctionExpr::string(
+            crate::plan::StringFunctionExpr::tuple_index(tuple, index, type_),
+        )),
+        ValueType::Float => Expr::function(FunctionExpr::float(
+            crate::plan::FloatFunctionExpr::tuple_index(tuple, index, type_),
+        )),
+        ValueType::Bool => Expr::function(FunctionExpr::bool(
+            crate::plan::BoolFunctionExpr::tuple_index(tuple, index, type_),
+        )),
+        ValueType::Nil => Expr::function(FunctionExpr::nil(
+            crate::plan::NilFunctionExpr::tuple_index(tuple, index, type_),
+        )),
+        ValueType::Tuple(_) => Expr::function(FunctionExpr::tuple(
+            crate::plan::TupleFunctionExpr::tuple_index(tuple, index, type_),
+        )),
+        ValueType::Function(_) => Expr::function(FunctionExpr::function(
+            FunctionFunctionExpr::tuple_index(tuple, index, type_),
+        )),
     }
 }
 
@@ -185,6 +311,7 @@ fn expression_type(expression: &Expr) -> InvalidExpressionType {
         ValueType::Float => InvalidExpressionType::Float,
         ValueType::Bool => InvalidExpressionType::Bool,
         ValueType::Nil => InvalidExpressionType::Nil,
+        ValueType::Tuple(_) => InvalidExpressionType::Tuple,
         ValueType::Function(_) => InvalidExpressionType::Function,
     }
 }
@@ -196,6 +323,7 @@ fn value_type_expression_type(type_: ValueType) -> InvalidExpressionType {
         ValueType::Float => InvalidExpressionType::Float,
         ValueType::Bool => InvalidExpressionType::Bool,
         ValueType::Nil => InvalidExpressionType::Nil,
+        ValueType::Tuple(_) => InvalidExpressionType::Tuple,
         ValueType::Function(_) => InvalidExpressionType::Function,
     }
 }
@@ -227,6 +355,18 @@ pub(in crate::planner::expression) fn typed_string_expr(value: &str) -> TypedExp
         location: crate::planner::support::dummy_span(),
         type_: gleam_core::type_::string(),
         value: value.into(),
+    }
+}
+
+#[cfg(test)]
+pub(in crate::planner::expression) fn typed_tuple_expr(
+    type_: std::sync::Arc<gleam_core::type_::Type>,
+    elements: Vec<TypedExpr>,
+) -> TypedExpr {
+    TypedExpr::Tuple {
+        location: crate::planner::support::dummy_span(),
+        type_,
+        elements,
     }
 }
 
@@ -265,7 +405,7 @@ pub(in crate::planner::expression) fn typed_prelude_constructor(
 mod tests {
     use super::{
         expression_type, invalid_expression_type, invalid_expression_type_for_value,
-        module_returning_typed_expr, typed_int_expr, typed_string_expr,
+        module_returning_typed_expr, typed_int_expr, typed_string_expr, typed_tuple_expr,
     };
     use crate::plan::{
         Expr, FunctionExpr, FunctionValue, NilFunctionId, RuntimeFunctionId, ValueType,
@@ -294,23 +434,6 @@ pub fn main() {
 "#,
                 PlanError::UnsupportedExpression {
                     kind: UnsupportedExpressionKind::List,
-                },
-            ),
-            (
-                r#"
-pub fn main() {
-  #(1, 2)
-  1
-}
-"#,
-                PlanError::UnsupportedExpression {
-                    kind: UnsupportedExpressionKind::Tuple,
-                },
-            ),
-            (
-                r#"pub fn main() { #(1, 2).0 }"#,
-                PlanError::UnsupportedExpression {
-                    kind: UnsupportedExpressionKind::TupleIndex,
                 },
             ),
             (
@@ -461,6 +584,32 @@ pub fn main() {
     }
 
     #[test]
+    fn reject_margin_plan_expr_error_propagates_through_typed_expression_helpers() {
+        let module_name = "main".into();
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module_name, &functions, &mut anonymous);
+        let expected = PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionShape {
+                kind: InvalidExpressionShapeKind::Invalid,
+            },
+        };
+
+        assert_eq!(
+            super::plan_int_expr(invalid_expr(type_::int()), &mut context),
+            Err(expected.clone()),
+        );
+        assert_eq!(
+            super::plan_string_expr(invalid_expr(type_::string()), &mut context),
+            Err(expected.clone()),
+        );
+        assert_eq!(
+            super::plan_float_expr(invalid_expr(type_::float()), &mut context),
+            Err(expected),
+        );
+    }
+
+    #[test]
     fn reject_margin_function_expression_type() {
         let expression = Expr::function(FunctionExpr::value(FunctionValue::new(
             RuntimeFunctionId::Nil(NilFunctionId(0)),
@@ -488,6 +637,230 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_tuple_index_result_families() {
+        let cases = [
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let values = #(True, Nil, add_one)
+  values.0
+}
+"#,
+            r#"
+fn text(value: String) {
+  value
+}
+
+pub fn main() {
+  let values = #(text)
+  values.0
+}
+"#,
+            r#"
+fn number(value: Float) {
+  value
+}
+
+pub fn main() {
+  let values = #(number)
+  values.0
+}
+"#,
+            r#"
+fn flag(value: Bool) {
+  value
+}
+
+pub fn main() {
+  let values = #(flag)
+  values.0
+}
+"#,
+            r#"
+fn unit(value: Nil) {
+  value
+}
+
+pub fn main() {
+  let values = #(unit)
+  values.0
+}
+"#,
+            r#"
+fn tuple(value: Int) {
+  #(value)
+}
+
+pub fn main() {
+  let values = #(tuple)
+  values.0
+}
+"#,
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn get() {
+  add_one
+}
+
+pub fn main() {
+  let values = #(get)
+  values.0
+}
+"#,
+            r#"
+pub fn main() {
+  let values = #(Nil)
+  values.0
+}
+"#,
+        ];
+
+        for src in cases {
+            assert!(plan_module(compile(src)).is_ok());
+        }
+    }
+
+    #[test]
+    fn reject_margin_tuple_expression_shapes() {
+        let tuple_int = type_::tuple(vec![type_::int()]);
+        let cases = [
+            (
+                TypedExpr::Tuple {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                    elements: vec![typed_int_expr(1)],
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::Tuple,
+                        actual: InvalidExpressionType::Int,
+                    },
+                },
+            ),
+            (
+                TypedExpr::Tuple {
+                    location: dummy_span(),
+                    type_: type_::tuple(vec![type_::list(type_::int())]),
+                    elements: vec![typed_int_expr(1)],
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::Tuple,
+                        actual: InvalidExpressionType::Unsupported,
+                    },
+                },
+            ),
+            (
+                TypedExpr::Tuple {
+                    location: dummy_span(),
+                    type_: type_::tuple(vec![type_::string()]),
+                    elements: vec![typed_int_expr(1)],
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::Tuple,
+                        actual: InvalidExpressionType::Tuple,
+                    },
+                },
+            ),
+            (
+                TypedExpr::Tuple {
+                    location: dummy_span(),
+                    type_: type_::tuple(vec![type_::int()]),
+                    elements: vec![invalid_expr(type_::int())],
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionShape {
+                        kind: InvalidExpressionShapeKind::Invalid,
+                    },
+                },
+            ),
+            (
+                TypedExpr::TupleIndex {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                    index: 0,
+                    tuple: Box::new(typed_int_expr(1)),
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::Tuple,
+                        actual: InvalidExpressionType::Int,
+                    },
+                },
+            ),
+            (
+                TypedExpr::TupleIndex {
+                    location: dummy_span(),
+                    type_: type_::list(type_::int()),
+                    index: 0,
+                    tuple: Box::new(typed_tuple_expr(tuple_int.clone(), vec![typed_int_expr(1)])),
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::Unsupported,
+                        actual: InvalidExpressionType::Tuple,
+                    },
+                },
+            ),
+            (
+                TypedExpr::TupleIndex {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                    index: 1,
+                    tuple: Box::new(typed_tuple_expr(tuple_int.clone(), vec![typed_int_expr(1)])),
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::Int,
+                        actual: InvalidExpressionType::Tuple,
+                    },
+                },
+            ),
+            (
+                TypedExpr::TupleIndex {
+                    location: dummy_span(),
+                    type_: type_::string(),
+                    index: 0,
+                    tuple: Box::new(typed_tuple_expr(tuple_int, vec![typed_int_expr(1)])),
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::String,
+                        actual: InvalidExpressionType::Int,
+                    },
+                },
+            ),
+            (
+                TypedExpr::TupleIndex {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                    index: 0,
+                    tuple: Box::new(invalid_expr(type_::tuple(vec![type_::int()]))),
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionShape {
+                        kind: InvalidExpressionShapeKind::Invalid,
+                    },
+                },
+            ),
+        ];
+
+        for (expression, expected) in cases {
+            assert_eq!(
+                plan_module(module_returning_typed_expr(expression)),
+                Err(expected)
+            );
+        }
+    }
+
+    #[test]
     fn reject_margin_float_expression_type_direct() {
         let module_name = "main".into();
         let functions = HashMap::new();
@@ -503,5 +876,13 @@ pub fn main() {
                 },
             }),
         );
+    }
+
+    fn invalid_expr(type_: std::sync::Arc<type_::Type>) -> TypedExpr {
+        TypedExpr::Invalid {
+            location: dummy_span(),
+            type_,
+            extra_information: None,
+        }
     }
 }

--- a/src/planner/expression/block.rs
+++ b/src/planner/expression/block.rs
@@ -1,7 +1,7 @@
 use crate::plan::{
     BoolExpr, BoolFunctionExpr, Expr, ExprKind, FloatExpr, FloatFunctionExpr, FunctionExpr,
     FunctionExprKind, FunctionFunctionExpr, IntExpr, IntFunctionExpr, NilExpr, NilFunctionExpr,
-    Step, StringExpr, StringFunctionExpr,
+    Step, StringExpr, StringFunctionExpr, TupleExpr, TupleFunctionExpr,
 };
 use crate::planner::context::PlanContext;
 use crate::planner::error::PlanError;
@@ -27,6 +27,7 @@ pub(super) fn block_expr(steps: Vec<Step>, return_: Expr) -> Expr {
         ExprKind::Float(return_) => Expr::float(FloatExpr::block(steps, return_)),
         ExprKind::Bool(return_) => Expr::bool(BoolExpr::block(steps, return_)),
         ExprKind::Nil(return_) => Expr::nil(NilExpr::block(steps, return_)),
+        ExprKind::Tuple(return_) => Expr::tuple(TupleExpr::block(steps, return_)),
         ExprKind::Function(return_) => match return_.into_kind() {
             FunctionExprKind::Int(return_) => {
                 Expr::function(FunctionExpr::int(IntFunctionExpr::block(steps, return_)))
@@ -43,6 +44,9 @@ pub(super) fn block_expr(steps: Vec<Step>, return_: Expr) -> Expr {
             FunctionExprKind::Nil(return_) => {
                 Expr::function(FunctionExpr::nil(NilFunctionExpr::block(steps, return_)))
             }
+            FunctionExprKind::Tuple(return_) => Expr::function(FunctionExpr::tuple(
+                TupleFunctionExpr::block(steps, return_),
+            )),
             FunctionExprKind::Function(return_) => Expr::function(FunctionExpr::function(
                 FunctionFunctionExpr::block(steps, return_),
             )),

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -42,7 +42,6 @@ pub(super) fn plan_call(
         arguments,
         context,
         None,
-        CallArgumentMode::Normal,
         FunctionValueCallMode::Allow,
     )
 }
@@ -78,12 +77,6 @@ enum FunctionValueCallMode {
     Reject,
 }
 
-#[derive(Clone, Copy)]
-enum CallArgumentMode {
-    Normal,
-    Use,
-}
-
 struct CaptureSubstitution {
     name: EcoString,
     value: Expr,
@@ -116,7 +109,6 @@ fn plan_call_expression(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
-    call_argument_mode: CallArgumentMode,
     function_value_call_mode: FunctionValueCallMode,
 ) -> Result<Expr, PlanError> {
     if let TypedExpr::Var { constructor, .. } = &fun {
@@ -139,12 +131,7 @@ fn plan_call_expression(
                         },
                     })?;
                 return direct::plan_direct_function_call(
-                    type_,
-                    function,
-                    arguments,
-                    context,
-                    capture,
-                    call_argument_mode,
+                    type_, function, arguments, context, capture,
                 );
             }
             ValueConstructorVariant::ModuleConstant { .. } => {
@@ -178,14 +165,7 @@ fn plan_call_expression(
         });
     }
 
-    function_value::plan_function_value_call(
-        type_,
-        fun,
-        arguments,
-        context,
-        capture,
-        call_argument_mode,
-    )
+    function_value::plan_function_value_call(type_, fun, arguments, context, capture)
 }
 
 #[cfg(test)]

--- a/src/planner/expression/call/argument.rs
+++ b/src/planner/expression/call/argument.rs
@@ -1,23 +1,18 @@
-use super::{CallArgumentMode, CaptureSubstitution};
-use crate::plan::{CallArg, Expr, ParamLocal, ValueType};
+use super::CaptureSubstitution;
+use crate::plan::{CallArg, Expr, ParamLocal, TupleFunctionLocalId, TupleLocalId, ValueType};
 use crate::planner::context::{FunctionParam, PlanContext};
-use crate::planner::error::{
-    InvalidCallShapeReason, InvalidTypedAstReason, InvalidUseShapeReason, PlanError,
-};
-use gleam_core::ast::{
-    CallArg as GleamCallArg, FunctionLiteralKind, ImplicitCallArgOrigin, TypedExpr,
-};
+use crate::planner::error::{InvalidCallShapeReason, InvalidTypedAstReason, PlanError};
+use gleam_core::ast::{CallArg as GleamCallArg, TypedExpr};
 
 pub(super) fn plan_call_args(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     params: &[FunctionParam],
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
-    call_argument_mode: CallArgumentMode,
 ) -> Result<Vec<CallArg>, PlanError> {
     let mut args = Vec::with_capacity(arguments.len());
     for (argument, param) in arguments.into_iter().zip(params) {
-        let expression = plan_argument_value(argument, capture, context, call_argument_mode)?;
+        let expression = plan_argument_value(argument, capture, context)?;
         let actual = expression.value_type();
         let arg = match expression.into_call_arg(&param.local) {
             Some(arg) => arg,
@@ -33,12 +28,11 @@ pub(super) fn plan_function_call_args(
     params: &[ValueType],
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
-    call_argument_mode: CallArgumentMode,
 ) -> Result<Vec<CallArg>, PlanError> {
     let locals = function_call_param_locals(params);
     let mut args = Vec::with_capacity(arguments.len());
     for (argument, local) in arguments.into_iter().zip(&locals) {
-        let expression = plan_argument_value(argument, capture, context, call_argument_mode)?;
+        let expression = plan_argument_value(argument, capture, context)?;
         let actual = expression.value_type();
         let arg = match expression.into_call_arg(local) {
             Some(arg) => arg,
@@ -55,11 +49,13 @@ fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
     let mut next_float = 0;
     let mut next_bool = 0;
     let mut next_nil = 0;
+    let mut next_tuple = 0;
     let mut next_int_function = 0;
     let mut next_string_function = 0;
     let mut next_float_function = 0;
     let mut next_bool_function = 0;
     let mut next_nil_function = 0;
+    let mut next_tuple_function = 0;
     let mut next_function_function = 0;
 
     params
@@ -88,6 +84,11 @@ fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
             ValueType::Nil => {
                 let local = ParamLocal::nil(crate::plan::NilLocalId(next_nil));
                 next_nil += 1;
+                local
+            }
+            ValueType::Tuple(type_) => {
+                let local = ParamLocal::tuple(TupleLocalId(next_tuple), type_.clone());
+                next_tuple += 1;
                 local
             }
             ValueType::Function(type_) => match type_.return_() {
@@ -131,6 +132,14 @@ fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
                     next_nil_function += 1;
                     local
                 }
+                ValueType::Tuple(_) => {
+                    let local = ParamLocal::tuple_function(
+                        TupleFunctionLocalId(next_tuple_function),
+                        type_.as_ref().clone(),
+                    );
+                    next_tuple_function += 1;
+                    local
+                }
                 ValueType::Function(_) => {
                     let local = ParamLocal::function_function(
                         crate::plan::FunctionFunctionLocalId(next_function_function),
@@ -160,14 +169,7 @@ fn plan_argument_value(
     argument: GleamCallArg<TypedExpr>,
     capture: Option<&CaptureSubstitution>,
     context: &mut PlanContext<'_>,
-    call_argument_mode: CallArgumentMode,
 ) -> Result<Expr, PlanError> {
-    if matches!(call_argument_mode, CallArgumentMode::Use)
-        && matches!(argument.implicit, Some(ImplicitCallArgOrigin::Use))
-    {
-        return plan_use_callback_argument(argument.value, context);
-    }
-
     if let Some(capture) = capture
         && super::is_capture_local(&argument.value, &capture.name)
     {
@@ -175,27 +177,6 @@ fn plan_argument_value(
     }
 
     super::super::plan_expr(argument.value, context)
-}
-
-fn plan_use_callback_argument(
-    argument: TypedExpr,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    match argument {
-        TypedExpr::Fn {
-            type_,
-            kind: FunctionLiteralKind::Use { .. },
-            arguments,
-            body,
-            ..
-        } => super::super::function::plan_use_callback(type_, arguments, body, context),
-        TypedExpr::Fn { .. } => Err(super::invalid_use_shape(
-            InvalidUseShapeReason::CallbackLiteralKindNotUse,
-        )),
-        _ => Err(super::invalid_use_shape(
-            InvalidUseShapeReason::CallbackNotFunctionLiteral,
-        )),
-    }
 }
 
 #[cfg(test)]
@@ -234,6 +215,10 @@ mod tests {
                     ValueType::Nil,
                 ))),
                 ValueType::Function(Box::new(FunctionType::new(
+                    vec![ValueType::Tuple(vec![ValueType::Int])],
+                    ValueType::Tuple(vec![ValueType::Int]),
+                ))),
+                ValueType::Function(Box::new(FunctionType::new(
                     Vec::new(),
                     ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int,))),
                 ))),
@@ -264,6 +249,13 @@ mod tests {
                 ParamLocal::nil_function(
                     crate::plan::NilFunctionLocalId(0),
                     FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+                ),
+                ParamLocal::tuple_function(
+                    crate::plan::TupleFunctionLocalId(0),
+                    FunctionType::new(
+                        vec![ValueType::Tuple(vec![ValueType::Int])],
+                        ValueType::Tuple(vec![ValueType::Int]),
+                    ),
                 ),
                 ParamLocal::function_function(
                     crate::plan::FunctionFunctionLocalId(0),

--- a/src/planner/expression/call/direct.rs
+++ b/src/planner/expression/call/direct.rs
@@ -1,7 +1,7 @@
-use super::{CallArgumentMode, CaptureSubstitution};
+use super::CaptureSubstitution;
 use crate::plan::{
     BoolExpr, CallArg, Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr, IntExpr, NilExpr,
-    RuntimeFunctionId, StringExpr, ValueType,
+    RuntimeFunctionId, StringExpr, TupleExpr, TupleFunctionExpr, ValueType,
 };
 use crate::planner::context::{FunctionInfo, PlanContext};
 use crate::planner::error::{InvalidCallShapeReason, InvalidTypedAstReason, PlanError};
@@ -15,7 +15,6 @@ pub(super) fn plan_direct_function_call(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
-    call_argument_mode: CallArgumentMode,
 ) -> Result<Expr, PlanError> {
     if function.arity() != arguments.len() {
         return Err(PlanError::InvalidTypedAst {
@@ -38,13 +37,7 @@ pub(super) fn plan_direct_function_call(
             },
         });
     }
-    let args = super::argument::plan_call_args(
-        arguments,
-        &function.params,
-        context,
-        capture,
-        call_argument_mode,
-    )?;
+    let args = super::argument::plan_call_args(arguments, &function.params, context, capture)?;
 
     Ok(call_expr(function_id, args))
 }
@@ -56,6 +49,9 @@ fn call_expr(function: RuntimeFunctionId, args: Vec<CallArg>) -> Expr {
         RuntimeFunctionId::Float(function) => Expr::float(FloatExpr::call(function, args)),
         RuntimeFunctionId::Bool(function) => Expr::bool(BoolExpr::call(function, args)),
         RuntimeFunctionId::Nil(function) => Expr::nil(NilExpr::call(function, args)),
+        RuntimeFunctionId::Tuple { id, return_type } => {
+            Expr::tuple(TupleExpr::call(id, args, return_type))
+        }
         RuntimeFunctionId::Function { id, return_type } => {
             function_returning_function_call_expr(id, args, return_type)
         }
@@ -82,6 +78,9 @@ fn function_returning_function_call_expr(
         )),
         crate::plan::FunctionFunctionId::Nil(function) => Expr::function(FunctionExpr::nil(
             crate::plan::NilFunctionExpr::call(function, args, return_type),
+        )),
+        crate::plan::FunctionFunctionId::Tuple(function) => Expr::function(FunctionExpr::tuple(
+            TupleFunctionExpr::call(function, args, return_type),
         )),
         crate::plan::FunctionFunctionId::Function(function) => Expr::function(
             FunctionExpr::function(FunctionFunctionExpr::call(function, args, return_type)),
@@ -253,7 +252,7 @@ pub fn main() {
         let (type_, _, _) = expect_call_statement_mut(
             &mut unsupported_return_type_call.definitions.functions[1].body[0],
         );
-        *type_ = type_::tuple(vec![type_::int()]);
+        *type_ = type_::list(type_::int());
         assert_eq!(
             plan_module(unsupported_return_type_call),
             Err(PlanError::InvalidTypedAst {

--- a/src/planner/expression/call/function_value.rs
+++ b/src/planner/expression/call/function_value.rs
@@ -1,4 +1,4 @@
-use super::{CallArgumentMode, CaptureSubstitution};
+use super::CaptureSubstitution;
 use crate::plan::{CallArg, Expr, FunctionExpr, FunctionFunctionExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
@@ -14,7 +14,6 @@ pub(super) fn plan_function_value_call(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
-    call_argument_mode: CallArgumentMode,
 ) -> Result<Expr, PlanError> {
     let function = {
         let expression = super::super::plan_expr(fun, context)?;
@@ -55,7 +54,6 @@ pub(super) fn plan_function_value_call(
         function_type.argument_types(),
         context,
         capture,
-        call_argument_mode,
     )?;
 
     function_call_expr(function, args, return_type)
@@ -94,6 +92,14 @@ fn function_call_expr(
         ValueType::Nil => match function.into_nil() {
             Some(function) => Ok(Expr::nil(crate::plan::NilExpr::function_call(
                 function, args,
+            ))),
+            None => Err(function_call_return_type_mismatch()),
+        },
+        ValueType::Tuple(return_type) => match function.into_tuple() {
+            Some(function) => Ok(Expr::tuple(crate::plan::TupleExpr::function_call(
+                function,
+                args,
+                return_type,
             ))),
             None => Err(function_call_return_type_mismatch()),
         },
@@ -137,6 +143,9 @@ fn function_returning_function_value_call_expr(
         ValueType::Nil => Expr::function(FunctionExpr::nil(
             crate::plan::NilFunctionExpr::function_call(function, args, return_type),
         )),
+        ValueType::Tuple(_) => Expr::function(FunctionExpr::tuple(
+            crate::plan::TupleFunctionExpr::function_call(function, args, return_type),
+        )),
         ValueType::Function(_) => Expr::function(FunctionExpr::function(
             FunctionFunctionExpr::function_call(function, args, return_type),
         )),
@@ -150,17 +159,17 @@ mod tests {
         function_returning_function_value_call_expr,
     };
     use crate::plan::{
-        BoolFunctionFunctionId, BoolFunctionId, FloatFunctionFunctionId, FloatFunctionId,
+        BoolFunctionFunctionId, BoolFunctionId, Expr, FloatFunctionFunctionId, FloatFunctionId,
         FunctionExpr, FunctionFunctionExpr, FunctionFunctionFunctionId, FunctionFunctionId,
         FunctionType, IntFunctionFunctionId, IntLocalId, LocalId, NilFunctionFunctionId,
         NilFunctionId, ParamLocal, RuntimeFunctionId, StringFunctionFunctionId, StringFunctionId,
-        ValueType,
+        TupleFunctionFunctionId, TupleFunctionId, TupleLocalId, ValueType,
     };
     use crate::planner::dsl::{
         block_int_function, bool_, bool_case_int_function, call_int_function, function,
         function_function_ref, function_ref, int, int_case_int_function, int_function_call_arg,
-        int_function_ref, let_int_function_step, local_int, local_int_function, module,
-        module_with_anonymous,
+        int_function_ref, let_int_function_step, local_int, local_int_function, local_tuple,
+        module, module_with_anonymous, string, tuple, tuple_arg, tuple_function_ref,
     };
     use crate::planner::expression::call::support::expect_call_statement_mut;
     use crate::planner::expression::{typed_int_expr, typed_string_expr};
@@ -392,6 +401,50 @@ pub fn main() {
                 ),
             ),
             [add_one, add_ten],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_function_value_call_tuple_argument() {
+        let actual = plan_module(compile(
+            r#"
+fn tuple_score(pair: #(Int, String)) {
+  pair.0
+}
+
+pub fn main() {
+  let function = tuple_score
+  function(#(41, "ok"))
+}
+"#,
+        ))
+        .expect("source should plan");
+        let pair_type = vec![ValueType::Int, ValueType::String];
+        let pair_param = ParamLocal::tuple(TupleLocalId(0), pair_type.clone());
+        let expected = module(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    local_int_function(0, "function", [ValueType::Tuple(pair_type.clone())]),
+                    [tuple_arg(
+                        0,
+                        tuple([Expr::from(int(41)), Expr::from(string("ok"))]),
+                    )],
+                ),
+            )
+            .step(let_int_function_step(
+                0,
+                "function",
+                int_function_ref(1, [pair_param.clone()]),
+            )),
+            [function(
+                "tuple_score",
+                local_tuple(0, "pair", pair_type.clone()).index_int(0),
+            )
+            .param_tuple(0, "pair", pair_type)],
         );
 
         assert_eq!(actual, expected);
@@ -730,6 +783,22 @@ pub fn main() {
             .value_type(),
             ValueType::Nil,
         );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::Tuple {
+                        id: TupleFunctionId(0),
+                        return_type: vec![ValueType::Int],
+                    },
+                    Vec::<ParamLocal>::new(),
+                )),
+                Vec::new(),
+                ValueType::Tuple(vec![ValueType::Int]),
+            )
+            .expect("tuple function call")
+            .value_type(),
+            ValueType::Tuple(vec![ValueType::Int]),
+        );
 
         let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
         assert_eq!(
@@ -770,6 +839,13 @@ pub fn main() {
             (
                 FunctionFunctionId::Nil(NilFunctionFunctionId(0)),
                 FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+            ),
+            (
+                FunctionFunctionId::Tuple(TupleFunctionFunctionId(0)),
+                FunctionType::new(
+                    vec![ValueType::Tuple(vec![ValueType::Int])],
+                    ValueType::Tuple(vec![ValueType::Int]),
+                ),
             ),
             (
                 FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),
@@ -844,6 +920,26 @@ pub fn main() {
                 FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
                 Vec::new(),
                 ValueType::Nil,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
+                Vec::new(),
+                ValueType::Tuple(vec![ValueType::Int]),
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(tuple_function_ref(
+                    0,
+                    Vec::<ParamLocal>::new(),
+                    [ValueType::Int],
+                )),
+                Vec::new(),
+                ValueType::Int,
             ),
             Err(function_call_return_type_mismatch()),
         );

--- a/src/planner/expression/call/implicit.rs
+++ b/src/planner/expression/call/implicit.rs
@@ -1,4 +1,4 @@
-use super::{CallArgumentMode, CaptureSubstitution, FunctionValueCallMode};
+use super::{CaptureSubstitution, FunctionValueCallMode};
 use crate::plan::Expr;
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
@@ -23,14 +23,13 @@ pub(super) fn plan_use_call(
             arguments,
             ..
         } => {
-            validate_use_call_arguments(&arguments)?;
+            let arguments = normalize_use_call_arguments(arguments)?;
             super::plan_call_expression(
                 type_,
                 *fun,
                 arguments,
                 context,
                 None,
-                CallArgumentMode::Use,
                 FunctionValueCallMode::Allow,
             )
         }
@@ -52,7 +51,6 @@ pub(super) fn plan_pipeline_direct_call(
         arguments,
         context,
         None,
-        CallArgumentMode::Normal,
         FunctionValueCallMode::Reject,
     )
 }
@@ -107,7 +105,6 @@ pub(super) fn plan_pipeline_hole_call(
             name: capture_name,
             value: pipe_value,
         }),
-        CallArgumentMode::Normal,
         FunctionValueCallMode::Reject,
     )
 }
@@ -147,7 +144,9 @@ fn pipeline_hole_body_call(
     }
 }
 
-fn validate_use_call_arguments(arguments: &[GleamCallArg<TypedExpr>]) -> Result<(), PlanError> {
+fn normalize_use_call_arguments(
+    mut arguments: Vec<GleamCallArg<TypedExpr>>,
+) -> Result<Vec<GleamCallArg<TypedExpr>>, PlanError> {
     if arguments.iter().any(|argument| argument.label.is_some()) {
         return Err(PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::CallShape {
@@ -180,13 +179,36 @@ fn validate_use_call_arguments(arguments: &[GleamCallArg<TypedExpr>]) -> Result<
         }
     }
 
-    match callback_index {
-        Some(index) if index + 1 == arguments.len() => Ok(()),
+    let callback_index = match callback_index {
+        Some(index) if index + 1 == arguments.len() => index,
         Some(_) => Err(super::invalid_use_shape(
             InvalidUseShapeReason::CallbackNotLast,
-        )),
+        ))?,
         None => Err(super::invalid_use_shape(
             InvalidUseShapeReason::MissingCallback,
+        ))?,
+    };
+
+    let callback = &mut arguments[callback_index];
+    callback.implicit = None;
+    normalize_use_callback(&mut callback.value)?;
+
+    Ok(arguments)
+}
+
+fn normalize_use_callback(callback: &mut TypedExpr) -> Result<(), PlanError> {
+    match callback {
+        TypedExpr::Fn { kind, .. } => match kind {
+            FunctionLiteralKind::Use { location } => {
+                *kind = FunctionLiteralKind::Anonymous { head: *location };
+                Ok(())
+            }
+            FunctionLiteralKind::Anonymous { .. } | FunctionLiteralKind::Capture { .. } => Err(
+                super::invalid_use_shape(InvalidUseShapeReason::CallbackLiteralKindNotUse),
+            ),
+        },
+        _ => Err(super::invalid_use_shape(
+            InvalidUseShapeReason::CallbackNotFunctionLiteral,
         )),
     }
 }

--- a/src/planner/expression/case/bool_subject.rs
+++ b/src/planner/expression/case/bool_subject.rs
@@ -138,6 +138,9 @@ fn bool_case_expr(subject: BoolExpr, true_: Expr, false_: Expr) -> Result<Expr, 
         }
         (ExprKind::Bool(true_), ExprKind::Bool(false_)) => BoolCaseBranches::Bool { true_, false_ },
         (ExprKind::Nil(true_), ExprKind::Nil(false_)) => BoolCaseBranches::Nil { true_, false_ },
+        (ExprKind::Tuple(true_), ExprKind::Tuple(false_)) => {
+            BoolCaseBranches::Tuple { true_, false_ }
+        }
         (ExprKind::Function(true_), ExprKind::Function(false_)) => {
             bool_function_case_branches(true_, false_)?
         }
@@ -174,6 +177,10 @@ fn bool_function_case_branches(
         (crate::plan::FunctionExprKind::Nil(true_), crate::plan::FunctionExprKind::Nil(false_)) => {
             Ok(BoolCaseBranches::NilFunction { true_, false_ })
         }
+        (
+            crate::plan::FunctionExprKind::Tuple(true_),
+            crate::plan::FunctionExprKind::Tuple(false_),
+        ) => Ok(BoolCaseBranches::TupleFunction { true_, false_ }),
         (
             crate::plan::FunctionExprKind::Function(true_),
             crate::plan::FunctionExprKind::Function(false_),

--- a/src/planner/expression/case/float_subject.rs
+++ b/src/planner/expression/case/float_subject.rs
@@ -126,6 +126,10 @@ fn float_case_expr(
             clauses: nil_case_clauses(clauses)?,
             fallback,
         },
+        ExprKind::Tuple(fallback) => FloatCaseBranches::Tuple {
+            clauses: tuple_case_clauses(clauses)?,
+            fallback,
+        },
         ExprKind::Function(fallback) => function_case_branches(clauses, fallback)?,
     };
 
@@ -197,6 +201,19 @@ fn nil_case_clauses(
     Ok(typed_clauses)
 }
 
+fn tuple_case_clauses(
+    clauses: Vec<(f64, Expr)>,
+) -> Result<Vec<(f64, crate::plan::TupleExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Tuple(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
 fn function_case_branches(
     clauses: Vec<(f64, Expr)>,
     fallback: crate::plan::FunctionExpr,
@@ -220,6 +237,10 @@ fn function_case_branches(
         }),
         crate::plan::FunctionExprKind::Nil(fallback) => Ok(FloatCaseBranches::NilFunction {
             clauses: nil_function_case_clauses(clauses)?,
+            fallback,
+        }),
+        crate::plan::FunctionExprKind::Tuple(fallback) => Ok(FloatCaseBranches::TupleFunction {
+            clauses: tuple_function_case_clauses(clauses)?,
             fallback,
         }),
         crate::plan::FunctionExprKind::Function(fallback) => {
@@ -304,6 +325,22 @@ fn nil_function_case_clauses(
             return Err(branch_return_type_mismatch());
         };
         let Some(clause) = clause.into_nil() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn tuple_function_case_clauses(
+    clauses: Vec<(f64, Expr)>,
+) -> Result<Vec<(f64, crate::plan::TupleFunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        let Some(clause) = clause.into_tuple() else {
             return Err(branch_return_type_mismatch());
         };
         typed_clauses.push((value, clause));
@@ -970,6 +1007,18 @@ pub fn main() {
         );
         assert_eq!(
             super::nil_function_case_clauses(vec![(1.0, int_function_ref_expr(0))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::tuple_case_clauses(vec![(1.0, Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::tuple_function_case_clauses(vec![(1.0, Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::tuple_function_case_clauses(vec![(1.0, int_function_ref_expr(0))]),
             Err(case_branch_return_type_mismatch()),
         );
         assert_eq!(

--- a/src/planner/expression/case/int_subject.rs
+++ b/src/planner/expression/case/int_subject.rs
@@ -127,6 +127,10 @@ fn int_case_expr(
             clauses: nil_case_clauses(clauses)?,
             fallback,
         },
+        ExprKind::Tuple(fallback) => IntCaseBranches::Tuple {
+            clauses: tuple_case_clauses(clauses)?,
+            fallback,
+        },
         ExprKind::Function(fallback) => function_case_branches(clauses, fallback)?,
     };
 
@@ -198,6 +202,19 @@ fn nil_case_clauses(
     Ok(typed_clauses)
 }
 
+fn tuple_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::TupleExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Tuple(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
 fn function_case_branches(
     clauses: Vec<(BigInt, Expr)>,
     fallback: crate::plan::FunctionExpr,
@@ -221,6 +238,10 @@ fn function_case_branches(
         }),
         crate::plan::FunctionExprKind::Nil(fallback) => Ok(IntCaseBranches::NilFunction {
             clauses: nil_function_case_clauses(clauses)?,
+            fallback,
+        }),
+        crate::plan::FunctionExprKind::Tuple(fallback) => Ok(IntCaseBranches::TupleFunction {
+            clauses: tuple_function_case_clauses(clauses)?,
             fallback,
         }),
         crate::plan::FunctionExprKind::Function(fallback) => {
@@ -305,6 +326,22 @@ fn nil_function_case_clauses(
             return Err(branch_return_type_mismatch());
         };
         let Some(clause) = clause.into_nil() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn tuple_function_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::TupleFunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        let Some(clause) = clause.into_tuple() else {
             return Err(branch_return_type_mismatch());
         };
         typed_clauses.push((value, clause));
@@ -565,6 +602,18 @@ fn duplicate_literal(value: Int) {
         );
         assert_eq!(
             super::nil_function_case_clauses(vec![(BigInt::from(1), int_function_ref_expr(0))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::tuple_case_clauses(vec![(BigInt::from(1), Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::tuple_function_case_clauses(vec![(BigInt::from(1), Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::tuple_function_case_clauses(vec![(BigInt::from(1), int_function_ref_expr(0),)]),
             Err(case_branch_return_type_mismatch()),
         );
         assert_eq!(

--- a/src/planner/expression/case/string_subject.rs
+++ b/src/planner/expression/case/string_subject.rs
@@ -129,6 +129,10 @@ fn string_case_expr(
             clauses: nil_case_clauses(clauses)?,
             fallback,
         },
+        ExprKind::Tuple(fallback) => StringCaseBranches::Tuple {
+            clauses: tuple_case_clauses(clauses)?,
+            fallback,
+        },
         ExprKind::Function(fallback) => function_case_branches(clauses, fallback)?,
     };
 
@@ -200,6 +204,19 @@ fn nil_case_clauses(
     Ok(typed_clauses)
 }
 
+fn tuple_case_clauses(
+    clauses: Vec<(EcoString, Expr)>,
+) -> Result<Vec<(EcoString, crate::plan::TupleExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Tuple(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
 fn function_case_branches(
     clauses: Vec<(EcoString, Expr)>,
     fallback: crate::plan::FunctionExpr,
@@ -223,6 +240,10 @@ fn function_case_branches(
         }),
         crate::plan::FunctionExprKind::Nil(fallback) => Ok(StringCaseBranches::NilFunction {
             clauses: nil_function_case_clauses(clauses)?,
+            fallback,
+        }),
+        crate::plan::FunctionExprKind::Tuple(fallback) => Ok(StringCaseBranches::TupleFunction {
+            clauses: tuple_function_case_clauses(clauses)?,
             fallback,
         }),
         crate::plan::FunctionExprKind::Function(fallback) => {
@@ -307,6 +328,22 @@ fn nil_function_case_clauses(
             return Err(branch_return_type_mismatch());
         };
         let Some(clause) = clause.into_nil() else {
+            return Err(branch_return_type_mismatch());
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn tuple_function_case_clauses(
+    clauses: Vec<(EcoString, Expr)>,
+) -> Result<Vec<(EcoString, crate::plan::TupleFunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(clause) = clause.into_kind() else {
+            return Err(branch_return_type_mismatch());
+        };
+        let Some(clause) = clause.into_tuple() else {
             return Err(branch_return_type_mismatch());
         };
         typed_clauses.push((value, clause));
@@ -996,6 +1033,18 @@ pub fn main() {
         );
         assert_eq!(
             super::nil_function_case_clauses(vec![("one".into(), int_function_ref_expr(0))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::tuple_case_clauses(vec![("one".into(), Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::tuple_function_case_clauses(vec![("one".into(), Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::tuple_function_case_clauses(vec![("one".into(), int_function_ref_expr(0))]),
             Err(case_branch_return_type_mismatch()),
         );
         assert_eq!(

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -35,37 +35,8 @@ pub(super) fn plan_anonymous(
     let function_type = anonymous_function_type(type_.as_ref())?;
     let error_name = context.anonymous_function_error_name();
     let params = function_params(error_name.clone(), &arguments)?;
-    validate_argument_types(&error_name, &function_type, &params).and_then(|()| {
-        plan_anonymous_with_valid_arguments(
-            function_type,
-            error_name,
-            params,
-            arguments,
-            body,
-            context,
-        )
-    })
-}
-
-pub(super) fn plan_use_callback(
-    type_: Arc<Type>,
-    arguments: Vec<TypedArg>,
-    body: Vec1<TypedStatement>,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    let function_type = anonymous_function_type(type_.as_ref())?;
-    let error_name = context.anonymous_function_error_name();
-    let params = function_params(error_name.clone(), &arguments)?;
-    validate_argument_types(&error_name, &function_type, &params).and_then(|()| {
-        plan_anonymous_with_valid_arguments(
-            function_type,
-            error_name,
-            params,
-            arguments,
-            body,
-            context,
-        )
-    })
+    validate_argument_types(&error_name, &function_type, &params)?;
+    plan_anonymous_with_valid_arguments(function_type, error_name, params, arguments, body, context)
 }
 
 fn plan_anonymous_with_valid_arguments(
@@ -77,9 +48,8 @@ fn plan_anonymous_with_valid_arguments(
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     let free_names = anonymous_free_variables(&arguments, &body);
-    context.capture_bindings(&free_names).and_then(|captures| {
-        plan_anonymous_with_captures(function_type, error_name, params, captures, body, context)
-    })
+    let captures = context.capture_bindings(&free_names)?;
+    plan_anonymous_with_captures(function_type, error_name, params, captures, body, context)
 }
 
 fn plan_anonymous_with_captures(
@@ -163,6 +133,15 @@ fn closure_expr(
         RuntimeFunctionId::Nil(runtime_id) => FunctionExpr::nil(
             crate::plan::NilFunctionExpr::closure(*runtime_id, params, captures, type_),
         ),
+        RuntimeFunctionId::Tuple { id, return_type } => {
+            FunctionExpr::tuple(crate::plan::TupleFunctionExpr::closure(
+                *id,
+                params,
+                captures,
+                type_,
+                return_type.clone(),
+            ))
+        }
         RuntimeFunctionId::Function { id, return_type } => {
             FunctionExpr::function(crate::plan::FunctionFunctionExpr::closure(
                 *id,
@@ -208,6 +187,12 @@ fn anonymous_function_type(type_: &Type) -> Result<FunctionType, PlanError> {
                 actual: InvalidExpressionType::Nil,
             },
         }),
+        Some(ValueType::Tuple(_)) => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionType {
+                expected: InvalidExpressionType::Function,
+                actual: InvalidExpressionType::Tuple,
+            },
+        }),
         None => Err(anonymous_function_type_error(type_)),
     }
 }
@@ -250,7 +235,11 @@ impl FreeVariables {
     }
 
     fn record(&mut self, name: &EcoString, bound: &HashSet<EcoString>) {
-        if !bound.contains(name) && self.seen.insert(name.clone()) {
+        if bound.contains(name) {
+            return;
+        }
+
+        if self.seen.insert(name.clone()) {
             self.names.push(name.clone());
         }
     }
@@ -351,11 +340,17 @@ fn collect_expr(expression: &TypedExpr, bound: &mut HashSet<EcoString>, free: &m
         TypedExpr::NegateBool { value, .. } | TypedExpr::NegateInt { value, .. } => {
             collect_expr(value, bound, free);
         }
+        TypedExpr::Tuple { elements, .. } => {
+            for element in elements {
+                collect_expr(element, bound, free);
+            }
+        }
+        TypedExpr::TupleIndex { tuple, .. } => {
+            collect_expr(tuple, bound, free);
+        }
         TypedExpr::List { .. }
         | TypedExpr::RecordAccess { .. }
         | TypedExpr::PositionalAccess { .. }
-        | TypedExpr::Tuple { .. }
-        | TypedExpr::TupleIndex { .. }
         | TypedExpr::Todo { .. }
         | TypedExpr::Panic { .. }
         | TypedExpr::Echo { .. }
@@ -422,14 +417,15 @@ fn validate_argument_types(
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        FunctionFunctionId, FunctionType, IntFunctionFunctionId, IntFunctionId, IntLocalId,
-        LocalId, ParamLocal, RuntimeFunctionId, ValueType,
+        Expr, FunctionFunctionId, FunctionType, IntFunctionFunctionId, IntFunctionId, IntLocalId,
+        LocalId, ParamLocal, RuntimeFunctionId, TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        call_int_function, capture_int, function, function_function_closure, function_function_ref,
-        function_ref, int, int_arg, int_function_call_arg, int_function_closure, int_function_ref,
-        int_return_tail_call, let_int_function_step, let_int_step, local_int, local_int_function,
-        module_with_anonymous,
+        call_int_function, capture_int, capture_tuple, function, function_function_closure,
+        function_function_ref, function_ref, int, int_arg, int_function_call_arg,
+        int_function_closure, int_function_ref, int_return_tail_call, let_int_function_step,
+        let_int_step, let_tuple_step, local_int, local_int_function, local_tuple,
+        module_with_anonymous, string, tuple, tuple_function_closure,
     };
     use crate::planner::error::{
         InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
@@ -439,8 +435,8 @@ mod tests {
     use crate::planner::plan_module;
     use crate::planner::support::{compile, dummy_span};
     use gleam_core::ast::{
-        Constant, FunctionLiteralKind, PipelineAssignmentKind, Statement, TypedArg, TypedExpr,
-        TypedModule, TypedPipelineAssignment, TypedStatement,
+        ArgNames, Constant, FunctionLiteralKind, PipelineAssignmentKind, Statement, TypedArg,
+        TypedExpr, TypedModule, TypedPipelineAssignment, TypedStatement,
     };
     use gleam_core::type_::ModuleValueConstructor;
 
@@ -670,6 +666,130 @@ pub fn main() {
     }
 
     #[test]
+    fn anonymous_free_variables_include_use_callback_call() {
+        assert_eq!(
+            anonymous_function_free_variables(
+                r#"
+fn with_value(value: Int, continue: fn(Int) -> Int) {
+  continue(value)
+}
+
+pub fn main() {
+  let use_value = 1
+  fn() {
+    use captured <- with_value(use_value)
+    captured
+  }
+  1
+}
+"#,
+            ),
+            vec!["use_value".to_string()],
+        );
+    }
+
+    #[test]
+    fn anonymous_free_variables_include_supported_expression_shapes() {
+        assert_eq!(
+            anonymous_function_free_variables(
+                r#"
+pub fn main() {
+  let block_value = 1
+  let case_subject = True
+  let pattern_source = 2
+  let case_value = 3
+  let negate_int_value = 4
+  let negate_bool_value = True
+  let tuple_value = #(5, 6)
+  fn() {
+    {
+      block_value
+    }
+    case case_subject {
+      True -> {
+        let branch_local = pattern_source
+        branch_local
+      }
+      False -> case_value
+    }
+    case !negate_bool_value {
+      True -> 0
+      False -> 1
+    }
+    -negate_int_value
+    tuple_value.0
+  }
+  1
+}
+"#,
+            ),
+            vec![
+                "block_value".to_string(),
+                "case_subject".to_string(),
+                "pattern_source".to_string(),
+                "case_value".to_string(),
+                "negate_bool_value".to_string(),
+                "negate_int_value".to_string(),
+                "tuple_value".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn closure_expr_preserves_tuple_return_family() {
+        let return_type = vec![ValueType::Int];
+        let expression = super::closure_expr(
+            &RuntimeFunctionId::Tuple {
+                id: TupleFunctionId(0),
+                return_type: return_type.clone(),
+            },
+            Vec::<ParamLocal>::new(),
+            Vec::new(),
+            FunctionType::new(Vec::new(), ValueType::Tuple(return_type.clone())),
+        );
+
+        assert_eq!(
+            expression.type_(),
+            &FunctionType::new(Vec::new(), ValueType::Tuple(return_type)),
+        );
+    }
+
+    #[test]
+    fn plan_tuple_returning_capturing_anonymous_function() {
+        let actual = plan_module(compile(
+            r#"
+pub fn main() {
+  let pair = #(1, "one")
+  fn() { pair }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let pair_type = [ValueType::Int, ValueType::String];
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                tuple_function_closure(
+                    0,
+                    Vec::<LocalId>::new(),
+                    [capture_tuple(0, local_tuple(0, "pair", pair_type.clone()))],
+                    pair_type.clone(),
+                ),
+            )
+            .step(let_tuple_step(
+                0,
+                "pair",
+                tuple([Expr::from(int(1)), Expr::from(string("one"))]),
+            )),
+            [],
+            [function("<anonymous:0>", local_tuple(0, "pair", pair_type))],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn reject_profile_function_capture_literal() {
         assert_eq!(
             plan_module(compile(
@@ -715,6 +835,10 @@ pub fn main() {
             (gleam_core::type_::float(), InvalidExpressionType::Float),
             (gleam_core::type_::bool(), InvalidExpressionType::Bool),
             (gleam_core::type_::nil(), InvalidExpressionType::Nil),
+            (
+                gleam_core::type_::tuple(vec![gleam_core::type_::int()]),
+                InvalidExpressionType::Tuple,
+            ),
         ] {
             let mut module = anonymous_function_module();
             let (expression_type, _, _) = anonymous_function_expression_mut(&mut module);
@@ -745,6 +869,21 @@ pub fn main() {
                     name: "<anonymous:0>".into(),
                     reason: InvalidFunctionShapeReason::ArgumentTypeMismatch,
                 },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_anonymous_function_param_shape_error_propagates() {
+        let mut module = anonymous_function_module();
+        let (_, arguments, _) = anonymous_function_expression_mut(&mut module);
+        arguments[0] = labelled_arg();
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::UnsupportedArgument {
+                function: "<anonymous:0>".into(),
+                reason: crate::planner::UnsupportedArgumentReason::Labelled,
             }),
         );
     }
@@ -981,5 +1120,44 @@ pub fn main() {
         };
 
         (type_, arguments, kind)
+    }
+
+    fn labelled_arg() -> TypedArg {
+        TypedArg {
+            names: ArgNames::NamedLabelled {
+                label: "label".into(),
+                label_location: dummy_span(),
+                name: "value".into(),
+                name_location: dummy_span(),
+            },
+            location: dummy_span(),
+            annotation: None,
+            type_: gleam_core::type_::int(),
+        }
+    }
+
+    fn anonymous_function_free_variables(src: &str) -> Vec<String> {
+        let module = compile(src);
+        let function = module
+            .definitions
+            .functions
+            .last()
+            .expect("main function should exist");
+        let (arguments, body) = function
+            .body
+            .iter()
+            .find_map(|statement| match statement {
+                Statement::Expression(TypedExpr::Fn {
+                    arguments, body, ..
+                }) => Some((arguments, body)),
+                _ => None,
+            })
+            .expect("expected anonymous function expression statement");
+
+        let mut names = Vec::new();
+        for name in super::anonymous_free_variables(arguments, body) {
+            names.push(name.to_string());
+        }
+        names
     }
 }

--- a/src/planner/expression/operator/equality.rs
+++ b/src/planner/expression/operator/equality.rs
@@ -32,13 +32,23 @@ fn reject_function_equality(
     right: &Expr,
     operator: UnsupportedBinOpKind,
 ) -> Result<(), PlanError> {
-    if matches!(left.value_type(), ValueType::Function(_))
-        || matches!(right.value_type(), ValueType::Function(_))
-    {
+    if contains_function_value(&left.value_type()) || contains_function_value(&right.value_type()) {
         return Err(PlanError::UnsupportedBinOp { operator });
     }
 
     Ok(())
+}
+
+fn contains_function_value(type_: &ValueType) -> bool {
+    match type_ {
+        ValueType::Function(_) => true,
+        ValueType::Tuple(elements) => elements.iter().any(contains_function_value),
+        ValueType::Int
+        | ValueType::Float
+        | ValueType::String
+        | ValueType::Bool
+        | ValueType::Nil => false,
+    }
 }
 
 #[cfg(test)]
@@ -98,6 +108,42 @@ fn add_one(value: Int) {
 
 pub fn main() {
   add_one != add_one
+}
+"#,
+            ),
+            PlanError::UnsupportedBinOp {
+                operator: UnsupportedBinOpKind::NotEqFunction,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_profile_tuple_equality_containing_function_value() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  #(1, add_one) == #(1, add_one)
+}
+"#,
+            ),
+            PlanError::UnsupportedBinOp {
+                operator: UnsupportedBinOpKind::EqFunction,
+            },
+        );
+        assert_eq!(
+            expect_plan_error(
+                r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  #(#(add_one)) != #(#(add_one))
 }
 "#,
             ),

--- a/src/planner/expression/var.rs
+++ b/src/planner/expression/var.rs
@@ -1,7 +1,7 @@
 use crate::plan::{
     BoolExpr, BoolFunctionExpr, Expr, FloatExpr, FloatFunctionExpr, FunctionExpr,
     FunctionFunctionExpr, IntExpr, IntFunctionExpr, LocalId, NilExpr, NilFunctionExpr, StringExpr,
-    StringFunctionExpr, ValueType,
+    StringFunctionExpr, TupleExpr, TupleFunctionExpr, ValueType,
 };
 use crate::planner::context::{FunctionLocalBinding, PlanContext};
 use crate::planner::error::{InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError};
@@ -17,6 +17,9 @@ pub(super) fn plan_var(
         ValueConstructorVariant::LocalVariable { .. } => {
             if let Some((local, type_)) = context.lookup_local(&name) {
                 return local_get(local, name, type_);
+            }
+            if let Some((local, type_)) = context.lookup_tuple_local(&name) {
+                return Ok(Expr::tuple(TupleExpr::local_get(local, name, type_)));
             }
             if let Some(binding) = context.lookup_function_local(&name) {
                 return Ok(function_local_get(binding, name));
@@ -96,6 +99,9 @@ fn function_local_get(binding: FunctionLocalBinding, name: EcoString) -> Expr {
         )),
         FunctionLocalBinding::Nil { local, type_ } => Expr::function(FunctionExpr::nil(
             NilFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::Tuple { local, type_ } => Expr::function(FunctionExpr::tuple(
+            TupleFunctionExpr::local_get(local, name, type_),
         )),
         FunctionLocalBinding::Function { local, type_ } => Expr::function(FunctionExpr::function(
             FunctionFunctionExpr::local_get(local, name, type_),

--- a/src/planner/function/return_body.rs
+++ b/src/planner/function/return_body.rs
@@ -6,7 +6,8 @@ use crate::plan::{
     IntFunctionExpr, IntFunctionExprKind, IntFunctionReturn, IntReturn, NilExpr, NilExprKind,
     NilFunctionExpr, NilFunctionExprKind, NilFunctionReturn, NilReturn, ReturnBody, ReturnExpr,
     RuntimeFunctionId, StringExpr, StringExprKind, StringFunctionExpr, StringFunctionExprKind,
-    StringFunctionReturn, StringReturn, ValueType,
+    StringFunctionReturn, StringReturn, TupleExpr, TupleExprKind, TupleFunctionExpr,
+    TupleFunctionExprKind, TupleFunctionReturn, TupleReturn, ValueType,
 };
 use crate::planner::error::{InvalidFunctionShapeReason, InvalidTypedAstReason, PlanError};
 use ecow::EcoString;
@@ -33,6 +34,15 @@ pub(super) fn function_return_expr(
         (ValueType::Nil, RuntimeFunctionId::Nil(runtime_id), ExprKind::Nil(actual)) => {
             Ok(ReturnExpr::nil_body(*runtime_id, nil_return(actual)))
         }
+        (
+            ValueType::Tuple(expected),
+            RuntimeFunctionId::Tuple { id, return_type },
+            ExprKind::Tuple(actual),
+        ) if expected == actual.type_() && expected == return_type => Ok(ReturnExpr::tuple_body(
+            *id,
+            expected.clone(),
+            tuple_return(actual),
+        )),
         (
             ValueType::Function(expected),
             RuntimeFunctionId::Function { id, return_type },
@@ -93,6 +103,14 @@ fn function_returning_function_expr(
                 runtime_id,
                 type_,
                 nil_function_return(actual),
+            ))
+        }
+        (FunctionFunctionId::Tuple(runtime_id), FunctionExprKind::Tuple(actual)) => {
+            let type_ = actual.type_().clone();
+            Ok(ReturnExpr::tuple_function_body(
+                runtime_id,
+                type_,
+                tuple_function_return(actual),
             ))
         }
         (FunctionFunctionId::Function(runtime_id), FunctionExprKind::Function(actual)) => {
@@ -387,6 +405,61 @@ fn float_return(expression: FloatExpr) -> FloatReturn {
     }
 }
 
+fn tuple_return(expression: TupleExpr) -> TupleReturn {
+    match expression.kind() {
+        TupleExprKind::Call { function, args } => ReturnBody::tail_call(*function, args.clone()),
+        TupleExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => ReturnBody::bool_case(
+            (**subject).clone(),
+            tuple_return((**true_).clone()),
+            tuple_return((**false_).clone()),
+        ),
+        TupleExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::int_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (value.clone(), tuple_return(branch.clone())))
+                .collect(),
+            tuple_return((**fallback).clone()),
+        ),
+        TupleExprKind::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::string_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (value.clone(), tuple_return(branch.clone())))
+                .collect(),
+            tuple_return((**fallback).clone()),
+        ),
+        TupleExprKind::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::float_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (*value, tuple_return(branch.clone())))
+                .collect(),
+            tuple_return((**fallback).clone()),
+        ),
+        TupleExprKind::Block { steps, return_ } => {
+            ReturnBody::block(steps.clone(), tuple_return((**return_).clone()))
+        }
+        _ => ReturnBody::expr(expression),
+    }
+}
+
 fn int_function_return(expression: IntFunctionExpr) -> IntFunctionReturn {
     match expression.kind() {
         IntFunctionExprKind::Call { function, args, .. } => {
@@ -667,6 +740,63 @@ fn nil_function_return(expression: NilFunctionExpr) -> NilFunctionReturn {
         ),
         NilFunctionExprKind::Block { steps, return_ } => {
             ReturnBody::block(steps.clone(), nil_function_return((**return_).clone()))
+        }
+        _ => ReturnBody::expr(expression),
+    }
+}
+
+fn tuple_function_return(expression: TupleFunctionExpr) -> TupleFunctionReturn {
+    match expression.kind() {
+        TupleFunctionExprKind::Call { function, args, .. } => {
+            ReturnBody::tail_call(*function, args.clone())
+        }
+        TupleFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => ReturnBody::bool_case(
+            (**subject).clone(),
+            tuple_function_return((**true_).clone()),
+            tuple_function_return((**false_).clone()),
+        ),
+        TupleFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::int_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (value.clone(), tuple_function_return(branch.clone())))
+                .collect(),
+            tuple_function_return((**fallback).clone()),
+        ),
+        TupleFunctionExprKind::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::string_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (value.clone(), tuple_function_return(branch.clone())))
+                .collect(),
+            tuple_function_return((**fallback).clone()),
+        ),
+        TupleFunctionExprKind::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::float_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (*value, tuple_function_return(branch.clone())))
+                .collect(),
+            tuple_function_return((**fallback).clone()),
+        ),
+        TupleFunctionExprKind::Block { steps, return_ } => {
+            ReturnBody::block(steps.clone(), tuple_function_return((**return_).clone()))
         }
         _ => ReturnBody::expr(expression),
     }

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -215,12 +215,8 @@ pub(super) fn function_params(
     let mut next_string = 0;
     let mut next_bool = 0;
     let mut next_nil = 0;
-    let mut next_int_function = 0;
-    let mut next_float_function = 0;
-    let mut next_string_function = 0;
-    let mut next_bool_function = 0;
-    let mut next_nil_function = 0;
-    let mut next_function_function = 0;
+    let mut next_tuple = 0;
+    let mut function_locals = FunctionParamLocalCounters::default();
 
     arguments
         .iter()
@@ -268,76 +264,87 @@ pub(super) fn function_params(
                     next_nil += 1;
                     local
                 }
-                ValueType::Function(type_) => function_param_local(
-                    type_,
-                    &mut next_int_function,
-                    &mut next_float_function,
-                    &mut next_string_function,
-                    &mut next_bool_function,
-                    &mut next_nil_function,
-                    &mut next_function_function,
-                ),
+                ValueType::Tuple(type_) => {
+                    let local =
+                        ParamLocal::tuple(crate::plan::TupleLocalId(next_tuple), type_.clone());
+                    next_tuple += 1;
+                    local
+                }
+                ValueType::Function(type_) => function_locals.next(type_),
             };
             Ok(FunctionParam { local, binding })
         })
         .collect()
 }
 
-fn function_param_local(
-    type_: &FunctionType,
-    next_int_function: &mut usize,
-    next_float_function: &mut usize,
-    next_string_function: &mut usize,
-    next_bool_function: &mut usize,
-    next_nil_function: &mut usize,
-    next_function_function: &mut usize,
-) -> ParamLocal {
-    match type_.return_() {
-        ValueType::Int => {
-            let local =
-                ParamLocal::int_function(IntFunctionLocalId(*next_int_function), type_.clone());
-            *next_int_function += 1;
-            local
-        }
-        ValueType::Float => {
-            let local = ParamLocal::float_function(
-                crate::plan::FloatFunctionLocalId(*next_float_function),
-                type_.clone(),
-            );
-            *next_float_function += 1;
-            local
-        }
-        ValueType::String => {
-            let local = ParamLocal::string_function(
-                crate::plan::StringFunctionLocalId(*next_string_function),
-                type_.clone(),
-            );
-            *next_string_function += 1;
-            local
-        }
-        ValueType::Bool => {
-            let local = ParamLocal::bool_function(
-                crate::plan::BoolFunctionLocalId(*next_bool_function),
-                type_.clone(),
-            );
-            *next_bool_function += 1;
-            local
-        }
-        ValueType::Nil => {
-            let local = ParamLocal::nil_function(
-                crate::plan::NilFunctionLocalId(*next_nil_function),
-                type_.clone(),
-            );
-            *next_nil_function += 1;
-            local
-        }
-        ValueType::Function(_) => {
-            let local = ParamLocal::function_function(
-                FunctionFunctionLocalId(*next_function_function),
-                type_.clone(),
-            );
-            *next_function_function += 1;
-            local
+#[derive(Default)]
+struct FunctionParamLocalCounters {
+    next_int: usize,
+    next_float: usize,
+    next_string: usize,
+    next_bool: usize,
+    next_nil: usize,
+    next_tuple: usize,
+    next_function: usize,
+}
+
+impl FunctionParamLocalCounters {
+    fn next(&mut self, type_: &FunctionType) -> ParamLocal {
+        match type_.return_() {
+            ValueType::Int => {
+                let local =
+                    ParamLocal::int_function(IntFunctionLocalId(self.next_int), type_.clone());
+                self.next_int += 1;
+                local
+            }
+            ValueType::Float => {
+                let local = ParamLocal::float_function(
+                    crate::plan::FloatFunctionLocalId(self.next_float),
+                    type_.clone(),
+                );
+                self.next_float += 1;
+                local
+            }
+            ValueType::String => {
+                let local = ParamLocal::string_function(
+                    crate::plan::StringFunctionLocalId(self.next_string),
+                    type_.clone(),
+                );
+                self.next_string += 1;
+                local
+            }
+            ValueType::Bool => {
+                let local = ParamLocal::bool_function(
+                    crate::plan::BoolFunctionLocalId(self.next_bool),
+                    type_.clone(),
+                );
+                self.next_bool += 1;
+                local
+            }
+            ValueType::Nil => {
+                let local = ParamLocal::nil_function(
+                    crate::plan::NilFunctionLocalId(self.next_nil),
+                    type_.clone(),
+                );
+                self.next_nil += 1;
+                local
+            }
+            ValueType::Tuple(_) => {
+                let local = ParamLocal::tuple_function(
+                    crate::plan::TupleFunctionLocalId(self.next_tuple),
+                    type_.clone(),
+                );
+                self.next_tuple += 1;
+                local
+            }
+            ValueType::Function(_) => {
+                let local = ParamLocal::function_function(
+                    FunctionFunctionLocalId(self.next_function),
+                    type_.clone(),
+                );
+                self.next_function += 1;
+                local
+            }
         }
     }
 }
@@ -620,6 +627,10 @@ fn higher(callback: fn(fn(Int) -> Int) -> Int) {
 fn getter(callback: fn() -> fn(Int) -> Int) {
   1
 }
+
+fn tuple_getter(callback: fn(#(Int)) -> #(String)) {
+  1
+}
 "#,
         ))
         .expect("source should plan");
@@ -642,6 +653,12 @@ fn getter(callback: fn() -> fn(Int) -> Int) {
                         Vec::new(),
                         ValueType::Function(Box::new(returned_function_type)),
                     ),
+                ),
+                function("tuple_getter", int(1)).param_tuple_function(
+                    0,
+                    "callback",
+                    [ValueType::Tuple(vec![ValueType::Int])],
+                    [ValueType::String],
                 ),
             ],
         );

--- a/src/planner/statement.rs
+++ b/src/planner/statement.rs
@@ -147,6 +147,10 @@ pub(in crate::planner) fn plan_variable_runtime_step(
             let local = context.define_nil_local(name.clone());
             Ok(Step::let_nil(local, name, value))
         }
+        ExprKind::Tuple(value) => {
+            let local = context.define_tuple_local(name.clone(), value.type_().to_vec());
+            Ok(Step::let_tuple(local, name, value))
+        }
         ExprKind::Function(value) => Ok(match value.into_kind() {
             FunctionExprKind::Int(value) => {
                 let local = context.define_int_function_local(name.clone(), value.type_().clone());
@@ -169,6 +173,11 @@ pub(in crate::planner) fn plan_variable_runtime_step(
             FunctionExprKind::Nil(value) => {
                 let local = context.define_nil_function_local(name.clone(), value.type_().clone());
                 Step::let_nil_function(local, name, value)
+            }
+            FunctionExprKind::Tuple(value) => {
+                let local =
+                    context.define_tuple_function_local(name.clone(), value.type_().clone());
+                Step::let_tuple_function(local, name, value)
             }
             FunctionExprKind::Function(value) => {
                 let local =

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -1,4 +1,4 @@
-use crate::plan::FunctionReturnFamily;
+use crate::plan::{FunctionReturnFamily, ValueType};
 
 pub(crate) type ExecutionResult<T> = Result<T, ExecutionError>;
 
@@ -16,6 +16,11 @@ enum ExecutionErrorKind {
         expected: FunctionReturnFamily,
         actual: FunctionReturnFamily,
     },
+    #[error("tuple index family mismatch (expected {expected:?}, got {actual:?})")]
+    TupleIndexFamilyMismatch {
+        expected: ValueType,
+        actual: ValueType,
+    },
 }
 
 impl ExecutionError {
@@ -27,12 +32,18 @@ impl ExecutionError {
             kind: ExecutionErrorKind::FunctionReturnFamilyMismatch { expected, actual },
         }
     }
+
+    pub(crate) fn tuple_index_family_mismatch(expected: ValueType, actual: ValueType) -> Self {
+        Self {
+            kind: ExecutionErrorKind::TupleIndexFamilyMismatch { expected, actual },
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::ExecutionError;
-    use crate::plan::FunctionReturnFamily;
+    use crate::plan::{FunctionReturnFamily, ValueType};
 
     #[test]
     fn function_return_family_mismatch_display() {
@@ -44,6 +55,19 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "execution invariant failed: function return family mismatch (expected Int, got String)",
+        );
+    }
+
+    #[test]
+    fn tuple_index_family_mismatch_display() {
+        let error = ExecutionError::tuple_index_family_mismatch(
+            ValueType::Tuple(vec![ValueType::Int]),
+            ValueType::String,
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "execution invariant failed: tuple index family mismatch (expected Tuple([Int]), got String)",
         );
     }
 }

--- a/src/runtime/expression.rs
+++ b/src/runtime/expression.rs
@@ -4,6 +4,7 @@ mod function;
 mod int;
 mod nil;
 mod string;
+mod tuple;
 
 use crate::plan::{ExecutionPlan, Expr, ExprKind, Value};
 use crate::runtime::ExecutionError;
@@ -15,11 +16,12 @@ pub(super) use self::{
     function::{
         eval_bool_function_expr, eval_float_function_expr, eval_function_expr,
         eval_function_function_expr, eval_int_function_expr, eval_nil_function_expr,
-        eval_string_function_expr,
+        eval_string_function_expr, eval_tuple_function_expr,
     },
     int::eval_int_expr,
     nil::eval_nil_expr,
     string::eval_string_expr,
+    tuple::{eval_tuple_expr, project_tuple_expr},
 };
 
 pub(super) fn eval_expr(
@@ -38,6 +40,7 @@ pub(super) fn eval_expr(
             eval_nil_expr(plan, frame, expression)?;
             Ok(Value::Nil)
         }
+        ExprKind::Tuple(expression) => Ok(Value::Tuple(eval_tuple_expr(plan, frame, expression)?)),
         ExprKind::Function(expression) => {
             let value = eval_function_expr(plan, frame, expression)?;
             Ok(Value::Function(value))

--- a/src/runtime/expression/bool.rs
+++ b/src/runtime/expression/bool.rs
@@ -1,5 +1,5 @@
-use super::{eval_expr, eval_float_expr, eval_int_expr, eval_string_expr};
-use crate::plan::{BoolExpr, BoolExprKind, ExecutionPlan};
+use super::{eval_expr, eval_float_expr, eval_int_expr, eval_string_expr, project_tuple_expr};
+use crate::plan::{BoolExpr, BoolExprKind, ExecutionPlan, Value, ValueType};
 use crate::runtime::ExecutionError;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -17,6 +17,15 @@ pub(in crate::runtime) fn eval_bool_expr(
         }
         BoolExprKind::FunctionCall { function, args } => {
             function::run_bool_function_call(plan, function, args, frame)
+        }
+        BoolExprKind::TupleIndex { tuple, index } => {
+            match project_tuple_expr(plan, frame, tuple, *index, ValueType::Bool)? {
+                Value::Bool(value) => Ok(value),
+                other => Err(ExecutionError::tuple_index_family_mismatch(
+                    ValueType::Bool,
+                    other.value_type(),
+                )),
+            }
         }
         BoolExprKind::Not(value) => Ok(!eval_bool_expr(plan, frame, value)?),
         BoolExprKind::LtInt { left, right } => {
@@ -135,7 +144,7 @@ mod tests {
         BoolExpr, BoolFunctionExpr, ExecutionPlan, Expr, FloatExpr, FloatFunctionExpr,
         FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionValue, FunctionId, FunctionPlan,
         FunctionReturnFamily, FunctionType, IntExpr, IntFunctionExpr, IntFunctionId, ReturnExpr,
-        Step, StringExpr, StringFunctionExpr, StringFunctionFunctionId, ValueType,
+        Step, StringExpr, StringFunctionExpr, StringFunctionFunctionId, TupleExpr, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
@@ -144,6 +153,33 @@ mod tests {
 
     thread_local! {
         static RIGHT_CALLED: Cell<bool> = const { Cell::new(false) };
+    }
+
+    #[test]
+    fn tuple_index_family_mismatch_returns_error() {
+        let plan = crate::runtime::plan_src("pub fn main() { True }");
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::string(StringExpr::value("one".into()))],
+            vec![ValueType::String],
+        );
+
+        assert_eq!(
+            eval_bool_expr(&plan, &mut frame, &BoolExpr::tuple_index(tuple, 0)),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Bool,
+                ValueType::String,
+            )),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::bool(BoolExpr::value(true))],
+            vec![ValueType::Bool],
+        );
+        assert_eq!(
+            eval_bool_expr(&plan, &mut frame, &BoolExpr::tuple_index(tuple, 0)),
+            Ok(true),
+        );
     }
 
     #[test]

--- a/src/runtime/expression/float.rs
+++ b/src/runtime/expression/float.rs
@@ -1,5 +1,5 @@
-use super::{eval_bool_expr, eval_int_expr, eval_string_expr};
-use crate::plan::{ExecutionPlan, FloatExpr, FloatExprKind};
+use super::{eval_bool_expr, eval_int_expr, eval_string_expr, project_tuple_expr};
+use crate::plan::{ExecutionPlan, FloatExpr, FloatExprKind, Value, ValueType};
 use crate::runtime::ExecutionError;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -17,6 +17,15 @@ pub(in crate::runtime) fn eval_float_expr(
         }
         FloatExprKind::FunctionCall { function, args } => {
             function::run_float_function_call(plan, function, args, frame)
+        }
+        FloatExprKind::TupleIndex { tuple, index } => {
+            match project_tuple_expr(plan, frame, tuple, *index, ValueType::Float)? {
+                Value::Float(value) => Ok(value),
+                other => Err(ExecutionError::tuple_index_family_mismatch(
+                    ValueType::Float,
+                    other.value_type(),
+                )),
+            }
         }
         FloatExprKind::Add { left, right } => {
             Ok(eval_float_expr(plan, frame, left)? + eval_float_expr(plan, frame, right)?)
@@ -102,10 +111,38 @@ mod tests {
         FloatFunctionId, FloatLocalId, FrameLayout, FunctionFunctionExpr, FunctionFunctionId,
         FunctionFunctionValue, FunctionId, FunctionPlan, FunctionReturnFamily, FunctionType,
         IntExpr, IntFunctionExpr, ReturnExpr, Step, StringExpr, StringFunctionExpr,
-        StringFunctionFunctionId, ValueType,
+        StringFunctionFunctionId, TupleExpr, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
+
+    #[test]
+    fn tuple_index_family_mismatch_returns_error() {
+        let plan = crate::runtime::plan_src("pub fn main() { 1.0 }");
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::float(FloatExpr::value(1.5))],
+            vec![ValueType::Float],
+        );
+
+        assert_eq!(
+            eval_float_expr(&plan, &mut frame, &FloatExpr::tuple_index(tuple, 0)),
+            Ok(1.5),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::string(StringExpr::value("one".into()))],
+            vec![ValueType::String],
+        );
+
+        assert_eq!(
+            eval_float_expr(&plan, &mut frame, &FloatExpr::tuple_index(tuple, 0)),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Float,
+                ValueType::String,
+            )),
+        );
+    }
 
     #[test]
     fn eval_float_division_by_zero_returns_zero() {

--- a/src/runtime/expression/function.rs
+++ b/src/runtime/expression/function.rs
@@ -4,6 +4,7 @@ mod int;
 mod nil;
 mod returning_function;
 mod string;
+mod tuple;
 
 use crate::plan::{ExecutionPlan, FunctionExpr, FunctionExprKind, FunctionValue};
 use crate::runtime::ExecutionError;
@@ -12,7 +13,7 @@ use crate::runtime::frame::Frame;
 pub(in crate::runtime) use self::{
     bool::eval_bool_function_expr, float::eval_float_function_expr, int::eval_int_function_expr,
     nil::eval_nil_function_expr, returning_function::eval_function_function_expr,
-    string::eval_string_function_expr,
+    string::eval_string_function_expr, tuple::eval_tuple_function_expr,
 };
 
 pub(in crate::runtime) fn eval_function_expr(
@@ -35,6 +36,9 @@ pub(in crate::runtime) fn eval_function_expr(
         }
         FunctionExprKind::Nil(expression) => {
             Ok(eval_nil_function_expr(plan, frame, expression)?.into())
+        }
+        FunctionExprKind::Tuple(expression) => {
+            Ok(eval_tuple_function_expr(plan, frame, expression)?.into())
         }
         FunctionExprKind::Function(expression) => {
             Ok(eval_function_function_expr(plan, frame, expression)?.into())

--- a/src/runtime/expression/function/bool.rs
+++ b/src/runtime/expression/function/bool.rs
@@ -1,7 +1,10 @@
-use crate::plan::{BoolFunctionExpr, BoolFunctionExprKind, BoolFunctionValue, ExecutionPlan};
+use crate::plan::{
+    BoolFunctionExpr, BoolFunctionExprKind, BoolFunctionValue, ExecutionPlan, FunctionValueKind,
+    Value, ValueType,
+};
 use crate::runtime::ExecutionError;
 use crate::runtime::expression::{
-    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr,
+    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr, project_tuple_expr,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -31,6 +34,26 @@ pub(in crate::runtime) fn eval_bool_function_expr(
             args,
             ..
         } => function::run_bool_function_function_call(plan, callee, args, frame),
+        BoolFunctionExprKind::TupleIndex {
+            tuple,
+            index,
+            type_,
+        } => {
+            let expected = ValueType::Function(Box::new(type_.clone()));
+            let value = project_tuple_expr(plan, frame, tuple, *index, expected.clone())?;
+            let actual = value.value_type();
+            match value {
+                Value::Function(function) => match function.kind() {
+                    FunctionValueKind::Bool(value) => Ok(value.clone()),
+                    _ => Err(ExecutionError::tuple_index_family_mismatch(
+                        expected, actual,
+                    )),
+                },
+                _ => Err(ExecutionError::tuple_index_family_mismatch(
+                    expected, actual,
+                )),
+            }
+        }
         BoolFunctionExprKind::BoolCase {
             subject,
             true_,
@@ -92,11 +115,89 @@ pub(in crate::runtime) fn eval_bool_function_expr(
 mod tests {
     use super::eval_bool_function_expr;
     use crate::plan::{
-        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, BoolLocalId, ExecutionPlan,
-        Expr, FloatExpr, FunctionId, FunctionPlan, IntExpr, IntFunctionId, ParamLocal, ReturnExpr,
-        Step,
+        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, BoolLocalId, CaptureArg,
+        ExecutionPlan, Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr, FunctionFunctionId,
+        FunctionFunctionValue, FunctionId, FunctionPlan, FunctionType, IntExpr, IntFunctionExpr,
+        IntFunctionId, IntFunctionValue, ParamLocal, ReturnExpr, Step, StringExpr, TupleExpr,
+        ValueType,
     };
+    use crate::plan::{BoolFunctionFunctionId, BoolFunctionLocalId};
+    use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
+
+    #[test]
+    fn eval_bool_function_local_closure_call_function_call_and_block() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        frame.set_bool_function(BoolFunctionLocalId(0), function_runtime_value());
+
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::local_get(BoolFunctionLocalId(0), "value".into(), type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::closure(
+                    BoolFunctionId(0),
+                    vec![ParamLocal::bool(BoolLocalId(0))],
+                    Vec::new(),
+                    type_(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::call(BoolFunctionFunctionId(0), Vec::new(), type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::function_call(
+                    FunctionFunctionExpr::value(FunctionFunctionValue::new(
+                        FunctionFunctionId::Bool(BoolFunctionFunctionId(0)),
+                        Vec::new(),
+                        type_(),
+                    )),
+                    Vec::new(),
+                    type_(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                    function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+    }
 
     #[test]
     fn eval_bool_function_bool_case_branches() {
@@ -169,6 +270,41 @@ mod tests {
     }
 
     #[test]
+    fn eval_bool_function_string_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::string_case(
+                    StringExpr::value("hit".into()),
+                    vec![("hit".into(), function_value())],
+                    other_function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::string_case(
+                    StringExpr::value("miss".into()),
+                    vec![("hit".into(), other_function_value())],
+                    function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+    }
+
+    #[test]
     fn eval_bool_function_float_case_branches() {
         let plan = plan();
         let mut frame = Frame::default();
@@ -223,6 +359,116 @@ mod tests {
         );
     }
 
+    #[test]
+    fn eval_bool_function_expr_propagates_operand_errors() {
+        assert_tuple_index_error(
+            ValueType::Bool,
+            BoolFunctionExpr::closure(
+                BoolFunctionId(0),
+                vec![ParamLocal::bool(BoolLocalId(0))],
+                vec![CaptureArg::bool(BoolLocalId(0), error_bool_expr())],
+                type_(),
+            ),
+        );
+        assert_function_tuple_index_error(BoolFunctionExpr::tuple_index(empty_tuple(), 0, type_()));
+        assert_tuple_index_error(
+            ValueType::Bool,
+            BoolFunctionExpr::bool_case(
+                error_bool_expr(),
+                function_value(),
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Int,
+            BoolFunctionExpr::int_case(
+                error_int_expr(),
+                vec![(1.into(), function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::String,
+            BoolFunctionExpr::string_case(
+                error_string_expr(),
+                vec![("hit".into(), function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Float,
+            BoolFunctionExpr::float_case(
+                error_float_expr(),
+                vec![(1.0, function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Bool,
+            BoolFunctionExpr::block(
+                vec![Step::evaluate(Expr::bool(error_bool_expr()))],
+                function_value(),
+            ),
+        );
+    }
+
+    #[test]
+    fn eval_bool_function_tuple_index() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::bool(function_value()))],
+            vec![ValueType::Function(Box::new(type_()))],
+        );
+
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::tuple_index(tuple, 0, type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            BoolFunctionId(0),
+        );
+
+        let mismatch_type = FunctionType::new(Vec::new(), ValueType::Int);
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::int(IntFunctionExpr::value(
+                IntFunctionValue::new(IntFunctionId(0), Vec::new()),
+            )))],
+            vec![ValueType::Function(Box::new(mismatch_type.clone()))],
+        );
+
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Function(Box::new(mismatch_type)),
+            )),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+        assert_eq!(
+            eval_bool_function_expr(
+                &plan,
+                &mut frame,
+                &BoolFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Int,
+            )),
+        );
+    }
+
     fn plan() -> ExecutionPlan {
         ExecutionPlan::new(
             "main".into(),
@@ -233,15 +479,22 @@ mod tests {
                 Vec::new(),
                 ReturnExpr::int(IntFunctionId(0), IntExpr::value(1.into())),
             ),
-            Vec::new(),
+            vec![FunctionPlan::new(
+                FunctionId::new(1),
+                "get_bool_value".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::bool_function(BoolFunctionFunctionId(0), function_value()),
+            )],
         )
     }
 
     fn function_value() -> BoolFunctionExpr {
-        BoolFunctionExpr::value(BoolFunctionValue::new(
-            BoolFunctionId(0),
-            vec![ParamLocal::bool(BoolLocalId(0))],
-        ))
+        BoolFunctionExpr::value(function_runtime_value())
+    }
+
+    fn function_runtime_value() -> BoolFunctionValue {
+        BoolFunctionValue::new(BoolFunctionId(0), vec![ParamLocal::bool(BoolLocalId(0))])
     }
 
     fn other_function_value() -> BoolFunctionExpr {
@@ -249,5 +502,53 @@ mod tests {
             BoolFunctionId(1),
             vec![ParamLocal::bool(BoolLocalId(0))],
         ))
+    }
+
+    fn type_() -> FunctionType {
+        FunctionType::new(vec![ValueType::Bool], ValueType::Bool)
+    }
+
+    fn assert_tuple_index_error(expected: ValueType, expression: BoolFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_bool_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(expected)),
+        );
+    }
+
+    fn assert_function_tuple_index_error(expression: BoolFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_bool_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(ValueType::Function(Box::new(type_())))),
+        );
+    }
+
+    fn tuple_index_error(expected: ValueType) -> ExecutionError {
+        ExecutionError::tuple_index_family_mismatch(expected, ValueType::Tuple(Vec::new()))
+    }
+
+    fn empty_tuple() -> TupleExpr {
+        TupleExpr::value(Vec::new(), Vec::new())
+    }
+
+    fn error_bool_expr() -> BoolExpr {
+        BoolExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_int_expr() -> IntExpr {
+        IntExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_string_expr() -> StringExpr {
+        StringExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::tuple_index(empty_tuple(), 0)
     }
 }

--- a/src/runtime/expression/function/float.rs
+++ b/src/runtime/expression/function/float.rs
@@ -1,7 +1,10 @@
-use crate::plan::{ExecutionPlan, FloatFunctionExpr, FloatFunctionExprKind, FloatFunctionValue};
+use crate::plan::{
+    ExecutionPlan, FloatFunctionExpr, FloatFunctionExprKind, FloatFunctionValue, FunctionValueKind,
+    Value, ValueType,
+};
 use crate::runtime::ExecutionError;
 use crate::runtime::expression::{
-    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr,
+    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr, project_tuple_expr,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -31,6 +34,26 @@ pub(in crate::runtime) fn eval_float_function_expr(
             args,
             ..
         } => function::run_float_function_function_call(plan, callee, args, frame),
+        FloatFunctionExprKind::TupleIndex {
+            tuple,
+            index,
+            type_,
+        } => {
+            let expected = ValueType::Function(Box::new(type_.clone()));
+            let value = project_tuple_expr(plan, frame, tuple, *index, expected.clone())?;
+            let actual = value.value_type();
+            match value {
+                Value::Function(function) => match function.kind() {
+                    FunctionValueKind::Float(value) => Ok(value.clone()),
+                    _ => Err(ExecutionError::tuple_index_family_mismatch(
+                        expected, actual,
+                    )),
+                },
+                _ => Err(ExecutionError::tuple_index_family_mismatch(
+                    expected, actual,
+                )),
+            }
+        }
         FloatFunctionExprKind::BoolCase {
             subject,
             true_,
@@ -94,10 +117,10 @@ mod tests {
     use crate::plan::{
         BoolExpr, BoolFunctionExpr, CaptureArg, ExecutionPlan, Expr, FloatExpr, FloatFunctionExpr,
         FloatFunctionFunctionId, FloatFunctionId, FloatFunctionLocalId, FloatFunctionValue,
-        FloatLocalId, FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionValue, FunctionId,
-        FunctionPlan, FunctionReturnFamily, FunctionType, IntExpr, IntFunctionExpr, IntFunctionId,
-        ParamLocal, ReturnExpr, Step, StringExpr, StringFunctionExpr, StringFunctionFunctionId,
-        ValueType,
+        FloatLocalId, FunctionExpr, FunctionFunctionExpr, FunctionFunctionId,
+        FunctionFunctionValue, FunctionId, FunctionPlan, FunctionReturnFamily, FunctionType,
+        IntExpr, IntFunctionExpr, IntFunctionId, ParamLocal, ReturnExpr, Step, StringExpr,
+        StringFunctionExpr, StringFunctionFunctionId, TupleExpr, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
@@ -325,6 +348,66 @@ mod tests {
                 )),
             );
         }
+    }
+
+    #[test]
+    fn eval_float_function_tuple_index() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::float(function_value()))],
+            vec![ValueType::Function(Box::new(type_()))],
+        );
+
+        assert_eq!(
+            eval_float_function_expr(
+                &plan,
+                &mut frame,
+                &FloatFunctionExpr::tuple_index(tuple, 0, type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            FloatFunctionId(0),
+        );
+
+        let mismatch_type = FunctionType::new(Vec::new(), ValueType::String);
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::string(
+                StringFunctionExpr::value(crate::plan::StringFunctionValue::new(
+                    crate::plan::StringFunctionId(0),
+                    Vec::new(),
+                )),
+            ))],
+            vec![ValueType::Function(Box::new(mismatch_type.clone()))],
+        );
+
+        assert_eq!(
+            eval_float_function_expr(
+                &plan,
+                &mut frame,
+                &FloatFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Function(Box::new(mismatch_type)),
+            )),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+        assert_eq!(
+            eval_float_function_expr(
+                &plan,
+                &mut frame,
+                &FloatFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Int,
+            )),
+        );
     }
 
     fn plan() -> ExecutionPlan {

--- a/src/runtime/expression/function/int.rs
+++ b/src/runtime/expression/function/int.rs
@@ -1,7 +1,10 @@
-use crate::plan::{ExecutionPlan, IntFunctionExpr, IntFunctionExprKind, IntFunctionValue};
+use crate::plan::{
+    ExecutionPlan, FunctionValueKind, IntFunctionExpr, IntFunctionExprKind, IntFunctionValue,
+    Value, ValueType,
+};
 use crate::runtime::ExecutionError;
 use crate::runtime::expression::{
-    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr,
+    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr, project_tuple_expr,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -31,6 +34,26 @@ pub(in crate::runtime) fn eval_int_function_expr(
             args,
             ..
         } => function::run_int_function_function_call(plan, callee, args, frame),
+        IntFunctionExprKind::TupleIndex {
+            tuple,
+            index,
+            type_,
+        } => {
+            let expected = ValueType::Function(Box::new(type_.clone()));
+            let value = project_tuple_expr(plan, frame, tuple, *index, expected.clone())?;
+            let actual = value.value_type();
+            match value {
+                Value::Function(function) => match function.kind() {
+                    FunctionValueKind::Int(value) => Ok(value.clone()),
+                    _ => Err(ExecutionError::tuple_index_family_mismatch(
+                        expected, actual,
+                    )),
+                },
+                _ => Err(ExecutionError::tuple_index_family_mismatch(
+                    expected, actual,
+                )),
+            }
+        }
         IntFunctionExprKind::BoolCase {
             subject,
             true_,
@@ -92,10 +115,88 @@ pub(in crate::runtime) fn eval_int_function_expr(
 mod tests {
     use super::eval_int_function_expr;
     use crate::plan::{
-        BoolExpr, ExecutionPlan, Expr, FloatExpr, FunctionId, FunctionPlan, IntExpr,
-        IntFunctionExpr, IntFunctionId, IntFunctionValue, IntLocalId, ParamLocal, ReturnExpr, Step,
+        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, CaptureArg, ExecutionPlan,
+        Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr, FunctionFunctionId,
+        FunctionFunctionValue, FunctionId, FunctionPlan, FunctionType, IntExpr, IntFunctionExpr,
+        IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId,
+        ParamLocal, ReturnExpr, Step, StringExpr, TupleExpr, ValueType,
     };
+    use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
+
+    #[test]
+    fn eval_int_function_local_closure_call_function_call_and_block() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        frame.set_int_function(IntFunctionLocalId(0), function_runtime_value());
+
+        assert_eq!(
+            eval_int_function_expr(
+                &plan,
+                &mut frame,
+                &IntFunctionExpr::local_get(IntFunctionLocalId(0), "value".into(), type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            IntFunctionId(0),
+        );
+        assert_eq!(
+            eval_int_function_expr(
+                &plan,
+                &mut frame,
+                &IntFunctionExpr::closure(
+                    IntFunctionId(0),
+                    vec![ParamLocal::int(IntLocalId(0))],
+                    Vec::new(),
+                    type_(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            IntFunctionId(0),
+        );
+        assert_eq!(
+            eval_int_function_expr(
+                &plan,
+                &mut frame,
+                &IntFunctionExpr::call(IntFunctionFunctionId(0), Vec::new(), type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            IntFunctionId(0),
+        );
+        assert_eq!(
+            eval_int_function_expr(
+                &plan,
+                &mut frame,
+                &IntFunctionExpr::function_call(
+                    FunctionFunctionExpr::value(FunctionFunctionValue::new(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                        Vec::new(),
+                        type_(),
+                    )),
+                    Vec::new(),
+                    type_(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            IntFunctionId(0),
+        );
+        assert_eq!(
+            eval_int_function_expr(
+                &plan,
+                &mut frame,
+                &IntFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                    function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            IntFunctionId(0),
+        );
+    }
 
     #[test]
     fn eval_int_function_bool_case_branches() {
@@ -160,6 +261,37 @@ mod tests {
     }
 
     #[test]
+    fn eval_int_function_string_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let function = eval_int_function_expr(
+            &plan,
+            &mut frame,
+            &IntFunctionExpr::string_case(
+                StringExpr::value("hit".into()),
+                vec![("hit".into(), function_value())],
+                other_function_value(),
+            ),
+        )
+        .expect("expression should evaluate");
+
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
+
+        let function = eval_int_function_expr(
+            &plan,
+            &mut frame,
+            &IntFunctionExpr::string_case(
+                StringExpr::value("miss".into()),
+                vec![("hit".into(), other_function_value())],
+                function_value(),
+            ),
+        )
+        .expect("expression should evaluate");
+
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
+    }
+
+    #[test]
     fn eval_int_function_float_case_branches() {
         let plan = plan();
         let mut frame = Frame::default();
@@ -207,6 +339,109 @@ mod tests {
         assert_eq!(function.runtime_id(), IntFunctionId(0));
     }
 
+    #[test]
+    fn eval_int_function_expr_propagates_operand_errors() {
+        assert_tuple_index_error(
+            ValueType::Int,
+            IntFunctionExpr::closure(
+                IntFunctionId(0),
+                vec![ParamLocal::int(IntLocalId(0))],
+                vec![CaptureArg::int(IntLocalId(0), error_int_expr())],
+                type_(),
+            ),
+        );
+        assert_function_tuple_index_error(IntFunctionExpr::tuple_index(empty_tuple(), 0, type_()));
+        assert_tuple_index_error(
+            ValueType::Bool,
+            IntFunctionExpr::bool_case(error_bool_expr(), function_value(), other_function_value()),
+        );
+        assert_tuple_index_error(
+            ValueType::Int,
+            IntFunctionExpr::int_case(
+                error_int_expr(),
+                vec![(1.into(), function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::String,
+            IntFunctionExpr::string_case(
+                error_string_expr(),
+                vec![("hit".into(), function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Float,
+            IntFunctionExpr::float_case(
+                error_float_expr(),
+                vec![(1.0, function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Int,
+            IntFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(error_int_expr()))],
+                function_value(),
+            ),
+        );
+    }
+
+    #[test]
+    fn eval_int_function_tuple_index() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::int(function_value()))],
+            vec![ValueType::Function(Box::new(type_()))],
+        );
+
+        let function = eval_int_function_expr(
+            &plan,
+            &mut frame,
+            &IntFunctionExpr::tuple_index(tuple, 0, type_()),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(function.runtime_id(), IntFunctionId(0));
+
+        let mismatch_type = FunctionType::new(Vec::new(), ValueType::Bool);
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::bool(BoolFunctionExpr::value(
+                BoolFunctionValue::new(BoolFunctionId(0), Vec::new()),
+            )))],
+            vec![ValueType::Function(Box::new(mismatch_type.clone()))],
+        );
+
+        assert_eq!(
+            eval_int_function_expr(
+                &plan,
+                &mut frame,
+                &IntFunctionExpr::tuple_index(tuple, 0, type_())
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Function(Box::new(mismatch_type)),
+            )),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+        assert_eq!(
+            eval_int_function_expr(
+                &plan,
+                &mut frame,
+                &IntFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Int,
+            )),
+        );
+    }
+
     fn plan() -> ExecutionPlan {
         ExecutionPlan::new(
             "main".into(),
@@ -217,15 +452,22 @@ mod tests {
                 Vec::new(),
                 ReturnExpr::int(IntFunctionId(0), IntExpr::value(1.into())),
             ),
-            Vec::new(),
+            vec![FunctionPlan::new(
+                FunctionId::new(1),
+                "get_int_value".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int_function(IntFunctionFunctionId(0), function_value()),
+            )],
         )
     }
 
     fn function_value() -> IntFunctionExpr {
-        IntFunctionExpr::value(IntFunctionValue::new(
-            IntFunctionId(0),
-            vec![ParamLocal::int(IntLocalId(0))],
-        ))
+        IntFunctionExpr::value(function_runtime_value())
+    }
+
+    fn function_runtime_value() -> IntFunctionValue {
+        IntFunctionValue::new(IntFunctionId(0), vec![ParamLocal::int(IntLocalId(0))])
     }
 
     fn other_function_value() -> IntFunctionExpr {
@@ -233,5 +475,53 @@ mod tests {
             IntFunctionId(1),
             vec![ParamLocal::int(IntLocalId(0))],
         ))
+    }
+
+    fn type_() -> FunctionType {
+        FunctionType::new(vec![ValueType::Int], ValueType::Int)
+    }
+
+    fn assert_tuple_index_error(expected: ValueType, expression: IntFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_int_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(expected)),
+        );
+    }
+
+    fn assert_function_tuple_index_error(expression: IntFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_int_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(ValueType::Function(Box::new(type_())))),
+        );
+    }
+
+    fn tuple_index_error(expected: ValueType) -> ExecutionError {
+        ExecutionError::tuple_index_family_mismatch(expected, ValueType::Tuple(Vec::new()))
+    }
+
+    fn empty_tuple() -> TupleExpr {
+        TupleExpr::value(Vec::new(), Vec::new())
+    }
+
+    fn error_bool_expr() -> BoolExpr {
+        BoolExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_int_expr() -> IntExpr {
+        IntExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_string_expr() -> StringExpr {
+        StringExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::tuple_index(empty_tuple(), 0)
     }
 }

--- a/src/runtime/expression/function/nil.rs
+++ b/src/runtime/expression/function/nil.rs
@@ -1,7 +1,10 @@
-use crate::plan::{ExecutionPlan, NilFunctionExpr, NilFunctionExprKind, NilFunctionValue};
+use crate::plan::{
+    ExecutionPlan, FunctionValueKind, NilFunctionExpr, NilFunctionExprKind, NilFunctionValue,
+    Value, ValueType,
+};
 use crate::runtime::ExecutionError;
 use crate::runtime::expression::{
-    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr,
+    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr, project_tuple_expr,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -31,6 +34,26 @@ pub(in crate::runtime) fn eval_nil_function_expr(
             args,
             ..
         } => function::run_nil_function_function_call(plan, callee, args, frame),
+        NilFunctionExprKind::TupleIndex {
+            tuple,
+            index,
+            type_,
+        } => {
+            let expected = ValueType::Function(Box::new(type_.clone()));
+            let value = project_tuple_expr(plan, frame, tuple, *index, expected.clone())?;
+            let actual = value.value_type();
+            match value {
+                Value::Function(function) => match function.kind() {
+                    FunctionValueKind::Nil(value) => Ok(value.clone()),
+                    _ => Err(ExecutionError::tuple_index_family_mismatch(
+                        expected, actual,
+                    )),
+                },
+                _ => Err(ExecutionError::tuple_index_family_mismatch(
+                    expected, actual,
+                )),
+            }
+        }
         NilFunctionExprKind::BoolCase {
             subject,
             true_,
@@ -92,10 +115,89 @@ pub(in crate::runtime) fn eval_nil_function_expr(
 mod tests {
     use super::eval_nil_function_expr;
     use crate::plan::{
-        BoolExpr, ExecutionPlan, Expr, FloatExpr, FunctionId, FunctionPlan, IntExpr, IntFunctionId,
-        NilFunctionExpr, NilFunctionId, NilFunctionValue, NilLocalId, ParamLocal, ReturnExpr, Step,
+        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, CaptureArg, ExecutionPlan,
+        Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr, FunctionFunctionId,
+        FunctionFunctionValue, FunctionId, FunctionPlan, FunctionType, IntExpr, IntFunctionId,
+        NilFunctionExpr, NilFunctionFunctionId, NilFunctionId, NilFunctionLocalId,
+        NilFunctionValue, NilLocalId, ParamLocal, ReturnExpr, Step, StringExpr, TupleExpr,
+        ValueType,
     };
+    use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
+
+    #[test]
+    fn eval_nil_function_local_closure_call_function_call_and_block() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        frame.set_nil_function(NilFunctionLocalId(0), function_runtime_value());
+
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::local_get(NilFunctionLocalId(0), "value".into(), type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::closure(
+                    NilFunctionId(0),
+                    vec![ParamLocal::nil(NilLocalId(0))],
+                    Vec::new(),
+                    type_(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::call(NilFunctionFunctionId(0), Vec::new(), type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::function_call(
+                    FunctionFunctionExpr::value(FunctionFunctionValue::new(
+                        FunctionFunctionId::Nil(NilFunctionFunctionId(0)),
+                        Vec::new(),
+                        type_(),
+                    )),
+                    Vec::new(),
+                    type_(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                    function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+    }
 
     #[test]
     fn eval_nil_function_bool_case_branches() {
@@ -168,6 +270,41 @@ mod tests {
     }
 
     #[test]
+    fn eval_nil_function_string_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::string_case(
+                    StringExpr::value("hit".into()),
+                    vec![("hit".into(), function_value())],
+                    other_function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::string_case(
+                    StringExpr::value("miss".into()),
+                    vec![("hit".into(), other_function_value())],
+                    function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+    }
+
+    #[test]
     fn eval_nil_function_float_case_branches() {
         let plan = plan();
         let mut frame = Frame::default();
@@ -222,6 +359,112 @@ mod tests {
         );
     }
 
+    #[test]
+    fn eval_nil_function_expr_propagates_operand_errors() {
+        assert_tuple_index_error(
+            ValueType::Nil,
+            NilFunctionExpr::closure(
+                NilFunctionId(0),
+                vec![ParamLocal::nil(NilLocalId(0))],
+                vec![CaptureArg::nil(NilLocalId(0), error_nil_expr())],
+                type_(),
+            ),
+        );
+        assert_function_tuple_index_error(NilFunctionExpr::tuple_index(empty_tuple(), 0, type_()));
+        assert_tuple_index_error(
+            ValueType::Bool,
+            NilFunctionExpr::bool_case(error_bool_expr(), function_value(), other_function_value()),
+        );
+        assert_tuple_index_error(
+            ValueType::Int,
+            NilFunctionExpr::int_case(
+                error_int_expr(),
+                vec![(1.into(), function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::String,
+            NilFunctionExpr::string_case(
+                error_string_expr(),
+                vec![("hit".into(), function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Float,
+            NilFunctionExpr::float_case(
+                error_float_expr(),
+                vec![(1.0, function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Nil,
+            NilFunctionExpr::block(
+                vec![Step::evaluate(Expr::nil(error_nil_expr()))],
+                function_value(),
+            ),
+        );
+    }
+
+    #[test]
+    fn eval_nil_function_tuple_index() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::nil(function_value()))],
+            vec![ValueType::Function(Box::new(type_()))],
+        );
+
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::tuple_index(tuple, 0, type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            NilFunctionId(0),
+        );
+
+        let mismatch_type = FunctionType::new(Vec::new(), ValueType::Bool);
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::bool(BoolFunctionExpr::value(
+                BoolFunctionValue::new(BoolFunctionId(0), Vec::new()),
+            )))],
+            vec![ValueType::Function(Box::new(mismatch_type.clone()))],
+        );
+
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Function(Box::new(mismatch_type)),
+            )),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+        assert_eq!(
+            eval_nil_function_expr(
+                &plan,
+                &mut frame,
+                &NilFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Int,
+            )),
+        );
+    }
+
     fn plan() -> ExecutionPlan {
         ExecutionPlan::new(
             "main".into(),
@@ -232,15 +475,22 @@ mod tests {
                 Vec::new(),
                 ReturnExpr::int(IntFunctionId(0), IntExpr::value(1.into())),
             ),
-            Vec::new(),
+            vec![FunctionPlan::new(
+                FunctionId::new(1),
+                "get_nil_value".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::nil_function(NilFunctionFunctionId(0), function_value()),
+            )],
         )
     }
 
     fn function_value() -> NilFunctionExpr {
-        NilFunctionExpr::value(NilFunctionValue::new(
-            NilFunctionId(0),
-            vec![ParamLocal::nil(NilLocalId(0))],
-        ))
+        NilFunctionExpr::value(function_runtime_value())
+    }
+
+    fn function_runtime_value() -> NilFunctionValue {
+        NilFunctionValue::new(NilFunctionId(0), vec![ParamLocal::nil(NilLocalId(0))])
     }
 
     fn other_function_value() -> NilFunctionExpr {
@@ -248,5 +498,57 @@ mod tests {
             NilFunctionId(1),
             vec![ParamLocal::nil(NilLocalId(0))],
         ))
+    }
+
+    fn type_() -> FunctionType {
+        FunctionType::new(vec![ValueType::Nil], ValueType::Nil)
+    }
+
+    fn assert_tuple_index_error(expected: ValueType, expression: NilFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_nil_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(expected)),
+        );
+    }
+
+    fn assert_function_tuple_index_error(expression: NilFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_nil_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(ValueType::Function(Box::new(type_())))),
+        );
+    }
+
+    fn tuple_index_error(expected: ValueType) -> ExecutionError {
+        ExecutionError::tuple_index_family_mismatch(expected, ValueType::Tuple(Vec::new()))
+    }
+
+    fn empty_tuple() -> TupleExpr {
+        TupleExpr::value(Vec::new(), Vec::new())
+    }
+
+    fn error_bool_expr() -> BoolExpr {
+        BoolExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_int_expr() -> IntExpr {
+        IntExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_string_expr() -> StringExpr {
+        StringExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_nil_expr() -> crate::plan::NilExpr {
+        crate::plan::NilExpr::tuple_index(empty_tuple(), 0)
     }
 }

--- a/src/runtime/expression/function/returning_function.rs
+++ b/src/runtime/expression/function/returning_function.rs
@@ -1,9 +1,10 @@
 use crate::plan::{
     ExecutionPlan, FunctionFunctionExpr, FunctionFunctionExprKind, FunctionFunctionValue,
+    FunctionValueKind, Value, ValueType,
 };
 use crate::runtime::ExecutionError;
 use crate::runtime::expression::{
-    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr,
+    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr, project_tuple_expr,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -35,6 +36,26 @@ pub(in crate::runtime) fn eval_function_function_expr(
             args,
             ..
         } => function::run_function_function_function_call(plan, callee, args, frame),
+        FunctionFunctionExprKind::TupleIndex {
+            tuple,
+            index,
+            type_,
+        } => {
+            let expected = ValueType::Function(Box::new(type_.clone()));
+            let value = project_tuple_expr(plan, frame, tuple, *index, expected.clone())?;
+            let actual = value.value_type();
+            match value {
+                Value::Function(function) => match function.kind() {
+                    FunctionValueKind::Function(value) => Ok(value.clone()),
+                    _ => Err(ExecutionError::tuple_index_family_mismatch(
+                        expected, actual,
+                    )),
+                },
+                _ => Err(ExecutionError::tuple_index_family_mismatch(
+                    expected, actual,
+                )),
+            }
+        }
         FunctionFunctionExprKind::BoolCase {
             subject,
             true_,
@@ -96,10 +117,12 @@ pub(in crate::runtime) fn eval_function_function_expr(
 mod tests {
     use super::eval_function_function_expr;
     use crate::plan::{
-        ExecutionPlan, FloatExpr, FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionValue,
-        FunctionId, FunctionPlan, FunctionType, IntExpr, IntFunctionFunctionId, IntFunctionId,
-        ReturnExpr, ValueType,
+        BoolExpr, CaptureArg, ExecutionPlan, Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr,
+        FunctionFunctionId, FunctionFunctionValue, FunctionId, FunctionPlan, FunctionType, IntExpr,
+        IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, IntFunctionValue, IntLocalId,
+        ReturnExpr, Step, StringExpr, TupleExpr, ValueType,
     };
+    use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
     use crate::runtime::{Value, run_src};
 
@@ -397,6 +420,191 @@ pub fn main() {
     }
 
     #[test]
+    fn eval_function_function_direct_closure_case_and_block_paths() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        let function = eval_function_function_expr(
+            &plan,
+            &mut frame,
+            &FunctionFunctionExpr::closure(
+                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                Vec::new(),
+                Vec::new(),
+                function_function_type(),
+                returned_int_function_type(),
+            ),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(
+            function.runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0))
+        );
+
+        let function = eval_function_function_expr(
+            &plan,
+            &mut frame,
+            &FunctionFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                function_function_value(),
+                other_function_function_value(),
+            ),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(
+            function.runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0))
+        );
+
+        let function = eval_function_function_expr(
+            &plan,
+            &mut frame,
+            &FunctionFunctionExpr::bool_case(
+                BoolExpr::value(false),
+                other_function_function_value(),
+                function_function_value(),
+            ),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(
+            function.runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0))
+        );
+
+        let function = eval_function_function_expr(
+            &plan,
+            &mut frame,
+            &FunctionFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), function_function_value())],
+                other_function_function_value(),
+            ),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(
+            function.runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0))
+        );
+
+        let function = eval_function_function_expr(
+            &plan,
+            &mut frame,
+            &FunctionFunctionExpr::int_case(
+                IntExpr::value(2.into()),
+                vec![(1.into(), other_function_function_value())],
+                function_function_value(),
+            ),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(
+            function.runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0))
+        );
+
+        let function = eval_function_function_expr(
+            &plan,
+            &mut frame,
+            &FunctionFunctionExpr::string_case(
+                StringExpr::value("hit".into()),
+                vec![("hit".into(), function_function_value())],
+                other_function_function_value(),
+            ),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(
+            function.runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0))
+        );
+
+        let function = eval_function_function_expr(
+            &plan,
+            &mut frame,
+            &FunctionFunctionExpr::string_case(
+                StringExpr::value("miss".into()),
+                vec![("hit".into(), other_function_function_value())],
+                function_function_value(),
+            ),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(
+            function.runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0))
+        );
+
+        let function = eval_function_function_expr(
+            &plan,
+            &mut frame,
+            &FunctionFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                function_function_value(),
+            ),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(
+            function.runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0))
+        );
+    }
+
+    #[test]
+    fn eval_function_function_expr_propagates_operand_errors() {
+        assert_tuple_index_error(
+            ValueType::Int,
+            FunctionFunctionExpr::closure(
+                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                Vec::new(),
+                vec![CaptureArg::int(IntLocalId(0), error_int_expr())],
+                function_function_type(),
+                returned_int_function_type(),
+            ),
+        );
+        assert_function_tuple_index_error(FunctionFunctionExpr::tuple_index(
+            empty_tuple(),
+            0,
+            returned_int_function_type(),
+        ));
+        assert_tuple_index_error(
+            ValueType::Bool,
+            FunctionFunctionExpr::bool_case(
+                error_bool_expr(),
+                function_function_value(),
+                other_function_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Int,
+            FunctionFunctionExpr::int_case(
+                error_int_expr(),
+                vec![(1.into(), function_function_value())],
+                other_function_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::String,
+            FunctionFunctionExpr::string_case(
+                error_string_expr(),
+                vec![("hit".into(), function_function_value())],
+                other_function_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Float,
+            FunctionFunctionExpr::float_case(
+                error_float_expr(),
+                vec![(1.0, function_function_value())],
+                other_function_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Int,
+            FunctionFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(error_int_expr()))],
+                function_function_value(),
+            ),
+        );
+    }
+
+    #[test]
     fn eval_function_function_block() {
         assert_returns_function_returning_int(
             r#"
@@ -418,6 +626,65 @@ pub fn main() {
         );
     }
 
+    #[test]
+    fn eval_function_function_tuple_index() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::function(
+                function_function_value(),
+            ))],
+            vec![ValueType::Function(Box::new(returned_int_function_type()))],
+        );
+
+        let function = eval_function_function_expr(
+            &plan,
+            &mut frame,
+            &FunctionFunctionExpr::tuple_index(tuple, 0, returned_int_function_type()),
+        )
+        .expect("expression should evaluate");
+        assert_eq!(
+            function.runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+        );
+
+        let int_function_type = FunctionType::new(Vec::new(), ValueType::Int);
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::int(IntFunctionExpr::value(
+                IntFunctionValue::new(IntFunctionId(0), Vec::new()),
+            )))],
+            vec![ValueType::Function(Box::new(int_function_type.clone()))],
+        );
+
+        assert_eq!(
+            eval_function_function_expr(
+                &plan,
+                &mut frame,
+                &FunctionFunctionExpr::tuple_index(tuple, 0, returned_int_function_type()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(returned_int_function_type())),
+                ValueType::Function(Box::new(int_function_type)),
+            )),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+        assert_eq!(
+            eval_function_function_expr(
+                &plan,
+                &mut frame,
+                &FunctionFunctionExpr::tuple_index(tuple, 0, returned_int_function_type()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(returned_int_function_type())),
+                ValueType::Int,
+            )),
+        );
+    }
+
     fn assert_returns_function_returning_int(src: &str) {
         assert_eq!(
             run_src(src),
@@ -434,6 +701,13 @@ pub fn main() {
 
     fn returned_int_function_type() -> FunctionType {
         FunctionType::new(vec![ValueType::Int], ValueType::Int)
+    }
+
+    fn function_function_type() -> FunctionType {
+        FunctionType::new(
+            Vec::new(),
+            ValueType::Function(Box::new(returned_int_function_type())),
+        )
     }
 
     fn function_function_value() -> FunctionFunctionExpr {
@@ -464,5 +738,51 @@ pub fn main() {
             ),
             Vec::new(),
         )
+    }
+
+    fn assert_tuple_index_error(expected: ValueType, expression: FunctionFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_function_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(expected)),
+        );
+    }
+
+    fn assert_function_tuple_index_error(expression: FunctionFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_function_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(ValueType::Function(Box::new(
+                returned_int_function_type()
+            )))),
+        );
+    }
+
+    fn tuple_index_error(expected: ValueType) -> ExecutionError {
+        ExecutionError::tuple_index_family_mismatch(expected, ValueType::Tuple(Vec::new()))
+    }
+
+    fn empty_tuple() -> TupleExpr {
+        TupleExpr::value(Vec::new(), Vec::new())
+    }
+
+    fn error_bool_expr() -> BoolExpr {
+        BoolExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_int_expr() -> IntExpr {
+        IntExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_string_expr() -> StringExpr {
+        StringExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::tuple_index(empty_tuple(), 0)
     }
 }

--- a/src/runtime/expression/function/string.rs
+++ b/src/runtime/expression/function/string.rs
@@ -1,7 +1,10 @@
-use crate::plan::{ExecutionPlan, StringFunctionExpr, StringFunctionExprKind, StringFunctionValue};
+use crate::plan::{
+    ExecutionPlan, FunctionValueKind, StringFunctionExpr, StringFunctionExprKind,
+    StringFunctionValue, Value, ValueType,
+};
 use crate::runtime::ExecutionError;
 use crate::runtime::expression::{
-    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr,
+    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr, project_tuple_expr,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -31,6 +34,26 @@ pub(in crate::runtime) fn eval_string_function_expr(
             args,
             ..
         } => function::run_string_function_function_call(plan, callee, args, frame),
+        StringFunctionExprKind::TupleIndex {
+            tuple,
+            index,
+            type_,
+        } => {
+            let expected = ValueType::Function(Box::new(type_.clone()));
+            let value = project_tuple_expr(plan, frame, tuple, *index, expected.clone())?;
+            let actual = value.value_type();
+            match value {
+                Value::Function(function) => match function.kind() {
+                    FunctionValueKind::String(value) => Ok(value.clone()),
+                    _ => Err(ExecutionError::tuple_index_family_mismatch(
+                        expected, actual,
+                    )),
+                },
+                _ => Err(ExecutionError::tuple_index_family_mismatch(
+                    expected, actual,
+                )),
+            }
+        }
         StringFunctionExprKind::BoolCase {
             subject,
             true_,
@@ -92,11 +115,89 @@ pub(in crate::runtime) fn eval_string_function_expr(
 mod tests {
     use super::eval_string_function_expr;
     use crate::plan::{
-        BoolExpr, ExecutionPlan, Expr, FloatExpr, FunctionId, FunctionPlan, IntExpr, IntFunctionId,
-        ParamLocal, ReturnExpr, Step, StringFunctionExpr, StringFunctionId, StringFunctionValue,
-        StringLocalId,
+        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionValue, CaptureArg, ExecutionPlan,
+        Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr, FunctionFunctionId,
+        FunctionFunctionValue, FunctionId, FunctionPlan, FunctionType, IntExpr, IntFunctionId,
+        ParamLocal, ReturnExpr, Step, StringExpr, StringFunctionExpr, StringFunctionFunctionId,
+        StringFunctionId, StringFunctionLocalId, StringFunctionValue, StringLocalId, TupleExpr,
+        ValueType,
     };
+    use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
+
+    #[test]
+    fn eval_string_function_local_closure_call_function_call_and_block() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        frame.set_string_function(StringFunctionLocalId(0), function_runtime_value());
+
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::local_get(StringFunctionLocalId(0), "value".into(), type_(),),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::closure(
+                    StringFunctionId(0),
+                    vec![ParamLocal::string(StringLocalId(0))],
+                    Vec::new(),
+                    type_(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::call(StringFunctionFunctionId(0), Vec::new(), type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::function_call(
+                    FunctionFunctionExpr::value(FunctionFunctionValue::new(
+                        FunctionFunctionId::String(StringFunctionFunctionId(0)),
+                        Vec::new(),
+                        type_(),
+                    )),
+                    Vec::new(),
+                    type_(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                    function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+    }
 
     #[test]
     fn eval_string_function_bool_case_branches() {
@@ -169,6 +270,41 @@ mod tests {
     }
 
     #[test]
+    fn eval_string_function_string_case_branches() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::string_case(
+                    StringExpr::value("hit".into()),
+                    vec![("hit".into(), function_value())],
+                    other_function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::string_case(
+                    StringExpr::value("miss".into()),
+                    vec![("hit".into(), other_function_value())],
+                    function_value(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+    }
+
+    #[test]
     fn eval_string_function_float_case_branches() {
         let plan = plan();
         let mut frame = Frame::default();
@@ -223,6 +359,120 @@ mod tests {
         );
     }
 
+    #[test]
+    fn eval_string_function_expr_propagates_operand_errors() {
+        assert_tuple_index_error(
+            ValueType::String,
+            StringFunctionExpr::closure(
+                StringFunctionId(0),
+                vec![ParamLocal::string(StringLocalId(0))],
+                vec![CaptureArg::string(StringLocalId(0), error_string_expr())],
+                type_(),
+            ),
+        );
+        assert_function_tuple_index_error(StringFunctionExpr::tuple_index(
+            empty_tuple(),
+            0,
+            type_(),
+        ));
+        assert_tuple_index_error(
+            ValueType::Bool,
+            StringFunctionExpr::bool_case(
+                error_bool_expr(),
+                function_value(),
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Int,
+            StringFunctionExpr::int_case(
+                error_int_expr(),
+                vec![(1.into(), function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::String,
+            StringFunctionExpr::string_case(
+                error_string_expr(),
+                vec![("hit".into(), function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Float,
+            StringFunctionExpr::float_case(
+                error_float_expr(),
+                vec![(1.0, function_value())],
+                other_function_value(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::String,
+            StringFunctionExpr::block(
+                vec![Step::evaluate(Expr::string(error_string_expr()))],
+                function_value(),
+            ),
+        );
+    }
+
+    #[test]
+    fn eval_string_function_tuple_index() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::string(function_value()))],
+            vec![ValueType::Function(Box::new(type_()))],
+        );
+
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::tuple_index(tuple, 0, type_()),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            StringFunctionId(0),
+        );
+
+        let mismatch_type = FunctionType::new(Vec::new(), ValueType::Bool);
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::bool(BoolFunctionExpr::value(
+                BoolFunctionValue::new(BoolFunctionId(0), Vec::new()),
+            )))],
+            vec![ValueType::Function(Box::new(mismatch_type.clone()))],
+        );
+
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Function(Box::new(mismatch_type)),
+            )),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+        assert_eq!(
+            eval_string_function_expr(
+                &plan,
+                &mut frame,
+                &StringFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(type_())),
+                ValueType::Int,
+            )),
+        );
+    }
+
     fn plan() -> ExecutionPlan {
         ExecutionPlan::new(
             "main".into(),
@@ -233,15 +483,25 @@ mod tests {
                 Vec::new(),
                 ReturnExpr::int(IntFunctionId(0), IntExpr::value(1.into())),
             ),
-            Vec::new(),
+            vec![FunctionPlan::new(
+                FunctionId::new(1),
+                "get_string_value".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::string_function(StringFunctionFunctionId(0), function_value()),
+            )],
         )
     }
 
     fn function_value() -> StringFunctionExpr {
-        StringFunctionExpr::value(StringFunctionValue::new(
+        StringFunctionExpr::value(function_runtime_value())
+    }
+
+    fn function_runtime_value() -> StringFunctionValue {
+        StringFunctionValue::new(
             StringFunctionId(0),
             vec![ParamLocal::string(StringLocalId(0))],
-        ))
+        )
     }
 
     fn other_function_value() -> StringFunctionExpr {
@@ -249,5 +509,53 @@ mod tests {
             StringFunctionId(1),
             vec![ParamLocal::string(StringLocalId(0))],
         ))
+    }
+
+    fn type_() -> FunctionType {
+        FunctionType::new(vec![ValueType::String], ValueType::String)
+    }
+
+    fn assert_tuple_index_error(expected: ValueType, expression: StringFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_string_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(expected)),
+        );
+    }
+
+    fn assert_function_tuple_index_error(expression: StringFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_string_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(ValueType::Function(Box::new(type_())))),
+        );
+    }
+
+    fn tuple_index_error(expected: ValueType) -> ExecutionError {
+        ExecutionError::tuple_index_family_mismatch(expected, ValueType::Tuple(Vec::new()))
+    }
+
+    fn empty_tuple() -> TupleExpr {
+        TupleExpr::value(Vec::new(), Vec::new())
+    }
+
+    fn error_bool_expr() -> BoolExpr {
+        BoolExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_int_expr() -> IntExpr {
+        IntExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_string_expr() -> StringExpr {
+        StringExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::tuple_index(empty_tuple(), 0)
     }
 }

--- a/src/runtime/expression/function/tuple.rs
+++ b/src/runtime/expression/function/tuple.rs
@@ -1,0 +1,776 @@
+use crate::plan::{
+    ExecutionPlan, TupleFunctionExpr, TupleFunctionExprKind, TupleFunctionValue, Value, ValueType,
+};
+use crate::runtime::ExecutionError;
+use crate::runtime::expression::{
+    eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr, project_tuple_expr,
+};
+use crate::runtime::frame::Frame;
+use crate::runtime::function;
+
+pub(in crate::runtime) fn eval_tuple_function_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &TupleFunctionExpr,
+) -> Result<TupleFunctionValue, ExecutionError> {
+    match expression.kind() {
+        TupleFunctionExprKind::Value(value) => Ok(value.clone()),
+        TupleFunctionExprKind::Closure {
+            runtime_id,
+            params,
+            captures,
+            return_type,
+        } => Ok(TupleFunctionValue::new_with_captures(
+            *runtime_id,
+            params.clone(),
+            function::eval_capture_args(plan, frame, captures)?,
+            return_type.clone(),
+        )),
+        TupleFunctionExprKind::LocalGet { local, .. } => Ok(frame.get_tuple_function(*local)),
+        TupleFunctionExprKind::Call { function, args, .. } => {
+            function::run_tuple_function_returning_function_call(plan, *function, args, frame)
+        }
+        TupleFunctionExprKind::FunctionCall {
+            function: callee,
+            args,
+            ..
+        } => function::run_tuple_function_function_call(plan, callee, args, frame),
+        TupleFunctionExprKind::TupleIndex {
+            tuple,
+            index,
+            type_,
+        } => {
+            match project_tuple_expr(
+                plan,
+                frame,
+                tuple,
+                *index,
+                ValueType::Function(Box::new(type_.clone())),
+            )? {
+                Value::Function(function) => match function.kind() {
+                    crate::plan::FunctionValueKind::Tuple(value) => Ok(value.clone()),
+                    _ => Err(ExecutionError::tuple_index_family_mismatch(
+                        ValueType::Function(Box::new(type_.clone())),
+                        Value::Function(function).value_type(),
+                    )),
+                },
+                other => Err(ExecutionError::tuple_index_family_mismatch(
+                    ValueType::Function(Box::new(type_.clone())),
+                    other.value_type(),
+                )),
+            }
+        }
+        TupleFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, frame, subject)? {
+                eval_tuple_function_expr(plan, frame, true_)
+            } else {
+                eval_tuple_function_expr(plan, frame, false_)
+            }
+        }
+        TupleFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_tuple_function_expr(plan, frame, branch);
+                }
+            }
+            eval_tuple_function_expr(plan, frame, fallback)
+        }
+        TupleFunctionExprKind::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_string_expr(plan, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_tuple_function_expr(plan, frame, branch);
+                }
+            }
+            eval_tuple_function_expr(plan, frame, fallback)
+        }
+        TupleFunctionExprKind::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_float_expr(plan, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_tuple_function_expr(plan, frame, branch);
+                }
+            }
+            eval_tuple_function_expr(plan, frame, fallback)
+        }
+        TupleFunctionExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, steps, frame)?;
+            eval_tuple_function_expr(plan, frame, return_)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::eval_tuple_function_expr;
+    use crate::plan::{
+        BoolExpr, CaptureArg, ExecutionPlan, Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr,
+        FunctionFunctionId, FunctionFunctionValue, FunctionId, FunctionPlan, FunctionType, IntExpr,
+        IntFunctionExpr, IntFunctionId, IntFunctionValue, ParamLocal, ReturnExpr, Step, StringExpr,
+        TupleExpr, TupleFunctionExpr, TupleFunctionFunctionId, TupleFunctionId,
+        TupleFunctionLocalId, TupleFunctionValue, TupleLocalId, Value, ValueType,
+    };
+    use crate::runtime::ExecutionError;
+    use crate::runtime::frame::Frame;
+    use crate::runtime::run_src;
+
+    #[test]
+    fn eval_tuple_function_value_local_call_function_call_block_and_closure() {
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+pub fn main() {
+  make
+}
+"#,
+        );
+
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+pub fn main() {
+  let f = make
+  f
+}
+"#,
+        );
+
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+fn get() {
+  make
+}
+
+pub fn main() {
+  get()
+}
+"#,
+        );
+
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+fn get() {
+  make
+}
+
+pub fn main() {
+  let getter = get
+  getter()
+}
+"#,
+        );
+
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+pub fn main() {
+  {
+    make
+  }
+}
+"#,
+        );
+
+        assert_returns_tuple_function(
+            r#"
+pub fn main() {
+  fn(value: Int) { #(value, "ok") }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn eval_tuple_function_case_and_tuple_index_paths() {
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+fn other(value: Int) {
+  #(value, "other")
+}
+
+pub fn main() {
+  case True {
+    True -> make
+    False -> other
+  }
+}
+"#,
+        );
+
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+fn other(value: Int) {
+  #(value, "other")
+}
+
+pub fn main() {
+  case 2 {
+    1 -> other
+    _ -> make
+  }
+}
+"#,
+        );
+
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+fn other(value: Int) {
+  #(value, "other")
+}
+
+pub fn main() {
+  case "hit" {
+    "hit" -> make
+    _ -> other
+  }
+}
+"#,
+        );
+
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+fn other(value: Int) {
+  #(value, "other")
+}
+
+pub fn main() {
+  case 1.0 {
+    2.0 -> other
+    _ -> make
+  }
+}
+"#,
+        );
+
+        assert_returns_tuple_function(
+            r#"
+fn make(value: Int) {
+  #(value, "ok")
+}
+
+fn other(value: Int) {
+  #(value, "other")
+}
+
+pub fn main() {
+  let functions = #(make, other)
+  functions.0
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn eval_tuple_function_expr_propagates_operand_errors() {
+        assert_tuple_index_error(
+            ValueType::Tuple(tuple_type()),
+            TupleFunctionExpr::closure(
+                TupleFunctionId(0),
+                vec![ParamLocal::tuple(TupleLocalId(0), tuple_type())],
+                vec![CaptureArg::tuple(TupleLocalId(0), error_tuple_expr())],
+                tuple_function_type(),
+                tuple_type(),
+            ),
+        );
+        assert_function_tuple_index_error(TupleFunctionExpr::tuple_index(
+            empty_tuple(),
+            0,
+            tuple_function_type(),
+        ));
+        assert_tuple_index_error(
+            ValueType::Bool,
+            TupleFunctionExpr::bool_case(
+                error_bool_expr(),
+                tuple_function_expr(),
+                other_tuple_function_expr(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Int,
+            TupleFunctionExpr::int_case(
+                error_int_expr(),
+                vec![(1.into(), tuple_function_expr())],
+                other_tuple_function_expr(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::String,
+            TupleFunctionExpr::string_case(
+                error_string_expr(),
+                vec![("hit".into(), tuple_function_expr())],
+                other_tuple_function_expr(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Float,
+            TupleFunctionExpr::float_case(
+                error_float_expr(),
+                vec![(1.0, tuple_function_expr())],
+                other_tuple_function_expr(),
+            ),
+        );
+        assert_tuple_index_error(
+            ValueType::Tuple(tuple_type()),
+            TupleFunctionExpr::block(
+                vec![Step::evaluate(Expr::tuple(error_tuple_expr()))],
+                tuple_function_expr(),
+            ),
+        );
+    }
+
+    #[test]
+    fn eval_tuple_function_direct_expression_paths() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        frame.set_tuple_function(TupleFunctionLocalId(0), tuple_function_value());
+
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::closure(
+                    TupleFunctionId(0),
+                    vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                    Vec::new(),
+                    tuple_function_type(),
+                    tuple_type(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::local_get(
+                    TupleFunctionLocalId(0),
+                    "make".into(),
+                    tuple_function_type(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::call(
+                    TupleFunctionFunctionId(0),
+                    Vec::new(),
+                    tuple_function_type(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::function_call(
+                    FunctionFunctionExpr::value(FunctionFunctionValue::new(
+                        FunctionFunctionId::Tuple(TupleFunctionFunctionId(0)),
+                        Vec::new(),
+                        tuple_function_type(),
+                    )),
+                    Vec::new(),
+                    tuple_function_type(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::tuple_index(
+                    TupleExpr::value(
+                        vec![Expr::function(FunctionExpr::tuple(tuple_function_expr()))],
+                        vec![ValueType::Function(Box::new(tuple_function_type()))],
+                    ),
+                    0,
+                    tuple_function_type(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::bool_case(
+                    BoolExpr::value(true),
+                    tuple_function_expr(),
+                    other_tuple_function_expr(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::bool_case(
+                    BoolExpr::value(false),
+                    other_tuple_function_expr(),
+                    tuple_function_expr(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::int_case(
+                    IntExpr::value(1.into()),
+                    vec![(1.into(), tuple_function_expr())],
+                    other_tuple_function_expr(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::int_case(
+                    IntExpr::value(2.into()),
+                    vec![(1.into(), other_tuple_function_expr())],
+                    tuple_function_expr(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::string_case(
+                    StringExpr::value("hit".into()),
+                    vec![("hit".into(), tuple_function_expr())],
+                    other_tuple_function_expr(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::string_case(
+                    StringExpr::value("miss".into()),
+                    vec![("hit".into(), other_tuple_function_expr())],
+                    tuple_function_expr(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::float_case(
+                    FloatExpr::value(1.0),
+                    vec![(1.0, tuple_function_expr())],
+                    other_tuple_function_expr(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::float_case(
+                    FloatExpr::value(2.0),
+                    vec![(1.0, other_tuple_function_expr())],
+                    tuple_function_expr(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                    tuple_function_expr(),
+                ),
+            )
+            .expect("expression should evaluate")
+            .runtime_id(),
+            TupleFunctionId(0),
+        );
+    }
+
+    #[test]
+    fn tuple_function_projection_invariant_error() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let int_function_type = FunctionType::new(Vec::new(), ValueType::Int);
+        let tuple_function_type = FunctionType::new(Vec::new(), ValueType::Tuple(tuple_type()));
+        let tuple = TupleExpr::value(
+            vec![Expr::function(FunctionExpr::int(IntFunctionExpr::value(
+                IntFunctionValue::new(IntFunctionId(0), Vec::new()),
+            )))],
+            vec![ValueType::Function(Box::new(int_function_type.clone()))],
+        );
+
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::tuple_index(tuple, 0, tuple_function_type.clone()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(tuple_function_type.clone())),
+                ValueType::Function(Box::new(int_function_type)),
+            )),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::tuple_index(tuple, 0, tuple_function_type.clone()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(tuple_function_type.clone())),
+                ValueType::Int,
+            )),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+        assert_eq!(
+            eval_tuple_function_expr(
+                &plan,
+                &mut frame,
+                &TupleFunctionExpr::tuple_index(tuple, 1, tuple_function_type.clone()),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Function(Box::new(tuple_function_type)),
+                ValueType::Tuple(vec![ValueType::Int]),
+            )),
+        );
+    }
+
+    fn assert_returns_tuple_function(src: &str) {
+        assert_eq!(
+            run_src(src),
+            Value::Function(
+                TupleFunctionValue::new(
+                    TupleFunctionId(0),
+                    vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                    tuple_type(),
+                )
+                .into(),
+            ),
+        );
+    }
+
+    fn tuple_type() -> Vec<ValueType> {
+        vec![ValueType::Int, ValueType::String]
+    }
+
+    fn tuple_function_value() -> TupleFunctionValue {
+        TupleFunctionValue::new(
+            TupleFunctionId(0),
+            vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+            tuple_type(),
+        )
+    }
+
+    fn tuple_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Int], ValueType::Tuple(tuple_type()))
+    }
+
+    fn tuple_function_expr() -> TupleFunctionExpr {
+        TupleFunctionExpr::value(tuple_function_value())
+    }
+
+    fn other_tuple_function_expr() -> TupleFunctionExpr {
+        TupleFunctionExpr::value(TupleFunctionValue::new(
+            TupleFunctionId(1),
+            vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+            tuple_type(),
+        ))
+    }
+
+    fn assert_tuple_index_error(expected: ValueType, expression: TupleFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_tuple_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(expected)),
+        );
+    }
+
+    fn assert_function_tuple_index_error(expression: TupleFunctionExpr) {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_tuple_function_expr(&plan, &mut frame, &expression),
+            Err(tuple_index_error(ValueType::Function(Box::new(
+                tuple_function_type()
+            )))),
+        );
+    }
+
+    fn tuple_index_error(expected: ValueType) -> ExecutionError {
+        ExecutionError::tuple_index_family_mismatch(expected, ValueType::Tuple(Vec::new()))
+    }
+
+    fn empty_tuple() -> TupleExpr {
+        TupleExpr::value(Vec::new(), Vec::new())
+    }
+
+    fn error_bool_expr() -> BoolExpr {
+        BoolExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_int_expr() -> IntExpr {
+        IntExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_string_expr() -> StringExpr {
+        StringExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_tuple_expr() -> TupleExpr {
+        TupleExpr::tuple_index(empty_tuple(), 0, tuple_type())
+    }
+
+    fn plan() -> ExecutionPlan {
+        ExecutionPlan::new(
+            "main".into(),
+            FunctionPlan::new(
+                FunctionId::new(0),
+                "main".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int(IntFunctionId(0), IntExpr::value(0.into())),
+            ),
+            vec![
+                FunctionPlan::new(
+                    FunctionId::new(1),
+                    "make".into(),
+                    vec![crate::plan::Param::named(
+                        ParamLocal::int(crate::plan::IntLocalId(0)),
+                        "value".into(),
+                    )],
+                    Vec::new(),
+                    ReturnExpr::tuple(
+                        TupleFunctionId(0),
+                        TupleExpr::value(
+                            vec![
+                                Expr::int(IntExpr::local_get(
+                                    crate::plan::IntLocalId(0),
+                                    "value".into(),
+                                )),
+                                Expr::string(StringExpr::value("ok".into())),
+                            ],
+                            tuple_type(),
+                        ),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(2),
+                    "get".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::tuple_function(TupleFunctionFunctionId(0), tuple_function_expr()),
+                ),
+            ],
+        )
+    }
+}

--- a/src/runtime/expression/int.rs
+++ b/src/runtime/expression/int.rs
@@ -1,5 +1,5 @@
-use super::{eval_bool_expr, eval_float_expr, eval_string_expr};
-use crate::plan::{ExecutionPlan, IntExpr, IntExprKind};
+use super::{eval_bool_expr, eval_float_expr, eval_string_expr, project_tuple_expr};
+use crate::plan::{ExecutionPlan, IntExpr, IntExprKind, Value, ValueType};
 use crate::runtime::ExecutionError;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -18,6 +18,15 @@ pub(in crate::runtime) fn eval_int_expr(
         }
         IntExprKind::FunctionCall { function, args } => {
             function::run_int_function_call(plan, function, args, frame)
+        }
+        IntExprKind::TupleIndex { tuple, index } => {
+            match project_tuple_expr(plan, frame, tuple, *index, ValueType::Int)? {
+                Value::Int(value) => Ok(value),
+                other => Err(ExecutionError::tuple_index_family_mismatch(
+                    ValueType::Int,
+                    other.value_type(),
+                )),
+            }
         }
         IntExprKind::Add { left, right } => {
             Ok(eval_int_expr(plan, frame, left)? + eval_int_expr(plan, frame, right)?)
@@ -114,7 +123,39 @@ fn eval_remainder_int(left: BigInt, right: BigInt) -> BigInt {
 
 #[cfg(test)]
 mod tests {
+    use super::eval_int_expr;
+    use crate::plan::{BoolExpr, Expr, FloatExpr, IntExpr, Step, StringExpr, TupleExpr, ValueType};
+    use crate::runtime::ExecutionError;
+    use crate::runtime::frame::Frame;
     use crate::runtime::{int, run_src};
+
+    #[test]
+    fn tuple_index_family_mismatch_returns_error() {
+        let plan = crate::runtime::plan_src("pub fn main() { 1 }");
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+
+        assert_eq!(
+            eval_int_expr(&plan, &mut frame, &IntExpr::tuple_index(tuple, 0)),
+            Ok(1.into()),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::string(StringExpr::value("one".into()))],
+            vec![ValueType::String],
+        );
+
+        assert_eq!(
+            eval_int_expr(&plan, &mut frame, &IntExpr::tuple_index(tuple, 0)),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Int,
+                ValueType::String,
+            )),
+        );
+    }
 
     #[test]
     fn eval_integer_arithmetic() {
@@ -514,5 +555,123 @@ pub fn main() {
             ),
             int(1),
         );
+    }
+
+    #[test]
+    fn eval_int_expr_propagates_operand_errors() {
+        let plan = crate::runtime::plan_src("pub fn main() { 1 }");
+        let mut frame = Frame::default();
+
+        for (expression, expected) in [
+            (
+                IntExpr::add(error_int_expr(), IntExpr::value(1.into())),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::add(IntExpr::value(1.into()), error_int_expr()),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::sub(error_int_expr(), IntExpr::value(1.into())),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::sub(IntExpr::value(1.into()), error_int_expr()),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::mult(error_int_expr(), IntExpr::value(1.into())),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::mult(IntExpr::value(1.into()), error_int_expr()),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::div(error_int_expr(), IntExpr::value(1.into())),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::div(IntExpr::value(1.into()), error_int_expr()),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::remainder(error_int_expr(), IntExpr::value(1.into())),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::remainder(IntExpr::value(1.into()), error_int_expr()),
+                ValueType::Int,
+            ),
+            (IntExpr::negate(error_int_expr()), ValueType::Int),
+            (
+                IntExpr::bool_case(
+                    error_bool_expr(),
+                    IntExpr::value(1.into()),
+                    IntExpr::value(0.into()),
+                ),
+                ValueType::Bool,
+            ),
+            (
+                IntExpr::int_case(
+                    error_int_expr(),
+                    vec![(1.into(), IntExpr::value(1.into()))],
+                    IntExpr::value(0.into()),
+                ),
+                ValueType::Int,
+            ),
+            (
+                IntExpr::string_case(
+                    error_string_expr(),
+                    vec![("one".into(), IntExpr::value(1.into()))],
+                    IntExpr::value(0.into()),
+                ),
+                ValueType::String,
+            ),
+            (
+                IntExpr::float_case(
+                    error_float_expr(),
+                    vec![(1.0, IntExpr::value(1.into()))],
+                    IntExpr::value(0.into()),
+                ),
+                ValueType::Float,
+            ),
+            (
+                IntExpr::block(
+                    vec![Step::evaluate(Expr::bool(error_bool_expr()))],
+                    IntExpr::value(1.into()),
+                ),
+                ValueType::Bool,
+            ),
+        ] {
+            assert_eq!(
+                eval_int_expr(&plan, &mut frame, &expression),
+                Err(tuple_index_error(expected)),
+            );
+        }
+    }
+
+    fn error_int_expr() -> IntExpr {
+        IntExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_bool_expr() -> BoolExpr {
+        BoolExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_string_expr() -> StringExpr {
+        StringExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn empty_tuple() -> TupleExpr {
+        TupleExpr::value(Vec::new(), Vec::new())
+    }
+
+    fn tuple_index_error(expected: ValueType) -> ExecutionError {
+        ExecutionError::tuple_index_family_mismatch(expected, ValueType::Tuple(Vec::new()))
     }
 }

--- a/src/runtime/expression/nil.rs
+++ b/src/runtime/expression/nil.rs
@@ -1,5 +1,5 @@
-use super::{eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr};
-use crate::plan::{ExecutionPlan, NilExpr, NilExprKind};
+use super::{eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr, project_tuple_expr};
+use crate::plan::{ExecutionPlan, NilExpr, NilExprKind, Value, ValueType};
 use crate::runtime::ExecutionError;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -20,6 +20,15 @@ pub(in crate::runtime) fn eval_nil_expr(
         }
         NilExprKind::FunctionCall { function, args } => {
             function::run_nil_function_call(plan, function, args, frame)
+        }
+        NilExprKind::TupleIndex { tuple, index } => {
+            match project_tuple_expr(plan, frame, tuple, *index, ValueType::Nil)? {
+                Value::Nil => Ok(()),
+                other => Err(ExecutionError::tuple_index_family_mismatch(
+                    ValueType::Nil,
+                    other.value_type(),
+                )),
+            }
         }
         NilExprKind::BoolCase {
             subject,
@@ -84,12 +93,36 @@ mod tests {
     use crate::plan::{
         BoolExpr, BoolFunctionExpr, ExecutionPlan, Expr, FunctionFunctionExpr, FunctionFunctionId,
         FunctionFunctionValue, FunctionId, FunctionPlan, FunctionReturnFamily, FunctionType,
-        IntExpr, IntFunctionExpr, IntFunctionId, NilFunctionExpr, ReturnExpr, Step,
-        StringFunctionFunctionId, ValueType,
+        IntExpr, IntFunctionExpr, IntFunctionId, NilExpr, NilFunctionExpr, ReturnExpr, Step,
+        StringFunctionFunctionId, TupleExpr, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
     use crate::runtime::{Value, run_src};
+
+    #[test]
+    fn tuple_index_family_mismatch_returns_error() {
+        let plan = crate::runtime::plan_src("pub fn main() { Nil }");
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+
+        assert_eq!(
+            eval_nil_expr(&plan, &mut frame, &NilExpr::tuple_index(tuple, 0)),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Nil,
+                ValueType::Int,
+            )),
+        );
+
+        let tuple = TupleExpr::value(vec![Expr::nil(NilExpr::value())], vec![ValueType::Nil]);
+        assert_eq!(
+            eval_nil_expr(&plan, &mut frame, &NilExpr::tuple_index(tuple, 0)),
+            Ok(()),
+        );
+    }
 
     #[test]
     fn eval_nil_value() {

--- a/src/runtime/expression/string.rs
+++ b/src/runtime/expression/string.rs
@@ -1,5 +1,5 @@
-use super::{eval_bool_expr, eval_float_expr, eval_int_expr};
-use crate::plan::{ExecutionPlan, StringExpr, StringExprKind};
+use super::{eval_bool_expr, eval_float_expr, eval_int_expr, project_tuple_expr};
+use crate::plan::{ExecutionPlan, StringExpr, StringExprKind, Value, ValueType};
 use crate::runtime::ExecutionError;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
@@ -18,6 +18,15 @@ pub(in crate::runtime) fn eval_string_expr(
         }
         StringExprKind::FunctionCall { function, args } => {
             function::run_string_function_call(plan, function, args, frame)
+        }
+        StringExprKind::TupleIndex { tuple, index } => {
+            match project_tuple_expr(plan, frame, tuple, *index, ValueType::String)? {
+                Value::String(value) => Ok(value),
+                other => Err(ExecutionError::tuple_index_family_mismatch(
+                    ValueType::String,
+                    other.value_type(),
+                )),
+            }
         }
         StringExprKind::Concatenate { left, right } => Ok(format!(
             "{}{}",
@@ -86,14 +95,42 @@ pub(in crate::runtime) fn eval_string_expr(
 mod tests {
     use super::eval_string_expr;
     use crate::plan::{
-        BoolExpr, BoolFunctionExpr, ExecutionPlan, Expr, FunctionFunctionExpr, FunctionFunctionId,
-        FunctionFunctionValue, FunctionId, FunctionPlan, FunctionReturnFamily, FunctionType,
-        IntExpr, IntFunctionExpr, IntFunctionId, ReturnExpr, Step, StringExpr, StringFunctionExpr,
-        StringFunctionFunctionId, ValueType,
+        BoolExpr, BoolFunctionExpr, ExecutionPlan, Expr, FloatExpr, FunctionFunctionExpr,
+        FunctionFunctionId, FunctionFunctionValue, FunctionId, FunctionPlan, FunctionReturnFamily,
+        FunctionType, IntExpr, IntFunctionExpr, IntFunctionId, ReturnExpr, Step, StringExpr,
+        StringFunctionExpr, StringFunctionFunctionId, TupleExpr, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
     use crate::runtime::{Value, run_src};
+
+    #[test]
+    fn tuple_index_family_mismatch_returns_error() {
+        let plan = crate::runtime::plan_src(r#"pub fn main() { "one" }"#);
+        let mut frame = Frame::default();
+        let tuple = TupleExpr::value(
+            vec![Expr::string(StringExpr::value("one".into()))],
+            vec![ValueType::String],
+        );
+
+        assert_eq!(
+            eval_string_expr(&plan, &mut frame, &StringExpr::tuple_index(tuple, 0)),
+            Ok("one".into()),
+        );
+
+        let tuple = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+
+        assert_eq!(
+            eval_string_expr(&plan, &mut frame, &StringExpr::tuple_index(tuple, 0)),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::String,
+                ValueType::Int,
+            )),
+        );
+    }
 
     #[test]
     fn eval_string_concatenation() {
@@ -344,6 +381,36 @@ pub fn main() {
             eval_string_expr(
                 &plan,
                 &mut frame,
+                &crate::plan::StringExpr::string_case(
+                    error_string_expr(),
+                    vec![("one".into(), crate::plan::StringExpr::value("one".into()))],
+                    crate::plan::StringExpr::value("other".into()),
+                ),
+            ),
+            Err(function_return_family_error_value(
+                FunctionReturnFamily::String,
+                FunctionReturnFamily::Bool,
+            )),
+        );
+        assert_eq!(
+            eval_string_expr(
+                &plan,
+                &mut frame,
+                &crate::plan::StringExpr::float_case(
+                    error_float_expr(),
+                    vec![(1.0, crate::plan::StringExpr::value("one".into()))],
+                    crate::plan::StringExpr::value("other".into()),
+                ),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Float,
+                ValueType::Tuple(Vec::new()),
+            )),
+        );
+        assert_eq!(
+            eval_string_expr(
+                &plan,
+                &mut frame,
                 &crate::plan::StringExpr::block(
                     vec![Step::evaluate(Expr::bool(error_bool_expr()))],
                     crate::plan::StringExpr::value("return".into()),
@@ -479,6 +546,10 @@ pub fn main() {
             ),
             Vec::new(),
         )
+    }
+
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::tuple_index(TupleExpr::value(Vec::new(), Vec::new()), 0)
     }
 
     fn string_function_function_expr() -> FunctionFunctionExpr {

--- a/src/runtime/expression/tuple.rs
+++ b/src/runtime/expression/tuple.rs
@@ -1,0 +1,543 @@
+use super::{eval_bool_expr, eval_float_expr, eval_int_expr, eval_string_expr};
+use crate::plan::{ExecutionPlan, TupleExpr, TupleExprKind, Value, ValueType};
+use crate::runtime::ExecutionError;
+use crate::runtime::frame::Frame;
+use crate::runtime::function;
+
+pub(in crate::runtime) fn eval_tuple_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    expression: &TupleExpr,
+) -> Result<Vec<Value>, ExecutionError> {
+    match expression.kind() {
+        TupleExprKind::Value(elements) => {
+            let mut values = Vec::with_capacity(elements.len());
+            for element in elements {
+                values.push(super::eval_expr(plan, frame, element)?);
+            }
+            Ok(values)
+        }
+        TupleExprKind::LocalGet { local, .. } => Ok(frame.get_tuple(*local)),
+        TupleExprKind::Call { function, args } => {
+            function::run_tuple_call(plan, *function, args, frame)
+        }
+        TupleExprKind::FunctionCall { function, args } => {
+            function::run_tuple_function_call(plan, function, args, frame)
+        }
+        TupleExprKind::TupleIndex { tuple, index } => {
+            let expected = ValueType::Tuple(expression.type_().to_vec());
+            match project_tuple_expr(plan, frame, tuple, *index, expected.clone())? {
+                Value::Tuple(values) => Ok(values),
+                other => Err(ExecutionError::tuple_index_family_mismatch(
+                    expected,
+                    other.value_type(),
+                )),
+            }
+        }
+        TupleExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, frame, subject)? {
+                eval_tuple_expr(plan, frame, true_)
+            } else {
+                eval_tuple_expr(plan, frame, false_)
+            }
+        }
+        TupleExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_tuple_expr(plan, frame, branch);
+                }
+            }
+            eval_tuple_expr(plan, frame, fallback)
+        }
+        TupleExprKind::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_string_expr(plan, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_tuple_expr(plan, frame, branch);
+                }
+            }
+            eval_tuple_expr(plan, frame, fallback)
+        }
+        TupleExprKind::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_float_expr(plan, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_tuple_expr(plan, frame, branch);
+                }
+            }
+            eval_tuple_expr(plan, frame, fallback)
+        }
+        TupleExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, steps, frame)?;
+            eval_tuple_expr(plan, frame, return_)
+        }
+    }
+}
+
+pub(in crate::runtime) fn project_tuple_expr(
+    plan: &ExecutionPlan,
+    frame: &mut Frame,
+    tuple: &TupleExpr,
+    index: usize,
+    expected: ValueType,
+) -> Result<Value, ExecutionError> {
+    let values = eval_tuple_expr(plan, frame, tuple)?;
+    let Some(value) = values.get(index).cloned() else {
+        return Err(ExecutionError::tuple_index_family_mismatch(
+            expected,
+            ValueType::Tuple(values.iter().map(Value::value_type).collect()),
+        ));
+    };
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{eval_tuple_expr, project_tuple_expr};
+    use crate::plan::{
+        BoolExpr, ExecutionPlan, Expr, FloatExpr, FunctionId, FunctionPlan, IntExpr, IntFunctionId,
+        ReturnExpr, Step, StringExpr, TupleExpr, TupleFunctionId, Value, ValueType,
+    };
+    use crate::runtime::ExecutionError;
+    use crate::runtime::frame::Frame;
+    use crate::runtime::{int, run_src};
+
+    #[test]
+    fn eval_tuple_expr_source_paths() {
+        assert_eq!(
+            run_src(
+                r#"
+pub fn main() {
+  #(1, "one")
+}
+"#,
+            ),
+            tuple(vec![int(1), string("one")]),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+pub fn main() {
+  let pair = #(1, "one")
+  pair
+}
+"#,
+            ),
+            tuple(vec![int(1), string("one")]),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+fn pair() {
+  #(1, "one")
+}
+
+pub fn main() {
+  pair()
+}
+"#,
+            ),
+            tuple(vec![int(1), string("one")]),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+fn pair() {
+  #(1, "one")
+}
+
+pub fn main() {
+  let f = pair
+  f()
+}
+"#,
+            ),
+            tuple(vec![int(1), string("one")]),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+pub fn main() {
+  let nested = #(#(1, "one"), 2)
+  nested.0
+}
+"#,
+            ),
+            tuple(vec![int(1), string("one")]),
+        );
+    }
+
+    #[test]
+    fn eval_tuple_expr_case_and_block_paths() {
+        assert_eq!(
+            run_src(
+                r#"
+pub fn main() {
+  case True {
+    True -> #(1, "hit")
+    False -> #(2, "miss")
+  }
+}
+"#,
+            ),
+            tuple(vec![int(1), string("hit")]),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+pub fn main() {
+  case 2 {
+    1 -> #(1, "hit")
+    _ -> #(2, "miss")
+  }
+}
+"#,
+            ),
+            tuple(vec![int(2), string("miss")]),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+pub fn main() {
+  case "hit" {
+    "hit" -> #(1, "hit")
+    _ -> #(2, "miss")
+  }
+}
+"#,
+            ),
+            tuple(vec![int(1), string("hit")]),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+pub fn main() {
+  case 1.0 {
+    2.0 -> #(1, "hit")
+    _ -> #(2, "miss")
+  }
+}
+"#,
+            ),
+            tuple(vec![int(2), string("miss")]),
+        );
+
+        assert_eq!(
+            run_src(
+                r#"
+pub fn main() {
+  {
+    let value = 1
+    #(value, "block")
+  }
+}
+"#,
+            ),
+            tuple(vec![int(1), string("block")]),
+        );
+    }
+
+    #[test]
+    fn eval_tuple_expr_direct_case_and_block_paths() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::call(TupleFunctionId(0), Vec::new(), tuple_type()),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::bool_case(BoolExpr::value(true), tuple_expr(1, "hit"), other_tuple(),),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::bool_case(BoolExpr::value(false), other_tuple(), tuple_expr(1, "hit"),),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::int_case(
+                    IntExpr::value(1.into()),
+                    vec![(1.into(), tuple_expr(1, "hit"))],
+                    other_tuple(),
+                ),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::int_case(
+                    IntExpr::value(2.into()),
+                    vec![(1.into(), other_tuple())],
+                    tuple_expr(1, "hit"),
+                ),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::string_case(
+                    StringExpr::value("hit".into()),
+                    vec![("hit".into(), tuple_expr(1, "hit"))],
+                    other_tuple(),
+                ),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::string_case(
+                    StringExpr::value("miss".into()),
+                    vec![("hit".into(), other_tuple())],
+                    tuple_expr(1, "hit"),
+                ),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::float_case(
+                    FloatExpr::value(1.0),
+                    vec![(1.0, tuple_expr(1, "hit"))],
+                    other_tuple(),
+                ),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::float_case(
+                    FloatExpr::value(2.0),
+                    vec![(1.0, other_tuple())],
+                    tuple_expr(1, "hit"),
+                ),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(0.into())))],
+                    tuple_expr(1, "hit"),
+                ),
+            ),
+            Ok(vec![int(1), string("hit")]),
+        );
+    }
+
+    #[test]
+    fn tuple_projection_invariant_errors() {
+        let plan = plan();
+        let mut frame = Frame::default();
+        let tuple_expr = TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        );
+
+        assert_eq!(
+            project_tuple_expr(&plan, &mut frame, &tuple_expr, 1, ValueType::String),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::String,
+                ValueType::Tuple(vec![ValueType::Int]),
+            )),
+        );
+
+        assert_eq!(
+            eval_tuple_expr(
+                &plan,
+                &mut frame,
+                &TupleExpr::tuple_index(tuple_expr, 0, vec![ValueType::String]),
+            ),
+            Err(ExecutionError::tuple_index_family_mismatch(
+                ValueType::Tuple(vec![ValueType::String]),
+                ValueType::Int,
+            )),
+        );
+    }
+
+    #[test]
+    fn eval_tuple_expr_propagates_operand_errors() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        for (expression, expected) in [
+            (
+                TupleExpr::value(vec![Expr::int(error_int_expr())], vec![ValueType::Int]),
+                ValueType::Int,
+            ),
+            (
+                TupleExpr::bool_case(error_bool_expr(), tuple_expr(1, "hit"), other_tuple()),
+                ValueType::Bool,
+            ),
+            (
+                TupleExpr::int_case(
+                    error_int_expr(),
+                    vec![(1.into(), tuple_expr(1, "hit"))],
+                    other_tuple(),
+                ),
+                ValueType::Int,
+            ),
+            (
+                TupleExpr::string_case(
+                    error_string_expr(),
+                    vec![("hit".into(), tuple_expr(1, "hit"))],
+                    other_tuple(),
+                ),
+                ValueType::String,
+            ),
+            (
+                TupleExpr::float_case(
+                    error_float_expr(),
+                    vec![(1.0, tuple_expr(1, "hit"))],
+                    other_tuple(),
+                ),
+                ValueType::Float,
+            ),
+            (
+                TupleExpr::block(
+                    vec![Step::evaluate(Expr::bool(error_bool_expr()))],
+                    tuple_expr(1, "hit"),
+                ),
+                ValueType::Bool,
+            ),
+        ] {
+            assert_eq!(
+                eval_tuple_expr(&plan, &mut frame, &expression),
+                Err(tuple_index_error(expected)),
+            );
+        }
+
+        assert_eq!(
+            eval_tuple_expr(&plan, &mut frame, &error_tuple_expr()),
+            Err(tuple_index_error(ValueType::Tuple(tuple_type()))),
+        );
+        assert_eq!(
+            project_tuple_expr(&plan, &mut frame, &error_tuple_expr(), 0, ValueType::Int),
+            Err(tuple_index_error(ValueType::Tuple(tuple_type()))),
+        );
+    }
+
+    fn error_int_expr() -> IntExpr {
+        IntExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_bool_expr() -> BoolExpr {
+        BoolExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_string_expr() -> StringExpr {
+        StringExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::tuple_index(empty_tuple(), 0)
+    }
+
+    fn error_tuple_expr() -> TupleExpr {
+        TupleExpr::tuple_index(empty_tuple(), 0, tuple_type())
+    }
+
+    fn empty_tuple() -> TupleExpr {
+        TupleExpr::value(Vec::new(), Vec::new())
+    }
+
+    fn tuple_index_error(expected: ValueType) -> ExecutionError {
+        ExecutionError::tuple_index_family_mismatch(expected, ValueType::Tuple(Vec::new()))
+    }
+
+    fn tuple(values: Vec<Value>) -> Value {
+        Value::Tuple(values)
+    }
+
+    fn string(value: &str) -> Value {
+        Value::String(value.into())
+    }
+
+    fn tuple_expr(int_value: i64, string_value: &str) -> TupleExpr {
+        TupleExpr::value(
+            vec![
+                Expr::int(IntExpr::value(int_value.into())),
+                Expr::string(StringExpr::value(string_value.into())),
+            ],
+            tuple_type(),
+        )
+    }
+
+    fn other_tuple() -> TupleExpr {
+        tuple_expr(2, "miss")
+    }
+
+    fn tuple_type() -> Vec<ValueType> {
+        vec![ValueType::Int, ValueType::String]
+    }
+
+    fn plan() -> ExecutionPlan {
+        ExecutionPlan::new(
+            "main".into(),
+            FunctionPlan::new(
+                FunctionId::new(0),
+                "main".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int(IntFunctionId(0), IntExpr::value(0.into())),
+            ),
+            vec![FunctionPlan::new(
+                FunctionId::new(1),
+                "tuple_value".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::tuple(TupleFunctionId(0), tuple_expr(1, "hit")),
+            )],
+        )
+    }
+}

--- a/src/runtime/frame.rs
+++ b/src/runtime/frame.rs
@@ -184,36 +184,41 @@ mod tests {
         FloatFunctionLocalId, FloatFunctionValue, FloatLocalId, FrameLayout, IntFunctionId,
         IntFunctionLocalId, IntFunctionValue, IntLocalId, NilFunctionId, NilFunctionLocalId,
         NilFunctionValue, NilLocalId, ParamLocal, StringFunctionId, StringFunctionLocalId,
-        StringFunctionValue, StringLocalId,
+        StringFunctionValue, StringLocalId, TupleFunctionId, TupleFunctionLocalId,
+        TupleFunctionValue, TupleLocalId, Value, ValueType,
     };
     use num_bigint::BigInt;
 
     #[test]
     fn frame_set_and_get_local() {
-        let frame = frame_with_layout(1, 1, 1, 1, 1);
+        let frame = frame_with_layout(1, 1, 1, 1, 1, 1);
         let mut frame = frame;
         let int_function = int_function_value();
         let float_function = float_function_value();
         let string_function = string_function_value();
         let bool_function = bool_function_value();
         let nil_function = nil_function_value();
+        let tuple_function = tuple_function_value();
 
         frame.set_int(IntLocalId(0), int(1));
         frame.set_float(FloatLocalId(0), 1.5);
         frame.set_string(StringLocalId(0), "geam".into());
         frame.set_bool(BoolLocalId(0), true);
         frame.set_nil(NilLocalId(0));
+        frame.set_tuple(TupleLocalId(0), vec![Value::Int(1.into())]);
         frame.set_int_function(IntFunctionLocalId(0), int_function.clone());
         frame.set_float_function(FloatFunctionLocalId(0), float_function.clone());
         frame.set_string_function(StringFunctionLocalId(0), string_function.clone());
         frame.set_bool_function(BoolFunctionLocalId(0), bool_function.clone());
         frame.set_nil_function(NilFunctionLocalId(0), nil_function.clone());
+        frame.set_tuple_function(TupleFunctionLocalId(0), tuple_function.clone());
 
         assert_eq!(frame.get_int(IntLocalId(0)), int(1));
         assert_eq!(frame.get_float(FloatLocalId(0)), 1.5);
         assert_eq!(frame.get_string(StringLocalId(0)), "geam");
         assert!(frame.get_bool(BoolLocalId(0)));
         assert_eq!(frame.get_nil(NilLocalId(0)), ());
+        assert_eq!(frame.get_tuple(TupleLocalId(0)), vec![Value::Int(1.into())]);
         assert_eq!(frame.get_int_function(IntFunctionLocalId(0)), int_function);
         assert_eq!(
             frame.get_float_function(FloatFunctionLocalId(0)),
@@ -228,24 +233,33 @@ mod tests {
             bool_function,
         );
         assert_eq!(frame.get_nil_function(NilFunctionLocalId(0)), nil_function);
+        assert_eq!(
+            frame.get_tuple_function(TupleFunctionLocalId(0)),
+            tuple_function,
+        );
     }
 
     #[test]
     fn frame_set_overwrites_local() {
-        let mut frame = frame_with_layout(1, 1, 0, 0, 0);
-        let _ = frame_with_layout(0, 0, 0, 0, 0);
+        let mut frame = frame_with_layout(1, 1, 0, 0, 0, 1);
+        let _ = frame_with_layout(0, 0, 0, 0, 0, 0);
 
         frame.set_int(IntLocalId(0), int(1));
         frame.set_int(IntLocalId(0), int(2));
         frame.set_float(FloatLocalId(0), 1.0);
         frame.set_float(FloatLocalId(0), 2.0);
+        frame.set_tuple(TupleLocalId(0), vec![Value::Int(1.into())]);
+        frame.set_tuple(TupleLocalId(0), vec![Value::Int(2.into())]);
         frame.set_int_function(IntFunctionLocalId(0), int_function_value());
         frame.set_int_function(IntFunctionLocalId(0), other_int_function_value());
         frame.set_float_function(FloatFunctionLocalId(0), float_function_value());
         frame.set_float_function(FloatFunctionLocalId(0), other_float_function_value());
+        frame.set_tuple_function(TupleFunctionLocalId(0), tuple_function_value());
+        frame.set_tuple_function(TupleFunctionLocalId(0), other_tuple_function_value());
 
         assert_eq!(frame.get_int(IntLocalId(0)), int(2));
         assert_eq!(frame.get_float(FloatLocalId(0)), 2.0);
+        assert_eq!(frame.get_tuple(TupleLocalId(0)), vec![Value::Int(2.into())]);
         assert_eq!(
             frame.get_int_function(IntFunctionLocalId(0)),
             other_int_function_value(),
@@ -253,6 +267,10 @@ mod tests {
         assert_eq!(
             frame.get_float_function(FloatFunctionLocalId(0)),
             other_float_function_value(),
+        );
+        assert_eq!(
+            frame.get_tuple_function(TupleFunctionLocalId(0)),
+            other_tuple_function_value(),
         );
     }
 
@@ -262,6 +280,7 @@ mod tests {
         strings: usize,
         bools: usize,
         nils: usize,
+        tuples: usize,
     ) -> Frame {
         let mut layout = FrameLayout::default();
         if ints > 0 {
@@ -279,11 +298,15 @@ mod tests {
         if nils > 0 {
             layout.include_nil(NilLocalId(nils - 1));
         }
+        if tuples > 0 {
+            layout.include_tuple(TupleLocalId(tuples - 1));
+        }
         layout.include_int_function(IntFunctionLocalId(0));
         layout.include_float_function(FloatFunctionLocalId(0));
         layout.include_string_function(StringFunctionLocalId(0));
         layout.include_bool_function(BoolFunctionLocalId(0));
         layout.include_nil_function(NilFunctionLocalId(0));
+        layout.include_tuple_function(TupleFunctionLocalId(0));
         Frame::new(layout)
     }
 
@@ -320,5 +343,21 @@ mod tests {
 
     fn nil_function_value() -> NilFunctionValue {
         NilFunctionValue::new(NilFunctionId(0), vec![ParamLocal::int(IntLocalId(0))])
+    }
+
+    fn tuple_function_value() -> TupleFunctionValue {
+        TupleFunctionValue::new(
+            TupleFunctionId(0),
+            vec![ParamLocal::int(IntLocalId(0))],
+            vec![ValueType::Int],
+        )
+    }
+
+    fn other_tuple_function_value() -> TupleFunctionValue {
+        TupleFunctionValue::new(
+            TupleFunctionId(1),
+            vec![ParamLocal::int(IntLocalId(0))],
+            vec![ValueType::Int],
+        )
     }
 }

--- a/src/runtime/frame.rs
+++ b/src/runtime/frame.rs
@@ -2,7 +2,8 @@ use crate::plan::{
     BoolFunctionLocalId, BoolFunctionValue, BoolLocalId, FloatFunctionLocalId, FloatFunctionValue,
     FloatLocalId, FrameLayout, FunctionFunctionLocalId, FunctionFunctionValue, IntFunctionLocalId,
     IntFunctionValue, IntLocalId, NilFunctionLocalId, NilFunctionValue, NilLocalId,
-    StringFunctionLocalId, StringFunctionValue, StringLocalId,
+    StringFunctionLocalId, StringFunctionValue, StringLocalId, TupleFunctionLocalId,
+    TupleFunctionValue, TupleLocalId, Value,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -13,11 +14,13 @@ pub(super) struct Frame {
     floats: Vec<f64>,
     strings: Vec<EcoString>,
     bools: Vec<bool>,
+    tuples: Vec<Vec<Value>>,
     int_functions: HashMap<IntFunctionLocalId, IntFunctionValue>,
     float_functions: HashMap<FloatFunctionLocalId, FloatFunctionValue>,
     string_functions: HashMap<StringFunctionLocalId, StringFunctionValue>,
     bool_functions: HashMap<BoolFunctionLocalId, BoolFunctionValue>,
     nil_functions: HashMap<NilFunctionLocalId, NilFunctionValue>,
+    tuple_functions: HashMap<TupleFunctionLocalId, TupleFunctionValue>,
     function_functions: HashMap<FunctionFunctionLocalId, FunctionFunctionValue>,
 }
 
@@ -28,11 +31,13 @@ impl Frame {
             floats: vec![0.0; layout.floats()],
             strings: vec![EcoString::default(); layout.strings()],
             bools: vec![false; layout.bools()],
+            tuples: vec![Vec::new(); layout.tuples()],
             int_functions: HashMap::with_capacity(layout.int_functions()),
             float_functions: HashMap::with_capacity(layout.float_functions()),
             string_functions: HashMap::with_capacity(layout.string_functions()),
             bool_functions: HashMap::with_capacity(layout.bool_functions()),
             nil_functions: HashMap::with_capacity(layout.nil_functions()),
+            tuple_functions: HashMap::with_capacity(layout.tuple_functions()),
             function_functions: HashMap::with_capacity(layout.function_functions()),
         }
     }
@@ -72,6 +77,14 @@ impl Frame {
     pub(super) fn set_nil(&mut self, _local: NilLocalId) {}
 
     pub(super) fn get_nil(&self, _local: NilLocalId) {}
+
+    pub(super) fn set_tuple(&mut self, local: TupleLocalId, value: Vec<Value>) {
+        set_slot(&mut self.tuples, local.0, value);
+    }
+
+    pub(super) fn get_tuple(&self, local: TupleLocalId) -> Vec<Value> {
+        self.tuples[local.0].clone()
+    }
 
     pub(super) fn set_int_function(&mut self, local: IntFunctionLocalId, value: IntFunctionValue) {
         self.int_functions.insert(local, value);
@@ -123,6 +136,18 @@ impl Frame {
 
     pub(super) fn get_nil_function(&self, local: NilFunctionLocalId) -> NilFunctionValue {
         self.nil_functions[&local].clone()
+    }
+
+    pub(super) fn set_tuple_function(
+        &mut self,
+        local: TupleFunctionLocalId,
+        value: TupleFunctionValue,
+    ) {
+        self.tuple_functions.insert(local, value);
+    }
+
+    pub(super) fn get_tuple_function(&self, local: TupleFunctionLocalId) -> TupleFunctionValue {
+        self.tuple_functions[&local].clone()
     }
 
     pub(super) fn set_function_function(
@@ -208,6 +233,7 @@ mod tests {
     #[test]
     fn frame_set_overwrites_local() {
         let mut frame = frame_with_layout(1, 1, 0, 0, 0);
+        let _ = frame_with_layout(0, 0, 0, 0, 0);
 
         frame.set_int(IntLocalId(0), int(1));
         frame.set_int(IntLocalId(0), int(2));

--- a/src/runtime/function.rs
+++ b/src/runtime/function.rs
@@ -9,13 +9,15 @@ use crate::plan::{
     BoolFunctionFunctionId, BoolFunctionId, CallArg, ExecutionPlan, FloatFunctionFunctionId,
     FloatFunctionId, FunctionFunctionFunctionId, FunctionFunctionValue, FunctionReturnFamily,
     FunctionValue, IntFunctionFunctionId, IntFunctionId, NilFunctionFunctionId, NilFunctionId,
-    RuntimeFunctionId, StringFunctionFunctionId, StringFunctionId, Value,
+    RuntimeFunctionId, StringFunctionFunctionId, StringFunctionId, TupleFunctionFunctionId,
+    TupleFunctionId, Value,
 };
 use crate::runtime::ExecutionError;
 use crate::runtime::error::ExecutionResult;
 use crate::runtime::expression::{
     eval_bool_function_expr, eval_float_function_expr, eval_function_function_expr,
     eval_int_function_expr, eval_nil_function_expr, eval_string_function_expr,
+    eval_tuple_function_expr,
 };
 use crate::runtime::frame::Frame;
 use bind::{bind_arguments, bind_function_value_arguments};
@@ -24,7 +26,8 @@ use num_bigint::BigInt;
 use return_body::{
     run_bool_function_loop, run_bool_loop, run_float_function_loop, run_float_loop,
     run_function_function_loop, run_int_function_loop, run_int_loop, run_nil_function_loop,
-    run_nil_loop, run_string_function_loop, run_string_loop,
+    run_nil_loop, run_string_function_loop, run_string_loop, run_tuple_function_loop,
+    run_tuple_loop,
 };
 
 pub(super) fn run_main(plan: &ExecutionPlan) -> ExecutionResult<Value> {
@@ -44,6 +47,9 @@ pub(super) fn run_main(plan: &ExecutionPlan) -> ExecutionResult<Value> {
         }
         RuntimeFunctionId::Nil(function) => {
             run_nil_call(plan, function, &[], &mut caller_frame).map(|_| Value::Nil)
+        }
+        RuntimeFunctionId::Tuple { id, .. } => {
+            run_tuple_call(plan, id, &[], &mut caller_frame).map(Value::Tuple)
         }
         RuntimeFunctionId::Function { id, .. } => {
             run_function_returning_function_call(plan, id, &[], &mut caller_frame)
@@ -127,6 +133,21 @@ pub(super) fn run_nil_call(
     run_nil_loop(plan, function, frame)
 }
 
+pub(super) fn run_tuple_call(
+    plan: &ExecutionPlan,
+    function: TupleFunctionId,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<Vec<Value>> {
+    let frame = bind_arguments(
+        plan,
+        args,
+        caller_frame,
+        plan.tuple_function(function).frame_layout(),
+    )?;
+    run_tuple_loop(plan, function, frame)
+}
+
 pub(in crate::runtime) fn run_int_function_call(
     plan: &ExecutionPlan,
     function: &crate::plan::IntFunctionExpr,
@@ -195,6 +216,20 @@ pub(in crate::runtime) fn run_nil_function_call(
     let frame =
         bind_function_value_arguments(plan, args, caller_frame, frame_layout, function.captures())?;
     run_nil_loop(plan, function.runtime_id(), frame)
+}
+
+pub(in crate::runtime) fn run_tuple_function_call(
+    plan: &ExecutionPlan,
+    function: &crate::plan::TupleFunctionExpr,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<Vec<Value>> {
+    let function = eval_tuple_function_expr(plan, caller_frame, function)?;
+    let runtime_function = plan.tuple_function(function.runtime_id());
+    let frame_layout = runtime_function.frame_layout();
+    let frame =
+        bind_function_value_arguments(plan, args, caller_frame, frame_layout, function.captures())?;
+    run_tuple_loop(plan, function.runtime_id(), frame)
 }
 
 pub(in crate::runtime) fn run_int_function_returning_function_call(
@@ -270,6 +305,21 @@ pub(in crate::runtime) fn run_nil_function_returning_function_call(
         plan.nil_function_function(function).frame_layout(),
     )?;
     run_nil_function_loop(plan, function, frame)
+}
+
+pub(in crate::runtime) fn run_tuple_function_returning_function_call(
+    plan: &ExecutionPlan,
+    function: TupleFunctionFunctionId,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<crate::plan::TupleFunctionValue> {
+    let frame = bind_arguments(
+        plan,
+        args,
+        caller_frame,
+        plan.tuple_function_function(function).frame_layout(),
+    )?;
+    run_tuple_function_loop(plan, function, frame)
 }
 
 pub(in crate::runtime) fn run_function_function_returning_function_call(
@@ -393,6 +443,27 @@ pub(in crate::runtime) fn run_nil_function_function_call(
     run_nil_function_loop(plan, function_id, frame)
 }
 
+pub(in crate::runtime) fn run_tuple_function_function_call(
+    plan: &ExecutionPlan,
+    function: &crate::plan::FunctionFunctionExpr,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<crate::plan::TupleFunctionValue> {
+    let function = eval_function_function_expr(plan, caller_frame, function)?;
+    let runtime_id = function.runtime_id();
+    let function_id = runtime_id
+        .tuple()
+        .ok_or(ExecutionError::function_return_family_mismatch(
+            FunctionReturnFamily::Tuple,
+            runtime_id.family(),
+        ))?;
+    let runtime_function = plan.tuple_function_function(function_id);
+    let frame_layout = runtime_function.frame_layout();
+    let frame =
+        bind_function_value_arguments(plan, args, caller_frame, frame_layout, function.captures())?;
+    run_tuple_function_loop(plan, function_id, frame)
+}
+
 pub(in crate::runtime) fn run_function_function_function_call(
     plan: &ExecutionPlan,
     function: &crate::plan::FunctionFunctionExpr,
@@ -441,6 +512,10 @@ fn run_function_returning_function_call(
             run_nil_function_returning_function_call(plan, function, args, caller_frame)
                 .map(Into::into)
         }
+        crate::plan::FunctionFunctionId::Tuple(function) => {
+            run_tuple_function_returning_function_call(plan, function, args, caller_frame)
+                .map(Into::into)
+        }
         crate::plan::FunctionFunctionId::Function(function) => {
             run_function_function_returning_function_call(plan, function, args, caller_frame)
                 .map(Into::into)
@@ -460,6 +535,8 @@ mod tests {
         run_nil_call, run_nil_function_call, run_nil_function_function_call,
         run_nil_function_returning_function_call, run_string_call, run_string_function_call,
         run_string_function_function_call, run_string_function_returning_function_call,
+        run_tuple_call, run_tuple_function_call, run_tuple_function_function_call,
+        run_tuple_function_returning_function_call,
     };
     use crate::plan::{
         BoolExpr, BoolFunctionExpr, BoolFunctionFunctionId, BoolFunctionId, BoolFunctionValue,
@@ -471,7 +548,8 @@ mod tests {
         IntFunctionFunctionId, IntFunctionId, IntFunctionValue, IntLocalId, NilExpr,
         NilFunctionExpr, NilFunctionFunctionId, NilFunctionId, NilFunctionValue, NilLocalId,
         ParamLocal, ReturnExpr, RuntimeFunctionId, Step, StringExpr, StringFunctionExpr,
-        StringFunctionFunctionId, StringFunctionId, StringFunctionValue, StringLocalId, ValueType,
+        StringFunctionFunctionId, StringFunctionId, StringFunctionValue, StringLocalId, TupleExpr,
+        TupleFunctionExpr, TupleFunctionFunctionId, TupleFunctionId, TupleFunctionValue, ValueType,
     };
     use crate::runtime::frame::Frame;
     use crate::runtime::{ExecutionError, Value, run_src};
@@ -528,6 +606,16 @@ mod tests {
                 &mut Frame::default(),
             ),
             FunctionReturnFamily::Nil,
+            FunctionReturnFamily::Int,
+        );
+        assert_function_return_family_mismatch(
+            run_tuple_function_function_call(
+                &plan,
+                &function_function_expr(FunctionFunctionId::Int(IntFunctionFunctionId(0))),
+                &[],
+                &mut Frame::default(),
+            ),
+            FunctionReturnFamily::Tuple,
             FunctionReturnFamily::Int,
         );
         assert_expected_function_got_int(run_function_function_function_call(
@@ -777,6 +865,16 @@ pub fn main() {
             Ok(ValueType::Nil),
         );
         assert_eq!(
+            run_tuple_function_function_call(
+                &plan,
+                &function_function_expr(FunctionFunctionId::Tuple(TupleFunctionFunctionId(0))),
+                &[],
+                &mut Frame::default(),
+            )
+            .map(|value| value.type_().return_().clone()),
+            Ok(ValueType::Tuple(vec![ValueType::Int])),
+        );
+        assert_eq!(
             run_function_function_function_call(
                 &plan,
                 &function_function_expr(FunctionFunctionId::Function(FunctionFunctionFunctionId(
@@ -816,6 +914,10 @@ pub fn main() {
         assert_eq!(
             run_nil_call(&plan, NilFunctionId(0), &[], &mut Frame::default()),
             Ok(()),
+        );
+        assert_eq!(
+            run_tuple_call(&plan, TupleFunctionId(0), &[], &mut Frame::default()),
+            Ok(vec![Value::Int(1.into())]),
         );
     }
 
@@ -884,6 +986,26 @@ pub fn main() {
             Ok(ValueType::Nil),
         );
         assert_eq!(
+            run_tuple_function_returning_function_call(
+                &plan,
+                TupleFunctionFunctionId(0),
+                &[],
+                &mut Frame::default(),
+            )
+            .map(|value| value.type_().return_().clone()),
+            Ok(ValueType::Tuple(vec![ValueType::Int])),
+        );
+        assert_eq!(
+            run_function_returning_function_call(
+                &plan,
+                FunctionFunctionId::Tuple(TupleFunctionFunctionId(0)),
+                &[],
+                &mut Frame::default(),
+            )
+            .map(|value| value.type_().return_().clone()),
+            Ok(ValueType::Tuple(vec![ValueType::Int])),
+        );
+        assert_eq!(
             run_function_function_returning_function_call(
                 &plan,
                 FunctionFunctionFunctionId(0),
@@ -932,6 +1054,12 @@ pub fn main() {
             &[failing_function_function_arg()],
             &mut Frame::default(),
         ));
+        assert_expected_function_got_int(run_tuple_call(
+            &plan,
+            TupleFunctionId(0),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
     }
 
     #[test]
@@ -965,6 +1093,12 @@ pub fn main() {
         assert_expected_function_got_int(run_nil_function_returning_function_call(
             &plan,
             NilFunctionFunctionId(0),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_tuple_function_returning_function_call(
+            &plan,
+            TupleFunctionFunctionId(0),
             &[failing_function_function_arg()],
             &mut Frame::default(),
         ));
@@ -1005,6 +1139,12 @@ pub fn main() {
             &[],
             &mut Frame::default(),
         ));
+        assert_expected_function_got_int(run_tuple_function_function_call(
+            &plan,
+            &expression,
+            &[],
+            &mut Frame::default(),
+        ));
         assert_expected_function_got_int(run_function_function_function_call(
             &plan,
             &expression,
@@ -1032,6 +1172,16 @@ pub fn main() {
         assert_expected_function_got_int(run_main(&plan_with_main(
             steps.clone(),
             ReturnExpr::nil(NilFunctionId(0), NilExpr::value()),
+        )));
+        assert_expected_function_got_int(run_main(&plan_with_main(
+            steps.clone(),
+            ReturnExpr::tuple(
+                TupleFunctionId(0),
+                TupleExpr::value(
+                    vec![Expr::int(IntExpr::value(1.into()))],
+                    vec![ValueType::Int],
+                ),
+            ),
         )));
         assert_expected_function_got_int(run_main(&plan_with_main(
             steps,
@@ -1089,6 +1239,16 @@ pub fn main() {
                 failing_function_function_expr(),
                 Vec::new(),
                 FunctionType::new(Vec::new(), ValueType::Nil),
+            ),
+            &[],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_tuple_function_call(
+            &plan,
+            &TupleFunctionExpr::function_call(
+                failing_function_function_expr(),
+                Vec::new(),
+                FunctionType::new(Vec::new(), ValueType::Tuple(vec![ValueType::Int])),
             ),
             &[],
             &mut Frame::default(),
@@ -1161,8 +1321,9 @@ pub fn main() {
                 function_plan(3, "float_function", steps.clone(), float_function_expr()),
                 function_plan(4, "bool_function", steps.clone(), bool_function_expr()),
                 function_plan(5, "nil_function", steps.clone(), nil_function_expr()),
+                function_plan(6, "tuple_function", steps.clone(), tuple_function_expr()),
                 function_plan(
-                    6,
+                    7,
                     "function_function",
                     steps,
                     function_function_expr_value(),
@@ -1233,6 +1394,19 @@ pub fn main() {
                     steps,
                     ReturnExpr::nil(NilFunctionId(0), NilExpr::value()),
                 ),
+                FunctionPlan::new(
+                    FunctionId::new(5),
+                    "tuple".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::tuple(
+                        TupleFunctionId(0),
+                        TupleExpr::value(
+                            vec![Expr::int(IntExpr::value(1.into()))],
+                            vec![ValueType::Int],
+                        ),
+                    ),
+                ),
             ],
         )
     }
@@ -1268,6 +1442,9 @@ pub fn main() {
             }
             FunctionExprKind::Nil(return_) => {
                 ReturnExpr::nil_function(NilFunctionFunctionId(0), return_)
+            }
+            FunctionExprKind::Tuple(return_) => {
+                ReturnExpr::tuple_function(TupleFunctionFunctionId(0), return_)
             }
             FunctionExprKind::Function(return_) => {
                 ReturnExpr::function_function(FunctionFunctionFunctionId(0), return_)
@@ -1307,6 +1484,14 @@ pub fn main() {
         FunctionExpr::nil(NilFunctionExpr::value(NilFunctionValue::new(
             NilFunctionId(0),
             Vec::new(),
+        )))
+    }
+
+    fn tuple_function_expr() -> FunctionExpr {
+        FunctionExpr::tuple(TupleFunctionExpr::value(TupleFunctionValue::new(
+            TupleFunctionId(0),
+            Vec::new(),
+            vec![ValueType::Int],
         )))
     }
 

--- a/src/runtime/function/bind.rs
+++ b/src/runtime/function/bind.rs
@@ -6,7 +6,8 @@ use crate::runtime::error::ExecutionResult;
 use crate::runtime::expression::{
     eval_bool_expr, eval_bool_function_expr, eval_float_expr, eval_float_function_expr,
     eval_function_function_expr, eval_int_expr, eval_int_function_expr, eval_nil_expr,
-    eval_nil_function_expr, eval_string_expr, eval_string_function_expr,
+    eval_nil_function_expr, eval_string_expr, eval_string_function_expr, eval_tuple_expr,
+    eval_tuple_function_expr,
 };
 use crate::runtime::frame::Frame;
 
@@ -62,6 +63,10 @@ fn bind_arguments_into(
                 eval_nil_expr(plan, caller_frame, value)?;
                 frame.set_nil(*local);
             }
+            CallArgKind::Tuple { local, value } => {
+                let value = eval_tuple_expr(plan, caller_frame, value)?;
+                frame.set_tuple(*local, value);
+            }
             CallArgKind::IntFunction { local, value } => {
                 let value = eval_int_function_expr(plan, caller_frame, value)?;
                 frame.set_int_function(*local, value);
@@ -81,6 +86,10 @@ fn bind_arguments_into(
             CallArgKind::NilFunction { local, value } => {
                 let value = eval_nil_function_expr(plan, caller_frame, value)?;
                 frame.set_nil_function(*local, value);
+            }
+            CallArgKind::TupleFunction { local, value } => {
+                let value = eval_tuple_function_expr(plan, caller_frame, value)?;
+                frame.set_tuple_function(*local, value);
             }
             CallArgKind::FunctionFunction { local, value } => {
                 let value = eval_function_function_expr(plan, caller_frame, value)?;
@@ -116,6 +125,9 @@ pub(in crate::runtime) fn eval_capture_args(
                 eval_nil_expr(plan, frame, value)?;
                 CaptureValue::nil(*local)
             }
+            CaptureArgKind::Tuple { local, value } => {
+                CaptureValue::tuple(*local, eval_tuple_expr(plan, frame, value)?)
+            }
             CaptureArgKind::IntFunction { local, value } => {
                 CaptureValue::int_function(*local, eval_int_function_expr(plan, frame, value)?)
             }
@@ -131,6 +143,9 @@ pub(in crate::runtime) fn eval_capture_args(
             }
             CaptureArgKind::NilFunction { local, value } => {
                 CaptureValue::nil_function(*local, eval_nil_function_expr(plan, frame, value)?)
+            }
+            CaptureArgKind::TupleFunction { local, value } => {
+                CaptureValue::tuple_function(*local, eval_tuple_function_expr(plan, frame, value)?)
             }
             CaptureArgKind::FunctionFunction { local, value } => CaptureValue::function_function(
                 *local,
@@ -150,6 +165,7 @@ fn bind_captures(frame: &mut Frame, captures: &[CaptureValue]) {
             CaptureValueKind::Float { local, value } => frame.set_float(*local, *value),
             CaptureValueKind::Bool { local, value } => frame.set_bool(*local, *value),
             CaptureValueKind::Nil { local } => frame.set_nil(*local),
+            CaptureValueKind::Tuple { local, value } => frame.set_tuple(*local, value.clone()),
             CaptureValueKind::IntFunction { local, value } => {
                 frame.set_int_function(*local, value.clone());
             }
@@ -165,6 +181,9 @@ fn bind_captures(frame: &mut Frame, captures: &[CaptureValue]) {
             CaptureValueKind::NilFunction { local, value } => {
                 frame.set_nil_function(*local, value.clone());
             }
+            CaptureValueKind::TupleFunction { local, value } => {
+                frame.set_tuple_function(*local, value.clone());
+            }
             CaptureValueKind::FunctionFunction { local, value } => {
                 frame.set_function_function(*local, value.clone());
             }
@@ -176,14 +195,16 @@ fn bind_captures(frame: &mut Frame, captures: &[CaptureValue]) {
 mod tests {
     use super::{bind_arguments, bind_function_value_arguments, eval_capture_args};
     use crate::plan::{
-        BoolExpr, BoolFunctionExpr, BoolFunctionLocalId, BoolLocalId, CallArg, CaptureArg,
-        ExecutionPlan, FloatFunctionExpr, FloatFunctionId, FloatFunctionLocalId,
-        FloatFunctionValue, FrameLayout, FunctionFunctionExpr, FunctionFunctionId,
-        FunctionFunctionLocalId, FunctionFunctionValue, FunctionId, FunctionPlan,
-        FunctionReturnFamily, FunctionType, IntExpr, IntFunctionExpr, IntFunctionFunctionId,
-        IntFunctionLocalId, IntLocalId, NilExpr, NilFunctionExpr, NilFunctionLocalId, NilLocalId,
-        ReturnExpr, StringExpr, StringFunctionExpr, StringFunctionLocalId, StringLocalId,
-        ValueType,
+        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue,
+        BoolLocalId, CallArg, CaptureArg, CaptureValue, ExecutionPlan, Expr, FloatExpr,
+        FloatFunctionExpr, FloatFunctionId, FloatFunctionLocalId, FloatFunctionValue, FloatLocalId,
+        FrameLayout, FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionLocalId,
+        FunctionFunctionValue, FunctionId, FunctionPlan, FunctionReturnFamily, FunctionType,
+        IntExpr, IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId,
+        IntFunctionValue, IntLocalId, NilExpr, NilFunctionExpr, NilFunctionId, NilFunctionLocalId,
+        NilFunctionValue, NilLocalId, ReturnExpr, StringExpr, StringFunctionExpr, StringFunctionId,
+        StringFunctionLocalId, StringFunctionValue, StringLocalId, TupleExpr, TupleFunctionExpr,
+        TupleFunctionId, TupleFunctionLocalId, TupleFunctionValue, TupleLocalId, Value, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
@@ -195,13 +216,16 @@ mod tests {
         let cases = [
             CallArg::int(IntLocalId(0), failing_int_expr()),
             CallArg::string(StringLocalId(0), failing_string_expr()),
+            CallArg::float(FloatLocalId(0), failing_float_expr()),
             CallArg::bool(BoolLocalId(0), failing_bool_expr()),
             CallArg::nil(NilLocalId(0), failing_nil_expr()),
+            CallArg::tuple(TupleLocalId(0), failing_tuple_expr()),
             CallArg::int_function(IntFunctionLocalId(0), failing_int_function_expr()),
             CallArg::string_function(StringFunctionLocalId(0), failing_string_function_expr()),
             CallArg::float_function(FloatFunctionLocalId(0), failing_float_function_expr()),
             CallArg::bool_function(BoolFunctionLocalId(0), failing_bool_function_expr()),
             CallArg::nil_function(NilFunctionLocalId(0), failing_nil_function_expr()),
+            CallArg::tuple_function(TupleFunctionLocalId(0), failing_tuple_function_expr()),
             CallArg::function_function(
                 FunctionFunctionLocalId(0),
                 failing_function_function_expr(),
@@ -219,15 +243,154 @@ mod tests {
     }
 
     #[test]
+    fn bind_arguments_evaluates_and_binds_all_value_families() {
+        let plan = plan();
+        let frame = bind_arguments(
+            &plan,
+            &[
+                CallArg::int(IntLocalId(0), IntExpr::value(1.into())),
+                CallArg::string(StringLocalId(0), StringExpr::value("one".into())),
+                CallArg::float(FloatLocalId(0), FloatExpr::value(1.5)),
+                CallArg::bool(BoolLocalId(0), BoolExpr::value(true)),
+                CallArg::nil(NilLocalId(0), NilExpr::value()),
+                CallArg::tuple(TupleLocalId(0), tuple_expr()),
+                CallArg::int_function(IntFunctionLocalId(0), int_function_expr()),
+                CallArg::string_function(StringFunctionLocalId(0), string_function_expr()),
+                CallArg::float_function(FloatFunctionLocalId(0), float_function_expr()),
+                CallArg::bool_function(BoolFunctionLocalId(0), bool_function_expr()),
+                CallArg::nil_function(NilFunctionLocalId(0), nil_function_expr()),
+                CallArg::tuple_function(TupleFunctionLocalId(0), tuple_function_expr()),
+                CallArg::function_function(FunctionFunctionLocalId(0), function_function_expr()),
+            ],
+            &mut Frame::default(),
+            all_family_layout(),
+        )
+        .expect("arguments should bind");
+
+        assert_eq!(frame.get_int(IntLocalId(0)), 1.into());
+        assert_eq!(frame.get_string(StringLocalId(0)), "one");
+        assert_eq!(frame.get_float(FloatLocalId(0)), 1.5);
+        assert!(frame.get_bool(BoolLocalId(0)));
+        assert_eq!(frame.get_nil(NilLocalId(0)), ());
+        assert_eq!(frame.get_tuple(TupleLocalId(0)), vec![Value::Int(1.into())]);
+        assert_eq!(
+            frame.get_int_function(IntFunctionLocalId(0)).runtime_id(),
+            IntFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_string_function(StringFunctionLocalId(0))
+                .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_float_function(FloatFunctionLocalId(0))
+                .runtime_id(),
+            FloatFunctionId(0),
+        );
+        assert_eq!(
+            frame.get_bool_function(BoolFunctionLocalId(0)).runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            frame.get_nil_function(NilFunctionLocalId(0)).runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_tuple_function(TupleFunctionLocalId(0))
+                .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_function_function(FunctionFunctionLocalId(0))
+                .runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+        );
+    }
+
+    #[test]
+    fn tuple_function_arguments_are_evaluated_and_bound() {
+        let plan = plan();
+        let frame = bind_arguments(
+            &plan,
+            &[CallArg::tuple_function(
+                TupleFunctionLocalId(0),
+                tuple_function_expr(),
+            )],
+            &mut Frame::default(),
+            FrameLayout::default(),
+        )
+        .expect("arguments should bind");
+
+        assert_eq!(
+            frame
+                .get_tuple_function(TupleFunctionLocalId(0))
+                .runtime_id(),
+            TupleFunctionId(0),
+        );
+    }
+
+    #[test]
+    fn bind_function_value_arguments_propagates_argument_evaluation_errors_after_captures() {
+        let plan = plan();
+        let captures = [CaptureValue::int(IntLocalId(1), 10.into())];
+        let mut frame_layout = FrameLayout::default();
+        frame_layout.include_int(IntLocalId(1));
+
+        assert_expected_function_got_int(bind_function_value_arguments(
+            &plan,
+            &[CallArg::int(IntLocalId(0), failing_int_expr())],
+            &mut Frame::default(),
+            frame_layout,
+            &captures,
+        ));
+    }
+
+    #[test]
+    fn eval_capture_args_propagates_typed_argument_evaluation_errors() {
+        let plan = plan();
+
+        let cases = [
+            CaptureArg::int(IntLocalId(0), failing_int_expr()),
+            CaptureArg::string(StringLocalId(0), failing_string_expr()),
+            CaptureArg::float(FloatLocalId(0), failing_float_expr()),
+            CaptureArg::bool(BoolLocalId(0), failing_bool_expr()),
+            CaptureArg::nil(NilLocalId(0), failing_nil_expr()),
+            CaptureArg::tuple(TupleLocalId(0), failing_tuple_expr()),
+            CaptureArg::int_function(IntFunctionLocalId(0), failing_int_function_expr()),
+            CaptureArg::string_function(StringFunctionLocalId(0), failing_string_function_expr()),
+            CaptureArg::float_function(FloatFunctionLocalId(0), failing_float_function_expr()),
+            CaptureArg::bool_function(BoolFunctionLocalId(0), failing_bool_function_expr()),
+            CaptureArg::nil_function(NilFunctionLocalId(0), failing_nil_function_expr()),
+            CaptureArg::tuple_function(TupleFunctionLocalId(0), failing_tuple_function_expr()),
+            CaptureArg::function_function(
+                FunctionFunctionLocalId(0),
+                failing_function_function_expr(),
+            ),
+        ];
+
+        for arg in cases {
+            assert_expected_function_got_int(eval_capture_args(
+                &plan,
+                &mut Frame::default(),
+                &[arg],
+            ));
+        }
+    }
+
+    #[test]
     fn float_function_captures_are_evaluated_and_bound() {
         let plan = plan();
         let captures = eval_capture_args(
             &plan,
             &mut Frame::default(),
-            &[CaptureArg::float_function(
-                FloatFunctionLocalId(0),
-                float_function_expr(),
-            )],
+            &[
+                CaptureArg::float_function(FloatFunctionLocalId(0), float_function_expr()),
+                CaptureArg::tuple_function(TupleFunctionLocalId(0), tuple_function_expr()),
+            ],
         )
         .expect("capture args should evaluate");
         let frame = bind_function_value_arguments(
@@ -244,6 +407,85 @@ mod tests {
                 .get_float_function(FloatFunctionLocalId(0))
                 .runtime_id(),
             FloatFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_tuple_function(TupleFunctionLocalId(0))
+                .runtime_id(),
+            TupleFunctionId(0),
+        );
+    }
+
+    #[test]
+    fn bind_function_value_arguments_binds_all_capture_families() {
+        let plan = plan();
+        let frame = bind_function_value_arguments(
+            &plan,
+            &[],
+            &mut Frame::default(),
+            all_family_layout(),
+            &[
+                CaptureValue::int(IntLocalId(0), 1.into()),
+                CaptureValue::string(StringLocalId(0), "one".into()),
+                CaptureValue::float(FloatLocalId(0), 1.5),
+                CaptureValue::bool(BoolLocalId(0), true),
+                CaptureValue::nil(NilLocalId(0)),
+                CaptureValue::tuple(TupleLocalId(0), vec![Value::Int(1.into())]),
+                CaptureValue::int_function(IntFunctionLocalId(0), int_function_value()),
+                CaptureValue::string_function(StringFunctionLocalId(0), string_function_value()),
+                CaptureValue::float_function(FloatFunctionLocalId(0), float_function_value()),
+                CaptureValue::bool_function(BoolFunctionLocalId(0), bool_function_value()),
+                CaptureValue::nil_function(NilFunctionLocalId(0), nil_function_value()),
+                CaptureValue::tuple_function(TupleFunctionLocalId(0), tuple_function_value()),
+                CaptureValue::function_function(
+                    FunctionFunctionLocalId(0),
+                    function_function_value(),
+                ),
+            ],
+        )
+        .expect("captures should bind");
+
+        assert_eq!(frame.get_int(IntLocalId(0)), 1.into());
+        assert_eq!(frame.get_string(StringLocalId(0)), "one");
+        assert_eq!(frame.get_float(FloatLocalId(0)), 1.5);
+        assert!(frame.get_bool(BoolLocalId(0)));
+        assert_eq!(frame.get_nil(NilLocalId(0)), ());
+        assert_eq!(frame.get_tuple(TupleLocalId(0)), vec![Value::Int(1.into())]);
+        assert_eq!(
+            frame.get_int_function(IntFunctionLocalId(0)).runtime_id(),
+            IntFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_string_function(StringFunctionLocalId(0))
+                .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_float_function(FloatFunctionLocalId(0))
+                .runtime_id(),
+            FloatFunctionId(0),
+        );
+        assert_eq!(
+            frame.get_bool_function(BoolFunctionLocalId(0)).runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            frame.get_nil_function(NilFunctionLocalId(0)).runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_tuple_function(TupleFunctionLocalId(0))
+                .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_function_function(FunctionFunctionLocalId(0))
+                .runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0)),
         );
     }
 
@@ -282,12 +524,47 @@ mod tests {
         StringExpr::function_call(failing_string_function_expr(), Vec::new())
     }
 
+    fn failing_float_expr() -> FloatExpr {
+        FloatExpr::function_call(failing_float_function_expr(), Vec::new())
+    }
+
     fn failing_bool_expr() -> BoolExpr {
         BoolExpr::function_call(failing_bool_function_expr(), Vec::new())
     }
 
     fn failing_nil_expr() -> NilExpr {
         NilExpr::function_call(failing_nil_function_expr(), Vec::new())
+    }
+
+    fn failing_tuple_expr() -> TupleExpr {
+        TupleExpr::function_call(
+            failing_tuple_function_expr(),
+            Vec::new(),
+            vec![ValueType::Int],
+        )
+    }
+
+    fn tuple_expr() -> TupleExpr {
+        TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        )
+    }
+
+    fn int_function_expr() -> IntFunctionExpr {
+        IntFunctionExpr::value(int_function_value())
+    }
+
+    fn int_function_value() -> IntFunctionValue {
+        IntFunctionValue::new(IntFunctionId(0), Vec::new())
+    }
+
+    fn string_function_expr() -> StringFunctionExpr {
+        StringFunctionExpr::value(string_function_value())
+    }
+
+    fn string_function_value() -> StringFunctionValue {
+        StringFunctionValue::new(StringFunctionId(0), Vec::new())
     }
 
     fn failing_int_function_expr() -> IntFunctionExpr {
@@ -315,7 +592,11 @@ mod tests {
     }
 
     fn float_function_expr() -> FloatFunctionExpr {
-        FloatFunctionExpr::value(FloatFunctionValue::new(FloatFunctionId(0), Vec::new()))
+        FloatFunctionExpr::value(float_function_value())
+    }
+
+    fn float_function_value() -> FloatFunctionValue {
+        FloatFunctionValue::new(FloatFunctionId(0), Vec::new())
     }
 
     fn failing_bool_function_expr() -> BoolFunctionExpr {
@@ -326,12 +607,74 @@ mod tests {
         )
     }
 
+    fn bool_function_expr() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(bool_function_value())
+    }
+
+    fn bool_function_value() -> BoolFunctionValue {
+        BoolFunctionValue::new(BoolFunctionId(0), Vec::new())
+    }
+
     fn failing_nil_function_expr() -> NilFunctionExpr {
         NilFunctionExpr::function_call(
             failing_function_function_expr(),
             Vec::new(),
             FunctionType::new(Vec::new(), ValueType::Nil),
         )
+    }
+
+    fn nil_function_expr() -> NilFunctionExpr {
+        NilFunctionExpr::value(nil_function_value())
+    }
+
+    fn nil_function_value() -> NilFunctionValue {
+        NilFunctionValue::new(NilFunctionId(0), Vec::new())
+    }
+
+    fn failing_tuple_function_expr() -> TupleFunctionExpr {
+        TupleFunctionExpr::function_call(
+            failing_function_function_expr(),
+            Vec::new(),
+            FunctionType::new(Vec::new(), ValueType::Tuple(vec![ValueType::Int])),
+        )
+    }
+
+    fn tuple_function_expr() -> TupleFunctionExpr {
+        TupleFunctionExpr::value(tuple_function_value())
+    }
+
+    fn tuple_function_value() -> TupleFunctionValue {
+        TupleFunctionValue::new(TupleFunctionId(0), Vec::new(), vec![ValueType::Int])
+    }
+
+    fn function_function_expr() -> FunctionFunctionExpr {
+        FunctionFunctionExpr::value(function_function_value())
+    }
+
+    fn function_function_value() -> FunctionFunctionValue {
+        FunctionFunctionValue::new(
+            FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+            Vec::new(),
+            FunctionType::new(Vec::new(), ValueType::Int),
+        )
+    }
+
+    fn all_family_layout() -> FrameLayout {
+        let mut layout = FrameLayout::default();
+        layout.include_int(IntLocalId(0));
+        layout.include_string(StringLocalId(0));
+        layout.include_float(FloatLocalId(0));
+        layout.include_bool(BoolLocalId(0));
+        layout.include_nil(NilLocalId(0));
+        layout.include_tuple(TupleLocalId(0));
+        layout.include_int_function(IntFunctionLocalId(0));
+        layout.include_string_function(StringFunctionLocalId(0));
+        layout.include_float_function(FloatFunctionLocalId(0));
+        layout.include_bool_function(BoolFunctionLocalId(0));
+        layout.include_nil_function(NilFunctionLocalId(0));
+        layout.include_tuple_function(TupleFunctionLocalId(0));
+        layout.include_function_function(FunctionFunctionLocalId(0));
+        layout
     }
 
     fn plan() -> ExecutionPlan {

--- a/src/runtime/function/return_body.rs
+++ b/src/runtime/function/return_body.rs
@@ -4,13 +4,14 @@ use crate::plan::{
     BoolFunctionFunctionId, BoolFunctionId, CallArg, ExecutionPlan, FloatFunctionFunctionId,
     FloatFunctionId, FunctionFunctionFunctionId, FunctionFunctionValue, IntFunctionFunctionId,
     IntFunctionId, NilFunctionFunctionId, NilFunctionId, ReturnBody, ReturnBodyKind,
-    StringFunctionFunctionId, StringFunctionId,
+    StringFunctionFunctionId, StringFunctionId, TupleFunctionFunctionId, TupleFunctionId, Value,
 };
 use crate::runtime::error::ExecutionResult;
 use crate::runtime::expression::{
     eval_bool_expr, eval_bool_function_expr, eval_float_expr, eval_float_function_expr,
     eval_function_function_expr, eval_int_expr, eval_int_function_expr, eval_nil_expr,
-    eval_nil_function_expr, eval_string_expr, eval_string_function_expr,
+    eval_nil_function_expr, eval_string_expr, eval_string_function_expr, eval_tuple_expr,
+    eval_tuple_function_expr,
 };
 use crate::runtime::frame::Frame;
 use ecow::EcoString;
@@ -218,6 +219,30 @@ pub(super) fn run_nil_loop(
     }
 }
 
+pub(super) fn run_tuple_loop(
+    plan: &ExecutionPlan,
+    mut function: TupleFunctionId,
+    mut frame: Frame,
+) -> ExecutionResult<Vec<Value>> {
+    loop {
+        let runtime_function = plan.tuple_function(function);
+        execute_steps(plan, runtime_function.steps(), &mut frame)?;
+        let eval = eval_tuple_expr;
+        let outcome = eval_return_body(plan, &mut frame, runtime_function.return_(), eval)?;
+        match outcome {
+            ReturnOutcome::Value(value) => return Ok(value),
+            ReturnOutcome::TailCall {
+                function: next,
+                args,
+            } => {
+                let frame_layout = plan.tuple_function(next).frame_layout();
+                frame = bind_arguments(plan, args, &mut frame, frame_layout)?;
+                function = next;
+            }
+        }
+    }
+}
+
 pub(super) fn run_int_function_loop(
     plan: &ExecutionPlan,
     mut function: IntFunctionFunctionId,
@@ -338,6 +363,30 @@ pub(super) fn run_nil_function_loop(
     }
 }
 
+pub(super) fn run_tuple_function_loop(
+    plan: &ExecutionPlan,
+    mut function: TupleFunctionFunctionId,
+    mut frame: Frame,
+) -> ExecutionResult<crate::plan::TupleFunctionValue> {
+    loop {
+        let runtime_function = plan.tuple_function_function(function);
+        execute_steps(plan, runtime_function.steps(), &mut frame)?;
+        let eval = eval_tuple_function_expr;
+        let outcome = eval_return_body(plan, &mut frame, runtime_function.return_(), eval)?;
+        match outcome {
+            ReturnOutcome::Value(value) => return Ok(value),
+            ReturnOutcome::TailCall {
+                function: next,
+                args,
+            } => {
+                let frame_layout = plan.tuple_function_function(next).frame_layout();
+                frame = bind_arguments(plan, args, &mut frame, frame_layout)?;
+                function = next;
+            }
+        }
+    }
+}
+
 pub(super) fn run_function_function_loop(
     plan: &ExecutionPlan,
     mut function: FunctionFunctionFunctionId,
@@ -367,7 +416,8 @@ mod tests {
     use super::{
         run_bool_function_loop, run_bool_loop, run_float_function_loop, run_float_loop,
         run_function_function_loop, run_int_function_loop, run_int_loop, run_nil_function_loop,
-        run_nil_loop, run_string_function_loop, run_string_loop,
+        run_nil_loop, run_string_function_loop, run_string_loop, run_tuple_function_loop,
+        run_tuple_loop,
     };
     use crate::plan::{
         BoolExpr, BoolFunctionExpr, BoolFunctionFunctionId, BoolFunctionId, BoolFunctionValue,
@@ -378,7 +428,8 @@ mod tests {
         IntFunctionFunctionId, IntFunctionId, IntFunctionValue, NilExpr, NilFunctionExpr,
         NilFunctionFunctionId, NilFunctionId, NilFunctionValue, ReturnBody, ReturnExpr, Step,
         StringExpr, StringFunctionExpr, StringFunctionFunctionId, StringFunctionId,
-        StringFunctionValue, ValueType,
+        StringFunctionValue, TupleExpr, TupleFunctionExpr, TupleFunctionFunctionId,
+        TupleFunctionId, TupleFunctionValue, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
@@ -400,6 +451,11 @@ mod tests {
         ));
         assert_expected_function_got_int(run_bool_loop(&plan, BoolFunctionId(0), Frame::default()));
         assert_expected_function_got_int(run_nil_loop(&plan, NilFunctionId(0), Frame::default()));
+        assert_expected_function_got_int(run_tuple_loop(
+            &plan,
+            TupleFunctionId(0),
+            Frame::default(),
+        ));
     }
 
     #[test]
@@ -429,6 +485,11 @@ mod tests {
         assert_expected_function_got_int(run_nil_function_loop(
             &plan,
             NilFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_tuple_function_loop(
+            &plan,
+            TupleFunctionFunctionId(0),
             Frame::default(),
         ));
         assert_expected_function_got_int(run_function_function_loop(
@@ -494,8 +555,9 @@ mod tests {
                 function_plan(3, "float_function", steps.clone(), float_function_expr()),
                 function_plan(4, "bool_function", steps.clone(), bool_function_expr()),
                 function_plan(5, "nil_function", steps.clone(), nil_function_expr()),
+                function_plan(6, "tuple_function", steps.clone(), tuple_function_expr()),
                 function_plan(
-                    6,
+                    7,
                     "function_function",
                     steps,
                     function_function_expr_value(),
@@ -540,8 +602,21 @@ mod tests {
                     FunctionId::new(4),
                     "nil".into(),
                     Vec::new(),
-                    steps,
+                    steps.clone(),
                     ReturnExpr::nil(NilFunctionId(0), NilExpr::value()),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(5),
+                    "tuple".into(),
+                    Vec::new(),
+                    steps,
+                    ReturnExpr::tuple(
+                        TupleFunctionId(0),
+                        TupleExpr::value(
+                            vec![Expr::int(IntExpr::value(1.into()))],
+                            vec![ValueType::Int],
+                        ),
+                    ),
                 ),
             ],
         )
@@ -618,6 +693,9 @@ mod tests {
             FunctionExprKind::Nil(return_) => {
                 ReturnExpr::nil_function(NilFunctionFunctionId(0), return_)
             }
+            FunctionExprKind::Tuple(return_) => {
+                ReturnExpr::tuple_function(TupleFunctionFunctionId(0), return_)
+            }
             FunctionExprKind::Function(return_) => {
                 ReturnExpr::function_function(FunctionFunctionFunctionId(0), return_)
             }
@@ -664,6 +742,14 @@ mod tests {
         FunctionExpr::nil(NilFunctionExpr::value(NilFunctionValue::new(
             NilFunctionId(0),
             Vec::new(),
+        )))
+    }
+
+    fn tuple_function_expr() -> FunctionExpr {
+        FunctionExpr::tuple(TupleFunctionExpr::value(TupleFunctionValue::new(
+            TupleFunctionId(0),
+            Vec::new(),
+            vec![ValueType::Int],
         )))
     }
 

--- a/src/runtime/function/steps.rs
+++ b/src/runtime/function/steps.rs
@@ -3,7 +3,8 @@ use crate::runtime::error::ExecutionResult;
 use crate::runtime::expression::{
     eval_bool_expr, eval_bool_function_expr, eval_expr, eval_float_expr, eval_float_function_expr,
     eval_function_function_expr, eval_int_expr, eval_int_function_expr, eval_nil_expr,
-    eval_nil_function_expr, eval_string_expr, eval_string_function_expr,
+    eval_nil_function_expr, eval_string_expr, eval_string_function_expr, eval_tuple_expr,
+    eval_tuple_function_expr,
 };
 use crate::runtime::frame::Frame;
 
@@ -34,6 +35,10 @@ pub(in crate::runtime) fn execute_steps(
                 eval_nil_expr(plan, frame, value)?;
                 frame.set_nil(*local);
             }
+            StepKind::LetTuple { local, value, .. } => {
+                let value = eval_tuple_expr(plan, frame, value)?;
+                frame.set_tuple(*local, value);
+            }
             StepKind::LetIntFunction { local, value, .. } => {
                 let value = eval_int_function_expr(plan, frame, value)?;
                 frame.set_int_function(*local, value);
@@ -54,6 +59,10 @@ pub(in crate::runtime) fn execute_steps(
                 let value = eval_nil_function_expr(plan, frame, value)?;
                 frame.set_nil_function(*local, value);
             }
+            StepKind::LetTupleFunction { local, value, .. } => {
+                let value = eval_tuple_function_expr(plan, frame, value)?;
+                frame.set_tuple_function(*local, value);
+            }
             StepKind::LetFunctionFunction { local, value, .. } => {
                 let value = eval_function_function_expr(plan, frame, value)?;
                 frame.set_function_function(*local, value);
@@ -71,12 +80,16 @@ pub(in crate::runtime) fn execute_steps(
 mod tests {
     use super::execute_steps;
     use crate::plan::{
-        BoolExpr, BoolFunctionExpr, BoolFunctionLocalId, BoolLocalId, ExecutionPlan,
-        FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionLocalId, FunctionFunctionValue,
-        FunctionId, FunctionPlan, FunctionReturnFamily, FunctionType, IntExpr, IntFunctionExpr,
-        IntFunctionFunctionId, IntFunctionLocalId, IntLocalId, NilExpr, NilFunctionExpr,
-        NilFunctionLocalId, NilLocalId, ReturnExpr, Step, StringExpr, StringFunctionExpr,
-        StringFunctionLocalId, StringLocalId, ValueType,
+        BoolExpr, BoolFunctionExpr, BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue,
+        BoolLocalId, ExecutionPlan, Expr, FloatExpr, FloatFunctionExpr, FloatFunctionId,
+        FloatFunctionLocalId, FloatFunctionValue, FloatLocalId, FrameLayout, FunctionFunctionExpr,
+        FunctionFunctionId, FunctionFunctionLocalId, FunctionFunctionValue, FunctionId,
+        FunctionPlan, FunctionReturnFamily, FunctionType, IntExpr, IntFunctionExpr,
+        IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId,
+        NilExpr, NilFunctionExpr, NilFunctionId, NilFunctionLocalId, NilFunctionValue, NilLocalId,
+        ReturnExpr, Step, StringExpr, StringFunctionExpr, StringFunctionId, StringFunctionLocalId,
+        StringFunctionValue, StringLocalId, TupleExpr, TupleFunctionExpr, TupleFunctionId,
+        TupleFunctionLocalId, TupleFunctionValue, TupleLocalId, Value, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
@@ -88,8 +101,10 @@ mod tests {
         let steps = [
             Step::let_int(IntLocalId(0), "x".into(), failing_int_expr()),
             Step::let_string(StringLocalId(0), "x".into(), failing_string_expr()),
+            Step::let_float(FloatLocalId(0), "x".into(), failing_float_expr()),
             Step::let_bool(BoolLocalId(0), "x".into(), failing_bool_expr()),
             Step::let_nil(NilLocalId(0), "x".into(), failing_nil_expr()),
+            Step::let_tuple(TupleLocalId(0), "x".into(), failing_tuple_expr()),
             Step::let_int_function(
                 IntFunctionLocalId(0),
                 "x".into(),
@@ -99,6 +114,11 @@ mod tests {
                 StringFunctionLocalId(0),
                 "x".into(),
                 failing_string_function_expr(),
+            ),
+            Step::let_float_function(
+                FloatFunctionLocalId(0),
+                "x".into(),
+                failing_float_function_expr(),
             ),
             Step::let_bool_function(
                 BoolFunctionLocalId(0),
@@ -110,6 +130,11 @@ mod tests {
                 "x".into(),
                 failing_nil_function_expr(),
             ),
+            Step::let_tuple_function(
+                TupleFunctionLocalId(0),
+                "x".into(),
+                failing_tuple_function_expr(),
+            ),
             Step::let_function_function(
                 FunctionFunctionLocalId(0),
                 "x".into(),
@@ -120,6 +145,80 @@ mod tests {
         for step in steps {
             assert_expected_function_got_int(execute_steps(&plan, &[step], &mut Frame::default()));
         }
+    }
+
+    #[test]
+    fn execute_steps_evaluates_and_binds_all_let_families() {
+        let plan = plan();
+        let mut frame = Frame::new(all_family_layout());
+        let steps = [
+            Step::let_int(IntLocalId(0), "x".into(), IntExpr::value(1.into())),
+            Step::let_string(
+                StringLocalId(0),
+                "x".into(),
+                StringExpr::value("one".into()),
+            ),
+            Step::let_float(FloatLocalId(0), "x".into(), FloatExpr::value(1.5)),
+            Step::let_bool(BoolLocalId(0), "x".into(), BoolExpr::value(true)),
+            Step::let_nil(NilLocalId(0), "x".into(), NilExpr::value()),
+            Step::let_tuple(TupleLocalId(0), "x".into(), tuple_expr()),
+            Step::let_int_function(IntFunctionLocalId(0), "x".into(), int_function_expr()),
+            Step::let_string_function(StringFunctionLocalId(0), "x".into(), string_function_expr()),
+            Step::let_float_function(FloatFunctionLocalId(0), "x".into(), float_function_expr()),
+            Step::let_bool_function(BoolFunctionLocalId(0), "x".into(), bool_function_expr()),
+            Step::let_nil_function(NilFunctionLocalId(0), "x".into(), nil_function_expr()),
+            Step::let_tuple_function(TupleFunctionLocalId(0), "x".into(), tuple_function_expr()),
+            Step::let_function_function(
+                FunctionFunctionLocalId(0),
+                "x".into(),
+                function_function_expr(),
+            ),
+        ];
+
+        execute_steps(&plan, &steps, &mut frame).expect("steps should execute");
+
+        assert_eq!(frame.get_int(IntLocalId(0)), 1.into());
+        assert_eq!(frame.get_string(StringLocalId(0)), "one");
+        assert_eq!(frame.get_float(FloatLocalId(0)), 1.5);
+        assert!(frame.get_bool(BoolLocalId(0)));
+        assert_eq!(frame.get_nil(NilLocalId(0)), ());
+        assert_eq!(frame.get_tuple(TupleLocalId(0)), vec![Value::Int(1.into())]);
+        assert_eq!(
+            frame.get_int_function(IntFunctionLocalId(0)).runtime_id(),
+            IntFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_string_function(StringFunctionLocalId(0))
+                .runtime_id(),
+            StringFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_float_function(FloatFunctionLocalId(0))
+                .runtime_id(),
+            FloatFunctionId(0),
+        );
+        assert_eq!(
+            frame.get_bool_function(BoolFunctionLocalId(0)).runtime_id(),
+            BoolFunctionId(0),
+        );
+        assert_eq!(
+            frame.get_nil_function(NilFunctionLocalId(0)).runtime_id(),
+            NilFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_tuple_function(TupleFunctionLocalId(0))
+                .runtime_id(),
+            TupleFunctionId(0),
+        );
+        assert_eq!(
+            frame
+                .get_function_function(FunctionFunctionLocalId(0))
+                .runtime_id(),
+            FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+        );
     }
 
     fn assert_expected_function_got_int<T>(actual: Result<T, ExecutionError>) {
@@ -157,12 +256,67 @@ mod tests {
         StringExpr::function_call(failing_string_function_expr(), Vec::new())
     }
 
+    fn failing_float_expr() -> FloatExpr {
+        FloatExpr::function_call(failing_float_function_expr(), Vec::new())
+    }
+
     fn failing_bool_expr() -> BoolExpr {
         BoolExpr::function_call(failing_bool_function_expr(), Vec::new())
     }
 
     fn failing_nil_expr() -> NilExpr {
         NilExpr::function_call(failing_nil_function_expr(), Vec::new())
+    }
+
+    fn failing_tuple_expr() -> TupleExpr {
+        TupleExpr::function_call(
+            failing_tuple_function_expr(),
+            Vec::new(),
+            vec![ValueType::Int],
+        )
+    }
+
+    fn tuple_expr() -> TupleExpr {
+        TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        )
+    }
+
+    fn int_function_expr() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(IntFunctionId(0), Vec::new()))
+    }
+
+    fn string_function_expr() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(StringFunctionId(0), Vec::new()))
+    }
+
+    fn float_function_expr() -> FloatFunctionExpr {
+        FloatFunctionExpr::value(FloatFunctionValue::new(FloatFunctionId(0), Vec::new()))
+    }
+
+    fn bool_function_expr() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(BoolFunctionId(0), Vec::new()))
+    }
+
+    fn nil_function_expr() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(NilFunctionId(0), Vec::new()))
+    }
+
+    fn tuple_function_expr() -> TupleFunctionExpr {
+        TupleFunctionExpr::value(TupleFunctionValue::new(
+            TupleFunctionId(0),
+            Vec::new(),
+            vec![ValueType::Int],
+        ))
+    }
+
+    fn function_function_expr() -> FunctionFunctionExpr {
+        FunctionFunctionExpr::value(FunctionFunctionValue::new(
+            FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+            Vec::new(),
+            FunctionType::new(Vec::new(), ValueType::Int),
+        ))
     }
 
     fn failing_int_function_expr() -> IntFunctionExpr {
@@ -178,6 +332,14 @@ mod tests {
             failing_function_function_expr(),
             Vec::new(),
             FunctionType::new(Vec::new(), ValueType::String),
+        )
+    }
+
+    fn failing_float_function_expr() -> FloatFunctionExpr {
+        FloatFunctionExpr::function_call(
+            failing_function_function_expr(),
+            Vec::new(),
+            FunctionType::new(Vec::new(), ValueType::Float),
         )
     }
 
@@ -197,6 +359,14 @@ mod tests {
         )
     }
 
+    fn failing_tuple_function_expr() -> TupleFunctionExpr {
+        TupleFunctionExpr::function_call(
+            failing_function_function_expr(),
+            Vec::new(),
+            FunctionType::new(Vec::new(), ValueType::Tuple(vec![ValueType::Int])),
+        )
+    }
+
     fn plan() -> ExecutionPlan {
         ExecutionPlan::new(
             "main".into(),
@@ -209,5 +379,23 @@ mod tests {
             ),
             Vec::new(),
         )
+    }
+
+    fn all_family_layout() -> FrameLayout {
+        let mut layout = FrameLayout::default();
+        layout.include_int(IntLocalId(0));
+        layout.include_string(StringLocalId(0));
+        layout.include_float(FloatLocalId(0));
+        layout.include_bool(BoolLocalId(0));
+        layout.include_nil(NilLocalId(0));
+        layout.include_tuple(TupleLocalId(0));
+        layout.include_int_function(IntFunctionLocalId(0));
+        layout.include_string_function(StringFunctionLocalId(0));
+        layout.include_float_function(FloatFunctionLocalId(0));
+        layout.include_bool_function(BoolFunctionLocalId(0));
+        layout.include_nil_function(NilFunctionLocalId(0));
+        layout.include_tuple_function(TupleFunctionLocalId(0));
+        layout.include_function_function(FunctionFunctionLocalId(0));
+        layout
     }
 }

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -27,6 +27,7 @@ mod values {
     execution_cases!("values";
         integer_return,
         float_value,
+        tuple_value,
         bool_value,
         nil_value,
     );
@@ -37,6 +38,7 @@ mod bindings {
         let_binding,
         let_discard_binding,
         float_let_binding,
+        tuple_let_binding,
         string_let_binding,
         bool_let_binding,
         nil_let_binding,
@@ -52,6 +54,7 @@ mod operators {
         float_arithmetic,
         float_comparison,
         float_division,
+        tuple_equality,
         string_concatenation,
         bool_operators,
         short_circuit_block_scope,
@@ -78,6 +81,8 @@ mod control_flow {
             string_case_return_families,
             string_case_function_values,
             string_case_function_returns,
+            tuple_projection_case,
+            tuple_case_return_families,
         );
     }
 }
@@ -86,6 +91,7 @@ mod pipeline {
     execution_cases!("pipeline";
         pipeline,
         float_pipeline,
+        tuple_pipeline,
     );
 }
 
@@ -95,6 +101,7 @@ mod functions {
             local_function_call,
             string_function_call,
             float_function_call,
+            tuple_function_call,
             bool_function_call,
             nil_function_call,
             function_after_main,
@@ -112,6 +119,7 @@ mod functions {
             function_value_case_callee,
             float_function_value_shapes,
             float_function_value_expressions,
+            tuple_function_value_projection,
             function_value_expression_steps,
             function_value_shadowing,
         );
@@ -150,6 +158,7 @@ mod functions {
             mutual_tail_recursion_bool,
             string_nil_tail_recursion,
             float_tail_recursion,
+            tuple_tail_recursion,
             block_case_tail_call,
             function_returning_tail_call,
             function_returning_tail_call_families,
@@ -172,6 +181,7 @@ mod functions {
             capturing_closure_nested,
             capturing_closure_shadowing,
             capturing_closure_value_families,
+            capturing_closure_tuple,
             capturing_closure_return_shapes,
         );
     }
@@ -185,6 +195,7 @@ mod functions {
             use_nested,
             use_capture,
             use_float_value,
+            use_tuple_value,
             use_block_scope,
             use_function_value_provider,
             use_inside_anonymous_function,
@@ -276,6 +287,14 @@ fn render_value(value: &Value) -> String {
         Value::String(value) => format!("String({value:?})"),
         Value::Bool(value) => format!("Bool({value})"),
         Value::Nil => "Nil".into(),
+        Value::Tuple(values) => format!(
+            "Tuple([{}])",
+            values
+                .iter()
+                .map(render_value)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
         Value::Function(function) => {
             let type_ = function.type_();
             format!("Function({})", render_function_type(&type_))
@@ -301,6 +320,14 @@ fn render_value_type(type_: &ValueType) -> String {
         ValueType::String => "String".into(),
         ValueType::Bool => "Bool".into(),
         ValueType::Nil => "Nil".into(),
+        ValueType::Tuple(elements) => format!(
+            "#({})",
+            elements
+                .iter()
+                .map(render_value_type)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
         ValueType::Function(type_) => render_function_type(type_),
     }
 }

--- a/tests/fixtures/execution/bindings/tuple_let_binding.gleam
+++ b/tests/fixtures/execution/bindings/tuple_let_binding.gleam
@@ -1,0 +1,6 @@
+pub fn main() {
+  let pair = #(1, "one")
+  pair.0
+}
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/control_flow/case/tuple_case_return_families.gleam
+++ b/tests/fixtures/execution/control_flow/case/tuple_case_return_families.gleam
@@ -1,0 +1,42 @@
+fn choose_from_bool(flag: Bool) {
+  case flag {
+    True -> #(1, "bool")
+    False -> #(0, "bool")
+  }
+}
+
+fn choose_from_int(value: Int) {
+  case value {
+    1 -> #(1, "int")
+    _ -> #(0, "int")
+  }
+}
+
+fn choose_from_string(value: String) {
+  case value {
+    "one" -> #(1, "string")
+    _ -> #(0, "string")
+  }
+}
+
+fn choose_from_float(value: Float) {
+  case value {
+    1.5 -> #(1, "float")
+    _ -> #(0, "float")
+  }
+}
+
+pub fn main() {
+  let a = {
+    let marker = 1
+    marker
+    choose_from_bool(True)
+  }
+  let b = choose_from_int(1)
+  let c = choose_from_string("one")
+  let d = choose_from_float(1.5)
+
+  #(a.0 + b.0 + c.0 + d.0, d.1)
+}
+
+// geam:expect Tuple([Int(4), String("float")])

--- a/tests/fixtures/execution/control_flow/case/tuple_projection_case.gleam
+++ b/tests/fixtures/execution/control_flow/case/tuple_projection_case.gleam
@@ -1,0 +1,20 @@
+pub fn main() {
+  let nested = #(#(1, "one"), #(True, 2.5), #(3, #(4, "four")), Nil)
+  let int_value = nested.0.0
+  let string_value = nested.0.1
+  let bool_value = nested.1.0
+  let float_value = nested.1.1
+  let tuple_value = nested.2.1
+  nested.3
+
+  case string_value {
+    "one" ->
+      case bool_value {
+        True -> #(int_value + tuple_value.0, float_value)
+        False -> #(0, 0.0)
+      }
+    _ -> #(0, 0.0)
+  }
+}
+
+// geam:expect Tuple([Int(5), Float(2.5)])

--- a/tests/fixtures/execution/functions/anonymous/capturing_closure_return_shapes.gleam
+++ b/tests/fixtures/execution/functions/anonymous/capturing_closure_return_shapes.gleam
@@ -14,6 +14,10 @@ fn nil_identity(value: Nil) {
   value
 }
 
+fn tuple_identity(value: #(Int, String)) {
+  value
+}
+
 fn get_int_identity() {
   int_identity
 }
@@ -26,6 +30,7 @@ pub fn main() {
   let string_function = string_identity
   let bool_function = bool_identity
   let nil_function = nil_identity
+  let tuple_function = tuple_identity
   let function_function = get_int_identity
 
   let stringer = fn(prefix) { { prefix <> suffix } }
@@ -36,6 +41,7 @@ pub fn main() {
   let run = fn(value) {
     let name = { string_function(stringer("ge")) }
     let ok = bool_function(booler(True))
+    let pair = tuple_function(#(0, "tuple"))
     nil_function(niler())
 
     let piped = value |> int_identity |> int_identity
@@ -43,7 +49,7 @@ pub fn main() {
     let indirect = function_function()
 
     case name == "geam" && ok {
-      True -> direct(piped)
+      True -> direct(piped + pair.0)
       False -> indirect(0)
     }
   }

--- a/tests/fixtures/execution/functions/anonymous/capturing_closure_return_shapes.gleam
+++ b/tests/fixtures/execution/functions/anonymous/capturing_closure_return_shapes.gleam
@@ -36,12 +36,13 @@ pub fn main() {
   let stringer = fn(prefix) { { prefix <> suffix } }
   let booler = fn(value) { !False && value && enabled }
   let niler = fn() { marker }
+  let tupler = fn(value) { #(value, suffix) }
   let getter = fn() { int_function }
 
   let run = fn(value) {
     let name = { string_function(stringer("ge")) }
     let ok = bool_function(booler(True))
-    let pair = tuple_function(#(0, "tuple"))
+    let pair = tuple_function(tupler(0))
     nil_function(niler())
 
     let piped = value |> int_identity |> int_identity

--- a/tests/fixtures/execution/functions/anonymous/capturing_closure_tuple.gleam
+++ b/tests/fixtures/execution/functions/anonymous/capturing_closure_tuple.gleam
@@ -1,0 +1,10 @@
+pub fn main() {
+  let pair = #(40, 2)
+  let add = fn() {
+    pair.0 + pair.1
+  }
+
+  add()
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/argument/function_value_argument_higher_order_return_shapes.gleam
+++ b/tests/fixtures/execution/functions/argument/function_value_argument_higher_order_return_shapes.gleam
@@ -16,6 +16,10 @@ fn int_to_nil(value: Int) {
   }
 }
 
+fn int_to_tuple(value: Int) {
+  #(value, "tuple")
+}
+
 fn apply_int_to_string(function: fn(Int) -> String, value: Int) {
   function(value)
 }
@@ -28,17 +32,23 @@ fn apply_int_to_nil(function: fn(Int) -> Nil, value: Int) {
   function(value)
 }
 
+fn apply_int_to_tuple(function: fn(Int) -> #(Int, String), value: Int) {
+  function(value)
+}
+
 pub fn main() {
   let string_apply_alias = apply_int_to_string
   let bool_apply_alias = apply_int_to_bool
   let nil_apply_alias = apply_int_to_nil
+  let tuple_apply_alias = apply_int_to_tuple
   let string_result = string_apply_alias(int_to_string, 1)
   let bool_result = bool_apply_alias(int_to_bool, 1)
+  let tuple_result = tuple_apply_alias(int_to_tuple, 42)
 
   nil_apply_alias(int_to_nil, 0)
 
   case string_result == "one" && bool_result {
-    True -> 42
+    True -> tuple_result.0
     False -> 0
   }
 }

--- a/tests/fixtures/execution/functions/argument/function_value_argument_return_shapes.gleam
+++ b/tests/fixtures/execution/functions/argument/function_value_argument_return_shapes.gleam
@@ -16,6 +16,10 @@ fn int_to_nil(value: Int) {
   }
 }
 
+fn int_to_tuple(value: Int) {
+  #(value, "tuple")
+}
+
 fn apply_int_to_string(function: fn(Int) -> String, value: Int) {
   function(value)
 }
@@ -28,14 +32,19 @@ fn apply_int_to_nil(function: fn(Int) -> Nil, value: Int) {
   function(value)
 }
 
+fn apply_int_to_tuple(function: fn(Int) -> #(Int, String), value: Int) {
+  function(value)
+}
+
 pub fn main() {
   let string_result = apply_int_to_string(int_to_string, 1)
   let bool_result = apply_int_to_bool(int_to_bool, 1)
+  let tuple_result = apply_int_to_tuple(int_to_tuple, 42)
 
   apply_int_to_nil(int_to_nil, 0)
 
   case string_result == "one" && bool_result {
-    True -> 42
+    True -> tuple_result.0
     False -> 0
   }
 }

--- a/tests/fixtures/execution/functions/basic/tuple_function_call.gleam
+++ b/tests/fixtures/execution/functions/basic/tuple_function_call.gleam
@@ -1,0 +1,13 @@
+fn first(pair: #(Int, String)) {
+  pair.0
+}
+
+fn pair() {
+  #(1, "one")
+}
+
+pub fn main() {
+  first(pair())
+}
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/functions/returning/function_returning_function_direct_shapes.gleam
+++ b/tests/fixtures/execution/functions/returning/function_returning_function_direct_shapes.gleam
@@ -14,6 +14,10 @@ fn nil_identity(value: Nil) {
   value
 }
 
+fn tuple_identity(value: #(Int, String)) {
+  value
+}
+
 fn get_int() {
   int_identity
 }
@@ -28,6 +32,10 @@ fn get_bool() {
 
 fn get_nil() {
   nil_identity
+}
+
+fn get_tuple() {
+  tuple_identity
 }
 
 fn run_int(getter: fn() -> fn(Int) -> Int, value: Int) {
@@ -46,14 +54,19 @@ fn run_nil(getter: fn() -> fn(Nil) -> Nil) {
   getter()(Nil)
 }
 
+fn run_tuple(getter: fn() -> fn(#(Int, String)) -> #(Int, String), value: #(Int, String)) {
+  getter()(value)
+}
+
 pub fn main() {
   let int_ok = get_int()(1) + run_int(get_int, 2) == 3
   let bool_ok = get_bool()(True) && !run_bool(get_bool, False)
+  let tuple_ok = get_tuple()(#(2, "ok")).0 + run_tuple(get_tuple, #(3, "ok")).0 == 5
 
   get_nil()(Nil)
   run_nil(get_nil)
 
-  case int_ok && bool_ok {
+  case int_ok && bool_ok && tuple_ok {
     True -> get_string()("ge") <> run_string(get_string, "am")
     False -> "bad"
   }

--- a/tests/fixtures/execution/functions/tail_call/function_returning_tail_call_families.gleam
+++ b/tests/fixtures/execution/functions/tail_call/function_returning_tail_call_families.gleam
@@ -10,6 +10,10 @@ fn to_nil(value: Int) {
   Nil
 }
 
+fn to_tuple(value: Int) {
+  #(value, "ok")
+}
+
 fn get_string(n: Int) {
   case n {
     0 -> to_string
@@ -31,6 +35,13 @@ fn get_nil(n: Int) {
   }
 }
 
+fn get_tuple(n: Int) {
+  case n {
+    0 -> to_tuple
+    _ -> get_tuple(n - 1)
+  }
+}
+
 fn get_getter(n: Int) {
   case n {
     0 -> get_string
@@ -42,14 +53,15 @@ pub fn main() {
   let string_fn = get_string(10000)
   let bool_fn = get_bool(10000)
   let nil_fn = get_nil(10000)
+  let tuple_fn = get_tuple(10000)
   let getter = get_getter(10000)
 
   nil_fn(0)
 
   case bool_fn(0) {
-    True -> string_fn(0) <> getter(0)(0)
+    True -> string_fn(0) <> getter(0)(0) <> tuple_fn(0).1
     False -> "bad"
   }
 }
 
-// geam:expect String("okok")
+// geam:expect String("okokok")

--- a/tests/fixtures/execution/functions/tail_call/tuple_tail_recursion.gleam
+++ b/tests/fixtures/execution/functions/tail_call/tuple_tail_recursion.gleam
@@ -1,0 +1,13 @@
+fn count_down(n: Int, acc: #(Int, Int)) {
+  case n {
+    0 -> acc
+    _ -> count_down(n - 1, #(acc.0 + 1, acc.1 + 1))
+  }
+}
+
+pub fn main() {
+  let result = count_down(10000, #(0, 0))
+  result.0 + result.1
+}
+
+// geam:expect Int(20000)

--- a/tests/fixtures/execution/functions/use/use_tuple_value.gleam
+++ b/tests/fixtures/execution/functions/use/use_tuple_value.gleam
@@ -1,0 +1,10 @@
+fn with_pair(continue: fn(#(Int, String)) -> String) {
+  continue(#(1, "one"))
+}
+
+pub fn main() {
+  use pair <- with_pair
+  pair.1
+}
+
+// geam:expect String("one")

--- a/tests/fixtures/execution/functions/value/function_value_expression_steps.gleam
+++ b/tests/fixtures/execution/functions/value/function_value_expression_steps.gleam
@@ -18,8 +18,16 @@ fn nil_value() {
   Nil
 }
 
+fn tuple_value() {
+  #(1, "value")
+}
+
 fn get_int_value() {
   int_value
+}
+
+fn get_tuple_value() {
+  tuple_value
 }
 
 pub fn main() {
@@ -28,7 +36,9 @@ pub fn main() {
   float_value
   bool_value
   nil_value
+  tuple_value
   get_int_value
+  get_tuple_value
 
   1
 }

--- a/tests/fixtures/execution/functions/value/tuple_function_value_projection.gleam
+++ b/tests/fixtures/execution/functions/value/tuple_function_value_projection.gleam
@@ -1,0 +1,74 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn stringify(value: Int) {
+  case value {
+    42 -> "ok"
+    _ -> "bad"
+  }
+}
+
+fn to_float(value: Int) {
+  value == 42
+  42.5
+}
+
+fn is_answer(value: Int) {
+  value == 42
+}
+
+fn ignore(_: Int) {
+  Nil
+}
+
+fn to_tuple(value: Int) {
+  #(value, "tuple")
+}
+
+fn tuple_score(pair: #(Int, String)) {
+  pair.0
+}
+
+fn apply(callback: fn(Int) -> Int, value: Int) {
+  callback(value)
+}
+
+fn get_add_one() {
+  add_one
+}
+
+fn pack() {
+  #(
+    add_one,
+    stringify,
+    to_float,
+    is_answer,
+    ignore,
+    to_tuple,
+    get_add_one,
+    tuple_score,
+    apply,
+    41,
+  )
+}
+
+pub fn main() {
+  let pair = pack()
+  let value = pair.0(pair.9)
+  let label = pair.1(value)
+  let decimal = pair.2(value)
+  let ok = pair.3(value)
+  pair.4(value)
+  let tuple = pair.5(value)
+  let getter = pair.6()
+  let tuple_argument = pair.7(tuple)
+  let function_argument = pair.8(add_one, value - 1)
+
+  case label == "ok" && decimal == 42.5 && ok && tuple.0 == 42 && tuple_argument == 42 && function_argument == 42 {
+    True -> getter(value - 1)
+    False -> 0
+  }
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/operators/tuple_equality.gleam
+++ b/tests/fixtures/execution/operators/tuple_equality.gleam
@@ -1,0 +1,5 @@
+pub fn main() {
+  #(#(1, "one"), True) == #(#(1, "one"), True)
+}
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/pipeline/tuple_pipeline.gleam
+++ b/tests/fixtures/execution/pipeline/tuple_pipeline.gleam
@@ -1,0 +1,10 @@
+fn second(pair: #(Int, String)) {
+  pair.1
+}
+
+pub fn main() {
+  #(1, "one")
+  |> second
+}
+
+// geam:expect String("one")

--- a/tests/fixtures/execution/values/tuple_value.gleam
+++ b/tests/fixtures/execution/values/tuple_value.gleam
@@ -1,0 +1,5 @@
+pub fn main() {
+  #(1, "one", True)
+}
+
+// geam:expect Tuple([Int(1), String("one"), Bool(true)])


### PR DESCRIPTION
- Add Tuple plan/runtime value and function families across expressions, frames, calls, captures, and return bodies.
- Lower Tuple literals and tuple index projections through typed planner result-family shapes.
- Propagate Tuple through existing supported flows including blocks, case returns, pipelines, use callbacks, closures, function values, and tail calls.
- Add tuple execution fixtures for values, bindings, projection, equality, functions, closures, pipeline, use, and tail recursion.
- Document and cover the narrow tuple projection execution invariant boundary.
