### PR TITLE
Split anonymous free-variable analysis

### DIFF
--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -1,3 +1,5 @@
+mod free_variables;
+
 use crate::plan::{
     CaptureArg, Expr, FunctionExpr, FunctionType, ParamLocal, RuntimeFunctionId, ValueType,
 };
@@ -9,12 +11,8 @@ use crate::planner::error::{
 use crate::planner::function::{anonymous_function_plan, plan_anonymous_function_body};
 use crate::planner::module::function_params;
 use ecow::EcoString;
-use gleam_core::ast::{
-    FunctionLiteralKind, Pattern, Statement, TypedArg, TypedExpr, TypedPipelineAssignment,
-    TypedStatement,
-};
-use gleam_core::type_::{Type, ValueConstructorVariant};
-use std::collections::HashSet;
+use gleam_core::ast::{FunctionLiteralKind, TypedArg, TypedStatement};
+use gleam_core::type_::Type;
 use std::sync::Arc;
 use vec1::Vec1;
 
@@ -47,7 +45,7 @@ fn plan_anonymous_with_valid_arguments(
     body: Vec1<TypedStatement>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let free_names = anonymous_free_variables(&arguments, &body);
+    let free_names = free_variables::anonymous_free_variables(&arguments, &body);
     let captures = context.capture_bindings(&free_names)?;
     plan_anonymous_with_captures(function_type, error_name, params, captures, body, context)
 }
@@ -222,195 +220,6 @@ fn anonymous_function_type_error(type_: &Type) -> PlanError {
                 kind: InvalidExpressionShapeKind::Invalid,
             },
         },
