### PR TITLE
Tighten DSL facade region coverage

### DIFF
--- a/src/planner/dsl/expression/case.rs
+++ b/src/planner/dsl/expression/case.rs
@@ -13,26 +13,44 @@ mod tests {
     use super::{bool_case_int, float_case_int, int_case_int, string_case_int};
     use crate::plan::IntExprKind;
     use crate::planner::dsl::expression::{bool_, float, int, string};
+    use ecow::EcoString;
+    use num_bigint::BigInt;
 
     #[test]
     fn case_facade_reexports_subject_family_helpers() {
-        assert!(matches!(
+        assert_eq!(
             bool_case_int(bool_(true), int(1), int(0)).0.kind(),
-            IntExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            &IntExprKind::BoolCase {
+                subject: Box::new(bool_(true).into()),
+                true_: Box::new(int(1).into()),
+                false_: Box::new(int(0).into()),
+            },
+        );
+        assert_eq!(
             int_case_int(int(1), [(1, int(1))], int(0)).0.kind(),
-            IntExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            &IntExprKind::IntCase {
+                subject: Box::new(int(1).into()),
+                clauses: vec![(BigInt::from(1), int(1).into())],
+                fallback: Box::new(int(0).into()),
+            },
+        );
+        assert_eq!(
             float_case_int(float(1.0), [(1.0, int(1))], int(0)).0.kind(),
-            IntExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            &IntExprKind::FloatCase {
+                subject: Box::new(float(1.0).into()),
+                clauses: vec![(1.0, int(1).into())],
+                fallback: Box::new(int(0).into()),
+            },
+        );
+        assert_eq!(
             string_case_int(string("key"), [("one", int(1))], int(0))
                 .0
                 .kind(),
-            IntExprKind::StringCase { .. },
-        ));
+            &IntExprKind::StringCase {
+                subject: Box::new(string("key").into()),
+                clauses: vec![(EcoString::from("one"), int(1).into())],
+                fallback: Box::new(int(0).into()),
+            },
+        );
     }
 }

--- a/src/planner/dsl/function.rs
+++ b/src/planner/dsl/function.rs
@@ -44,8 +44,8 @@ mod tests {
     use super::function;
     use crate::plan::{
         BoolFunctionId, FloatFunctionId, FunctionFunctionId, FunctionId, FunctionType,
-        IntFunctionFunctionId, IntFunctionId, ListFunctionId, NilFunctionId, ParamLocal,
-        RuntimeFunctionId, Step, StepKind, StringFunctionId, ValueType,
+        IntFunctionFunctionId, IntFunctionId, IntLocalId, ListFunctionId, NilFunctionId,
+        ParamLocal, RuntimeFunctionId, Step, StepKind, StringFunctionId, ValueType,
     };
     use crate::planner::context::FunctionRuntimeIds;
     use crate::planner::dsl::expression::{
@@ -105,11 +105,18 @@ mod tests {
         assert_eq!(function.name(), "main");
         assert_eq!(function.params().len(), 11);
         assert_eq!(function.steps().len(), 7);
-        assert!(matches!(
+        assert_eq!(
             function.steps()[0].kind(),
-            StepKind::LetInt { .. }
-        ));
-        assert!(matches!(function.steps()[6].kind(), StepKind::Evaluate(_)));
+            &StepKind::LetInt {
+                local: IntLocalId(1),
+                name: "x".into(),
+                value: int(2).into(),
+            },
+        );
+        assert_eq!(
+            function.steps()[6].kind(),
+            &StepKind::Evaluate(int(3).into()),
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Bring `planner/dsl/function.rs` and `planner/dsl/expression/case.rs` region coverage to 100%.
- Replace broad `matches!` checks with exact DSL-generated plan shape assertions.
- Keep the coverage work inside the owning DSL facade tests.
