### PR TITLE
Support final assignment returns

### DIFF
--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -38,8 +38,6 @@ pub enum UnsupportedStatementKind {
     Assert,
     #[error("assert as final statement")]
     AssertAsFinalStatement,
-    #[error("assignment as final statement")]
-    AssignmentAsFinalStatement,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -6,11 +6,12 @@ use crate::planner::context::{
     AnonymousFunctions, FunctionInfo, FunctionParam, FunctionRuntimeIds,
 };
 use crate::planner::error::{
-    PlanError, UnsupportedArgumentReason, UnsupportedFunctionReason, UnsupportedTopLevelKind,
+    PlanError, UnsupportedArgumentReason, UnsupportedExpressionKind, UnsupportedFunctionReason,
+    UnsupportedTopLevelKind,
 };
 use crate::planner::function::{function_name, plan_function};
 use ecow::EcoString;
-use gleam_core::ast::{ArgNames, TypedFunction, TypedModule};
+use gleam_core::ast::{ArgNames, Statement, TypedExpr, TypedFunction, TypedModule};
 use gleam_core::type_::Type;
 use std::collections::HashMap;
 
@@ -113,6 +114,7 @@ fn function_table(
 
     for function in functions {
         let name = function_name(function)?;
+        reject_todo_body(function)?;
         let return_type = function_return_type(name.clone(), &function.return_type)?;
         let params = function_params(name.clone(), &function.arguments)?;
         seeds.push(FunctionSeed {
@@ -204,6 +206,19 @@ fn function_return_type(name: EcoString, type_: &Type) -> Result<ValueType, Plan
         name,
         reason: UnsupportedFunctionReason::UnsupportedReturnType,
     })
+}
+
+fn reject_todo_body(function: &TypedFunction) -> Result<(), PlanError> {
+    if matches!(
+        function.body.as_slice(),
+        [Statement::Expression(TypedExpr::Todo { .. })]
+    ) {
+        return Err(PlanError::UnsupportedExpression {
+            kind: UnsupportedExpressionKind::Todo,
+        });
+    }
+
+    Ok(())
 }
 
 pub(super) fn function_params(
@@ -458,6 +473,21 @@ pub fn main(value: Int) {
             PlanError::UnsupportedFunction {
                 name: "main".into(),
                 reason: UnsupportedFunctionReason::MainWithArguments,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_profile_empty_source_body_is_todo() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Todo,
             },
         );
     }

--- a/src/planner/statement.rs
+++ b/src/planner/statement.rs
@@ -1,4 +1,8 @@
-use crate::plan::{ExprKind, FunctionExprKind, Step};
+use crate::plan::{
+    BoolExpr, BoolFunctionExpr, Expr, ExprKind, FloatExpr, FloatFunctionExpr, FunctionExpr,
+    FunctionExprKind, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr, ListFunctionExpr,
+    NilExpr, NilFunctionExpr, Step, StringExpr, StringFunctionExpr, TupleExpr, TupleFunctionExpr,
+};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
     InvalidTypedAstReason, InvalidUseShapeReason, PlanError, UnsupportedAssignmentKind,
@@ -49,10 +53,10 @@ fn plan_ordered_steps_and_return(
 
     let return_ = match last_statement {
         Statement::Expression(expression) => plan_expr(expression, context)?,
-        Statement::Assignment(_) => {
-            return Err(PlanError::UnsupportedStatement {
-                kind: UnsupportedStatementKind::AssignmentAsFinalStatement,
-            });
+        Statement::Assignment(assignment) => {
+            let planned = plan_final_assignment(*assignment, context)?;
+            steps.extend(planned.steps);
+            planned.return_
         }
         Statement::Use(use_) => plan_use_statement(use_, context)?,
         Statement::Assert(_) => {
@@ -93,6 +97,42 @@ fn plan_assignment(
     assignment: TypedAssignment,
     context: &mut PlanContext<'_>,
 ) -> Result<Step, PlanError> {
+    let (pattern, value) = plan_assignment_parts(assignment, context)?;
+    match pattern {
+        BindingPattern::Named(name) => plan_variable_runtime_step(name, value, context),
+        BindingPattern::Discard => Ok(Step::evaluate(value)),
+    }
+}
+
+struct PlannedFinalAssignment {
+    steps: Vec<Step>,
+    return_: Expr,
+}
+
+fn plan_final_assignment(
+    assignment: TypedAssignment,
+    context: &mut PlanContext<'_>,
+) -> Result<PlannedFinalAssignment, PlanError> {
+    let (pattern, value) = plan_assignment_parts(assignment, context)?;
+    Ok(match pattern {
+        BindingPattern::Named(name) => {
+            let (step, return_) = plan_variable_runtime_step_and_return(name, value, context);
+            PlannedFinalAssignment {
+                steps: vec![step],
+                return_,
+            }
+        }
+        BindingPattern::Discard => PlannedFinalAssignment {
+            steps: Vec::new(),
+            return_: value,
+        },
+    })
+}
+
+fn plan_assignment_parts(
+    assignment: TypedAssignment,
+    context: &mut PlanContext<'_>,
+) -> Result<(BindingPattern, Expr), PlanError> {
     match assignment.kind {
         AssignmentKind::Let => {}
         AssignmentKind::Generated => {
@@ -109,10 +149,7 @@ fn plan_assignment(
 
     let pattern = plan_binding_pattern(assignment.pattern)?;
     let value = plan_expr(assignment.value, context)?;
-    match pattern {
-        BindingPattern::Named(name) => plan_variable_runtime_step(name, value, context),
-        BindingPattern::Discard => Ok(Step::evaluate(value)),
-    }
+    Ok((pattern, value))
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -126,73 +163,152 @@ pub(in crate::planner) fn plan_variable_runtime_step(
     value: crate::plan::Expr,
     context: &mut PlanContext<'_>,
 ) -> Result<Step, PlanError> {
+    Ok(plan_variable_runtime_step_and_return(name, value, context).0)
+}
+
+fn plan_variable_runtime_step_and_return(
+    name: EcoString,
+    value: crate::plan::Expr,
+    context: &mut PlanContext<'_>,
+) -> (Step, Expr) {
     match value.into_kind() {
         ExprKind::Int(value) => {
             let local = context.define_int_local(name.clone());
-            Ok(Step::let_int(local, name, value))
+            (
+                Step::let_int(local, name.clone(), value),
+                Expr::int(IntExpr::local_get(local, name)),
+            )
         }
         ExprKind::String(value) => {
             let local = context.define_string_local(name.clone());
-            Ok(Step::let_string(local, name, value))
+            (
+                Step::let_string(local, name.clone(), value),
+                Expr::string(StringExpr::local_get(local, name)),
+            )
         }
         ExprKind::Float(value) => {
             let local = context.define_float_local(name.clone());
-            Ok(Step::let_float(local, name, value))
+            (
+                Step::let_float(local, name.clone(), value),
+                Expr::float(FloatExpr::local_get(local, name)),
+            )
         }
         ExprKind::Bool(value) => {
             let local = context.define_bool_local(name.clone());
-            Ok(Step::let_bool(local, name, value))
+            (
+                Step::let_bool(local, name.clone(), value),
+                Expr::bool(BoolExpr::local_get(local, name)),
+            )
         }
         ExprKind::Nil(value) => {
             let local = context.define_nil_local(name.clone());
-            Ok(Step::let_nil(local, name, value))
+            (
+                Step::let_nil(local, name.clone(), value),
+                Expr::nil(NilExpr::local_get(local, name)),
+            )
         }
         ExprKind::Tuple(value) => {
             let local = context.define_tuple_local(name.clone(), value.type_().to_vec());
-            Ok(Step::let_tuple(local, name, value))
+            let type_ = value.type_().to_vec();
+            (
+                Step::let_tuple(local, name.clone(), value),
+                Expr::tuple(TupleExpr::local_get(local, name, type_)),
+            )
         }
         ExprKind::List(value) => {
             let local = context.define_list_local(name.clone(), value.element_type().clone());
-            Ok(Step::let_list(local, name, value))
+            let element_type = value.element_type().clone();
+            (
+                Step::let_list(local, name.clone(), value),
+                Expr::list(ListExpr::local_get(local, name, element_type)),
+            )
         }
-        ExprKind::Function(value) => Ok(match value.into_kind() {
+        ExprKind::Function(value) => match value.into_kind() {
             FunctionExprKind::Int(value) => {
                 let local = context.define_int_function_local(name.clone(), value.type_().clone());
-                Step::let_int_function(local, name, value)
+                let type_ = value.type_().clone();
+                (
+                    Step::let_int_function(local, name.clone(), value),
+                    Expr::function(FunctionExpr::int(IntFunctionExpr::local_get(
+                        local, name, type_,
+                    ))),
+                )
             }
             FunctionExprKind::String(value) => {
                 let local =
                     context.define_string_function_local(name.clone(), value.type_().clone());
-                Step::let_string_function(local, name, value)
+                let type_ = value.type_().clone();
+                (
+                    Step::let_string_function(local, name.clone(), value),
+                    Expr::function(FunctionExpr::string(StringFunctionExpr::local_get(
+                        local, name, type_,
+                    ))),
+                )
             }
             FunctionExprKind::Float(value) => {
                 let local =
                     context.define_float_function_local(name.clone(), value.type_().clone());
-                Step::let_float_function(local, name, value)
+                let type_ = value.type_().clone();
+                (
+                    Step::let_float_function(local, name.clone(), value),
+                    Expr::function(FunctionExpr::float(FloatFunctionExpr::local_get(
+                        local, name, type_,
+                    ))),
+                )
             }
             FunctionExprKind::Bool(value) => {
                 let local = context.define_bool_function_local(name.clone(), value.type_().clone());
-                Step::let_bool_function(local, name, value)
+                let type_ = value.type_().clone();
+                (
+                    Step::let_bool_function(local, name.clone(), value),
+                    Expr::function(FunctionExpr::bool(BoolFunctionExpr::local_get(
+                        local, name, type_,
+                    ))),
+                )
             }
             FunctionExprKind::Nil(value) => {
                 let local = context.define_nil_function_local(name.clone(), value.type_().clone());
-                Step::let_nil_function(local, name, value)
+                let type_ = value.type_().clone();
+                (
+                    Step::let_nil_function(local, name.clone(), value),
+                    Expr::function(FunctionExpr::nil(NilFunctionExpr::local_get(
+                        local, name, type_,
+                    ))),
+                )
             }
             FunctionExprKind::Tuple(value) => {
                 let local =
                     context.define_tuple_function_local(name.clone(), value.type_().clone());
-                Step::let_tuple_function(local, name, value)
+                let type_ = value.type_().clone();
+                (
+                    Step::let_tuple_function(local, name.clone(), value),
+                    Expr::function(FunctionExpr::tuple(TupleFunctionExpr::local_get(
+                        local, name, type_,
+                    ))),
+                )
             }
             FunctionExprKind::List(value) => {
                 let local = context.define_list_function_local(name.clone(), value.type_().clone());
-                Step::let_list_function(local, name, value)
+                let type_ = value.type_().clone();
+                (
+                    Step::let_list_function(local, name.clone(), value),
+                    Expr::function(FunctionExpr::list(ListFunctionExpr::local_get(
+                        local, name, type_,
+                    ))),
+                )
             }
             FunctionExprKind::Function(value) => {
                 let local =
                     context.define_function_function_local(name.clone(), value.type_().clone());
-                Step::let_function_function(local, name, value)
+                let type_ = value.type_().clone();
+                (
+                    Step::let_function_function(local, name.clone(), value),
+                    Expr::function(FunctionExpr::function(FunctionFunctionExpr::local_get(
+                        local, name, type_,
+                    ))),
+                )
             }
-        }),
+        },
     }
 }
 
@@ -439,20 +555,57 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_final_statement_positions() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+    fn plan_final_assignment_returns_assigned_value_from_binding_step() {
+        let actual = plan_module(compile(
+            r#"
 pub fn main() {
   let x = 1
 }
 "#,
-            ),
-            PlanError::UnsupportedStatement {
-                kind: UnsupportedStatementKind::AssignmentAsFinalStatement,
-            },
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", local_int(0, "x")).let_int(0, "x", int(1)),
+            [],
         );
 
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_final_discard_assignment_returns_assigned_value_without_binding_step() {
+        let actual = plan_module(compile(
+            r#"
+pub fn main() {
+  let _ = 1
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module("main", function("main", int(1)), []);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_profile_final_assignment_value_is_validated() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  let x = echo 1
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Echo,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_profile_final_assert_statement() {
         assert_eq!(
             expect_plan_error(
                 r#"

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -49,6 +49,13 @@ mod bindings {
     );
 }
 
+mod statements {
+    execution_cases!("statements";
+        final_assignment,
+        final_discard_assignment,
+    );
+}
+
 mod operators {
     execution_cases!("operators";
         integer_arithmetic,
@@ -237,6 +244,7 @@ mod rejection {
 
     mod entrypoint {
         rejection_cases!("entrypoint";
+            empty_body,
             missing_main,
             main_with_arguments,
             unsupported_body,
@@ -284,7 +292,6 @@ mod rejection {
     mod statements {
         rejection_cases!("statements";
             assert_statement,
-            final_assignment,
             final_assert,
         );
     }

--- a/tests/fixtures/execution/statements/final_assignment.gleam
+++ b/tests/fixtures/execution/statements/final_assignment.gleam
@@ -1,3 +1,5 @@
 pub fn main() {
   let value = 1
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/statements/final_discard_assignment.gleam
+++ b/tests/fixtures/execution/statements/final_discard_assignment.gleam
@@ -1,0 +1,5 @@
+pub fn main() {
+  let _ = 1
+}
+
+// geam:expect Int(1)

--- a/tests/fixtures/rejection/entrypoint/empty_body.gleam
+++ b/tests/fixtures/rejection/entrypoint/empty_body.gleam
@@ -1,0 +1,2 @@
+pub fn main() {
+}


### PR DESCRIPTION
- Lower final let assignments through the normal assignment path and return the
  assigned value from the new local binding.
- Return discard final assignment values without creating a binding step.
- Move final assignment fixtures from rejection to execution coverage.
- Reject empty Gleam source bodies as todo expressions instead of masking them
  as unsupported return types.

Example: `pub fn main() { let value = 1 }` now evaluates to `Int(1)`.

Validation:
- `cargo fmt --check`
- `cargo test --quiet`
- `cargo test --locked --quiet`
- `cargo clippy --all-targets -- -D warnings`
- `cargo llvm-cov --summary-only --fail-under-lines 100`
- `git diff --check`
