### PR TITLE
Tighten plan shape region coverage

### DIFF
--- a/src/plan/function.rs
+++ b/src/plan/function.rs
@@ -868,14 +868,15 @@ mod tests {
         BoolFunctionValue, BoolLocalId, FloatExpr, FloatFunctionExpr, FloatFunctionFunctionId,
         FloatFunctionId, FloatFunctionLocalId, FloatFunctionValue, FloatLocalId, FrameLayout,
         FunctionFunctionExpr, FunctionFunctionFunctionId, FunctionFunctionId,
-        FunctionFunctionValue, FunctionId, FunctionType, IntExpr, IntFunctionExpr,
-        IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId,
-        ListExpr, ListFunctionExpr, ListFunctionFunctionId, ListFunctionId, ListFunctionLocalId,
-        ListFunctionValue, ListLocalId, NilExpr, NilFunctionExpr, NilFunctionFunctionId,
-        NilFunctionId, NilFunctionLocalId, NilFunctionValue, StringExpr, StringFunctionExpr,
-        StringFunctionFunctionId, StringFunctionId, StringFunctionLocalId, StringFunctionValue,
-        TupleExpr, TupleFunctionExpr, TupleFunctionFunctionId, TupleFunctionId,
-        TupleFunctionLocalId, TupleFunctionValue, ValueType,
+        FunctionFunctionLocalId, FunctionFunctionValue, FunctionId, FunctionType, IntExpr,
+        IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId,
+        IntFunctionValue, IntLocalId, ListExpr, ListFunctionExpr, ListFunctionFunctionId,
+        ListFunctionId, ListFunctionLocalId, ListFunctionValue, ListLocalId, NilExpr,
+        NilFunctionExpr, NilFunctionFunctionId, NilFunctionId, NilFunctionLocalId,
+        NilFunctionValue, StringExpr, StringFunctionExpr, StringFunctionFunctionId,
+        StringFunctionId, StringFunctionLocalId, StringFunctionValue, TupleExpr, TupleFunctionExpr,
+        TupleFunctionFunctionId, TupleFunctionId, TupleFunctionLocalId, TupleFunctionValue,
+        ValueType,
     };
     use num_bigint::BigInt;
 
@@ -1158,6 +1159,20 @@ mod tests {
             ValueType::Function(Box::new(FunctionType::new(
                 vec![ValueType::List(Box::new(ValueType::Int))],
                 ValueType::List(Box::new(ValueType::String)),
+            ))),
+        );
+        assert_eq!(
+            ParamLocal::function_function(
+                FunctionFunctionLocalId(0),
+                FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+                ),
+            )
+            .value_type(),
+            ValueType::Function(Box::new(FunctionType::new(
+                Vec::new(),
+                ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
             ))),
         );
     }

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -239,18 +239,26 @@ mod tests {
 
     #[test]
     fn step_kind_accessors() {
-        assert!(matches!(
+        assert_eq!(
             Step::let_int(IntLocalId(0), "x".into(), IntExpr::value(BigInt::from(1))).kind(),
-            StepKind::LetInt { .. },
-        ));
-        assert!(matches!(
+            &StepKind::LetInt {
+                local: IntLocalId(0),
+                name: "x".into(),
+                value: IntExpr::value(BigInt::from(1)),
+            },
+        );
+        assert_eq!(
             Step::let_int_function(IntFunctionLocalId(0), "f".into(), function_expr()).kind(),
-            StepKind::LetIntFunction { .. },
-        ));
-        assert!(matches!(
+            &StepKind::LetIntFunction {
+                local: IntFunctionLocalId(0),
+                name: "f".into(),
+                value: function_expr(),
+            },
+        );
+        assert_eq!(
             Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1)))).kind(),
-            StepKind::Evaluate(_),
-        ));
+            &StepKind::Evaluate(Expr::int(IntExpr::value(BigInt::from(1)))),
+        );
     }
 
     fn function_expr() -> crate::plan::IntFunctionExpr {


### PR DESCRIPTION
Tighten plan shape region coverage

- Bring `plan/function.rs` and `plan/step.rs` region coverage to 100%.
- Cover the function-returning-function `ParamLocal::value_type` family.
- Replace broad step kind checks with exact `StepKind` shape assertions.