-    }
-}
-
-fn anonymous_free_variables(arguments: &[TypedArg], body: &Vec1<TypedStatement>) -> Vec<EcoString> {
-    let mut bound = HashSet::new();
-    for argument in arguments {
-        bound.extend(argument.get_variable_name().cloned());
-    }
-
-    let mut free = FreeVariables::new();
-    collect_statements(body.as_slice(), &mut bound, &mut free);
-    free.names
-}
-
-struct FreeVariables {
-    names: Vec<EcoString>,
-    seen: HashSet<EcoString>,
-}
-
-impl FreeVariables {
-    fn new() -> Self {
-        Self {
-            names: Vec::new(),
-            seen: HashSet::new(),
-        }
-    }
-
-    fn record(&mut self, name: &EcoString, bound: &HashSet<EcoString>) {
-        if bound.contains(name) {
-            return;
-        }
-
-        if self.seen.insert(name.clone()) {
-            self.names.push(name.clone());
-        }
-    }
-}
-
-fn collect_statements(
-    statements: &[TypedStatement],
-    bound: &mut HashSet<EcoString>,
-    free: &mut FreeVariables,
-) {
-    for statement in statements {
-        collect_statement(statement, bound, free);
-    }
-}
-
-fn collect_statement(
-    statement: &TypedStatement,
-    bound: &mut HashSet<EcoString>,
-    free: &mut FreeVariables,
-) {
-    match statement {
-        Statement::Expression(expression) => collect_expr(expression, bound, free),
-        Statement::Assignment(assignment) => {
-            collect_expr(&assignment.value, bound, free);
-            collect_variable_pattern_bound_name(&assignment.pattern, bound);
-        }
-        Statement::Use(use_) => {
-            collect_expr(&use_.call, bound, free);
-        }
-        Statement::Assert(_) => {}
-    }
-}
-
-fn collect_expr(expression: &TypedExpr, bound: &mut HashSet<EcoString>, free: &mut FreeVariables) {
-    match expression {
-        TypedExpr::Int { .. }
-        | TypedExpr::Float { .. }
-        | TypedExpr::String { .. }
-        | TypedExpr::Invalid { .. } => {}
-        TypedExpr::Var {
-            name, constructor, ..
-        } => {
-            if matches!(
-                constructor.variant,
-                ValueConstructorVariant::LocalVariable { .. }
-            ) {
-                free.record(name, bound);
-            }
-        }
-        TypedExpr::Block { statements, .. } => {
-            let mut block_bound = bound.clone();
-            collect_statements(statements.as_slice(), &mut block_bound, free);
-        }
-        TypedExpr::Pipeline {
-            first_value,
-            assignments,
-            finally,
-            ..
-        } => {
-            let mut pipeline_bound = bound.clone();
-            collect_pipeline_assignment(first_value, &mut pipeline_bound, free);
-            for (assignment, _) in assignments {
-                collect_pipeline_assignment(assignment, &mut pipeline_bound, free);
-            }
-            collect_expr(finally, &mut pipeline_bound, free);
-        }
-        TypedExpr::Fn {
-            arguments, body, ..
-        } => {
-            for name in anonymous_free_variables(arguments, body) {
-                free.record(&name, bound);
-            }
-        }
-        TypedExpr::Call { fun, arguments, .. } => {
-            collect_expr(fun, bound, free);
-            for argument in arguments {
-                collect_expr(&argument.value, bound, free);
-            }
-        }
-        TypedExpr::BinOp { left, right, .. } => {
-            collect_expr(left, bound, free);
-            collect_expr(right, bound, free);
-        }
-        TypedExpr::Case {
-            subjects, clauses, ..
-        } => {
-            for subject in subjects {
-                collect_expr(subject, bound, free);
-            }
-            for clause in clauses {
-                let mut branch_bound = bound.clone();
-                for pattern in &clause.pattern {
-                    collect_variable_pattern_bound_name(pattern, &mut branch_bound);
-                }
-                collect_expr(&clause.then, &mut branch_bound, free);
-            }
-        }
-        TypedExpr::NegateBool { value, .. } | TypedExpr::NegateInt { value, .. } => {
-            collect_expr(value, bound, free);
-        }
-        TypedExpr::Tuple { elements, .. } => {
-            for element in elements {
-                collect_expr(element, bound, free);
-            }
-        }
-        TypedExpr::TupleIndex { tuple, .. } => {
-            collect_expr(tuple, bound, free);
-        }
-        TypedExpr::List { elements, tail, .. } => {
-            for element in elements {
-                collect_expr(element, bound, free);
-            }
-            if let Some(tail) = tail {
-                collect_expr(tail, bound, free);
-            }
-        }
-        TypedExpr::RecordAccess { .. }
-        | TypedExpr::PositionalAccess { .. }
-        | TypedExpr::Todo { .. }
-        | TypedExpr::Panic { .. }
-        | TypedExpr::Echo { .. }
-        | TypedExpr::BitArray { .. }
-        | TypedExpr::RecordUpdate { .. }
-        | TypedExpr::ModuleSelect { .. } => {}
-    }
-}
-
-fn collect_pipeline_assignment(
-    assignment: &TypedPipelineAssignment,
-    bound: &mut HashSet<EcoString>,
-    free: &mut FreeVariables,
-) {
-    collect_expr(&assignment.value, bound, free);
-    bound.insert(assignment.name.clone());
-}
-
-fn collect_variable_pattern_bound_name(
-    pattern: &Pattern<Arc<Type>>,
-    bound: &mut HashSet<EcoString>,
-) {
-    match pattern {
-        Pattern::Variable { name, .. } => {
-            bound.insert(name.clone());
-        }
-        Pattern::Int { .. }
-        | Pattern::Float { .. }
-        | Pattern::String { .. }
-        | Pattern::Assign { .. }
-        | Pattern::List { .. }
-        | Pattern::Constructor { .. }
-        | Pattern::Tuple { .. }
-        | Pattern::BitArray { .. }
-        | Pattern::StringPrefix { .. }
-        | Pattern::BitArraySize(_)
-        | Pattern::Discard { .. }
-        | Pattern::Invalid { .. } => {}
     }
 }
 
