### PR TITLE
Tighten call planner region coverage

### DIFF
--- a/src/planner/dsl.rs
+++ b/src/planner/dsl.rs
@@ -4,16 +4,16 @@ mod module;
 
 pub(crate) use expression::{
     block_function, block_int, block_int_function, bool_, bool_arg, bool_case_int_function,
-    bool_function_ref, call_bool, call_int, call_int_function, call_int_returning_function,
-    capture_int, capture_tuple, equal, evaluate_step, float, float_function_ref,
-    function_function_closure, function_function_ref, function_ref, int, int_arg,
-    int_case_int_function, int_function_arg, int_function_call_arg, int_function_closure,
-    int_function_ref, let_bool_function_step, let_bool_step, let_int_function_step, let_int_step,
-    let_list_step, let_nil_function_step, let_nil_step, let_string_function_step, let_string_step,
-    let_tuple_step, list, list_function_ref, list_spread, local_bool, local_float, local_int,
-    local_int_function, local_list, local_nil, local_string, local_tuple, nil, nil_arg,
-    nil_function_ref, not_equal, string, string_arg, string_function_ref, tuple, tuple_arg,
-    tuple_function_closure, tuple_function_ref,
+    bool_function_ref, call_bool, call_float, call_int, call_int_function,
+    call_int_returning_function, call_list, capture_int, capture_tuple, equal, evaluate_step,
+    float, float_arg, float_function_ref, function_function_closure, function_function_ref,
+    function_ref, int, int_arg, int_case_int_function, int_function_arg, int_function_call_arg,
+    int_function_closure, int_function_ref, let_bool_function_step, let_bool_step, let_float_step,
+    let_int_function_step, let_int_step, let_list_step, let_nil_function_step, let_nil_step,
+    let_string_function_step, let_string_step, let_tuple_step, list, list_function_ref,
+    list_spread, local_bool, local_float, local_int, local_int_function, local_list, local_nil,
+    local_string, local_tuple, nil, nil_arg, nil_function_ref, not_equal, string, string_arg,
+    string_function_ref, tuple, tuple_arg, tuple_function_closure, tuple_function_ref,
 };
 pub(crate) use function::{
     bool_function_return_block, bool_function_return_bool_case, bool_function_return_expr,

--- a/src/planner/dsl/expression/call.rs
+++ b/src/planner/dsl/expression/call.rs
@@ -1,7 +1,8 @@
-use super::{Bool, Int, IntFunction, Nil, String};
+use super::{Bool, Float, Int, IntFunction, List, Nil, String};
 use crate::plan::{
-    BoolExpr, BoolFunctionId, CallArg, FunctionType, IntExpr, IntFunctionExpr,
-    IntFunctionFunctionId, IntFunctionId, NilExpr, NilFunctionId, StringExpr, StringFunctionId,
+    BoolExpr, BoolFunctionId, CallArg, FloatExpr, FloatFunctionId, FunctionType, IntExpr,
+    IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, ListExpr, ListFunctionId, NilExpr,
+    NilFunctionId, StringExpr, StringFunctionId, ValueType,
 };
 
 pub(crate) fn call_int(function: usize, args: impl IntoIterator<Item = CallArg>) -> Int {
@@ -18,6 +19,13 @@ pub(crate) fn call_string(function: usize, args: impl IntoIterator<Item = CallAr
     ))
 }
 
