### PR TITLE
Tighten operator region coverage

### DIFF
--- a/src/planner/expression/operator.rs
+++ b/src/planner/expression/operator.rs
@@ -58,7 +58,7 @@ pub(super) fn plan_negate_bool(
 
 #[cfg(test)]
 mod tests {
-    use super::super::{module_returning_typed_expr, typed_int_expr};
+    use super::super::{module_returning_typed_expr, typed_int_expr, typed_prelude_constructor};
     use crate::planner::dsl::{
         function, int, int_arg, int_return_tail_call, local_bool, local_int, module,
     };
@@ -66,6 +66,7 @@ mod tests {
     use crate::planner::support::{compile, dummy_span};
     use crate::planner::{InvalidExpressionType, InvalidTypedAstReason, PlanError};
     use gleam_core::ast::TypedExpr;
+    use gleam_core::type_;
 
     #[test]
     fn plan_negation_expressions() {
@@ -99,6 +100,18 @@ pub fn main() {
 
     #[test]
     fn reject_margin_negation_type_mismatch() {
+        assert_eq!(
+            plan_module(module_returning_typed_expr(TypedExpr::NegateInt {
+                location: dummy_span(),
+                value: Box::new(typed_prelude_constructor("True", type_::bool())),
+            })),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Int,
+                    actual: InvalidExpressionType::Bool,
+                },
+            }),
+        );
         assert_eq!(
             plan_module(module_returning_typed_expr(TypedExpr::NegateBool {
                 location: dummy_span(),

--- a/src/planner/expression/operator/arithmetic.rs
+++ b/src/planner/expression/operator/arithmetic.rs
@@ -109,8 +109,10 @@ mod tests {
     };
     use crate::planner::dsl::{float, function, int, module};
     use crate::planner::plan_module;
-    use crate::planner::support::{compile, dummy_span};
-    use crate::planner::{InvalidExpressionType, InvalidTypedAstReason, PlanError};
+    use crate::planner::support::{compile, dummy_span, expect_plan_error};
+    use crate::planner::{
+        InvalidExpressionType, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
+    };
     use gleam_core::ast::{BinOp, TypedExpr};
     use gleam_core::type_;
 
@@ -190,6 +192,212 @@ pub fn div() {
     }
 
     #[test]
+    fn reject_profile_arithmetic_operand_errors_propagate() {
+        for (name, src) in [
+            (
+                "add int left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } + 1
+}
+"#,
+            ),
+            (
+                "add int right",
+                r#"
+pub fn main() {
+  1 + {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "sub int left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } - 1
+}
+"#,
+            ),
+            (
+                "sub int right",
+                r#"
+pub fn main() {
+  1 - {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "mult int left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } * 1
+}
+"#,
+            ),
+            (
+                "mult int right",
+                r#"
+pub fn main() {
+  1 * {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "div int left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } / 1
+}
+"#,
+            ),
+            (
+                "div int right",
+                r#"
+pub fn main() {
+  1 / {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "remainder int left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } % 1
+}
+"#,
+            ),
+            (
+                "remainder int right",
+                r#"
+pub fn main() {
+  1 % {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "add float left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1.0
+  } +. 1.0
+}
+"#,
+            ),
+            (
+                "add float right",
+                r#"
+pub fn main() {
+  1.0 +. {
+    panic
+    1.0
+  }
+}
+"#,
+            ),
+            (
+                "sub float left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1.0
+  } -. 1.0
+}
+"#,
+            ),
+            (
+                "sub float right",
+                r#"
+pub fn main() {
+  1.0 -. {
+    panic
+    1.0
+  }
+}
+"#,
+            ),
+            (
+                "mult float left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1.0
+  } *. 1.0
+}
+"#,
+            ),
+            (
+                "mult float right",
+                r#"
+pub fn main() {
+  1.0 *. {
+    panic
+    1.0
+  }
+}
+"#,
+            ),
+            (
+                "div float left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1.0
+  } /. 1.0
+}
+"#,
+            ),
+            (
+                "div float right",
+                r#"
+pub fn main() {
+  1.0 /. {
+    panic
+    1.0
+  }
+}
+"#,
+            ),
+        ] {
+            assert_panic_reject(name, src);
+        }
+    }
+
+    #[test]
     fn reject_margin_integer_arithmetic_type_mismatch() {
         assert_eq!(
             plan_module(module_returning_typed_expr(TypedExpr::BinOp {
@@ -238,6 +446,16 @@ pub fn div() {
                     actual: InvalidExpressionType::Nil,
                 },
             }),
+        );
+    }
+
+    fn assert_panic_reject(name: &str, src: &str) {
+        assert_eq!(
+            expect_plan_error(src),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Panic,
+            },
+            "{name}",
         );
     }
 }

--- a/src/planner/expression/operator/boolean.rs
+++ b/src/planner/expression/operator/boolean.rs
@@ -83,6 +83,21 @@ pub fn main() {
             expect_plan_error(
                 r#"
 pub fn main() {
+  {
+    panic
+    False
+  } || True
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Panic,
+            },
+        );
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
   True || {
     panic
     False

--- a/src/planner/expression/operator/equality.rs
+++ b/src/planner/expression/operator/equality.rs
@@ -57,7 +57,7 @@ mod tests {
     use crate::planner::dsl::{bool_, equal, function, int, module, not_equal};
     use crate::planner::plan_module;
     use crate::planner::support::{compile, expect_plan_error};
-    use crate::planner::{PlanError, UnsupportedBinOpKind};
+    use crate::planner::{PlanError, UnsupportedBinOpKind, UnsupportedExpressionKind};
 
     #[test]
     fn plan_equality_operators() {
@@ -80,6 +80,58 @@ pub fn not_equal() {
         );
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_profile_equality_operand_errors_propagate() {
+        for (name, src) in [
+            (
+                "equal left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } == 1
+}
+"#,
+            ),
+            (
+                "equal right",
+                r#"
+pub fn main() {
+  1 == {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "not equal left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } != 1
+}
+"#,
+            ),
+            (
+                "not equal right",
+                r#"
+pub fn main() {
+  1 != {
+    panic
+    1
+  }
+}
+"#,
+            ),
+        ] {
+            assert_panic_reject(name, src);
+        }
     }
 
     #[test]
@@ -187,6 +239,16 @@ pub fn main() {
             PlanError::UnsupportedBinOp {
                 operator: UnsupportedBinOpKind::NotEqFunction,
             },
+        );
+    }
+
+    fn assert_panic_reject(name: &str, src: &str) {
+        assert_eq!(
+            expect_plan_error(src),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Panic,
+            },
+            "{name}",
         );
     }
 }

--- a/src/planner/expression/operator/ordering.rs
+++ b/src/planner/expression/operator/ordering.rs
@@ -95,7 +95,8 @@ pub(super) fn gte_float(
 mod tests {
     use crate::planner::dsl::{float, function, int, module};
     use crate::planner::plan_module;
-    use crate::planner::support::compile;
+    use crate::planner::support::{compile, expect_plan_error};
+    use crate::planner::{PlanError, UnsupportedExpressionKind};
 
     #[test]
     fn plan_integer_ordering() {
@@ -165,5 +166,199 @@ pub fn gte() {
         );
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_profile_ordering_operand_errors_propagate() {
+        for (name, src) in [
+            (
+                "lt int left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } < 1
+}
+"#,
+            ),
+            (
+                "lt int right",
+                r#"
+pub fn main() {
+  1 < {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "lte int left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } <= 1
+}
+"#,
+            ),
+            (
+                "lte int right",
+                r#"
+pub fn main() {
+  1 <= {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "gt int left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } > 1
+}
+"#,
+            ),
+            (
+                "gt int right",
+                r#"
+pub fn main() {
+  1 > {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "gte int left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1
+  } >= 1
+}
+"#,
+            ),
+            (
+                "gte int right",
+                r#"
+pub fn main() {
+  1 >= {
+    panic
+    1
+  }
+}
+"#,
+            ),
+            (
+                "lt float left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1.0
+  } <. 1.0
+}
+"#,
+            ),
+            (
+                "lt float right",
+                r#"
+pub fn main() {
+  1.0 <. {
+    panic
+    1.0
+  }
+}
+"#,
+            ),
+            (
+                "lte float left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1.0
+  } <=. 1.0
+}
+"#,
+            ),
+            (
+                "lte float right",
+                r#"
+pub fn main() {
+  1.0 <=. {
+    panic
+    1.0
+  }
+}
+"#,
+            ),
+            (
+                "gt float left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1.0
+  } >. 1.0
+}
+"#,
+            ),
+            (
+                "gt float right",
+                r#"
+pub fn main() {
+  1.0 >. {
+    panic
+    1.0
+  }
+}
+"#,
+            ),
+            (
+                "gte float left",
+                r#"
+pub fn main() {
+  {
+    panic
+    1.0
+  } >=. 1.0
+}
+"#,
+            ),
+            (
+                "gte float right",
+                r#"
+pub fn main() {
+  1.0 >=. {
+    panic
+    1.0
+  }
+}
+"#,
+            ),
+        ] {
+            assert_panic_reject(name, src);
+        }
+    }
+
+    fn assert_panic_reject(name: &str, src: &str) {
+        assert_eq!(
+            expect_plan_error(src),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Panic,
+            },
+            "{name}",
+        );
     }
 }


### PR DESCRIPTION
Cover planner operator operand error propagation across arithmetic, ordering,
boolean, and equality helpers.

Add the missing unary integer negation margin case so the operator planner
scope reaches 100% region coverage while keeping source/profile and typed-AST
margin tests separated.
