### PR TITLE
Support constant declarations

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,7 +49,7 @@ cargo fmt --check
 cargo clippy --all-targets -- -D warnings
 ```
 
-## Line Coverage
+## Coverage
 
 Geam uses `cargo-llvm-cov` for local line coverage. It is LLVM-based, works well
 on macOS, and keeps generated reports under `target/`.
@@ -66,6 +66,22 @@ Print a line coverage summary:
 ```sh
 cargo llvm-cov --summary-only
 ```
+
+Line coverage is the current enforced gate, and Geam keeps it at 100%. Region
+coverage is not yet an enforced gate, but it is a useful direction for tightening
+tests as the supported profile grows. Prefer tests that cover meaningful region
+gaps when the missing region maps to a real planner, plan, or runtime branch.
+
+When a coverage gap is hard to explain from the summary alone, split the target
+and inspect LLVM's region and instantiation detail before adding fixtures:
+
+```sh
+cargo llvm-cov --lib --text --show-instantiations --show-missing-lines
+```
+
+Use that report to decide where the test belongs. Public execution behavior
+belongs in fixture-based integration tests; planner or runtime implementation
+branches belong in the owning unit test next to that module.
 
 Generate an HTML report:
 

--- a/src/planner/error/invalid.rs
+++ b/src/planner/error/invalid.rs
@@ -55,8 +55,6 @@ pub enum InvalidExpressionShapeKind {
     FunctionCaptureLiteral,
     #[error("module select")]
     ModuleSelect,
-    #[error("module constant")]
-    ModuleConstant,
     #[error("positional access")]
     PositionalAccess,
     #[error("prelude constructor")]

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -60,6 +60,8 @@ pub enum UnsupportedExpressionKind {
     UnsupportedListElementType,
     #[error("panic")]
     Panic,
+    #[error("record constructor")]
+    RecordConstructor,
     #[error("todo")]
     Todo,
     #[error("function literal type is not supported")]

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -4,8 +4,6 @@ use thiserror::Error;
 pub enum UnsupportedTopLevelKind {
     #[error("import")]
     Import,
-    #[error("constant")]
-    Constant,
     #[error("custom type")]
     CustomType,
 }

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -7,10 +7,11 @@ use crate::plan::Expr;
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
     InvalidCallShapeReason, InvalidTypedAstReason, InvalidUseShapeReason, PlanError,
+    UnsupportedExpressionKind,
 };
 use ecow::EcoString;
 use gleam_core::ast::{CallArg as GleamCallArg, TypedExpr};
-use gleam_core::type_::{Type, ValueConstructorVariant};
+use gleam_core::type_::{PRELUDE_MODULE_NAME, Type, ValueConstructorVariant};
 use std::sync::Arc;
 
 pub(super) fn plan_call(
@@ -121,6 +122,13 @@ fn plan_call_expression(
                 });
             }
             ValueConstructorVariant::ModuleConstant { .. } => {}
+            ValueConstructorVariant::Record { module, arity, .. }
+                if module == PRELUDE_MODULE_NAME && *arity > 0 =>
+            {
+                return Err(PlanError::UnsupportedExpression {
+                    kind: UnsupportedExpressionKind::RecordConstructor,
+                });
+            }
             ValueConstructorVariant::Record { .. } => {
                 return Err(PlanError::InvalidTypedAst {
                     reason: InvalidTypedAstReason::CallShape {
@@ -220,12 +228,32 @@ pub fn main() {
 
 #[cfg(test)]
 mod tests {
+    use super::super::{module_returning_typed_expr, typed_prelude_constructor};
     use super::support::{expect_call_statement_mut, expect_var_constructor_mut};
     use crate::planner::plan_module;
     use crate::planner::support::{compile, dummy_span};
-    use crate::planner::{InvalidCallShapeReason, InvalidTypedAstReason, PlanError};
+    use crate::planner::{
+        InvalidCallShapeReason, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
+    };
     use gleam_core::ast::{ImplicitCallArgOrigin, Statement, TypedExpr, TypedModule};
     use gleam_core::type_::{self, ValueConstructorVariant, error::VariableOrigin};
+
+    #[test]
+    fn reject_profile_prelude_record_constructor_call() {
+        assert_eq!(
+            plan_module(compile(
+                r#"
+pub fn main() {
+  Ok(1)
+  1
+}
+"#,
+            )),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::RecordConstructor,
+            }),
+        );
+    }
 
     #[test]
     fn reject_margin_module_constant_call_shape() {
@@ -376,6 +404,21 @@ pub fn main() {
         record_constructor_call.definitions.custom_types.clear();
         assert_eq!(
             plan_module(record_constructor_call),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CallShape {
+                    reason: InvalidCallShapeReason::RecordConstructor,
+                },
+            }),
+        );
+
+        assert_eq!(
+            plan_module(module_returning_typed_expr(TypedExpr::Call {
+                location: dummy_span(),
+                type_: type_::bool(),
+                fun: Box::new(typed_prelude_constructor("True", type_::bool())),
+                arguments: Vec::new(),
+                open_parenthesis: Some(0),
+            })),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CallShape {
                     reason: InvalidCallShapeReason::RecordConstructor,

--- a/src/planner/expression/call.rs
+++ b/src/planner/expression/call.rs
@@ -111,13 +111,16 @@ fn plan_call_expression(
                     type_, function, arguments, context, capture,
                 );
             }
-            ValueConstructorVariant::ModuleConstant { .. } => {
+            ValueConstructorVariant::ModuleConstant { literal, .. }
+                if literal.type_().fn_types().is_none() =>
+            {
                 return Err(PlanError::InvalidTypedAst {
                     reason: InvalidTypedAstReason::CallShape {
                         reason: InvalidCallShapeReason::ModuleConstant,
                     },
                 });
             }
+            ValueConstructorVariant::ModuleConstant { .. } => {}
             ValueConstructorVariant::Record { .. } => {
                 return Err(PlanError::InvalidTypedAst {
                     reason: InvalidTypedAstReason::CallShape {

--- a/src/planner/expression/var.rs
+++ b/src/planner/expression/var.rs
@@ -6,7 +6,9 @@ use crate::plan::{
     NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr, TupleFunctionExpr, ValueType,
 };
 use crate::planner::context::{FunctionLocalBinding, PlanContext};
-use crate::planner::error::{InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError};
+use crate::planner::error::{
+    InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
+};
 use ecow::EcoString;
 use gleam_core::type_::{PRELUDE_MODULE_NAME, ValueConstructor, ValueConstructorVariant};
 
@@ -39,16 +41,26 @@ pub(super) fn plan_var(
             module,
             arity,
             ..
-        } if arity == 0 && module == PRELUDE_MODULE_NAME => match name.as_str() {
-            "True" => Ok(Expr::bool(BoolExpr::value(true))),
-            "False" => Ok(Expr::bool(BoolExpr::value(false))),
-            "Nil" => Ok(Expr::nil(NilExpr::value())),
-            _ => Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionShape {
-                    kind: InvalidExpressionShapeKind::PreludeConstructor,
-                },
-            }),
-        },
+        } if module == PRELUDE_MODULE_NAME => {
+            if arity == 0 {
+                match name.as_str() {
+                    "True" => return Ok(Expr::bool(BoolExpr::value(true))),
+                    "False" => return Ok(Expr::bool(BoolExpr::value(false))),
+                    "Nil" => return Ok(Expr::nil(NilExpr::value())),
+                    _ => {
+                        return Err(PlanError::InvalidTypedAst {
+                            reason: InvalidTypedAstReason::ExpressionShape {
+                                kind: InvalidExpressionShapeKind::PreludeConstructor,
+                            },
+                        });
+                    }
+                }
+            }
+
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::RecordConstructor,
+            })
+        }
         ValueConstructorVariant::ModuleFn {
             module,
             name,
@@ -151,11 +163,13 @@ mod tests {
         local_float, local_int, local_int_function, local_nil, local_string, module, nil,
     };
     use crate::planner::plan_module;
-    use crate::planner::support::compile;
-    use crate::planner::{InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError};
+    use crate::planner::support::{compile, dummy_span};
+    use crate::planner::{
+        InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
+    };
     use ecow::EcoString;
-    use gleam_core::ast::{Statement, TypedExpr, TypedStatement};
-    use gleam_core::type_;
+    use gleam_core::ast::{Publicity, Statement, TypedExpr, TypedStatement};
+    use gleam_core::type_::{self, Deprecation, ValueConstructor, ValueConstructorVariant};
 
     #[test]
     fn plan_local_variables() {
@@ -433,6 +447,25 @@ pub fn main() {
     }
 
     #[test]
+    fn prelude_record_constructor_values_are_profile_out() {
+        assert_eq!(
+            plan_module(module_returning_typed_expr(
+                typed_prelude_record_constructor(
+                    "Ok",
+                    type_::fn_(
+                        vec![type_::int()],
+                        type_::result(type_::int(), type_::nil()),
+                    ),
+                    1,
+                )
+            )),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::RecordConstructor,
+            }),
+        );
+    }
+
+    #[test]
     fn reject_margin_local_type_shape_mismatch() {
         assert_eq!(
             super::local_get(
@@ -474,6 +507,32 @@ pub fn main() {
             panic!("expected variable expression");
         };
         (name, constructor)
+    }
+
+    fn typed_prelude_record_constructor(
+        name: &str,
+        type_: std::sync::Arc<type_::Type>,
+        arity: u16,
+    ) -> TypedExpr {
+        TypedExpr::Var {
+            location: dummy_span(),
+            name: name.into(),
+            constructor: ValueConstructor {
+                publicity: Publicity::Private,
+                deprecation: Deprecation::NotDeprecated,
+                type_,
+                variant: ValueConstructorVariant::Record {
+                    name: name.into(),
+                    arity,
+                    field_map: None,
+                    location: dummy_span(),
+                    module: type_::PRELUDE_MODULE_NAME.into(),
+                    variants_count: 1,
+                    variant_index: 0,
+                    documentation: None,
+                },
+            },
+        }
     }
 
     #[test]

--- a/src/planner/expression/var.rs
+++ b/src/planner/expression/var.rs
@@ -1,3 +1,5 @@
+mod constant;
+
 use crate::plan::{
     BoolExpr, BoolFunctionExpr, Expr, FloatExpr, FloatFunctionExpr, FunctionExpr,
     FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr, ListFunctionExpr, LocalId, NilExpr,
@@ -73,9 +75,12 @@ pub(super) fn plan_var(
                 kind: InvalidExpressionShapeKind::ModuleSelect,
             },
         }),
+        ValueConstructorVariant::ModuleConstant {
+            module, literal, ..
+        } if module == *context.module_name => constant::plan(literal, context),
         ValueConstructorVariant::ModuleConstant { .. } => Err(PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::ExpressionShape {
-                kind: InvalidExpressionShapeKind::ModuleConstant,
+                kind: InvalidExpressionShapeKind::ModuleSelect,
             },
         }),
         ValueConstructorVariant::Record { .. } => Err(PlanError::InvalidTypedAst {
@@ -388,25 +393,6 @@ pub fn main() {
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::ExpressionShape {
                     kind: InvalidExpressionShapeKind::ModuleSelect,
-                },
-            }),
-        );
-
-        let mut module_constant = compile(
-            r#"
-const answer = 1
-
-pub fn main() {
-  answer
-}
-"#,
-        );
-        module_constant.definitions.constants.clear();
-        assert_eq!(
-            plan_module(module_constant),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionShape {
-                    kind: InvalidExpressionShapeKind::ModuleConstant,
                 },
             }),
         );

--- a/src/planner/expression/var/constant.rs
+++ b/src/planner/expression/var/constant.rs
@@ -304,12 +304,13 @@ mod tests {
 const number = 1
 const ratio = 1.5
 const label = "ge" <> "am"
+const pair = #(1, "one")
 const truth = True
 const falsehood = False
 const nothing = Nil
 
 pub fn main() {
-  #(number, ratio, label, truth, falsehood, nothing)
+  #(number, ratio, label, pair, truth, falsehood, nothing)
 }
 "#,
         ))
@@ -322,6 +323,7 @@ pub fn main() {
                     Expr::from(int(1)),
                     Expr::from(float(1.5)),
                     Expr::from(string("ge").concatenate(string("am"))),
+                    Expr::from(tuple([Expr::from(int(1)), Expr::from(string("one"))])),
                     Expr::from(bool_(true)),
                     Expr::from(bool_(false)),
                     Expr::from(nil()),

--- a/src/planner/expression/var/constant.rs
+++ b/src/planner/expression/var/constant.rs
@@ -249,7 +249,9 @@ fn plan_record(
     if arguments_are_empty {
         plan_record_constructor(name, module, arity)
     } else {
-        invalid_expression_shape(InvalidExpressionShapeKind::RecordConstructor)
+        Err(PlanError::UnsupportedExpression {
+            kind: UnsupportedExpressionKind::RecordConstructor,
+        })
     }
 }
 
@@ -258,13 +260,23 @@ fn plan_record_constructor(
     module: ecow::EcoString,
     arity: u16,
 ) -> Result<Expr, PlanError> {
-    if arity == 0 && module == PRELUDE_MODULE_NAME {
-        match name.as_str() {
-            "True" => Ok(Expr::bool(BoolExpr::value(true))),
-            "False" => Ok(Expr::bool(BoolExpr::value(false))),
-            "Nil" => Ok(Expr::nil(NilExpr::value())),
-            _ => invalid_expression_shape(InvalidExpressionShapeKind::PreludeConstructor),
+    if module == PRELUDE_MODULE_NAME {
+        if arity == 0 {
+            match name.as_str() {
+                "True" => return Ok(Expr::bool(BoolExpr::value(true))),
+                "False" => return Ok(Expr::bool(BoolExpr::value(false))),
+                "Nil" => return Ok(Expr::nil(NilExpr::value())),
+                _ => {
+                    return invalid_expression_shape(
+                        InvalidExpressionShapeKind::PreludeConstructor,
+                    );
+                }
+            }
         }
+
+        Err(PlanError::UnsupportedExpression {
+            kind: UnsupportedExpressionKind::RecordConstructor,
+        })
     } else {
         invalid_expression_shape(InvalidExpressionShapeKind::RecordConstructor)
     }
@@ -423,11 +435,95 @@ pub fn main() {
 }
 "#,
             ),
-            PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionShape {
-                    kind: InvalidExpressionShapeKind::RecordConstructor,
-                },
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::RecordConstructor,
             },
+        );
+    }
+
+    #[test]
+    fn constant_literal_child_errors_propagate() {
+        assert_eq!(
+            plan_constant_literal(Constant::Tuple {
+                location: dummy_span(),
+                elements: vec![
+                    Constant::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    },
+                    Constant::BitArray {
+                        location: dummy_span(),
+                        segments: Vec::new(),
+                    },
+                ],
+                type_: type_::tuple(vec![type_::int(), type_::bit_array()]),
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: vec![
+                    Constant::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    },
+                    Constant::BitArray {
+                        location: dummy_span(),
+                        segments: Vec::new(),
+                    },
+                ],
+                type_: type_::list(type_::int()),
+                tail: None,
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::StringConcatenation {
+                location: dummy_span(),
+                left: Box::new(Constant::String {
+                    location: dummy_span(),
+                    value: "left".into(),
+                }),
+                right: Box::new(Constant::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                }),
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::list(type_::bit_array()),
+                tail: None,
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::UnsupportedListElementType,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::list(type_::int()),
+                tail: Some(Box::new(Constant::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                })),
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
         );
     }
 
@@ -477,26 +573,6 @@ pub fn main() {
             }),
         );
         assert_eq!(
-            plan_constant_literal(Constant::Tuple {
-                location: dummy_span(),
-                elements: vec![
-                    Constant::Int {
-                        location: dummy_span(),
-                        value: "1".into(),
-                        int_value: 1.into(),
-                    },
-                    Constant::BitArray {
-                        location: dummy_span(),
-                        segments: Vec::new(),
-                    },
-                ],
-                type_: type_::tuple(vec![type_::int(), type_::bit_array()]),
-            }),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::BitArray,
-            }),
-        );
-        assert_eq!(
             plan_constant_literal(Constant::List {
                 location: dummy_span(),
                 elements: Vec::new(),
@@ -521,45 +597,6 @@ pub fn main() {
                 reason: InvalidTypedAstReason::ExpressionType {
                     expected: InvalidExpressionType::List,
                     actual: InvalidExpressionType::Unsupported,
-                },
-            }),
-        );
-        assert_eq!(
-            plan_constant_literal(Constant::List {
-                location: dummy_span(),
-                elements: vec![
-                    Constant::Int {
-                        location: dummy_span(),
-                        value: "1".into(),
-                        int_value: 1.into(),
-                    },
-                    Constant::BitArray {
-                        location: dummy_span(),
-                        segments: Vec::new(),
-                    },
-                ],
-                type_: type_::list(type_::int()),
-                tail: None,
-            }),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::BitArray,
-            }),
-        );
-        assert_eq!(
-            plan_constant_literal(Constant::List {
-                location: dummy_span(),
-                elements: vec![Constant::Int {
-                    location: dummy_span(),
-                    value: "1".into(),
-                    int_value: 1.into(),
-                }],
-                type_: type_::list(type_::string()),
-                tail: None,
-            }),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionType {
-                    expected: InvalidExpressionType::String,
-                    actual: InvalidExpressionType::Int,
                 },
             }),
         );
@@ -670,22 +707,6 @@ pub fn main() {
         assert_eq!(
             plan_constant_literal(Constant::StringConcatenation {
                 location: dummy_span(),
-                left: Box::new(Constant::BitArray {
-                    location: dummy_span(),
-                    segments: Vec::new(),
-                }),
-                right: Box::new(Constant::String {
-                    location: dummy_span(),
-                    value: "right".into(),
-                }),
-            }),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::BitArray,
-            }),
-        );
-        assert_eq!(
-            plan_constant_literal(Constant::StringConcatenation {
-                location: dummy_span(),
                 left: Box::new(Constant::String {
                     location: dummy_span(),
                     value: "left".into(),
@@ -704,33 +725,6 @@ pub fn main() {
             }),
         );
         assert_eq!(
-            plan_constant_literal(Constant::StringConcatenation {
-                location: dummy_span(),
-                left: Box::new(Constant::String {
-                    location: dummy_span(),
-                    value: "left".into(),
-                }),
-                right: Box::new(Constant::BitArray {
-                    location: dummy_span(),
-                    segments: Vec::new(),
-                }),
-            }),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::BitArray,
-            }),
-        );
-        assert_eq!(
-            plan_constant_literal(Constant::List {
-                location: dummy_span(),
-                elements: Vec::new(),
-                type_: type_::list(type_::bit_array()),
-                tail: None,
-            }),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::UnsupportedListElementType,
-            }),
-        );
-        assert_eq!(
             plan_constant_literal(Constant::List {
                 location: dummy_span(),
                 elements: Vec::new(),
@@ -746,20 +740,6 @@ pub fn main() {
                     expected: InvalidExpressionType::List,
                     actual: InvalidExpressionType::Int,
                 },
-            }),
-        );
-        assert_eq!(
-            plan_constant_literal(Constant::List {
-                location: dummy_span(),
-                elements: Vec::new(),
-                type_: type_::list(type_::int()),
-                tail: Some(Box::new(Constant::BitArray {
-                    location: dummy_span(),
-                    segments: Vec::new(),
-                })),
-            }),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::BitArray,
             }),
         );
         assert_eq!(
@@ -919,6 +899,25 @@ pub fn main() {
     }
 
     #[test]
+    fn constant_prelude_record_constructor_values_are_profile_out() {
+        assert_eq!(
+            plan_constant_literal(Constant::Var {
+                location: dummy_span(),
+                module: None,
+                name: "Ok".into(),
+                constructor: Some(Box::new(record_constructor("Ok", "gleam", 1))),
+                type_: type_::fn_(
+                    vec![type_::int()],
+                    type_::result(type_::int(), type_::nil())
+                ),
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::RecordConstructor,
+            }),
+        );
+    }
+
+    #[test]
     fn reject_margin_constant_module_constructor_shapes() {
         let mut missing_function = function_constant_module();
         missing_function.definitions.functions.retain(|function| {
@@ -970,7 +969,7 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_margin_module_constant_literal_shapes() {
+    fn module_constant_literal_child_errors_propagate() {
         assert_eq!(
             plan_module(module_with_main_constant_literal(
                 Constant::StringConcatenation {
@@ -993,6 +992,28 @@ pub fn main() {
             plan_module(module_with_main_constant_literal(
                 Constant::StringConcatenation {
                     location: dummy_span(),
+                    left: Box::new(Constant::String {
+                        location: dummy_span(),
+                        value: "left".into(),
+                    }),
+                    right: Box::new(Constant::BitArray {
+                        location: dummy_span(),
+                        segments: Vec::new(),
+                    }),
+                }
+            )),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_module_constant_literal_shapes() {
+        assert_eq!(
+            plan_module(module_with_main_constant_literal(
+                Constant::StringConcatenation {
+                    location: dummy_span(),
                     left: Box::new(Constant::Int {
                         location: dummy_span(),
                         value: "1".into(),
@@ -1009,24 +1030,6 @@ pub fn main() {
                     expected: InvalidExpressionType::String,
                     actual: InvalidExpressionType::Int,
                 },
-            }),
-        );
-        assert_eq!(
-            plan_module(module_with_main_constant_literal(
-                Constant::StringConcatenation {
-                    location: dummy_span(),
-                    left: Box::new(Constant::String {
-                        location: dummy_span(),
-                        value: "left".into(),
-                    }),
-                    right: Box::new(Constant::BitArray {
-                        location: dummy_span(),
-                        segments: Vec::new(),
-                    }),
-                }
-            )),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::BitArray,
             }),
         );
         assert_eq!(

--- a/src/planner/expression/var/constant.rs
+++ b/src/planner/expression/var/constant.rs
@@ -1,0 +1,1168 @@
+use super::super::{invalid_expression_type, invalid_expression_type_for_value};
+use crate::plan::{
+    BoolExpr, Expr, FloatExpr, FunctionExpr, IntExpr, ListExpr, NilExpr, StringExpr, TupleExpr,
+    ValueType,
+};
+use crate::planner::context::PlanContext;
+use crate::planner::error::{
+    InvalidExpressionShapeKind, InvalidExpressionType, InvalidTypedAstReason, PlanError,
+    UnsupportedExpressionKind,
+};
+use gleam_core::ast::Constant;
+use gleam_core::type_::{PRELUDE_MODULE_NAME, Type, ValueConstructor, ValueConstructorVariant};
+use std::sync::Arc;
+
+pub(super) fn plan(
+    literal: Constant<Arc<Type>>,
+    context: &PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    match literal {
+        Constant::Int { int_value, .. } => Ok(Expr::int(IntExpr::value(int_value))),
+        Constant::Float { float_value, .. } => {
+            Ok(Expr::float(FloatExpr::value(float_value.value())))
+        }
+        Constant::String { value, .. } => Ok(Expr::string(StringExpr::value(value))),
+        Constant::StringConcatenation { left, right, .. } => {
+            let left = plan_string(*left, context)?;
+            let right = plan_string(*right, context)?;
+
+            Ok(Expr::string(StringExpr::concatenate(left, right)))
+        }
+        Constant::Tuple {
+            elements, type_, ..
+        } => plan_tuple(elements, type_, context),
+        Constant::List {
+            elements,
+            tail,
+            type_,
+            ..
+        } => plan_list(elements, tail.map(|tail| *tail), type_, context),
+        Constant::Var { constructor, .. } => {
+            plan_var(constructor.map(|constructor| *constructor), context)
+        }
+        Constant::Record {
+            arguments,
+            record_constructor,
+            ..
+        } => plan_record(
+            arguments,
+            record_constructor.map(|constructor| *constructor),
+        ),
+        Constant::BitArray { .. } => Err(PlanError::UnsupportedExpression {
+            kind: UnsupportedExpressionKind::BitArray,
+        }),
+        Constant::Todo { .. } => Err(PlanError::UnsupportedExpression {
+            kind: UnsupportedExpressionKind::Todo,
+        }),
+        Constant::RecordUpdate { .. } => {
+            invalid_expression_shape(InvalidExpressionShapeKind::RecordUpdate)
+        }
+        Constant::Invalid { .. } => invalid_expression_shape(InvalidExpressionShapeKind::Invalid),
+    }
+}
+
+fn plan_string(
+    literal: Constant<Arc<Type>>,
+    context: &PlanContext<'_>,
+) -> Result<StringExpr, PlanError> {
+    let expression = plan(literal, context)?;
+    let actual = expression.value_type();
+    match expression.into_string() {
+        Some(expression) => Ok(expression),
+        None => Err(invalid_expression_type_for_value(ValueType::String, actual)),
+    }
+}
+
+fn plan_tuple(
+    elements: Vec<Constant<Arc<Type>>>,
+    type_: Arc<Type>,
+    context: &PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let planned_elements = elements
+        .into_iter()
+        .map(|element| plan(element, context))
+        .collect::<Result<Vec<_>, _>>()?;
+    let actual_type = planned_elements
+        .iter()
+        .map(Expr::value_type)
+        .collect::<Vec<_>>();
+    let expected_type = match ValueType::from_gleam(type_.as_ref()) {
+        Some(ValueType::Tuple(type_)) => type_,
+        Some(actual) => {
+            return Err(invalid_expression_type_for_value(
+                ValueType::Tuple(actual_type),
+                actual,
+            ));
+        }
+        None => {
+            return Err(invalid_expression_type(
+                InvalidExpressionType::Tuple,
+                InvalidExpressionType::Unsupported,
+            ));
+        }
+    };
+
+    if expected_type != actual_type {
+        return Err(invalid_expression_type_for_value(
+            ValueType::Tuple(expected_type),
+            ValueType::Tuple(actual_type),
+        ));
+    }
+
+    Ok(Expr::tuple(TupleExpr::value(
+        planned_elements,
+        expected_type,
+    )))
+}
+
+fn plan_list(
+    elements: Vec<Constant<Arc<Type>>>,
+    tail: Option<Constant<Arc<Type>>>,
+    type_: Arc<Type>,
+    context: &PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let planned_elements = elements
+        .into_iter()
+        .map(|element| plan(element, context))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let Some(list_element_type) = type_.list_type() else {
+        return match ValueType::from_gleam(type_.as_ref()) {
+            Some(actual) => Err(invalid_expression_type_for_value(
+                ValueType::List(Box::new(ValueType::Nil)),
+                actual,
+            )),
+            None => Err(invalid_expression_type(
+                InvalidExpressionType::List,
+                InvalidExpressionType::Unsupported,
+            )),
+        };
+    };
+    let expected_element_type = match ValueType::from_gleam(list_element_type.as_ref()) {
+        Some(type_) => type_,
+        None => {
+            return Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::UnsupportedListElementType,
+            });
+        }
+    };
+
+    for element in &planned_elements {
+        let actual = element.value_type();
+        if actual != expected_element_type {
+            return Err(invalid_expression_type_for_value(
+                expected_element_type.clone(),
+                actual,
+            ));
+        }
+    }
+
+    let Some(tail) = tail else {
+        return Ok(Expr::list(ListExpr::value(
+            planned_elements,
+            expected_element_type,
+        )));
+    };
+    let tail = plan(tail, context)?;
+    let actual = tail.value_type();
+    let Some(tail) = tail.into_list() else {
+        return Err(invalid_expression_type_for_value(
+            ValueType::List(Box::new(expected_element_type.clone())),
+            actual,
+        ));
+    };
+    if tail.element_type() != &expected_element_type {
+        return Err(invalid_expression_type_for_value(
+            ValueType::List(Box::new(expected_element_type.clone())),
+            ValueType::List(Box::new(tail.element_type().clone())),
+        ));
+    }
+
+    Ok(Expr::list(ListExpr::spread(
+        planned_elements,
+        tail,
+        expected_element_type,
+    )))
+}
+
+fn plan_var(
+    constructor: Option<ValueConstructor>,
+    context: &PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let Some(constructor) = constructor else {
+        return invalid_expression_shape(InvalidExpressionShapeKind::Invalid);
+    };
+
+    match constructor.variant {
+        ValueConstructorVariant::ModuleConstant {
+            module, literal, ..
+        } if module == *context.module_name => plan(literal, context),
+        ValueConstructorVariant::ModuleFn {
+            module,
+            name,
+            external_erlang,
+            external_javascript,
+            ..
+        } if module == *context.module_name
+            && external_erlang.is_none()
+            && external_javascript.is_none() =>
+        {
+            let Some(function) = context.lookup_function(&name) else {
+                return Err(PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::UnknownLocal { name },
+                });
+            };
+
+            Ok(Expr::function(FunctionExpr::value(function.value())))
+        }
+        ValueConstructorVariant::ModuleConstant { .. }
+        | ValueConstructorVariant::ModuleFn { .. } => {
+            invalid_expression_shape(InvalidExpressionShapeKind::ModuleSelect)
+        }
+        ValueConstructorVariant::Record {
+            name,
+            module,
+            arity,
+            ..
+        } => plan_record_constructor(name, module, arity),
+        ValueConstructorVariant::LocalVariable { .. } => {
+            invalid_expression_shape(InvalidExpressionShapeKind::Invalid)
+        }
+    }
+}
+
+fn plan_record(
+    arguments: Option<Vec<gleam_core::ast::CallArg<Constant<Arc<Type>>>>>,
+    constructor: Option<ValueConstructor>,
+) -> Result<Expr, PlanError> {
+    let Some(constructor) = constructor else {
+        return invalid_expression_shape(InvalidExpressionShapeKind::RecordConstructor);
+    };
+    let ValueConstructorVariant::Record {
+        name,
+        module,
+        arity,
+        ..
+    } = constructor.variant
+    else {
+        return invalid_expression_shape(InvalidExpressionShapeKind::Invalid);
+    };
+    let arguments_are_empty = arguments.as_ref().is_none_or(Vec::is_empty);
+
+    if arguments_are_empty {
+        plan_record_constructor(name, module, arity)
+    } else {
+        invalid_expression_shape(InvalidExpressionShapeKind::RecordConstructor)
+    }
+}
+
+fn plan_record_constructor(
+    name: ecow::EcoString,
+    module: ecow::EcoString,
+    arity: u16,
+) -> Result<Expr, PlanError> {
+    if arity == 0 && module == PRELUDE_MODULE_NAME {
+        match name.as_str() {
+            "True" => Ok(Expr::bool(BoolExpr::value(true))),
+            "False" => Ok(Expr::bool(BoolExpr::value(false))),
+            "Nil" => Ok(Expr::nil(NilExpr::value())),
+            _ => invalid_expression_shape(InvalidExpressionShapeKind::PreludeConstructor),
+        }
+    } else {
+        invalid_expression_shape(InvalidExpressionShapeKind::RecordConstructor)
+    }
+}
+
+fn invalid_expression_shape(kind: InvalidExpressionShapeKind) -> Result<Expr, PlanError> {
+    Err(PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionShape { kind },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plan;
+    use crate::plan::{Expr, IntLocalId, LocalId, ValueType};
+    use crate::planner::context::{AnonymousFunctions, PlanContext};
+    use crate::planner::dsl::{
+        bool_, call_int_function, float, function, int, int_function_call_arg, int_function_ref,
+        list, list_spread, local_int, module, nil, string, tuple,
+    };
+    use crate::planner::error::{
+        InvalidExpressionShapeKind, InvalidExpressionType, InvalidTypedAstReason, PlanError,
+        UnsupportedExpressionKind,
+    };
+    use crate::planner::plan_module;
+    use crate::planner::support::{compile, dummy_span, expect_plan_error};
+    use gleam_core::analyse::Inferred;
+    use gleam_core::ast::{Constant, Publicity, RecordBeingUpdated, Statement, TypedExpr};
+    use gleam_core::type_::error::VariableOrigin;
+    use gleam_core::type_::{self, Deprecation, ValueConstructor, ValueConstructorVariant};
+    use std::collections::HashMap;
+
+    #[test]
+    fn plan_constant_value_families() {
+        let actual = plan_module(compile(
+            r#"
+const number = 1
+const ratio = 1.5
+const label = "ge" <> "am"
+const truth = True
+const falsehood = False
+const nothing = Nil
+
+pub fn main() {
+  #(number, ratio, label, truth, falsehood, nothing)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                tuple([
+                    Expr::from(int(1)),
+                    Expr::from(float(1.5)),
+                    Expr::from(string("ge").concatenate(string("am"))),
+                    Expr::from(bool_(true)),
+                    Expr::from(bool_(false)),
+                    Expr::from(nil()),
+                ]),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_constant_compound_alias_and_list_spread() {
+        let actual = plan_module(compile(
+            r#"
+const rest = [2, 3]
+const values = [1, ..rest]
+
+pub fn main() {
+  values
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                list_spread(
+                    [int(1)],
+                    list([int(2), int(3)], ValueType::Int),
+                    ValueType::Int,
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_constant_function_value_call() {
+        let actual = plan_module(compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+const f = add_one
+
+pub fn main() {
+  f(41)
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                call_int_function(
+                    int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                    [int_function_call_arg(0, int(41))],
+                ),
+            ),
+            [function("add_one", local_int(0, "value").add_int(int(1))).param_int(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_profile_unsupported_constant_values() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+const bits = <<1>>
+
+pub fn main() {
+  bits
+  1
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            },
+        );
+        assert_eq!(
+            expect_plan_error(
+                r#"
+const result = Ok(1)
+
+pub fn main() {
+  result
+  1
+}
+"#,
+            ),
+            PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::RecordConstructor,
+                },
+            },
+        );
+    }
+
+    #[test]
+    fn reject_margin_invalid_constant_shapes() {
+        assert_eq!(
+            plan_constant_literal(Constant::Tuple {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::int(),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Tuple,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Tuple {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::tuple(vec![type_::bit_array()]),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Tuple,
+                    actual: InvalidExpressionType::Unsupported,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Tuple {
+                location: dummy_span(),
+                elements: vec![Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }],
+                type_: type_::tuple(vec![type_::string()]),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Tuple,
+                    actual: InvalidExpressionType::Tuple,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Tuple {
+                location: dummy_span(),
+                elements: vec![Constant::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                }],
+                type_: type_::tuple(vec![type_::bit_array()]),
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::int(),
+                tail: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::List,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::generic_var(0),
+                tail: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::List,
+                    actual: InvalidExpressionType::Unsupported,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: vec![Constant::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                }],
+                type_: type_::list(type_::bit_array()),
+                tail: None,
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: vec![Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }],
+                type_: type_::list(type_::string()),
+                tail: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::String,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: vec![Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }],
+                type_: type_::list(type_::float()),
+                tail: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Float,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: vec![Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }],
+                type_: type_::list(type_::bool()),
+                tail: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Bool,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: vec![Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }],
+                type_: type_::list(type_::nil()),
+                tail: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Nil,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: vec![Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }],
+                type_: type_::list(type_::fn_(vec![type_::int()], type_::int())),
+                tail: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Function,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Invalid {
+                location: dummy_span(),
+                type_: type_::int(),
+                extra_information: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::StringConcatenation {
+                location: dummy_span(),
+                left: Box::new(Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }),
+                right: Box::new(Constant::String {
+                    location: dummy_span(),
+                    value: "right".into(),
+                }),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::String,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::StringConcatenation {
+                location: dummy_span(),
+                left: Box::new(Constant::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                }),
+                right: Box::new(Constant::String {
+                    location: dummy_span(),
+                    value: "right".into(),
+                }),
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::StringConcatenation {
+                location: dummy_span(),
+                left: Box::new(Constant::String {
+                    location: dummy_span(),
+                    value: "left".into(),
+                }),
+                right: Box::new(Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::String,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::list(type_::bit_array()),
+                tail: None,
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::UnsupportedListElementType,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::list(type_::int()),
+                tail: Some(Box::new(Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                })),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::List,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::list(type_::int()),
+                tail: Some(Box::new(Constant::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                })),
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::list(type_::int()),
+                tail: Some(Box::new(Constant::List {
+                    location: dummy_span(),
+                    elements: vec![Constant::String {
+                        location: dummy_span(),
+                        value: "one".into(),
+                    }],
+                    type_: type_::list(type_::string()),
+                    tail: None,
+                })),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::List,
+                    actual: InvalidExpressionType::List,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Var {
+                location: dummy_span(),
+                module: None,
+                name: "missing".into(),
+                constructor: None,
+                type_: type_::int(),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Var {
+                location: dummy_span(),
+                module: None,
+                name: "local".into(),
+                constructor: Some(Box::new(ValueConstructor::local_variable(
+                    dummy_span(),
+                    VariableOrigin::generated(),
+                    type_::int(),
+                ))),
+                type_: type_::int(),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Var {
+                location: dummy_span(),
+                module: None,
+                name: "Other".into(),
+                constructor: Some(Box::new(record_constructor("Other", "gleam", 0))),
+                type_: type_::bool(),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::PreludeConstructor,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Var {
+                location: dummy_span(),
+                module: None,
+                name: "Boxed".into(),
+                constructor: Some(Box::new(record_constructor("Boxed", "main", 0))),
+                type_: type_::int(),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::RecordConstructor,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Record {
+                location: dummy_span(),
+                module: None,
+                name: "Boxed".into(),
+                arguments: None,
+                type_: type_::int(),
+                field_map: Inferred::Unknown,
+                record_constructor: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::RecordConstructor,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Record {
+                location: dummy_span(),
+                module: None,
+                name: "Broken".into(),
+                arguments: None,
+                type_: type_::int(),
+                field_map: Inferred::Unknown,
+                record_constructor: Some(Box::new(ValueConstructor::local_variable(
+                    dummy_span(),
+                    VariableOrigin::generated(),
+                    type_::int(),
+                ))),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Todo {
+                location: dummy_span(),
+                type_: type_::int(),
+                message: None,
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Todo,
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::RecordUpdate {
+                location: dummy_span(),
+                constructor_location: dummy_span(),
+                module: None,
+                name: "Boxed".into(),
+                record: RecordBeingUpdated {
+                    base: Box::new(Constant::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    }),
+                    location: dummy_span(),
+                },
+                arguments: Vec::new(),
+                type_: type_::int(),
+                field_map: Inferred::Unknown,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::RecordUpdate,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_constant_module_constructor_shapes() {
+        let mut missing_function = function_constant_module();
+        missing_function.definitions.functions.retain(|function| {
+            function
+                .name
+                .as_ref()
+                .is_some_and(|(_, name)| name == "main")
+        });
+        assert_eq!(
+            plan_module(missing_function),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::UnknownLocal {
+                    name: "add_one".into(),
+                },
+            }),
+        );
+
+        let mut non_current_function = function_constant_module();
+        let module = module_fn_constant_alias_module_mut(&mut non_current_function);
+        *module = "other".into();
+        assert_eq!(
+            plan_module(non_current_function),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::ModuleSelect,
+                },
+            }),
+        );
+
+        let mut non_current_constant = compile(
+            r#"
+const answer = 1
+
+pub fn main() {
+  answer
+}
+"#,
+        );
+        let module = module_constant_module_mut(&mut non_current_constant);
+        *module = "other".into();
+        assert_eq!(
+            plan_module(non_current_constant),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::ModuleSelect,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn module_fn_constant_alias_module_mut_panics_on_constant_alias() {
+        let result = std::panic::catch_unwind(|| {
+            let mut module = compile(
+                r#"
+const answer = 1
+const f = answer
+
+pub fn main() {
+  f
+}
+"#,
+            );
+
+            module_fn_constant_alias_module_mut(&mut module);
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn module_constant_module_mut_panics_on_function_reference() {
+        let result = std::panic::catch_unwind(|| {
+            let mut module = compile(
+                r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  add_one
+}
+"#,
+            );
+
+            module_constant_module_mut(&mut module);
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn constant_alias_constructor_mut_panics_on_function_reference() {
+        let result = std::panic::catch_unwind(|| {
+            let mut module = compile(
+                r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  add_one
+}
+"#,
+            );
+
+            constant_alias_constructor_mut(&mut module);
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn constant_alias_constructor_mut_panics_on_value_literal() {
+        let result = std::panic::catch_unwind(|| {
+            let mut module = compile(
+                r#"
+const answer = 1
+
+pub fn main() {
+  answer
+}
+"#,
+            );
+
+            constant_alias_constructor_mut(&mut module);
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn main_var_constructor_mut_panics_on_multiple_statements() {
+        let result = std::panic::catch_unwind(|| {
+            let mut module = compile(
+                r#"
+pub fn main() {
+  let value = 1
+  value
+}
+"#,
+            );
+
+            main_var_constructor_mut(&mut module);
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn main_var_constructor_mut_panics_on_non_variable_expression() {
+        let result = std::panic::catch_unwind(|| {
+            let mut module = compile(
+                r#"
+pub fn main() {
+  1
+}
+"#,
+            );
+
+            main_var_constructor_mut(&mut module);
+        });
+
+        assert!(result.is_err());
+    }
+
+    fn plan_constant_literal(
+        literal: Constant<std::sync::Arc<type_::Type>>,
+    ) -> Result<Expr, PlanError> {
+        let module_name = "main".into();
+        let functions = HashMap::new();
+        let mut anonymous_functions = AnonymousFunctions::default();
+        let context = PlanContext::new(&module_name, &functions, &mut anonymous_functions);
+
+        plan(literal, &context)
+    }
+
+    fn record_constructor(name: &str, module: &str, arity: u16) -> ValueConstructor {
+        ValueConstructor {
+            publicity: Publicity::Private,
+            deprecation: Deprecation::NotDeprecated,
+            variant: ValueConstructorVariant::Record {
+                name: name.into(),
+                arity,
+                field_map: None,
+                location: dummy_span(),
+                module: module.into(),
+                variants_count: 1,
+                variant_index: 0,
+                documentation: None,
+            },
+            type_: type_::int(),
+        }
+    }
+
+    fn function_constant_module() -> gleam_core::ast::TypedModule {
+        compile(
+            r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+const f = add_one
+
+pub fn main() {
+  f
+}
+"#,
+        )
+    }
+
+    fn module_fn_constant_alias_module_mut(
+        module: &mut gleam_core::ast::TypedModule,
+    ) -> &mut ecow::EcoString {
+        let ValueConstructorVariant::ModuleFn { module, .. } =
+            &mut constant_alias_constructor_mut(module).variant
+        else {
+            panic!("expected module function constant alias");
+        };
+
+        module
+    }
+
+    fn module_constant_module_mut(
+        module: &mut gleam_core::ast::TypedModule,
+    ) -> &mut ecow::EcoString {
+        let ValueConstructorVariant::ModuleConstant { module, .. } =
+            &mut main_var_constructor_mut(module).variant
+        else {
+            panic!("expected module constant constructor");
+        };
+
+        module
+    }
+
+    fn constant_alias_constructor_mut(
+        module: &mut gleam_core::ast::TypedModule,
+    ) -> &mut ValueConstructor {
+        let ValueConstructorVariant::ModuleConstant { literal, .. } =
+            &mut main_var_constructor_mut(module).variant
+        else {
+            panic!("expected module constant constructor");
+        };
+        let Constant::Var {
+            constructor: Some(constructor),
+            ..
+        } = literal
+        else {
+            panic!("expected constant alias");
+        };
+
+        constructor
+    }
+
+    fn main_var_constructor_mut(
+        module: &mut gleam_core::ast::TypedModule,
+    ) -> &mut ValueConstructor {
+        let function = module
+            .definitions
+            .functions
+            .iter_mut()
+            .find(|function| {
+                function
+                    .name
+                    .as_ref()
+                    .is_some_and(|(_, name)| name == "main")
+            })
+            .expect("main function should exist");
+        let [Statement::Expression(expression)] = function.body.as_mut_slice() else {
+            panic!("expected single expression statement");
+        };
+        let TypedExpr::Var { constructor, .. } = expression else {
+            panic!("expected variable expression");
+        };
+
+        constructor
+    }
+}

--- a/src/planner/expression/var/constant.rs
+++ b/src/planner/expression/var/constant.rs
@@ -247,11 +247,15 @@ fn plan_record(
     let arguments_are_empty = arguments.as_ref().is_none_or(Vec::is_empty);
 
     if arguments_are_empty {
-        plan_record_constructor(name, module, arity)
-    } else {
+        return plan_record_constructor(name, module, arity);
+    }
+
+    if module == PRELUDE_MODULE_NAME && arity > 0 {
         Err(PlanError::UnsupportedExpression {
             kind: UnsupportedExpressionKind::RecordConstructor,
         })
+    } else {
+        invalid_expression_shape(InvalidExpressionShapeKind::RecordConstructor)
     }
 }
 
@@ -833,6 +837,56 @@ pub fn main() {
                 type_: type_::int(),
                 field_map: Inferred::Unknown,
                 record_constructor: None,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::RecordConstructor,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Record {
+                location: dummy_span(),
+                module: None,
+                name: "Boxed".into(),
+                arguments: Some(vec![gleam_core::ast::CallArg {
+                    label: None,
+                    location: dummy_span(),
+                    value: Constant::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    },
+                    implicit: None,
+                }]),
+                type_: type_::int(),
+                field_map: Inferred::Unknown,
+                record_constructor: Some(Box::new(record_constructor("Boxed", "main", 1))),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::RecordConstructor,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Record {
+                location: dummy_span(),
+                module: None,
+                name: "True".into(),
+                arguments: Some(vec![gleam_core::ast::CallArg {
+                    label: None,
+                    location: dummy_span(),
+                    value: Constant::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    },
+                    implicit: None,
+                }]),
+                type_: type_::bool(),
+                field_map: Inferred::Unknown,
+                record_constructor: Some(Box::new(record_constructor("True", "gleam", 0))),
             }),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::ExpressionShape {

--- a/src/planner/expression/var/constant.rs
+++ b/src/planner/expression/var/constant.rs
@@ -51,13 +51,9 @@ pub(super) fn plan(
         Constant::BitArray { .. } => Err(PlanError::UnsupportedExpression {
             kind: UnsupportedExpressionKind::BitArray,
         }),
-        Constant::Todo { .. } => Err(PlanError::UnsupportedExpression {
-            kind: UnsupportedExpressionKind::Todo,
-        }),
-        Constant::RecordUpdate { .. } => {
-            invalid_expression_shape(InvalidExpressionShapeKind::RecordUpdate)
+        Constant::Todo { .. } | Constant::RecordUpdate { .. } | Constant::Invalid { .. } => {
+            invalid_expression_shape(InvalidExpressionShapeKind::Invalid)
         }
-        Constant::Invalid { .. } => invalid_expression_shape(InvalidExpressionShapeKind::Invalid),
     }
 }
 
@@ -238,6 +234,7 @@ fn plan_record(
     let Some(constructor) = constructor else {
         return invalid_expression_shape(InvalidExpressionShapeKind::RecordConstructor);
     };
+
     let ValueConstructorVariant::Record {
         name,
         module,
@@ -480,11 +477,18 @@ pub fn main() {
         assert_eq!(
             plan_constant_literal(Constant::Tuple {
                 location: dummy_span(),
-                elements: vec![Constant::BitArray {
-                    location: dummy_span(),
-                    segments: Vec::new(),
-                }],
-                type_: type_::tuple(vec![type_::bit_array()]),
+                elements: vec![
+                    Constant::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    },
+                    Constant::BitArray {
+                        location: dummy_span(),
+                        segments: Vec::new(),
+                    },
+                ],
+                type_: type_::tuple(vec![type_::int(), type_::bit_array()]),
             }),
             Err(PlanError::UnsupportedExpression {
                 kind: UnsupportedExpressionKind::BitArray,
@@ -521,11 +525,18 @@ pub fn main() {
         assert_eq!(
             plan_constant_literal(Constant::List {
                 location: dummy_span(),
-                elements: vec![Constant::BitArray {
-                    location: dummy_span(),
-                    segments: Vec::new(),
-                }],
-                type_: type_::list(type_::bit_array()),
+                elements: vec![
+                    Constant::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    },
+                    Constant::BitArray {
+                        location: dummy_span(),
+                        segments: Vec::new(),
+                    },
+                ],
+                type_: type_::list(type_::int()),
                 tail: None,
             }),
             Err(PlanError::UnsupportedExpression {
@@ -688,6 +699,22 @@ pub fn main() {
                     expected: InvalidExpressionType::String,
                     actual: InvalidExpressionType::Int,
                 },
+            }),
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::StringConcatenation {
+                location: dummy_span(),
+                left: Box::new(Constant::String {
+                    location: dummy_span(),
+                    value: "left".into(),
+                }),
+                right: Box::new(Constant::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                }),
+            }),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
             }),
         );
         assert_eq!(
@@ -857,8 +884,10 @@ pub fn main() {
                 type_: type_::int(),
                 message: None,
             }),
-            Err(PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::Todo,
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
             }),
         );
         assert_eq!(
@@ -881,7 +910,7 @@ pub fn main() {
             }),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::ExpressionShape {
-                    kind: InvalidExpressionShapeKind::RecordUpdate,
+                    kind: InvalidExpressionShapeKind::Invalid,
                 },
             }),
         );
@@ -939,6 +968,102 @@ pub fn main() {
     }
 
     #[test]
+    fn reject_margin_module_constant_literal_shapes() {
+        assert_eq!(
+            plan_module(module_with_main_constant_literal(
+                Constant::StringConcatenation {
+                    location: dummy_span(),
+                    left: Box::new(Constant::BitArray {
+                        location: dummy_span(),
+                        segments: Vec::new(),
+                    }),
+                    right: Box::new(Constant::String {
+                        location: dummy_span(),
+                        value: "right".into(),
+                    }),
+                }
+            )),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+        assert_eq!(
+            plan_module(module_with_main_constant_literal(
+                Constant::StringConcatenation {
+                    location: dummy_span(),
+                    left: Box::new(Constant::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    }),
+                    right: Box::new(Constant::String {
+                        location: dummy_span(),
+                        value: "right".into(),
+                    }),
+                }
+            )),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::String,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_module(module_with_main_constant_literal(
+                Constant::StringConcatenation {
+                    location: dummy_span(),
+                    left: Box::new(Constant::String {
+                        location: dummy_span(),
+                        value: "left".into(),
+                    }),
+                    right: Box::new(Constant::BitArray {
+                        location: dummy_span(),
+                        segments: Vec::new(),
+                    }),
+                }
+            )),
+            Err(PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::BitArray,
+            }),
+        );
+        assert_eq!(
+            plan_module(module_with_main_constant_literal(
+                Constant::StringConcatenation {
+                    location: dummy_span(),
+                    left: Box::new(Constant::String {
+                        location: dummy_span(),
+                        value: "left".into(),
+                    }),
+                    right: Box::new(Constant::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    }),
+                }
+            )),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::String,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_module(module_with_main_constant_literal(Constant::Invalid {
+                location: dummy_span(),
+                type_: type_::int(),
+                extra_information: None,
+            })),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+    }
+
+    #[test]
     fn module_fn_constant_alias_module_mut_panics_on_constant_alias() {
         let result = std::panic::catch_unwind(|| {
             let mut module = compile(
@@ -974,6 +1099,27 @@ pub fn main() {
             );
 
             module_constant_module_mut(&mut module);
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn main_module_constant_literal_mut_panics_on_function_reference() {
+        let result = std::panic::catch_unwind(|| {
+            let mut module = compile(
+                r#"
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  add_one
+}
+"#,
+            );
+
+            main_module_constant_literal_mut(&mut module);
         });
 
         assert!(result.is_err());
@@ -1099,6 +1245,23 @@ pub fn main() {
         )
     }
 
+    fn module_with_main_constant_literal(
+        literal: Constant<std::sync::Arc<type_::Type>>,
+    ) -> gleam_core::ast::TypedModule {
+        let mut module = compile(
+            r#"
+const value = 1
+
+pub fn main() {
+  value
+}
+"#,
+        );
+        *main_module_constant_literal_mut(&mut module) = literal;
+
+        module
+    }
+
     fn module_fn_constant_alias_module_mut(
         module: &mut gleam_core::ast::TypedModule,
     ) -> &mut ecow::EcoString {
@@ -1121,6 +1284,18 @@ pub fn main() {
         };
 
         module
+    }
+
+    fn main_module_constant_literal_mut(
+        module: &mut gleam_core::ast::TypedModule,
+    ) -> &mut Constant<std::sync::Arc<type_::Type>> {
+        let ValueConstructorVariant::ModuleConstant { literal, .. } =
+            &mut main_var_constructor_mut(module).variant
+        else {
+            panic!("expected module constant constructor");
+        };
+
+        literal
     }
 
     fn constant_alias_constructor_mut(

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -19,17 +19,11 @@ pub fn plan_module(module: TypedModule) -> Result<ExecutionPlan, PlanError> {
     let definitions = module.definitions;
 
     let imports = definitions.imports.len();
-    let constants = definitions.constants.len();
     let custom_types = definitions.custom_types.len();
 
     if imports != 0 {
         return Err(PlanError::UnsupportedTopLevel {
             kind: UnsupportedTopLevelKind::Import,
-        });
-    }
-    if constants != 0 {
-        return Err(PlanError::UnsupportedTopLevel {
-            kind: UnsupportedTopLevelKind::Constant,
         });
     }
     if custom_types != 0 {
@@ -469,21 +463,20 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_constant_definition() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+    fn plan_constant_definition() {
+        let actual = plan_module(compile(
+            r#"
 const answer = 42
 
 pub fn main() {
   answer
 }
 "#,
-            ),
-            PlanError::UnsupportedTopLevel {
-                kind: UnsupportedTopLevelKind::Constant,
-            },
-        );
+        ))
+        .expect("source should plan");
+        let expected = module("main", function("main", int(42)), []);
+
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -855,19 +848,6 @@ pub fn main() {
 
     #[test]
     fn reject_profile_top_level_non_function_definitions() {
-        assert_plan_error(
-            r#"
-const answer = 42
-
-pub fn main() {
-  answer
-}
-"#,
-            PlanError::UnsupportedTopLevel {
-                kind: UnsupportedTopLevelKind::Constant,
-            },
-        );
-
         assert_plan_error(
             r#"
 pub type Boxed {

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -259,6 +259,7 @@ mod rejection {
         rejection_cases!("module_items";
             import,
             constant_bit_array,
+            constant_list_bit_array,
             constant_result_constructor,
             custom_type,
             external_function,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -37,6 +37,9 @@ mod values {
 
 mod module_items {
     execution_cases!("module_items";
+        constant,
+        constant_value_families,
+        constant_function_value,
         type_alias,
         type_alias_function_signature,
         type_alias_compound_signature,
@@ -255,7 +258,8 @@ mod rejection {
     mod module_items {
         rejection_cases!("module_items";
             import,
-            constant,
+            constant_bit_array,
+            constant_result_constructor,
             custom_type,
             external_function,
         );

--- a/tests/fixtures/execution/module_items/constant.gleam
+++ b/tests/fixtures/execution/module_items/constant.gleam
@@ -3,3 +3,5 @@ const answer = 42
 pub fn main() {
   answer
 }
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/module_items/constant_function_value.gleam
+++ b/tests/fixtures/execution/module_items/constant_function_value.gleam
@@ -1,0 +1,11 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+const f = add_one
+
+pub fn main() {
+  f(41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/module_items/constant_value_families.gleam
+++ b/tests/fixtures/execution/module_items/constant_value_families.gleam
@@ -2,14 +2,15 @@ const int = 1
 const float = 1.5
 const string = "ge" <> "am"
 const bool = True
+const falsehood = False
 const nil = Nil
 const rest = [2, 3]
 const list = [1, ..rest]
 const alias = list
-const tuple = #(int, float, string, bool, nil, alias)
+const tuple = #(int, float, string, bool, falsehood, nil, alias)
 
 pub fn main() {
   tuple
 }
 
-// geam:expect Tuple([Int(1), Float(1.5), String("geam"), Bool(true), Nil, List(Int)([Int(1), Int(2), Int(3)])])
+// geam:expect Tuple([Int(1), Float(1.5), String("geam"), Bool(true), Bool(false), Nil, List(Int)([Int(1), Int(2), Int(3)])])

--- a/tests/fixtures/execution/module_items/constant_value_families.gleam
+++ b/tests/fixtures/execution/module_items/constant_value_families.gleam
@@ -1,0 +1,15 @@
+const int = 1
+const float = 1.5
+const string = "ge" <> "am"
+const bool = True
+const nil = Nil
+const rest = [2, 3]
+const list = [1, ..rest]
+const alias = list
+const tuple = #(int, float, string, bool, nil, alias)
+
+pub fn main() {
+  tuple
+}
+
+// geam:expect Tuple([Int(1), Float(1.5), String("geam"), Bool(true), Nil, List(Int)([Int(1), Int(2), Int(3)])])

--- a/tests/fixtures/rejection/module_items/constant_bit_array.gleam
+++ b/tests/fixtures/rejection/module_items/constant_bit_array.gleam
@@ -1,0 +1,6 @@
+const bits = <<1>>
+
+pub fn main() {
+  bits
+  1
+}

--- a/tests/fixtures/rejection/module_items/constant_list_bit_array.gleam
+++ b/tests/fixtures/rejection/module_items/constant_list_bit_array.gleam
@@ -1,0 +1,6 @@
+const values = [<<1>>]
+
+pub fn main() {
+  values
+  1
+}

--- a/tests/fixtures/rejection/module_items/constant_result_constructor.gleam
+++ b/tests/fixtures/rejection/module_items/constant_result_constructor.gleam
@@ -1,0 +1,6 @@
+const result = Ok(1)
+
+pub fn main() {
+  result
+  1
+}


### PR DESCRIPTION
Allow top-level `const` declarations to participate in planning when referenced from executable code.

- Lower module constants through the existing expression planner instead of adding a runtime constant table.
- Support constant values for primitives, string concatenation, tuples, lists and list spreads, current-module aliases, current-module function references, and prelude `True` / `False` / `Nil`.
- Keep unsupported constant shapes such as bit arrays and result/record constructors behind profile rejection fixtures.
- Tighten constant typed-AST margin coverage and document region coverage diagnostics in the testing guide.