@@ -685,79 +494,6 @@ pub fn main() {
         );
 
         assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn anonymous_free_variables_include_use_callback_call() {
-        assert_eq!(
-            anonymous_function_free_variables(
-                r#"
-fn with_value(value: Int, continue: fn(Int) -> Int) {
-  continue(value)
-}
-
-pub fn main() {
-  let use_value = 1
-  fn() {
-    use captured <- with_value(use_value)
-    captured
-  }
-  1
-}
-"#,
-            ),
-            vec!["use_value".to_string()],
-        );
-    }
-
-    #[test]
-    fn anonymous_free_variables_include_supported_expression_shapes() {
-        assert_eq!(
-            anonymous_function_free_variables(
-                r#"
-pub fn main() {
-  let block_value = 1
-  let case_subject = True
-  let pattern_source = 2
-  let case_value = 3
-  let negate_int_value = 4
-  let negate_bool_value = True
-  let tuple_value = #(5, 6)
-  let list_tail_value = [7]
-  fn() {
-    {
-      block_value
-    }
-    case case_subject {
-      True -> {
-        let branch_local = pattern_source
-        branch_local
-      }
-      False -> case_value
-    }
-    case !negate_bool_value {
-      True -> 0
-      False -> 1
-    }
-    -negate_int_value
-    tuple_value.0
-    [0, ..list_tail_value]
-  }
-  1
-}
-"#,
-            ),
-            vec![
-                "block_value".to_string(),
-                "case_subject".to_string(),
-                "pattern_source".to_string(),
-                "case_value".to_string(),
-                "negate_bool_value".to_string(),
-                "negate_int_value".to_string(),
-                "tuple_value".to_string(),
-                "list_tail_value".to_string(),
-            ],
-        );
     }
 
     #[test]
@@ -1173,30 +909,5 @@ pub fn main() {
             annotation: None,
             type_: gleam_core::type_::int(),
         }
-    }
-
-    fn anonymous_function_free_variables(src: &str) -> Vec<String> {
-        let module = compile(src);
-        let function = module
-            .definitions
-            .functions
-            .last()
-            .expect("main function should exist");
-        let (arguments, body) = function
-            .body
-            .iter()
-            .find_map(|statement| match statement {
-                Statement::Expression(TypedExpr::Fn {
-                    arguments, body, ..
-                }) => Some((arguments, body)),
-                _ => None,
-            })
-            .expect("expected anonymous function expression statement");
-
-        let mut names = Vec::new();
-        for name in super::anonymous_free_variables(arguments, body) {
-            names.push(name.to_string());
-        }
-        names
     }
 }

