### PR TITLE
Support labelled function arguments

### DIFF
--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -30,6 +30,7 @@ pub(super) struct FunctionInfo {
 pub(super) struct FunctionParam {
     pub(super) local: ParamLocal,
     pub(super) binding: ParamBinding,
+    pub(super) label: Option<EcoString>,
 }
 
 pub(super) struct PlanContext<'a> {

--- a/src/planner/error/invalid.rs
+++ b/src/planner/error/invalid.rs
@@ -41,6 +41,8 @@ pub enum InvalidFunctionShapeReason {
     Anonymous,
     #[error("empty function bodies are not supported")]
     EmptyBody,
+    #[error("labelled function argument")]
+    LabelledArgument,
     #[error("function return type does not match body")]
     ReturnTypeMismatch,
 }
@@ -145,8 +147,6 @@ pub enum InvalidCaseShapeReason {
 pub enum InvalidPipelineShapeReason {
     #[error("invalid hole capture")]
     InvalidHoleCapture,
-    #[error("labelled arguments")]
-    LabelledArguments,
     #[error("missing pipe argument")]
     MissingPipeArgument,
     #[error("multiple pipe arguments")]

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -24,8 +24,6 @@ pub enum UnsupportedFunctionReason {
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedArgumentReason {
-    #[error("labelled arguments are not supported")]
-    Labelled,
     #[error("argument type is not supported")]
     UnsupportedType,
 }

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -19,14 +19,6 @@ pub(super) fn plan_call(
     arguments: Vec<GleamCallArg<TypedExpr>>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    if arguments.iter().any(|argument| argument.label.is_some()) {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CallShape {
-                reason: InvalidCallShapeReason::LabelledArguments,
-            },
-        });
-    }
-
     if arguments.iter().any(|argument| argument.implicit.is_some()) {
         return Err(PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::CallShape {

--- a/src/planner/expression/call/direct.rs
+++ b/src/planner/expression/call/direct.rs
@@ -4,7 +4,7 @@ use crate::plan::{
     ListFunctionExpr, NilExpr, RuntimeFunctionId, StringExpr, TupleExpr, TupleFunctionExpr,
     ValueType,
 };
-use crate::planner::context::{FunctionInfo, PlanContext};
+use crate::planner::context::{FunctionInfo, FunctionParam, PlanContext};
 use crate::planner::error::{InvalidCallShapeReason, InvalidTypedAstReason, PlanError};
 use gleam_core::ast::{CallArg as GleamCallArg, TypedExpr};
 use gleam_core::type_::Type;
@@ -38,9 +38,29 @@ pub(super) fn plan_direct_function_call(
             },
         });
     }
+    validate_argument_labels(&arguments, &function.params)?;
     let args = super::argument::plan_call_args(arguments, &function.params, context, capture)?;
 
     Ok(call_expr(function_id, args))
+}
+
+fn validate_argument_labels(
+    arguments: &[GleamCallArg<TypedExpr>],
+    params: &[FunctionParam],
+) -> Result<(), PlanError> {
+    for (argument, param) in arguments.iter().zip(params) {
+        if let Some(label) = &argument.label
+            && param.label.as_ref() != Some(label)
+        {
+            return Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::LabelledArguments,
+                },
+            });
+        }
+    }
+
+    Ok(())
 }
 
 fn call_expr(function: RuntimeFunctionId, args: Vec<CallArg>) -> Expr {
@@ -221,6 +241,36 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_labelled_direct_call_uses_function_param_order() {
+        let actual = plan_module(compile(
+            r#"
+fn add(to base: Int, value amount: Int) {
+  base + amount
+}
+
+pub fn main() {
+  add(value: 2, to: 40)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_tail_call(1, [int_arg(0, int(40)), int_arg(1, int(2))]),
+            ),
+            [
+                function("add", local_int(0, "base").add_int(local_int(1, "amount")))
+                    .param_int(0, "base")
+                    .param_int(1, "amount"),
+            ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn reject_margin_direct_local_function_call_shapes() {
         let mut arity_mismatch_call = compile(
             r#"
@@ -351,6 +401,29 @@ pub fn main() {
             typed_int_expr(1),
             InvalidExpressionType::Nil,
             InvalidExpressionType::Int,
+        );
+
+        let mut wrong_label_call = compile(
+            r#"
+fn add(to base: Int, value amount: Int) {
+  base + amount
+}
+
+pub fn main() {
+  add(to: 1, value: 2)
+}
+"#,
+        );
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut wrong_label_call.definitions.functions[1].body[0]);
+        arguments[0].label = Some("wrong".into());
+        assert_eq!(
+            plan_module(wrong_label_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::LabelledArguments,
+                },
+            }),
         );
     }
 

--- a/src/planner/expression/call/function_value.rs
+++ b/src/planner/expression/call/function_value.rs
@@ -15,6 +15,14 @@ pub(super) fn plan_function_value_call(
     context: &mut PlanContext<'_>,
     capture: Option<&CaptureSubstitution>,
 ) -> Result<Expr, PlanError> {
+    if arguments.iter().any(|argument| argument.label.is_some()) {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CallShape {
+                reason: InvalidCallShapeReason::LabelledArguments,
+            },
+        });
+    }
+
     let function = {
         let expression = super::super::plan_expr(fun, context)?;
         let actual = super::super::expression_type(&expression);
@@ -614,6 +622,30 @@ pub fn main() {
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CallShape {
                     reason: InvalidCallShapeReason::FunctionCallArityMismatch,
+                },
+            }),
+        );
+
+        let mut labelled_argument_call = compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let function = add_one
+  function(1)
+}
+"#,
+        );
+        let (_, _, arguments) =
+            expect_call_statement_mut(&mut labelled_argument_call.definitions.functions[1].body[1]);
+        arguments[0].label = Some("value".into());
+        assert_eq!(
+            plan_module(labelled_argument_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::LabelledArguments,
                 },
             }),
         );

