### PR TITLE
Support pipeline function-value calls

### DIFF
--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -106,6 +106,4 @@ pub enum UnsupportedCaseReason {
 pub enum UnsupportedPipelineReason {
     #[error("echo")]
     Echo,
-    #[error("function value pipeline calls are not supported")]
-    FunctionValueCall,
 }

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -7,7 +7,6 @@ use crate::plan::Expr;
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
     InvalidCallShapeReason, InvalidTypedAstReason, InvalidUseShapeReason, PlanError,
-    UnsupportedPipelineReason,
 };
 use ecow::EcoString;
 use gleam_core::ast::{CallArg as GleamCallArg, TypedExpr};
@@ -36,14 +35,7 @@ pub(super) fn plan_call(
         });
     }
 
-    plan_call_expression(
-        type_,
-        fun,
-        arguments,
-        context,
-        None,
-        FunctionValueCallMode::Allow,
-    )
+    plan_call_expression(type_, fun, arguments, context, None)
 }
 
 pub(super) fn plan_use_call(
@@ -69,12 +61,6 @@ pub(super) fn plan_pipeline_hole_call(
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     implicit::plan_pipeline_hole_call(type_, fun, arguments, context)
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum FunctionValueCallMode {
-    Allow,
-    Reject,
 }
 
 struct CaptureSubstitution {
@@ -109,7 +95,6 @@ fn plan_call_expression(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
-    function_value_call_mode: FunctionValueCallMode,
 ) -> Result<Expr, PlanError> {
     if let TypedExpr::Var { constructor, .. } = &fun {
         match &constructor.variant {
@@ -157,12 +142,6 @@ fn plan_call_expression(
             }
             ValueConstructorVariant::LocalVariable { .. } => {}
         }
-    }
-
-    if function_value_call_mode == FunctionValueCallMode::Reject {
-        return Err(PlanError::UnsupportedPipeline {
-            reason: UnsupportedPipelineReason::FunctionValueCall,
-        });
     }
 
     function_value::plan_function_value_call(type_, fun, arguments, context, capture)

--- a/src/planner/expression/call/implicit.rs
+++ b/src/planner/expression/call/implicit.rs
@@ -1,4 +1,4 @@
-use super::{CaptureSubstitution, FunctionValueCallMode};
+use super::CaptureSubstitution;
 use crate::plan::Expr;
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
@@ -24,14 +24,7 @@ pub(super) fn plan_use_call(
             ..
         } => {
             let arguments = normalize_use_call_arguments(arguments)?;
-            super::plan_call_expression(
-                type_,
-                *fun,
-                arguments,
-                context,
-                None,
-                FunctionValueCallMode::Allow,
-            )
+            super::plan_call_expression(type_, *fun, arguments, context, None)
         }
         _ => Err(super::invalid_use_shape(InvalidUseShapeReason::NonCallRhs)),
     }
@@ -45,14 +38,7 @@ pub(super) fn plan_pipeline_direct_call(
 ) -> Result<Expr, PlanError> {
     pipe_argument(&arguments)?;
 
-    super::plan_call_expression(
-        type_,
-        fun,
-        arguments,
-        context,
-        None,
-        FunctionValueCallMode::Reject,
-    )
+    super::plan_call_expression(type_, fun, arguments, context, None)
 }
 
 pub(super) fn plan_pipeline_hole_call(
@@ -105,7 +91,6 @@ pub(super) fn plan_pipeline_hole_call(
             name: capture_name,
             value: pipe_value,
         }),
-        FunctionValueCallMode::Reject,
     )
 }
 

--- a/src/planner/expression/pipeline.rs
+++ b/src/planner/expression/pipeline.rs
@@ -104,11 +104,14 @@ fn invalid_pipeline_shape(reason: InvalidPipelineShapeReason) -> PlanError {
 
 #[cfg(test)]
 mod tests {
+    use crate::plan::{IntLocalId, LocalId};
     use crate::planner::dsl::{
-        block_int, bool_, bool_arg, bool_return_block, bool_return_tail_call, call_int, function,
-        int, int_arg, int_return_block, int_return_tail_call, let_bool_step, let_int_step,
-        let_nil_step, let_string_step, local_bool, local_int, local_nil, local_string, module, nil,
-        nil_arg, nil_return_block, nil_return_tail_call, string, string_arg, string_return_block,
+        block_int, bool_, bool_arg, bool_return_block, bool_return_tail_call, call_int,
+        call_int_function, function, int, int_arg, int_function_call_arg, int_function_ref,
+        int_return_block, int_return_expr, int_return_tail_call, let_bool_step,
+        let_int_function_step, let_int_step, let_nil_step, let_string_step, local_bool, local_int,
+        local_int_function, local_nil, local_string, module, module_with_anonymous, nil, nil_arg,
+        nil_return_block, nil_return_tail_call, string, string_arg, string_return_block,
         string_return_tail_call,
     };
     use crate::planner::plan_module;
@@ -318,6 +321,110 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_pipeline_function_value_call_shape() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let f = add_one
+  1 |> f
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "_pipe", int(1))],
+                    int_return_expr(call_int_function(
+                        local_int_function(0, "f", [LocalId::Int(IntLocalId(0))]),
+                        [int_function_call_arg(0, local_int(0, "_pipe"))],
+                    )),
+                ),
+            )
+            .step(let_int_function_step(
+                0,
+                "f",
+                int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+            )),
+            [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_pipeline_anonymous_function_value_call_shape() {
+        let actual = plan_module(compile(r#"pub fn main() { 1 |> fn(value) { value } }"#))
+            .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "_pipe", int(1))],
+                    int_return_expr(call_int_function(
+                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                        [int_function_call_arg(0, local_int(0, "_pipe"))],
+                    )),
+                ),
+            ),
+            [],
+            [function("<anonymous:0>", local_int(0, "value")).param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_pipeline_function_value_hole_call_shape() {
+        let actual = plan_module(compile(
+            r#"
+fn subtract(left: Int, right: Int) {
+  left - right
+}
+
+pub fn main() {
+  let f = subtract
+  1 |> f(10, _)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let params = [LocalId::Int(IntLocalId(0)), LocalId::Int(IntLocalId(1))];
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "_pipe", int(1))],
+                    int_return_expr(call_int_function(
+                        local_int_function(0, "f", params),
+                        [
+                            int_function_call_arg(0, int(10)),
+                            int_function_call_arg(1, local_int(0, "_pipe")),
+                        ],
+                    )),
+                ),
+            )
+            .step(let_int_function_step(0, "f", int_function_ref(1, params))),
+            [function(
+                "subtract",
+                local_int(0, "left").sub_int(local_int(1, "right")),
+            )
+            .param_int(0, "left")
+            .param_int(1, "right")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_pipeline_middle_explicit_hole() {
         let actual = plan_module(compile(
             r#"
@@ -430,24 +537,6 @@ fn identity_nil(value: Nil) {
             expect_plan_error(r#"pub fn main() { 1 |> echo }"#),
             PlanError::UnsupportedPipeline {
                 reason: UnsupportedPipelineReason::Echo,
-            },
-        );
-        assert_eq!(
-            expect_plan_error(r#"pub fn main() { 1 |> fn(x) { x } }"#),
-            PlanError::UnsupportedPipeline {
-                reason: UnsupportedPipelineReason::FunctionValueCall,
-            },
-        );
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  1 |> fn(right) { fn(left) { left + right } }(2)
-}
-"#,
-            ),
-            PlanError::UnsupportedPipeline {
-                reason: UnsupportedPipelineReason::FunctionValueCall,
             },
         );
         assert_eq!(

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -98,6 +98,10 @@ mod pipeline {
         float_pipeline,
         tuple_pipeline,
         list_pipeline,
+        function_value_call,
+        anonymous_function_call,
+        function_value_hole_call,
+        function_returning_function_call,
     );
 }
 
@@ -313,8 +317,6 @@ mod rejection {
     mod pipeline {
         rejection_cases!("pipeline";
             echo,
-            anonymous_function_call,
-            function_value_call,
         );
     }
 }

--- a/tests/fixtures/execution/pipeline/anonymous_function_call.gleam
+++ b/tests/fixtures/execution/pipeline/anonymous_function_call.gleam
@@ -1,3 +1,5 @@
 pub fn main() {
   1 |> fn(value) { value }
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/pipeline/function_returning_function_call.gleam
+++ b/tests/fixtures/execution/pipeline/function_returning_function_call.gleam
@@ -1,0 +1,5 @@
+pub fn main() {
+  1 |> fn(right) { fn(left) { left + right } }(2)
+}
+
+// geam:expect Int(3)

--- a/tests/fixtures/execution/pipeline/function_value_call.gleam
+++ b/tests/fixtures/execution/pipeline/function_value_call.gleam
@@ -6,3 +6,5 @@ pub fn main() {
   let f = add_one
   1 |> f
 }
+
+// geam:expect Int(2)

--- a/tests/fixtures/execution/pipeline/function_value_hole_call.gleam
+++ b/tests/fixtures/execution/pipeline/function_value_hole_call.gleam
@@ -1,0 +1,10 @@
+fn subtract(left: Int, right: Int) {
+  left - right
+}
+
+pub fn main() {
+  let f = subtract
+  1 |> f(10, _)
+}
+
+// geam:expect Int(9)


### PR DESCRIPTION
- Reuse function-value call lowering for pipeline callee expressions.
- Keep direct local function pipelines as tail calls while function-value callees
  stay as FunctionCall expressions.
- Cover local function values, anonymous function values, explicit-hole calls,
  and function-returning-function callees.

Examples: `let f = add_one; 1 |> f`, `1 |> fn(value) { value }`,
and `1 |> f(10, _)` now evaluate through the function-value call path.
