### PR TITLE
Tighten expression region coverage

### DIFF
--- a/src/planner/expression/function/free_variables.rs
+++ b/src/planner/expression/function/free_variables.rs
@@ -201,8 +201,11 @@ fn collect_variable_pattern_bound_name(
 
 #[cfg(test)]
 mod tests {
-    use crate::planner::support::compile;
-    use gleam_core::ast::{Statement, TypedExpr};
+    use crate::planner::support::{compile, dummy_span};
+    use gleam_core::ast::{Publicity, Statement, TypedExpr};
+    use gleam_core::type_::error::VariableOrigin;
+    use gleam_core::type_::{self, Deprecation, ValueConstructor, ValueConstructorVariant};
+    use vec1::Vec1;
 
     #[test]
     fn anonymous_free_variables_include_use_callback_call() {
@@ -237,14 +240,18 @@ pub fn main() {
   let case_subject = True
   let pattern_source = 2
   let case_value = 3
+  let repeated_value = 4
   let negate_int_value = 4
   let negate_bool_value = True
   let tuple_value = #(5, 6)
+  let list_element_value = 7
   let list_tail_value = [7]
   fn() {
     {
       block_value
     }
+    repeated_value
+    repeated_value
     case case_subject {
       True -> {
         let branch_local = pattern_source
@@ -258,6 +265,7 @@ pub fn main() {
     }
     -negate_int_value
     tuple_value.0
+    [list_element_value]
     [0, ..list_tail_value]
   }
   1
@@ -266,15 +274,32 @@ pub fn main() {
             ),
             vec![
                 "block_value".to_string(),
+                "repeated_value".to_string(),
                 "case_subject".to_string(),
                 "pattern_source".to_string(),
                 "case_value".to_string(),
                 "negate_bool_value".to_string(),
                 "negate_int_value".to_string(),
                 "tuple_value".to_string(),
+                "list_element_value".to_string(),
                 "list_tail_value".to_string(),
             ],
         );
+    }
+
+    #[test]
+    fn anonymous_free_variables_include_synthetic_negate_int() {
+        let body = Vec1::new(Statement::Expression(TypedExpr::NegateInt {
+            location: dummy_span(),
+            value: Box::new(typed_local_int_variable("negate_int_value")),
+        }));
+
+        let mut names = Vec::new();
+        for name in super::anonymous_free_variables(&[], &body) {
+            names.push(name.to_string());
+        }
+
+        assert_eq!(names, vec!["negate_int_value".to_string()]);
     }
 
     fn anonymous_function_free_variables(src: &str) -> Vec<String> {
@@ -300,5 +325,21 @@ pub fn main() {
             names.push(name.to_string());
         }
         names
+    }
+
+    fn typed_local_int_variable(name: &str) -> TypedExpr {
+        TypedExpr::Var {
+            location: dummy_span(),
+            name: name.into(),
+            constructor: ValueConstructor {
+                publicity: Publicity::Private,
+                deprecation: Deprecation::NotDeprecated,
+                type_: type_::int(),
+                variant: ValueConstructorVariant::LocalVariable {
+                    location: dummy_span(),
+                    origin: VariableOrigin::generated(),
+                },
+            },
+        }
     }
 }

--- a/src/runtime/expression/function/float.rs
+++ b/src/runtime/expression/function/float.rs
@@ -408,6 +408,18 @@ mod tests {
                 ValueType::Int,
             )),
         );
+
+        let tuple = error_tuple_expr();
+        assert_eq!(
+            eval_float_function_expr(
+                &plan,
+                &mut frame,
+                &FloatFunctionExpr::tuple_index(tuple, 0, type_()),
+            ),
+            Err(tuple_index_error(ValueType::Tuple(vec![
+                ValueType::Function(Box::new(type_()))
+            ]))),
+        );
     }
 
     fn plan() -> ExecutionPlan {
@@ -500,6 +512,22 @@ mod tests {
             Vec::new(),
             FunctionType::new(Vec::new(), ValueType::String),
         ))