--- a/src/planner/expression/call/implicit.rs
+++ b/src/planner/expression/call/implicit.rs
@@ -2,8 +2,7 @@ use super::CaptureSubstitution;
 use crate::plan::Expr;
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
-    InvalidCallShapeReason, InvalidPipelineShapeReason, InvalidTypedAstReason,
-    InvalidUseShapeReason, PlanError,
+    InvalidPipelineShapeReason, InvalidTypedAstReason, InvalidUseShapeReason, PlanError,
 };
 use ecow::EcoString;
 use gleam_core::ast::{
@@ -63,13 +62,6 @@ pub(super) fn plan_pipeline_hole_call(
     let (fun, arguments) = pipeline_hole_body_call(body.next())?;
     if body.next().is_some() {
         return Err(invalid_hole_capture());
-    }
-    if arguments.iter().any(|argument| argument.label.is_some()) {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::LabelledArguments,
-            },
-        });
     }
     if arguments.iter().any(|argument| argument.implicit.is_some()) {
         return Err(PlanError::InvalidTypedAst {
@@ -132,14 +124,6 @@ fn pipeline_hole_body_call(
 fn normalize_use_call_arguments(
     mut arguments: Vec<GleamCallArg<TypedExpr>>,
 ) -> Result<Vec<GleamCallArg<TypedExpr>>, PlanError> {
-    if arguments.iter().any(|argument| argument.label.is_some()) {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CallShape {
-                reason: InvalidCallShapeReason::LabelledArguments,
-            },
-        });
-    }
-
     let mut callback_index = None;
     for (index, argument) in arguments.iter().enumerate() {
         match argument.implicit {
@@ -209,14 +193,6 @@ fn count_capture_arguments(
 }
 
 fn pipe_argument(arguments: &[GleamCallArg<TypedExpr>]) -> Result<&TypedExpr, PlanError> {
-    if arguments.iter().any(|argument| argument.label.is_some()) {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::LabelledArguments,
-            },
-        });
-    }
-
     let mut pipe_argument = None;
     for argument in arguments {
         match argument.implicit {

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -9,7 +9,7 @@ use crate::planner::error::{
     InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
 };
 use crate::planner::function::{anonymous_function_plan, plan_anonymous_function_body};
-use crate::planner::module::function_params;
+use crate::planner::module::{ParamLabelPolicy, function_params};
 use ecow::EcoString;
 use gleam_core::ast::{
     CAPTURE_VARIABLE, CallArg as GleamCallArg, FunctionLiteralKind, Statement, TypedArg, TypedExpr,
@@ -38,7 +38,7 @@ pub(super) fn plan_anonymous(
 
     let function_type = anonymous_function_type(type_.as_ref())?;
     let error_name = context.anonymous_function_error_name();
-    let params = function_params(error_name.clone(), &arguments)?;
+    let params = function_params(error_name.clone(), &arguments, ParamLabelPolicy::Reject)?;
     validate_argument_types(&error_name, &function_type, &params)?;
     plan_anonymous_with_valid_arguments(function_type, error_name, params, arguments, body, context)
 }
@@ -648,6 +648,53 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_function_capture_labelled_argument() {
+        let actual = plan_module(compile(
+            r#"
+fn add(to base: Int, value amount: Int) {
+  base + amount
+}
+
+pub fn main() {
+  let add_one = add(to: 1, value: _)
+  add_one(41)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let add_one = int_function_ref(2, [LocalId::Int(IntLocalId(0))]);
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    local_int_function(0, "add_one", [LocalId::Int(IntLocalId(0))]),
+                    [int_function_call_arg(0, int(41))],
+                ),
+            )
+            .step(let_int_function_step(0, "add_one", add_one)),
+            [
+                function("add", local_int(0, "base").add_int(local_int(1, "amount")))
+                    .param_int(0, "base")
+                    .param_int(1, "amount"),
+            ],
+            [function(
+                "<anonymous:0>",
+                int_return_tail_call(
+                    1,
+                    [
+                        int_arg(0, int(1)),
+                        int_arg(1, local_int(0, CAPTURE_VARIABLE)),
+                    ],
+                ),
+            )
+            .param_int(0, CAPTURE_VARIABLE)],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_function_capture_literal_with_closure_capture() {
         let actual = plan_module(compile(
             r#"
@@ -771,9 +818,11 @@ pub fn main() {
 
         assert_eq!(
             plan_module(module),
-            Err(PlanError::UnsupportedArgument {
-                function: "<anonymous:0>".into(),
-                reason: crate::planner::UnsupportedArgumentReason::Labelled,
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::FunctionShape {
+                    name: "<anonymous:0>".into(),
+                    reason: InvalidFunctionShapeReason::LabelledArgument,
+                },
             }),
         );
     }

--- a/src/planner/expression/pipeline.rs
+++ b/src/planner/expression/pipeline.rs
@@ -321,6 +321,78 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_pipeline_labelled_direct_call_uses_function_param_order() {
+        let actual = plan_module(compile(
+            r#"
+fn add(to base: Int, value amount: Int) {
+  base + amount
+}
+
+pub fn main() {
+  2 |> add(to: 40)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "_pipe", int(2))],
+                    int_return_tail_call(
+                        1,
+                        [int_arg(0, int(40)), int_arg(1, local_int(0, "_pipe"))],
+                    ),
+                ),
+            ),
+            [
+                function("add", local_int(0, "base").add_int(local_int(1, "amount")))
+                    .param_int(0, "base")
+                    .param_int(1, "amount"),
+            ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_pipeline_labelled_hole_call_uses_hole_position() {
+        let actual = plan_module(compile(
+            r#"
+fn add(to base: Int, value amount: Int) {
+  base + amount
+}
+
+pub fn main() {
+  2 |> add(to: 40, value: _)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "_pipe", int(2))],
+                    int_return_tail_call(
+                        1,
+                        [int_arg(0, int(40)), int_arg(1, local_int(0, "_pipe"))],
+                    ),
+                ),
+            ),
+            [
+                function("add", local_int(0, "base").add_int(local_int(1, "amount")))
+                    .param_int(0, "base")
+                    .param_int(1, "amount"),
+            ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_pipeline_function_value_call_shape() {
         let actual = plan_module(compile(
             r#"
@@ -642,7 +714,7 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_margin_pipeline_labelled_arguments() {
+    fn reject_margin_pipeline_labelled_argument_reaches_call_boundary() {
         let mut labelled_argument = compile_pipeline_module();
         let (_, _, finally, _) =
             expect_pipeline_statement_mut(&mut labelled_argument.definitions.functions[1].body[0]);
@@ -650,9 +722,11 @@ pub fn main() {
         arguments[0].label = Some("value".into());
         assert_eq!(
             plan_module(labelled_argument),
-            Err(invalid_pipeline_shape(
-                InvalidPipelineShapeReason::LabelledArguments,
-            )),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::LabelledArguments,
+                },
+            }),
         );
     }
 
@@ -769,19 +843,6 @@ pub fn main() {
             plan_module(extra_body_statement),
             Err(invalid_pipeline_shape(
                 InvalidPipelineShapeReason::InvalidHoleCapture,
-            )),
-        );
-
-        let mut labelled_inner_argument = compile_hole_pipeline_module();
-        let (_, _, body) = expect_pipeline_hole_capture_mut(
-            &mut labelled_inner_argument.definitions.functions[1].body[0],
-        );
-        let arguments = expect_call_arguments_mut(expect_expression_statement_mut(&mut body[0]));
-        arguments[0].label = Some("left".into());
-        assert_eq!(
-            plan_module(labelled_inner_argument),
-            Err(invalid_pipeline_shape(
-                InvalidPipelineShapeReason::LabelledArguments,
             )),
         );
 

--- a/src/planner/function.rs
+++ b/src/planner/function.rs
@@ -160,8 +160,7 @@ mod tests {
     use crate::planner::plan_module;
     use crate::planner::support::{compile, compile_minimal_module, expect_plan_error};
     use crate::planner::{
-        InvalidFunctionShapeReason, InvalidTypedAstReason, PlanError, UnsupportedArgumentReason,
-        UnsupportedFunctionReason,
+        InvalidFunctionShapeReason, InvalidTypedAstReason, PlanError, UnsupportedFunctionReason,
     };
 
     #[test]
@@ -1357,24 +1356,31 @@ pub fn nil_main() {
     }
 
     #[test]
-    fn reject_profile_labelled_arguments() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn identity(value value: Int) {
+    fn plan_labelled_discard_argument_preserves_param_slot() {
+        let actual = plan_module(compile(
+            r#"
+fn pick(ignored _: Int, value value: Int) {
   value
 }
 
 pub fn main() {
-  identity(1)
+  pick(value: 2, ignored: 1)
 }
 "#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_tail_call(1, [int_arg(0, int(1)), int_arg(1, int(2))]),
             ),
-            PlanError::UnsupportedArgument {
-                function: "identity".into(),
-                reason: UnsupportedArgumentReason::Labelled,
-            },
+            [function("pick", local_int(1, "value"))
+                .discard_int_param(0)
+                .param_int(1, "value")],
         );
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -6,8 +6,8 @@ use crate::planner::context::{
     AnonymousFunctions, FunctionInfo, FunctionParam, FunctionRuntimeIds,
 };
 use crate::planner::error::{
-    PlanError, UnsupportedArgumentReason, UnsupportedExpressionKind, UnsupportedFunctionReason,
-    UnsupportedTopLevelKind,
+    InvalidFunctionShapeReason, InvalidTypedAstReason, PlanError, UnsupportedArgumentReason,
+    UnsupportedExpressionKind, UnsupportedFunctionReason, UnsupportedTopLevelKind,
 };
 use crate::planner::function::{function_name, plan_function};
 use ecow::EcoString;
@@ -110,7 +110,7 @@ fn function_table(
         let name = function_name(function)?;
         reject_todo_body(function)?;
         let return_type = function_return_type(name.clone(), &function.return_type)?;
-        let params = function_params(name.clone(), &function.arguments)?;
+        let params = function_params(name.clone(), &function.arguments, ParamLabelPolicy::Allow)?;
         seeds.push(FunctionSeed {
             name,
             function: function.clone(),
@@ -218,6 +218,7 @@ fn reject_todo_body(function: &TypedFunction) -> Result<(), PlanError> {
 pub(super) fn function_params(
     function_name: EcoString,
     arguments: &[gleam_core::ast::TypedArg],
+    label_policy: ParamLabelPolicy,
 ) -> Result<Vec<FunctionParam>, PlanError> {
     let mut next_int = 0;
     let mut next_float = 0;
@@ -231,13 +232,25 @@ pub(super) fn function_params(
     arguments
         .iter()
         .map(|argument| {
-            let binding = match &argument.names {
-                ArgNames::Named { name, .. } => ParamBinding::Named(name.clone()),
-                ArgNames::Discard { .. } => ParamBinding::Discard,
-                ArgNames::LabelledDiscard { .. } | ArgNames::NamedLabelled { .. } => {
-                    return Err(PlanError::UnsupportedArgument {
-                        function: function_name.clone(),
-                        reason: UnsupportedArgumentReason::Labelled,
+            let (binding, label) = match &argument.names {
+                ArgNames::Named { name, .. } => (ParamBinding::Named(name.clone()), None),
+                ArgNames::Discard { .. } => (ParamBinding::Discard, None),
+                ArgNames::NamedLabelled { label, name, .. }
+                    if label_policy == ParamLabelPolicy::Allow =>
+                {
+                    (ParamBinding::Named(name.clone()), Some(label.clone()))
+                }
+                ArgNames::LabelledDiscard { label, .. }
+                    if label_policy == ParamLabelPolicy::Allow =>
+                {
+                    (ParamBinding::Discard, Some(label.clone()))
+                }
+                ArgNames::NamedLabelled { .. } | ArgNames::LabelledDiscard { .. } => {
+                    return Err(PlanError::InvalidTypedAst {
+                        reason: InvalidTypedAstReason::FunctionShape {
+                            name: function_name.clone(),
+                            reason: InvalidFunctionShapeReason::LabelledArgument,
+                        },
                     });
                 }
             };
@@ -290,9 +303,19 @@ pub(super) fn function_params(
                 }
                 ValueType::Function(type_) => function_locals.next(type_),
             };
-            Ok(FunctionParam { local, binding })
+            Ok(FunctionParam {
+                local,
+                binding,
+                label,
+            })
         })
         .collect()
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParamLabelPolicy {
+    Allow,
+    Reject,
 }
 
 #[derive(Default)]
@@ -808,24 +831,26 @@ fn count(values: Bits) {
     }
 
     #[test]
-    fn reject_profile_labelled_function_argument() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn identity(value value: Int) {
-  value
+    fn plan_labelled_function_argument_uses_local_name() {
+        let actual = plan_module(compile(
+            r#"
+fn identity(value local: Int) {
+  local
 }
 
 pub fn main() {
-  identity(1)
+  identity(value: 1)
 }
 "#,
-            ),
-            PlanError::UnsupportedArgument {
-                function: "identity".into(),
-                reason: UnsupportedArgumentReason::Labelled,
-            },
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", int_return_tail_call(1, [int_arg(0, int(1))])),
+            [function("identity", local_int(0, "local")).param_int(0, "local")],
         );
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/src/planner/statement.rs
+++ b/src/planner/statement.rs
@@ -374,10 +374,11 @@ mod tests {
     use crate::plan::{BoolLocalId, IntLocalId, LocalId, NilLocalId, StringLocalId, ValueType};
     use crate::planner::dsl::{
         bool_, bool_case_int_function, bool_function_ref, call_int_function, capture_int, function,
-        int, int_function_arg, int_function_call_arg, int_function_closure, int_function_ref,
-        int_return_tail_call, let_bool_function_step, let_int_function_step, let_nil_function_step,
-        let_string_function_step, local_bool, local_int, local_int_function, local_nil,
-        local_string, module, module_with_anonymous, nil_function_ref, string_function_ref,
+        int, int_arg, int_function_arg, int_function_call_arg, int_function_closure,
+        int_function_ref, int_return_tail_call, let_bool_function_step, let_int_function_step,
+        let_nil_function_step, let_string_function_step, local_bool, local_int, local_int_function,
+        local_nil, local_string, module, module_with_anonymous, nil_function_ref,
+        string_function_ref,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, compile_minimal_module, dummy_span, expect_plan_error};
@@ -765,6 +766,51 @@ pub fn main() {
                 local_int(0, "value").add_int(local_int(1, "base")),
             )
             .param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_use_syntax_with_labelled_provider_argument() {
+        let actual = plan_module(compile(
+            r#"
+fn with_value(value value: Int, continue continue: fn(Int) -> Int) {
+  continue(value)
+}
+
+pub fn main() {
+  use value <- with_value(value: 41)
+  value + 1
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module_with_anonymous(
+            "main",
+            function(
+                "main",
+                int_return_tail_call(
+                    1,
+                    [
+                        int_arg(0, int(41)),
+                        int_function_arg(0, int_function_ref(2, [LocalId::Int(IntLocalId(0))])),
+                    ],
+                ),
+            ),
+            [function(
+                "with_value",
+                call_int_function(
+                    local_int_function(0, "continue", [ValueType::Int]),
+                    [int_function_call_arg(0, local_int(0, "value"))],
+                ),
+            )
+            .param_int(0, "value")
+            .param_int_function(0, "continue", [ValueType::Int])],
+            [
+                function("<anonymous:0>", local_int(0, "value").add_int(int(1)))
+                    .param_int(0, "value"),
+            ],
         );
 
         assert_eq!(actual, expected);

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -114,6 +114,8 @@ mod pipeline {
         float_pipeline,
         tuple_pipeline,
         list_pipeline,
+        labelled_argument,
+        labelled_hole_argument,
         function_value_call,
         anonymous_function_call,
         function_value_hole_call,
@@ -158,6 +160,9 @@ mod functions {
         execution_cases!("functions/argument";
             discard_argument,
             discard_mixed_arguments,
+            labelled_argument,
+            labelled_argument_call,
+            labelled_discard_argument,
             function_value_argument_callback,
             function_value_argument_discard,
             function_value_argument_float,
@@ -210,6 +215,7 @@ mod functions {
             anonymous_list_function,
             anonymous_function_main_returning_function,
             function_capture_literal,
+            function_capture_labelled_argument,
             function_capture_literal_first_argument,
             function_capture_literal_closure,
             function_capture_literal_local_function_value,
@@ -230,6 +236,7 @@ mod functions {
         execution_cases!("functions/use";
             use_no_assignment,
             use_value,
+            use_labelled_argument,
             use_discard_assignment,
             use_multiple_assignments,
             use_nested,
@@ -265,7 +272,6 @@ mod rejection {
 
     mod functions {
         rejection_cases!("functions";
-            labelled_argument,
             generic_function,
             unsupported_argument_type,
             unsupported_function_argument_type,

--- a/tests/fixtures/execution/functions/anonymous/function_capture_labelled_argument.gleam
+++ b/tests/fixtures/execution/functions/anonymous/function_capture_labelled_argument.gleam
@@ -1,0 +1,10 @@
+fn add(to base: Int, value amount: Int) {
+  base + amount
+}
+
+pub fn main() {
+  let add_one = add(to: 1, value: _)
+  add_one(41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/argument/labelled_argument.gleam
+++ b/tests/fixtures/execution/functions/argument/labelled_argument.gleam
@@ -5,3 +5,5 @@ fn identity(value value: Int) {
 pub fn main() {
   identity(1)
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/functions/argument/labelled_argument_call.gleam
+++ b/tests/fixtures/execution/functions/argument/labelled_argument_call.gleam
@@ -1,0 +1,9 @@
+fn add(to base: Int, value amount: Int) {
+  base + amount
+}
+
+pub fn main() {
+  add(value: 2, to: 40)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/functions/argument/labelled_discard_argument.gleam
+++ b/tests/fixtures/execution/functions/argument/labelled_discard_argument.gleam
@@ -1,0 +1,9 @@
+fn ignore(value _: Int) {
+  1
+}
+
+pub fn main() {
+  ignore(value: 41)
+}
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/functions/use/use_labelled_argument.gleam
+++ b/tests/fixtures/execution/functions/use/use_labelled_argument.gleam
@@ -1,0 +1,10 @@
+fn with_value(value value: Int, continue continue: fn(Int) -> Int) {
+  continue(value)
+}
+
+pub fn main() {
+  use value <- with_value(value: 41)
+  value + 1
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/pipeline/labelled_argument.gleam
+++ b/tests/fixtures/execution/pipeline/labelled_argument.gleam
@@ -1,0 +1,9 @@
+fn add(to base: Int, value amount: Int) {
+  base + amount
+}
+
+pub fn main() {
+  2 |> add(to: 40)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/pipeline/labelled_hole_argument.gleam
+++ b/tests/fixtures/execution/pipeline/labelled_hole_argument.gleam
@@ -1,0 +1,9 @@
+fn add(to base: Int, value amount: Int) {
+  base + amount
+}
+
+pub fn main() {
+  2 |> add(to: 40, value: _)
+}
+
+// geam:expect Int(42)


### PR DESCRIPTION
- Store top-level argument labels as planner-only call matching metadata.
- Allow labelled direct calls through use, pipeline, and capture-literal paths.
- Keep function-value labelled calls and anonymous labelled params as typed-AST
  margin rejects.

Example:

```gleam
fn add(to base: Int, value amount: Int) {
  base + amount
}

pub fn main() {
  add(value: 2, to: 40)
}
```