+pub(crate) fn call_float(function: usize, args: impl IntoIterator<Item = CallArg>) -> Float {
+    Float(FloatExpr::call(
+        FloatFunctionId(function),
+        args.into_iter().collect(),
+    ))
+}
+
 pub(crate) fn call_bool(function: usize, args: impl IntoIterator<Item = CallArg>) -> Bool {
     Bool(BoolExpr::call(
         BoolFunctionId(function),
@@ -29,6 +37,18 @@ pub(crate) fn call_nil(function: usize, args: impl IntoIterator<Item = CallArg>)
     Nil(NilExpr::call(
         NilFunctionId(function),
         args.into_iter().collect(),
+    ))
+}
+
+pub(crate) fn call_list(
+    function: usize,
+    args: impl IntoIterator<Item = CallArg>,
+    element_type: ValueType,
+) -> List {
+    List(ListExpr::call(
+        ListFunctionId(function),
+        args.into_iter().collect(),
+        element_type,
     ))
 }
 
@@ -57,10 +77,12 @@ pub(crate) fn call_int_function(
 #[cfg(test)]
 mod tests {
     use super::{
-        call_bool, call_int, call_int_function, call_int_returning_function, call_nil, call_string,
+        call_bool, call_float, call_int, call_int_function, call_int_returning_function, call_list,
+        call_nil, call_string,
     };
     use crate::plan::{
-        BoolExprKind, FunctionType, IntExprKind, NilExprKind, ParamLocal, StringExprKind, ValueType,
+        BoolExprKind, FloatExprKind, FunctionType, IntExprKind, ListExprKind, NilExprKind,
+        ParamLocal, StringExprKind, ValueType,
     };
     use crate::planner::dsl::expression::{int, int_arg, int_function_ref, string, string_arg};
 
@@ -75,10 +97,18 @@ mod tests {
             StringExprKind::Call { .. },
         ));
         assert!(matches!(
+            call_float(0, []).0.kind(),
+            FloatExprKind::Call { .. },
+        ));
+        assert!(matches!(
             call_bool(0, []).0.kind(),
             BoolExprKind::Call { .. },
         ));
         assert!(matches!(call_nil(0, []).0.kind(), NilExprKind::Call { .. },));
+        assert!(matches!(
+            call_list(0, [], ValueType::Int).0.kind(),
+            ListExprKind::Call { .. },
+        ));
     }
 
     #[test]

--- a/src/planner/expression/call/direct.rs
+++ b/src/planner/expression/call/direct.rs
@@ -119,14 +119,16 @@ fn function_returning_function_call_expr(
 mod tests {
     use super::function_returning_function_call_expr;
     use crate::plan::{
-        BoolFunctionFunctionId, FunctionFunctionFunctionId, FunctionFunctionId, FunctionType,
-        IntFunctionFunctionId, IntLocalId, LocalId, NilFunctionFunctionId,
-        StringFunctionFunctionId, ValueType,
+        BoolFunctionFunctionId, FloatFunctionFunctionId, FunctionFunctionFunctionId,
+        FunctionFunctionId, FunctionType, IntFunctionFunctionId, IntLocalId,
+        ListFunctionFunctionId, LocalId, NilFunctionFunctionId, StringFunctionFunctionId,
+        TupleFunctionFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        call_int_function, function, int, int_arg, int_function_arg, int_function_call_arg,
-        int_function_ref, int_return_tail_call, let_int_function_step, local_int,
-        local_int_function, module,
+        call_float, call_int_function, call_list, float, float_arg, function, int, int_arg,
+        int_function_arg, int_function_call_arg, int_function_ref, int_return_tail_call,
+        let_float_step, let_int_function_step, let_list_step, list, list_return_expr, local_float,
+        local_int, local_int_function, local_list, module, return_list,
     };
     use crate::planner::expression::call::support::expect_call_statement_mut;
     use crate::planner::expression::{typed_int_expr, typed_string_expr};
@@ -264,6 +266,56 @@ pub fn main() {
                 function("add", local_int(0, "base").add_int(local_int(1, "amount")))
                     .param_int(0, "base")
                     .param_int(1, "amount"),
+            ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_float_and_list_direct_call_shapes() {
+        let actual = plan_module(compile(
+            r#"
+fn half(value: Float) {
+  value /. 2.0
+}
+
+fn singleton(value: Int) {
+  [value]
+}
+
+pub fn main() {
+  let half_value = half(3.0)
+  let values = singleton(1)
+  values
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                return_list(
+                    ValueType::Int,
+                    list_return_expr(local_list(0, "values", ValueType::Int)),
+                ),
+            )
+            .step(let_float_step(
+                0,
+                "half_value",
+                call_float(0, [float_arg(0, float(3.0))]),
+            ))
+            .step(let_list_step(
+                0,
+                "values",
+                call_list(1, [int_arg(0, int(1))], ValueType::Int),
+            )),
+            [
+                function("half", local_float(0, "value").div_float(float(2.0)))
+                    .param_float(0, "value"),
+                function("singleton", list([local_int(0, "value")], ValueType::Int))
+                    .param_int(0, "value"),
             ],
         );
 
@@ -531,12 +583,30 @@ pub fn main() {
                 FunctionType::new(vec![ValueType::String], ValueType::String),
             ),
             (
+                FunctionFunctionId::Float(FloatFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::Float], ValueType::Float),
+            ),
+            (
                 FunctionFunctionId::Bool(BoolFunctionFunctionId(0)),
                 FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
             ),
             (
                 FunctionFunctionId::Nil(NilFunctionFunctionId(0)),
                 FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+            ),
+            (
+                FunctionFunctionId::Tuple(TupleFunctionFunctionId(0)),
+                FunctionType::new(
+                    vec![ValueType::Tuple(vec![ValueType::Int])],
+                    ValueType::Tuple(vec![ValueType::Int]),
+                ),
+            ),
+            (
+                FunctionFunctionId::List(ListFunctionFunctionId(0)),
+                FunctionType::new(
+                    vec![ValueType::List(Box::new(ValueType::Int))],
+                    ValueType::List(Box::new(ValueType::Int)),
+                ),
             ),
             (
                 FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),

--- a/src/planner/expression/call/implicit.rs
+++ b/src/planner/expression/call/implicit.rs
@@ -238,3 +238,107 @@ fn invalid_hole_capture() -> PlanError {
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::planner::plan_module;
+    use crate::planner::support::{compile, compile_minimal_module, dummy_span};
+    use crate::planner::{InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError};
+    use gleam_core::ast::{
+        CallArg, Constant, ImplicitCallArgOrigin, Statement, TypedExpr, TypedModule,
+    };
+    use gleam_core::type_::{self, ModuleValueConstructor};
+    use num_bigint::BigInt;
+
+    #[test]
+    fn reject_margin_pipeline_hole_call_pipe_value_expression_shape() {
+        let mut module = compile_hole_pipeline_module();
+        let pipe_argument = expect_pipe_argument_mut(&mut module.definitions.functions[1].body[0]);
+        pipe_argument.value = typed_module_select_expr();
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::ModuleSelect,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "expected pipeline expression statement")]
+    fn expect_pipe_argument_mut_panics_on_non_pipeline() {
+        let mut module = compile_minimal_module();
+
+        expect_pipe_argument_mut(&mut module.definitions.functions[0].body[0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected pipeline final call")]
+    fn expect_pipe_argument_mut_panics_on_non_call_final() {
+        let mut module = compile_hole_pipeline_module();
+        let finally = expect_pipeline_final_mut(&mut module.definitions.functions[1].body[0]);
+        **finally = super::super::super::typed_int_expr(1);
+
+        expect_pipe_argument_mut(&mut module.definitions.functions[1].body[0]);
+    }
+
+    fn compile_hole_pipeline_module() -> TypedModule {
+        compile(
+            r#"
+fn subtract(left: Int, right: Int) {
+  left - right
+}
+
+pub fn main() {
+  1 |> subtract(10, _)
+}
+"#,
+        )
+    }
+
+    fn expect_pipe_argument_mut(
+        statement: &mut gleam_core::ast::TypedStatement,
+    ) -> &mut CallArg<TypedExpr> {
+        let finally = expect_pipeline_final_mut(statement);
+        let TypedExpr::Call { arguments, .. } = finally.as_mut() else {
+            panic!("expected pipeline final call");
+        };
+
+        arguments
+            .iter_mut()
+            .find(|argument| argument.implicit == Some(ImplicitCallArgOrigin::Pipe))
+            .expect("expected pipe argument")
+    }
+
+    fn expect_pipeline_final_mut(
+        statement: &mut gleam_core::ast::TypedStatement,
+    ) -> &mut Box<TypedExpr> {
+        let Statement::Expression(TypedExpr::Pipeline { finally, .. }) = statement else {
+            panic!("expected pipeline expression statement");
+        };
+
+        finally
+    }
+
+    fn typed_module_select_expr() -> TypedExpr {
+        TypedExpr::ModuleSelect {
+            location: dummy_span(),
+            field_start: 0,
+            type_: type_::int(),
+            label: "answer".into(),
+            module_name: "other".into(),
+            module_alias: "other".into(),
+            constructor: ModuleValueConstructor::Constant {
+                literal: Constant::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: BigInt::from(1),
+                },
+                location: dummy_span(),
+                documentation: None,
+            },
+        }
+    }
+}

--- a/src/planner/expression/pipeline.rs
+++ b/src/planner/expression/pipeline.rs
@@ -752,11 +752,11 @@ pub fn main() {
             &mut missing_pipe_argument.definitions.functions[1].body[0],
         );
         let arguments = expect_call_arguments_mut(finally);
-        for argument in arguments {
-            if argument.implicit == Some(ImplicitCallArgOrigin::Pipe) {
-                argument.implicit = None;
-            }
-        }
+        let pipe_argument = arguments
+            .iter_mut()
+            .find(|argument| argument.implicit == Some(ImplicitCallArgOrigin::Pipe))
+            .expect("expected pipe argument");
+        pipe_argument.implicit = None;
         assert_eq!(
             plan_module(missing_pipe_argument),
             Err(invalid_pipeline_shape(


### PR DESCRIPTION
- Bring `planner/expression/call*` region coverage to 100%.
- Cover Float and List direct call return-family shapes with expected-plan tests.
- Keep pipeline hole pipe-value margin coverage in the call implicit planner while leaving pipeline shape tests in `pipeline`.