+    }
+
+    fn error_tuple_expr() -> TupleExpr {
+        TupleExpr::tuple_index(
+            empty_tuple(),
+            0,
+            vec![ValueType::Function(Box::new(type_()))],
+        )
+    }
+
+    fn empty_tuple() -> TupleExpr {
+        TupleExpr::value(Vec::new(), Vec::new())
+    }
+
+    fn tuple_index_error(expected: ValueType) -> ExecutionError {
+        ExecutionError::tuple_index_family_mismatch(expected, ValueType::Tuple(Vec::new()))
     }
 
     fn function_value() -> FloatFunctionExpr {

--- a/src/runtime/expression/nil.rs
+++ b/src/runtime/expression/nil.rs
@@ -91,9 +91,10 @@ pub(in crate::runtime) fn eval_nil_expr(
 mod tests {
     use super::eval_nil_expr;
     use crate::plan::{
-        BoolExpr, BoolFunctionExpr, ExecutionPlan, Expr, FunctionFunctionExpr, FunctionFunctionId,
-        FunctionFunctionValue, FunctionId, FunctionPlan, FunctionReturnFamily, FunctionType,
-        IntExpr, IntFunctionExpr, IntFunctionId, NilExpr, NilFunctionExpr, ReturnExpr, Step,
+        BoolExpr, BoolFunctionExpr, ExecutionPlan, Expr, FloatExpr, FloatFunctionExpr,
+        FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionValue, FunctionId, FunctionPlan,
+        FunctionReturnFamily, FunctionType, IntExpr, IntFunctionExpr, IntFunctionFunctionId,
+        IntFunctionId, NilExpr, NilFunctionExpr, ReturnExpr, Step, StringExpr, StringFunctionExpr,
         StringFunctionFunctionId, TupleExpr, ValueType,
     };
     use crate::runtime::ExecutionError;
@@ -320,6 +321,35 @@ pub fn main() {
             eval_nil_expr(
                 &plan,
                 &mut frame,
+                &crate::plan::NilExpr::string_case(
+                    error_string_expr(),
+                    vec![("one".into(), crate::plan::NilExpr::value())],
+                    crate::plan::NilExpr::value(),
+                ),
+            ),
+            Err(function_return_family_error(
+                FunctionReturnFamily::String,
+                FunctionReturnFamily::Int,
+            )),
+        );
+        assert_eq!(
+            eval_nil_expr(
+                &plan,
+                &mut frame,
+                &crate::plan::NilExpr::float_case(
+                    error_float_expr(),
+                    vec![(1.0, crate::plan::NilExpr::value())],
+                    crate::plan::NilExpr::value(),
+                ),
+            ),
+            Err(function_return_family_error_value(
+                FunctionReturnFamily::Float
+            )),
+        );
+        assert_eq!(
+            eval_nil_expr(
+                &plan,
+                &mut frame,
                 &crate::plan::NilExpr::block(
                     vec![Step::evaluate(Expr::bool(error_bool_expr()))],
                     crate::plan::NilExpr::value(),
@@ -462,12 +492,34 @@ pub fn main() {
         )
     }
 
+    fn error_float_expr() -> FloatExpr {
+        FloatExpr::function_call(
+            FloatFunctionExpr::function_call(
+                function_function_expr(),
+                Vec::new(),
+                FunctionType::new(Vec::new(), ValueType::Float),
+            ),
+            Vec::new(),
+        )
+    }
+
     fn error_int_expr() -> IntExpr {
         IntExpr::function_call(
             IntFunctionExpr::function_call(
                 function_function_expr(),
                 Vec::new(),
                 FunctionType::new(Vec::new(), ValueType::Int),
+            ),
+            Vec::new(),
+        )
+    }
+
+    fn error_string_expr() -> StringExpr {
+        StringExpr::function_call(
+            StringFunctionExpr::function_call(
+                int_function_function_expr(),
+                Vec::new(),
+                FunctionType::new(Vec::new(), ValueType::String),
             ),
             Vec::new(),
         )
@@ -492,7 +544,22 @@ pub fn main() {
         ))
     }
 
+    fn int_function_function_expr() -> FunctionFunctionExpr {
+        FunctionFunctionExpr::value(FunctionFunctionValue::new(
+            FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+            Vec::new(),
+            FunctionType::new(Vec::new(), ValueType::Int),
+        ))
+    }
+
     fn function_return_family_error_value(expected: FunctionReturnFamily) -> ExecutionError {
-        ExecutionError::function_return_family_mismatch(expected, FunctionReturnFamily::String)
+        function_return_family_error(expected, FunctionReturnFamily::String)
+    }
+
+    fn function_return_family_error(
+        expected: FunctionReturnFamily,
+        actual: FunctionReturnFamily,
+    ) -> ExecutionError {
+        ExecutionError::function_return_family_mismatch(expected, actual)
     }
 }


### PR DESCRIPTION
- Bring free-variable, Nil, and float-function expression region coverage to 100%.
- Cover free-variable collection for repeated locals, list elements, and synthetic integer negation.
- Cover Nil case subject errors and float-function tuple projection error propagation.
