### PR TITLE
Support type alias declarations

### DIFF
--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -8,8 +8,6 @@ pub enum UnsupportedTopLevelKind {
     Constant,
     #[error("custom type")]
     CustomType,
-    #[error("type alias")]
-    TypeAlias,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -21,7 +21,6 @@ pub fn plan_module(module: TypedModule) -> Result<ExecutionPlan, PlanError> {
     let imports = definitions.imports.len();
     let constants = definitions.constants.len();
     let custom_types = definitions.custom_types.len();
-    let type_aliases = definitions.type_aliases.len();
 
     if imports != 0 {
         return Err(PlanError::UnsupportedTopLevel {
@@ -36,11 +35,6 @@ pub fn plan_module(module: TypedModule) -> Result<ExecutionPlan, PlanError> {
     if custom_types != 0 {
         return Err(PlanError::UnsupportedTopLevel {
             kind: UnsupportedTopLevelKind::CustomType,
-        });
-    }
-    if type_aliases != 0 {
-        return Err(PlanError::UnsupportedTopLevel {
-            kind: UnsupportedTopLevelKind::TypeAlias,
         });
     }
 
@@ -426,6 +420,32 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_type_alias_function_signature_as_underlying_type() {
+        let actual = plan_module(compile(
+            r#"
+pub type UserId =
+  Int
+
+fn identity(value: UserId) -> UserId {
+  value
+}
+
+pub fn main() {
+  identity(41)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", int_return_tail_call(1, [int_arg(0, int(41))])),
+            [function("identity", local_int(0, "value")).param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn reject_profile_constant_definition() {
         assert_eq!(
             expect_plan_error(
@@ -764,6 +784,30 @@ fn count(values: BitArray) {
     }
 
     #[test]
+    fn reject_profile_type_alias_resolved_to_unsupported_argument_type() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub type Bits =
+  BitArray
+
+pub fn main() {
+  1
+}
+
+fn count(values: Bits) {
+  1
+}
+"#,
+            ),
+            PlanError::UnsupportedArgument {
+                function: "count".into(),
+                reason: UnsupportedArgumentReason::UnsupportedType,
+            },
+        );
+    }
+
+    #[test]
     fn reject_profile_labelled_function_argument() {
         assert_eq!(
             expect_plan_error(
@@ -811,20 +855,6 @@ pub fn main() {
 "#,
             PlanError::UnsupportedTopLevel {
                 kind: UnsupportedTopLevelKind::CustomType,
-            },
-        );
-
-        assert_plan_error(
-            r#"
-pub type UserId =
-  Int
-
-pub fn main() {
-  1
-}
-"#,
-            PlanError::UnsupportedTopLevel {
-                kind: UnsupportedTopLevelKind::TypeAlias,
             },
         );
     }

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -35,6 +35,15 @@ mod values {
     );
 }
 
+mod module_items {
+    execution_cases!("module_items";
+        type_alias,
+        type_alias_function_signature,
+        type_alias_compound_signature,
+        type_alias_generic_signature,
+    );
+}
+
 mod bindings {
     execution_cases!("bindings";
         let_binding,
@@ -241,7 +250,6 @@ mod rejection {
             import,
             constant,
             custom_type,
-            type_alias,
             external_function,
         );
     }

--- a/tests/fixtures/execution/module_items/type_alias.gleam
+++ b/tests/fixtures/execution/module_items/type_alias.gleam
@@ -4,3 +4,5 @@ pub type UserId =
 pub fn main() {
   1
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/module_items/type_alias_compound_signature.gleam
+++ b/tests/fixtures/execution/module_items/type_alias_compound_signature.gleam
@@ -1,0 +1,15 @@
+pub type UserId =
+  Int
+
+pub type UserNames =
+  #(UserId, List(String))
+
+fn pair(id: UserId, names: List(String)) -> UserNames {
+  #(id, names)
+}
+
+pub fn main() {
+  pair(1, ["one"])
+}
+
+// geam:expect Tuple([Int(1), List(String)([String("one")])])

--- a/tests/fixtures/execution/module_items/type_alias_function_signature.gleam
+++ b/tests/fixtures/execution/module_items/type_alias_function_signature.gleam
@@ -1,0 +1,12 @@
+pub type UserId =
+  Int
+
+fn identity(value: UserId) -> UserId {
+  value
+}
+
+pub fn main() {
+  identity(41)
+}
+
+// geam:expect Int(41)

--- a/tests/fixtures/execution/module_items/type_alias_generic_signature.gleam
+++ b/tests/fixtures/execution/module_items/type_alias_generic_signature.gleam
@@ -1,0 +1,12 @@
+pub type Values(value) =
+  List(value)
+
+fn identity(values: Values(Int)) -> Values(Int) {
+  values
+}
+
+pub fn main() {
+  identity([1])
+}
+
+// geam:expect List(Int)([Int(1)])


### PR DESCRIPTION
- Allow top-level type aliases without adding execution plan nodes.
- Keep alias validation at executable use sites through existing type lowering.
- Move type alias coverage from rejection to execution fixtures and cover
  signature, compound, and generic alias use.

Example:

pub type UserId =
  Int

fn identity(value: UserId) -> UserId {
  value
}