--- a/src/planner/expression/function/free_variables.rs
+++ b/src/planner/expression/function/free_variables.rs
@@ -1,0 +1,304 @@
+use ecow::EcoString;
+use gleam_core::ast::{
+    Pattern, Statement, TypedArg, TypedExpr, TypedPipelineAssignment, TypedStatement,
+};
+use gleam_core::type_::{Type, ValueConstructorVariant};
+use std::collections::HashSet;
+use std::sync::Arc;
+use vec1::Vec1;
+
+pub(super) fn anonymous_free_variables(
+    arguments: &[TypedArg],
+    body: &Vec1<TypedStatement>,
+) -> Vec<EcoString> {
+    let mut bound = HashSet::new();
+    for argument in arguments {
+        bound.extend(argument.get_variable_name().cloned());
+    }
+
+    let mut free = FreeVariables::new();
+    collect_statements(body.as_slice(), &mut bound, &mut free);
+    free.names
+}
+
+struct FreeVariables {
+    names: Vec<EcoString>,
+    seen: HashSet<EcoString>,
+}
+
+impl FreeVariables {
+    fn new() -> Self {
+        Self {
+            names: Vec::new(),
+            seen: HashSet::new(),
+        }
+    }
+
+    fn record(&mut self, name: &EcoString, bound: &HashSet<EcoString>) {
+        if bound.contains(name) {
+            return;
+        }
+
+        if self.seen.insert(name.clone()) {
+            self.names.push(name.clone());
+        }
+    }
+}
+
+fn collect_statements(
+    statements: &[TypedStatement],
+    bound: &mut HashSet<EcoString>,
+    free: &mut FreeVariables,
+) {
+    for statement in statements {
+        collect_statement(statement, bound, free);
+    }
+}
+
+fn collect_statement(
+    statement: &TypedStatement,
+    bound: &mut HashSet<EcoString>,
+    free: &mut FreeVariables,
+) {
+    match statement {
+        Statement::Expression(expression) => collect_expr(expression, bound, free),
+        Statement::Assignment(assignment) => {
+            collect_expr(&assignment.value, bound, free);
+            collect_variable_pattern_bound_name(&assignment.pattern, bound);
+        }
+        Statement::Use(use_) => {
+            collect_expr(&use_.call, bound, free);
+        }
+        Statement::Assert(_) => {}
+    }
+}
+
+fn collect_expr(expression: &TypedExpr, bound: &mut HashSet<EcoString>, free: &mut FreeVariables) {
+    match expression {
+        TypedExpr::Int { .. }
+        | TypedExpr::Float { .. }
+        | TypedExpr::String { .. }
+        | TypedExpr::Invalid { .. } => {}
+        TypedExpr::Var {
+            name, constructor, ..
+        } => {
+            if matches!(
+                constructor.variant,
+                ValueConstructorVariant::LocalVariable { .. }
+            ) {
+                free.record(name, bound);
+            }
+        }
+        TypedExpr::Block { statements, .. } => {
+            let mut block_bound = bound.clone();
+            collect_statements(statements.as_slice(), &mut block_bound, free);
+        }
+        TypedExpr::Pipeline {
+            first_value,
+            assignments,
+            finally,
+            ..
+        } => {
+            let mut pipeline_bound = bound.clone();
+            collect_pipeline_assignment(first_value, &mut pipeline_bound, free);
+            for (assignment, _) in assignments {
+                collect_pipeline_assignment(assignment, &mut pipeline_bound, free);
+            }
+            collect_expr(finally, &mut pipeline_bound, free);
+        }
+        TypedExpr::Fn {
+            arguments, body, ..
+        } => {
+            for name in anonymous_free_variables(arguments, body) {
+                free.record(&name, bound);
+            }
+        }
+        TypedExpr::Call { fun, arguments, .. } => {
+            collect_expr(fun, bound, free);
+            for argument in arguments {
+                collect_expr(&argument.value, bound, free);
+            }
+        }
+        TypedExpr::BinOp { left, right, .. } => {
+            collect_expr(left, bound, free);
+            collect_expr(right, bound, free);
+        }
+        TypedExpr::Case {
+            subjects, clauses, ..
+        } => {
+            for subject in subjects {
+                collect_expr(subject, bound, free);
+            }
+            for clause in clauses {
+                let mut branch_bound = bound.clone();
+                for pattern in &clause.pattern {
+                    collect_variable_pattern_bound_name(pattern, &mut branch_bound);
+                }
+                collect_expr(&clause.then, &mut branch_bound, free);
+            }
+        }
+        TypedExpr::NegateBool { value, .. } | TypedExpr::NegateInt { value, .. } => {
+            collect_expr(value, bound, free);
+        }
+        TypedExpr::Tuple { elements, .. } => {
+            for element in elements {
+                collect_expr(element, bound, free);
+            }
+        }
+        TypedExpr::TupleIndex { tuple, .. } => {
+            collect_expr(tuple, bound, free);
+        }
+        TypedExpr::List { elements, tail, .. } => {
+            for element in elements {
+                collect_expr(element, bound, free);
+            }
+            if let Some(tail) = tail {
+                collect_expr(tail, bound, free);
+            }
+        }
+        TypedExpr::RecordAccess { .. }
+        | TypedExpr::PositionalAccess { .. }
+        | TypedExpr::Todo { .. }
+        | TypedExpr::Panic { .. }
+        | TypedExpr::Echo { .. }
+        | TypedExpr::BitArray { .. }
+        | TypedExpr::RecordUpdate { .. }
+        | TypedExpr::ModuleSelect { .. } => {}
+    }
+}
+
+fn collect_pipeline_assignment(
+    assignment: &TypedPipelineAssignment,
+    bound: &mut HashSet<EcoString>,
+    free: &mut FreeVariables,
+) {
+    collect_expr(&assignment.value, bound, free);
+    bound.insert(assignment.name.clone());
+}
+
+fn collect_variable_pattern_bound_name(
+    pattern: &Pattern<Arc<Type>>,
+    bound: &mut HashSet<EcoString>,
+) {
+    match pattern {
+        Pattern::Variable { name, .. } => {
+            bound.insert(name.clone());
+        }
+        Pattern::Int { .. }
+        | Pattern::Float { .. }
+        | Pattern::String { .. }
+        | Pattern::Assign { .. }
+        | Pattern::List { .. }
+        | Pattern::Constructor { .. }
+        | Pattern::Tuple { .. }
+        | Pattern::BitArray { .. }
+        | Pattern::StringPrefix { .. }
+        | Pattern::BitArraySize(_)
+        | Pattern::Discard { .. }
+        | Pattern::Invalid { .. } => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::planner::support::compile;
+    use gleam_core::ast::{Statement, TypedExpr};
+
+    #[test]
+    fn anonymous_free_variables_include_use_callback_call() {
+        assert_eq!(
+            anonymous_function_free_variables(
+                r#"
+fn with_value(value: Int, continue: fn(Int) -> Int) {
+  continue(value)
+}
+
+pub fn main() {
+  let use_value = 1
+  fn() {
+    use captured <- with_value(use_value)
+    captured
+  }
+  1
+}
+"#,
+            ),
+            vec!["use_value".to_string()],
+        );
+    }
+
+    #[test]
+    fn anonymous_free_variables_include_supported_expression_shapes() {
+        assert_eq!(
+            anonymous_function_free_variables(
+                r#"
+pub fn main() {
+  let block_value = 1
+  let case_subject = True
+  let pattern_source = 2
+  let case_value = 3
+  let negate_int_value = 4
+  let negate_bool_value = True
+  let tuple_value = #(5, 6)
+  let list_tail_value = [7]
+  fn() {
+    {
+      block_value
+    }
+    case case_subject {
+      True -> {
+        let branch_local = pattern_source
+        branch_local
+      }
+      False -> case_value
+    }
+    case !negate_bool_value {
+      True -> 0
+      False -> 1
+    }
+    -negate_int_value
+    tuple_value.0
+    [0, ..list_tail_value]
+  }
+  1
+}
+"#,
+            ),
+            vec![
+                "block_value".to_string(),
+                "case_subject".to_string(),
+                "pattern_source".to_string(),
+                "case_value".to_string(),
+                "negate_bool_value".to_string(),
+                "negate_int_value".to_string(),
+                "tuple_value".to_string(),
+                "list_tail_value".to_string(),
+            ],
+        );
+    }
+
+    fn anonymous_function_free_variables(src: &str) -> Vec<String> {
+        let module = compile(src);
+        let function = module
+            .definitions
+            .functions
+            .last()
+            .expect("main function should exist");
+        let (arguments, body) = function
+            .body
+            .iter()
+            .find_map(|statement| match statement {
+                Statement::Expression(TypedExpr::Fn {
+                    arguments, body, ..
+                }) => Some((arguments, body)),
+                _ => None,
+            })
+            .expect("expected anonymous function expression statement");
+
+        let mut names = Vec::new();
+        for name in super::anonymous_free_variables(arguments, body) {
+            names.push(name.to_string());
+        }
+        names
+    }
+}


### PR DESCRIPTION
- Move anonymous function free-variable collection into a dedicated child module.
- Keep function.rs focused on anonymous function lowering and closure construction.
- Colocate free-variable collector tests with the module that owns the traversal.
- Preserve existing planner behavior and anonymous function plan shapes.
