### PR TITLE
Support list spread expressions

### DIFF
--- a/src/plan/expression.rs
+++ b/src/plan/expression.rs
@@ -357,7 +357,6 @@ impl Expr {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn into_list(self) -> Option<ListExpr> {
         match self.kind {
             ExprKind::List(expression) => Some(expression),

--- a/src/plan/expression/list.rs
+++ b/src/plan/expression/list.rs
@@ -12,6 +12,10 @@ pub struct ListExpr {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum ListExprKind {
     Value(Vec<super::Expr>),
+    Spread {
+        elements: Vec<super::Expr>,
+        tail: Box<ListExpr>,
+    },
     LocalGet {
         local: ListLocalId,
         name: EcoString,
@@ -59,6 +63,20 @@ impl ListExpr {
         Self {
             element_type: Box::new(element_type),
             kind: ListExprKind::Value(elements),
+        }
+    }
+
+    pub(crate) fn spread(
+        elements: Vec<super::Expr>,
+        tail: ListExpr,
+        element_type: ValueType,
+    ) -> Self {
+        Self {
+            element_type: Box::new(element_type),
+            kind: ListExprKind::Spread {
+                elements,
+                tail: Box::new(tail),
+            },
         }
     }
 
@@ -191,6 +209,15 @@ mod tests {
     fn list_expr_kind_accessors() {
         assert!(matches!(list_value().kind(), ListExprKind::Value(_)));
         assert!(matches!(
+            ListExpr::spread(
+                vec![Expr::int(IntExpr::value(0.into()))],
+                list_value(),
+                element_type()
+            )
+            .kind(),
+            ListExprKind::Spread { .. }
+        ));
+        assert!(matches!(
             ListExpr::local_get(ListLocalId(0), "values".into(), element_type()).kind(),
             ListExprKind::LocalGet { .. }
         ));
@@ -250,6 +277,15 @@ mod tests {
     #[test]
     fn list_expr_element_type() {
         assert_eq!(list_value().element_type(), &element_type());
+        assert_eq!(
+            ListExpr::spread(
+                vec![Expr::int(IntExpr::value(0.into()))],
+                list_value(),
+                element_type()
+            )
+            .element_type(),
+            &element_type(),
+        );
         assert_eq!(
             ListExpr::bool_case(BoolExpr::value(true), list_value(), list_value()).element_type(),
             &element_type(),

--- a/src/plan/frame/expression.rs
+++ b/src/plan/frame/expression.rs
@@ -437,6 +437,12 @@ impl FrameLayout {
                     self.include_expr(element);
                 }
             }
+            ListExprKind::Spread { elements, tail } => {
+                for element in elements {
+                    self.include_expr(element);
+                }
+                self.include_list_expr(tail);
+            }
             ListExprKind::LocalGet { local, .. } => self.include_list(*local),
             ListExprKind::Call { args, .. } => self.include_call_args(args),
             ListExprKind::FunctionCall { function, args } => {
@@ -936,6 +942,14 @@ mod tests {
                 ))],
                 list_type(),
             ))),
+            Step::evaluate(Expr::list(ListExpr::spread(
+                vec![Expr::int(IntExpr::local_get(
+                    IntLocalId(3),
+                    "spread_element".into(),
+                ))],
+                ListExpr::local_get(ListLocalId(13), "spread_tail".into(), list_type()),
+                list_type(),
+            ))),
             Step::evaluate(Expr::list(ListExpr::local_get(
                 ListLocalId(0),
                 "local".into(),
@@ -1014,11 +1028,11 @@ mod tests {
 
         let layout = FrameLayout::from_function_parts(&[], &steps, &return_);
 
-        assert_eq!(layout.ints(), 3);
+        assert_eq!(layout.ints(), 4);
         assert_eq!(layout.floats(), 1);
         assert_eq!(layout.strings(), 1);
         assert_eq!(layout.bools(), 1);
-        assert_eq!(layout.lists(), 13);
+        assert_eq!(layout.lists(), 14);
         assert_eq!(layout.list_functions(), 1);
     }
 

--- a/src/planner/dsl.rs
+++ b/src/planner/dsl.rs
@@ -10,7 +10,7 @@ pub(crate) use expression::{
     int_case_int_function, int_function_arg, int_function_call_arg, int_function_closure,
     int_function_ref, let_bool_function_step, let_bool_step, let_int_function_step, let_int_step,
     let_list_step, let_nil_function_step, let_nil_step, let_string_function_step, let_string_step,
-    let_tuple_step, list, list_function_ref, local_bool, local_float, local_int,
+    let_tuple_step, list, list_function_ref, list_spread, local_bool, local_float, local_int,
     local_int_function, local_list, local_nil, local_string, local_tuple, nil, nil_arg,
     nil_function_ref, not_equal, string, string_arg, string_function_ref, tuple, tuple_arg,
     tuple_function_closure, tuple_function_ref,

--- a/src/planner/dsl/expression/value.rs
+++ b/src/planner/dsl/expression/value.rs
@@ -41,9 +41,21 @@ pub(crate) fn list(
     ))
 }
 
+pub(crate) fn list_spread(
+    elements: impl IntoIterator<Item = impl Into<Expr>>,
+    tail: List,
+    element_type: ValueType,
+) -> List {
+    List(ListExpr::spread(
+        elements.into_iter().map(Into::into).collect(),
+        tail.into(),
+        element_type,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{bool_, float, int, list, nil, string, tuple};
+    use super::{bool_, float, int, list, list_spread, nil, string, tuple};
     use crate::plan::ValueType;
     use crate::plan::{Expr, ExprKind};
 
@@ -63,6 +75,15 @@ mod tests {
         ));
         assert!(matches!(
             Expr::from(list([int(1)], ValueType::Int)).kind(),
+            ExprKind::List(_),
+        ));
+        assert!(matches!(
+            Expr::from(list_spread(
+                [int(1)],
+                list([int(2)], ValueType::Int),
+                ValueType::Int,
+            ))
+            .kind(),
             ExprKind::List(_),
         ));
     }

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -66,8 +66,6 @@ pub enum UnsupportedExpressionKind {
     Echo,
     #[error("function capture literal")]
     FunctionCaptureLiteral,
-    #[error("list spread")]
-    ListSpread,
     #[error("list element type is not supported")]
     UnsupportedListElementType,
     #[error("panic")]

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -168,12 +168,6 @@ fn plan_list(
     tail: Option<TypedExpr>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    if tail.is_some() {
-        return Err(PlanError::UnsupportedExpression {
-            kind: UnsupportedExpressionKind::ListSpread,
-        });
-    }
-
     let planned_elements = elements
         .into_iter()
         .map(|element| plan_expr(element, context))
@@ -211,8 +205,32 @@ fn plan_list(
         }
     }
 
-    Ok(Expr::list(ListExpr::value(
+    let Some(tail) = tail else {
+        return Ok(Expr::list(ListExpr::value(
+            planned_elements,
+            expected_element_type,
+        )));
+    };
+
+    let tail = plan_expr(tail, context)?;
+    let actual = tail.value_type();
+    let tail = tail.into_list().ok_or_else(|| {
+        invalid_expression_type_for_value(
+            ValueType::List(Box::new(expected_element_type.clone())),
+            actual,
+        )
+    })?;
+
+    if tail.element_type() != &expected_element_type {
+        return Err(invalid_expression_type_for_value(
+            ValueType::List(Box::new(expected_element_type.clone())),
+            ValueType::List(Box::new(tail.element_type().clone())),
+        ));
+    }
+
+    Ok(Expr::list(ListExpr::spread(
         planned_elements,
+        tail,
         expected_element_type,
     )))
 }
@@ -479,9 +497,9 @@ mod tests {
     use crate::planner::context::{AnonymousFunctions, PlanContext};
     use crate::planner::dsl::{
         bool_, bool_function_ref, float, float_function_ref, function, function_function_ref, int,
-        int_function_ref, let_list_step, let_tuple_step, list, list_function_ref, local_bool,
-        local_float, local_int, local_list, local_nil, local_string, local_tuple, module, nil,
-        nil_function_ref, string, string_function_ref, tuple, tuple_function_ref,
+        int_function_ref, let_list_step, let_tuple_step, list, list_function_ref, list_spread,
+        local_bool, local_float, local_int, local_list, local_nil, local_string, local_tuple,
+        module, nil, nil_function_ref, string, string_function_ref, tuple, tuple_function_ref,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, dummy_span, expect_plan_error};
@@ -497,18 +515,6 @@ mod tests {
     #[test]
     fn reject_profile_expression_variants() {
         let cases = [
-            (
-                r#"
-pub fn main() {
-  let rest = [2, 3]
-  [1, ..rest]
-  1
-}
-"#,
-                PlanError::UnsupportedExpression {
-                    kind: UnsupportedExpressionKind::ListSpread,
-                },
-            ),
             (
                 r#"
 pub fn main() {
@@ -1255,6 +1261,37 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_list_spread_literal_shape() {
+        assert_eq!(
+            plan_module(compile(
+                r#"
+pub fn main() {
+  let rest = [2, 3]
+  [1, ..rest]
+}
+"#,
+            )),
+            Ok(module(
+                "main",
+                function(
+                    "main",
+                    list_spread(
+                        [int(1)],
+                        local_list(0, "rest", ValueType::Int),
+                        ValueType::Int
+                    ),
+                )
+                .step(let_list_step(
+                    0,
+                    "rest",
+                    list([int(2), int(3)], ValueType::Int),
+                )),
+                [],
+            )),
+        );
+    }
+
+    #[test]
     fn reject_margin_tuple_expression_shapes() {
         let tuple_int = type_::tuple(vec![type_::int()]);
         let cases = [
@@ -1470,6 +1507,39 @@ pub fn main() {
                 PlanError::InvalidTypedAst {
                     reason: InvalidTypedAstReason::ExpressionShape {
                         kind: InvalidExpressionShapeKind::Invalid,
+                    },
+                },
+            ),
+            (
+                TypedExpr::List {
+                    location: dummy_span(),
+                    type_: type_::list(type_::int()),
+                    elements: vec![typed_int_expr(1)],
+                    tail: Some(Box::new(typed_int_expr(2))),
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::List,
+                        actual: InvalidExpressionType::Int,
+                    },
+                },
+            ),
+            (
+                TypedExpr::List {
+                    location: dummy_span(),
+                    type_: type_::list(type_::int()),
+                    elements: vec![typed_int_expr(1)],
+                    tail: Some(Box::new(TypedExpr::List {
+                        location: dummy_span(),
+                        type_: type_::list(type_::string()),
+                        elements: vec![typed_string_expr("two")],
+                        tail: None,
+                    })),
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionType {
+                        expected: InvalidExpressionType::List,
+                        actual: InvalidExpressionType::List,
                     },
                 },
             ),

--- a/src/planner/expression/block.rs
+++ b/src/planner/expression/block.rs
@@ -407,15 +407,14 @@ pub fn main() {
                 r#"
 pub fn main() {
   {
-    let rest = [2]
-    [1, ..rest]
+    panic
     1
   }
 }
 "#,
             ),
             PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::ListSpread,
+                kind: UnsupportedExpressionKind::Panic,
             },
         );
     }
@@ -431,15 +430,14 @@ fn add_one(value: Int) {
 
 pub fn main() {
   {
-    let rest = [2]
-    [1, ..rest]
+    panic
     add_one
   }
 }
 "#,
             ),
             PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::ListSpread,
+                kind: UnsupportedExpressionKind::Panic,
             },
         );
     }

--- a/src/planner/expression/case.rs
+++ b/src/planner/expression/case.rs
@@ -236,8 +236,7 @@ pub fn main() {
   case True {
     _ -> 1
     True -> {
-      let rest = [2]
-      [1, ..rest]
+      panic
       2
     }
   }
@@ -245,7 +244,7 @@ pub fn main() {
 "#,
             ),
             PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::ListSpread,
+                kind: UnsupportedExpressionKind::Panic,
             },
         );
 
@@ -256,8 +255,7 @@ pub fn main() {
   case 1 {
     _ -> 1
     1 -> {
-      let rest = [2]
-      [1, ..rest]
+      panic
       2
     }
   }
@@ -265,7 +263,7 @@ pub fn main() {
 "#,
             ),
             PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::ListSpread,
+                kind: UnsupportedExpressionKind::Panic,
             },
         );
     }

--- a/src/planner/expression/case/float_subject.rs
+++ b/src/planner/expression/case/float_subject.rs
@@ -840,8 +840,7 @@ pub fn main() {
   case 1.0 {
     1.0 -> 1
     1.0 -> {
-      let rest = [2]
-      [1, ..rest]
+      panic
       2
     }
     _ -> 0
@@ -850,7 +849,7 @@ pub fn main() {
 "#,
             ),
             PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::ListSpread,
+                kind: UnsupportedExpressionKind::Panic,
             },
         );
     }

--- a/src/planner/expression/case/int_subject.rs
+++ b/src/planner/expression/case/int_subject.rs
@@ -923,8 +923,7 @@ pub fn main() {
   case 1 {
     1 -> 1
     1 -> {
-      let rest = [2]
-      [1, ..rest]
+      panic
       2
     }
     _ -> 0
@@ -933,7 +932,7 @@ pub fn main() {
 "#,
             ),
             PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::ListSpread,
+                kind: UnsupportedExpressionKind::Panic,
             },
         );
     }

--- a/src/planner/expression/case/string_subject.rs
+++ b/src/planner/expression/case/string_subject.rs
@@ -680,8 +680,7 @@ pub fn main() {
   case "one" {
     "one" -> 1
     "one" -> {
-      let rest = [2]
-      [1, ..rest]
+      panic
       2
     }
     _ -> 0
@@ -690,7 +689,7 @@ pub fn main() {
 "#,
             ),
             PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::ListSpread,
+                kind: UnsupportedExpressionKind::Panic,
             },
         );
     }

--- a/src/planner/expression/operator/boolean.rs
+++ b/src/planner/expression/operator/boolean.rs
@@ -69,15 +69,14 @@ pub fn or_op() {
                 r#"
 pub fn main() {
   False && {
-    let rest = [1]
-    [0, ..rest]
+    panic
     True
   }
 }
 "#,
             ),
             PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::ListSpread,
+                kind: UnsupportedExpressionKind::Panic,
             },
         );
         assert_eq!(
@@ -85,15 +84,14 @@ pub fn main() {
                 r#"
 pub fn main() {
   True || {
-    let rest = [1]
-    [0, ..rest]
+    panic
     False
   }
 }
 "#,
             ),
             PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::ListSpread,
+                kind: UnsupportedExpressionKind::Panic,
             },
         );
     }

--- a/src/runtime/expression/list.rs
+++ b/src/runtime/expression/list.rs
@@ -17,6 +17,15 @@ pub(in crate::runtime) fn eval_list_expr(
             }
             Ok(ListValue::new(expression.element_type().clone(), values))
         }
+        ListExprKind::Spread { elements, tail } => {
+            let mut values = Vec::with_capacity(elements.len());
+            for element in elements {
+                values.push(super::eval_expr(plan, frame, element)?);
+            }
+            values.extend(eval_list_expr(plan, frame, tail)?.values().iter().cloned());
+
+            Ok(ListValue::new(expression.element_type().clone(), values))
+        }
         ListExprKind::LocalGet { local, .. } => Ok(frame.get_list(*local)),
         ListExprKind::Call { function, args } => {
             function::run_list_call(plan, *function, args, frame)
@@ -128,6 +137,40 @@ mod tests {
                 &ListExpr::call(ListFunctionId(0), Vec::new(), element_type()),
             ),
             Ok(list_value(1)),
+        );
+    }
+
+    #[test]
+    fn eval_list_expr_evaluates_spread_prefix_before_tail() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_list_expr(
+                &plan,
+                &mut frame,
+                &ListExpr::spread(
+                    vec![Expr::int(IntExpr::value(0.into()))],
+                    list_expr(1),
+                    element_type(),
+                ),
+            ),
+            Ok(ListValue::new(
+                element_type(),
+                vec![Value::Int(0.into()), Value::Int(1.into())],
+            )),
+        );
+        assert_eq!(
+            eval_list_expr(
+                &plan,
+                &mut frame,
+                &ListExpr::spread(
+                    vec![Expr::int(error_int_expr())],
+                    error_list_expr(),
+                    element_type(),
+                ),
+            ),
+            Err(tuple_index_error(ValueType::Int)),
         );
     }
 
@@ -292,6 +335,18 @@ mod tests {
             (
                 ListExpr::value(vec![Expr::int(error_int_expr())], element_type()),
                 ValueType::Int,
+            ),
+            (
+                ListExpr::spread(
+                    vec![Expr::int(error_int_expr())],
+                    list_expr(1),
+                    element_type(),
+                ),
+                ValueType::Int,
+            ),
+            (
+                ListExpr::spread(Vec::new(), error_list_expr(), element_type()),
+                ValueType::List(Box::new(element_type())),
             ),
             (
                 ListExpr::bool_case(error_bool_expr(), list_expr(1), list_expr(2)),

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -29,6 +29,7 @@ mod values {
         float_value,
         tuple_value,
         list_value,
+        list_spread,
         bool_value,
         nil_value,
     );
@@ -127,6 +128,7 @@ mod functions {
             float_function_value_expressions,
             tuple_function_value_projection,
             list_function_value,
+            function_value_block_list_spread,
             function_value_expression_steps,
             function_value_shadowing,
         );
@@ -263,9 +265,7 @@ mod rejection {
             echo,
             bit_array,
             result_constructor,
-            list_spread,
             unsupported_list_element_type,
-            function_value_block_list_spread,
         );
     }
 

--- a/tests/fixtures/execution/functions/value/function_value_block_list_spread.gleam
+++ b/tests/fixtures/execution/functions/value/function_value_block_list_spread.gleam
@@ -9,3 +9,5 @@ pub fn main() {
     add_one
   }
 }
+
+// geam:expect Function(fn(Int) -> Int)

--- a/tests/fixtures/execution/values/list_spread.gleam
+++ b/tests/fixtures/execution/values/list_spread.gleam
@@ -2,3 +2,5 @@ pub fn main() {
   let rest = [2, 3]
   [1, ..rest]
 }
+
+// geam:expect List(Int)([Int(1), Int(2), Int(3)])


### PR DESCRIPTION
- Lower list literal spread syntax into an explicit ListExpr spread shape.
- Evaluate spread prefixes before appending the tail list at runtime.
- Move list spread fixtures from rejection to execution coverage.
- Cover planner shape, frame dependencies, runtime evaluation, and margin errors.

Example: `let rest = [2, 3]; [1, ..rest]` now evaluates to `[1, 2, 3]`.
