### PR TITLE
Tighten planner facade region coverage

### DIFF
--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -116,6 +116,8 @@ Errors make boundaries visible:
 - Use `Option` for lookups or partial conversions when the caller owns the
   boundary meaning of absence. If all callers translate `None` into the same
   failure boundary, return `Result` or a structured reason instead.
+- Keep fallibility meaningful: an internal helper may return `Result` only when
+  it creates or propagates a real failure boundary.
 - When the accepted profile grows into an area that was previously rejected by a
   broad `Unsupported*` variant, revisit that variant. Rename or split it if the
   old name also describes behavior that is now supported.

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -582,10 +582,7 @@ impl<'a> PlanContext<'a> {
             .collect()
     }
 
-    pub(super) fn define_captures(
-        &mut self,
-        captures: Vec<CaptureBinding>,
-    ) -> Result<Vec<CaptureArg>, PlanError> {
+    pub(super) fn define_captures(&mut self, captures: Vec<CaptureBinding>) -> Vec<CaptureArg> {
         captures
             .into_iter()
             .map(|capture| self.define_capture(capture))
@@ -602,116 +599,98 @@ impl<'a> PlanContext<'a> {
         result
     }
 
-    fn define_capture(&mut self, capture: CaptureBinding) -> Result<CaptureArg, PlanError> {
+    fn define_capture(&mut self, capture: CaptureBinding) -> CaptureArg {
         match capture.binding {
             LocalBinding::Primitive(LocalId::Int(local)) => {
                 let target = self.define_int_local(capture.name.clone());
-                Ok(CaptureArg::int(
-                    target,
-                    IntExpr::local_get(local, capture.name),
-                ))
+                CaptureArg::int(target, IntExpr::local_get(local, capture.name))
             }
             LocalBinding::Primitive(LocalId::Float(local)) => {
                 let target = self.define_float_local(capture.name.clone());
-                Ok(CaptureArg::float(
-                    target,
-                    FloatExpr::local_get(local, capture.name),
-                ))
+                CaptureArg::float(target, FloatExpr::local_get(local, capture.name))
             }
             LocalBinding::Primitive(LocalId::String(local)) => {
                 let target = self.define_string_local(capture.name.clone());
-                Ok(CaptureArg::string(
-                    target,
-                    StringExpr::local_get(local, capture.name),
-                ))
+                CaptureArg::string(target, StringExpr::local_get(local, capture.name))
             }
             LocalBinding::Primitive(LocalId::Bool(local)) => {
                 let target = self.define_bool_local(capture.name.clone());
-                Ok(CaptureArg::bool(
-                    target,
-                    BoolExpr::local_get(local, capture.name),
-                ))
+                CaptureArg::bool(target, BoolExpr::local_get(local, capture.name))
             }
             LocalBinding::Primitive(LocalId::Nil(local)) => {
                 let target = self.define_nil_local(capture.name.clone());
-                Ok(CaptureArg::nil(
-                    target,
-                    NilExpr::local_get(local, capture.name),
-                ))
+                CaptureArg::nil(target, NilExpr::local_get(local, capture.name))
             }
             LocalBinding::Tuple { local, type_ } => {
                 let target = self.define_tuple_local(capture.name.clone(), type_.clone());
-                Ok(CaptureArg::tuple(
-                    target,
-                    TupleExpr::local_get(local, capture.name, type_),
-                ))
+                CaptureArg::tuple(target, TupleExpr::local_get(local, capture.name, type_))
             }
             LocalBinding::List {
                 local,
                 element_type,
             } => {
                 let target = self.define_list_local(capture.name.clone(), element_type.clone());
-                Ok(CaptureArg::list(
+                CaptureArg::list(
                     target,
                     ListExpr::local_get(local, capture.name, element_type),
-                ))
+                )
             }
             LocalBinding::Function(FunctionLocalBinding::Int { local, type_ }) => {
                 let target = self.define_int_function_local(capture.name.clone(), type_.clone());
-                Ok(CaptureArg::int_function(
+                CaptureArg::int_function(
                     target,
                     IntFunctionExpr::local_get(local, capture.name, type_),
-                ))
+                )
             }
             LocalBinding::Function(FunctionLocalBinding::Float { local, type_ }) => {
                 let target = self.define_float_function_local(capture.name.clone(), type_.clone());
-                Ok(CaptureArg::float_function(
+                CaptureArg::float_function(
                     target,
                     FloatFunctionExpr::local_get(local, capture.name, type_),
-                ))
+                )
             }
             LocalBinding::Function(FunctionLocalBinding::String { local, type_ }) => {
                 let target = self.define_string_function_local(capture.name.clone(), type_.clone());
-                Ok(CaptureArg::string_function(
+                CaptureArg::string_function(
                     target,
                     StringFunctionExpr::local_get(local, capture.name, type_),
-                ))
+                )
             }
             LocalBinding::Function(FunctionLocalBinding::Bool { local, type_ }) => {
                 let target = self.define_bool_function_local(capture.name.clone(), type_.clone());
-                Ok(CaptureArg::bool_function(
+                CaptureArg::bool_function(
                     target,
                     BoolFunctionExpr::local_get(local, capture.name, type_),
-                ))
+                )
             }
             LocalBinding::Function(FunctionLocalBinding::Nil { local, type_ }) => {
                 let target = self.define_nil_function_local(capture.name.clone(), type_.clone());
-                Ok(CaptureArg::nil_function(
+                CaptureArg::nil_function(
                     target,
                     NilFunctionExpr::local_get(local, capture.name, type_),
-                ))
+                )
             }
             LocalBinding::Function(FunctionLocalBinding::Tuple { local, type_ }) => {
                 let target = self.define_tuple_function_local(capture.name.clone(), type_.clone());
-                Ok(CaptureArg::tuple_function(
+                CaptureArg::tuple_function(
                     target,
                     TupleFunctionExpr::local_get(local, capture.name, type_),
-                ))
+                )
             }
             LocalBinding::Function(FunctionLocalBinding::List { local, type_ }) => {
                 let target = self.define_list_function_local(capture.name.clone(), type_.clone());
-                Ok(CaptureArg::list_function(
+                CaptureArg::list_function(
                     target,
                     ListFunctionExpr::local_get(local, capture.name, type_),
-                ))
+                )
             }
             LocalBinding::Function(FunctionLocalBinding::Function { local, type_ }) => {
                 let target =
                     self.define_function_function_local(capture.name.clone(), type_.clone());
-                Ok(CaptureArg::function_function(
+                CaptureArg::function_function(
                     target,
                     FunctionFunctionExpr::local_get(local, capture.name, type_),
-                ))
+                )
             }
         }
     }
@@ -1236,7 +1215,7 @@ mod tests {
 
         context.define_float_function_local("f".into(), type_.clone());
         let captures = context.capture_bindings(&[EcoString::from("f")]).unwrap();
-        let captures = context.define_captures(captures).unwrap();
+        let captures = context.define_captures(captures);
 
         assert_eq!(
             captures[0],
@@ -1257,7 +1236,7 @@ mod tests {
 
         context.define_tuple_function_local("f".into(), type_.clone());
         let captures = context.capture_bindings(&[EcoString::from("f")]).unwrap();
-        let captures = context.define_captures(captures).unwrap();
+        let captures = context.define_captures(captures);
 
         assert_eq!(
             captures[0],
@@ -1285,7 +1264,7 @@ mod tests {
         let captures = context
             .capture_bindings(&[EcoString::from("values"), EcoString::from("f")])
             .unwrap();
-        let captures = context.define_captures(captures).unwrap();
+        let captures = context.define_captures(captures);
 
         assert_eq!(
             captures,
@@ -1328,7 +1307,7 @@ mod tests {
                 "function_fn".into(),
             ])
             .unwrap();
-        let captures = context.define_captures(captures).unwrap();
+        let captures = context.define_captures(captures);
 
         assert_eq!(
             captures,

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -1515,6 +1515,19 @@ pub fn main() {
                     location: dummy_span(),
                     type_: type_::list(type_::int()),
                     elements: vec![typed_int_expr(1)],
+                    tail: Some(Box::new(invalid_expr(type_::list(type_::int())))),
+                },
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionShape {
+                        kind: InvalidExpressionShapeKind::Invalid,
+                    },
+                },
+            ),
+            (
+                TypedExpr::List {
+                    location: dummy_span(),
+                    type_: type_::list(type_::int()),
+                    elements: vec![typed_int_expr(1)],
                     tail: Some(Box::new(typed_int_expr(2))),
                 },
                 PlanError::InvalidTypedAst {

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -1068,18 +1068,25 @@ pub fn main() {
             |_: &mut Vec<TypedArg>, body: &mut vec1::Vec1<TypedStatement>| {
                 let arguments = function_capture_literal_body_call_args_mut(body);
                 let capture_index = capture_argument_index(arguments);
-                if let TypedExpr::Var { constructor, .. } = &mut arguments[capture_index].value {
-                    constructor.variant = gleam_core::type_::ValueConstructorVariant::Record {
-                        name: "Capture".into(),
-                        arity: 1,
-                        field_map: None,
-                        location: dummy_span(),
-                        module: "main".into(),
-                        variants_count: 1,
-                        variant_index: 0,
-                        documentation: None,
-                    };
-                }
+                arguments[capture_index].value = TypedExpr::Var {
+                    location: dummy_span(),
+                    name: CAPTURE_VARIABLE.into(),
+                    constructor: gleam_core::type_::ValueConstructor {
+                        publicity: gleam_core::ast::Publicity::Private,
+                        deprecation: gleam_core::type_::Deprecation::NotDeprecated,
+                        type_: gleam_core::type_::int(),
+                        variant: gleam_core::type_::ValueConstructorVariant::Record {
+                            name: "Capture".into(),
+                            arity: 1,
+                            field_map: None,
+                            location: dummy_span(),
+                            module: "main".into(),
+                            variants_count: 1,
+                            variant_index: 0,
+                            documentation: None,
+                        },
+                    },
+                };
             },
         ] {
             let mut module = function_capture_literal_module();

--- a/src/planner/function.rs
+++ b/src/planner/function.rs
@@ -75,7 +75,7 @@ pub(super) fn plan_anonymous_function_body(
     context: &mut PlanContext<'_>,
 ) -> Result<PlannedFunctionBody, PlanError> {
     let params = define_params(params, context);
-    let captures = context.define_captures(captures)?;
+    let captures = context.define_captures(captures);
     let planned = crate::planner::statement::plan_non_empty_steps_and_return(body, context)?;
     let return_ = function_return_expr(name, return_type, runtime_id, planned.return_)?;
 


### PR DESCRIPTION
Tighten planner facade region coverage

- Bring `planner/expression.rs`, `planner/expression/function.rs`, and `planner/function.rs` region coverage to 100%.
- Cover list spread tail error propagation and capture literal margin shape cleanup.
- Remove impossible capture definition fallibility and document the helper fallibility boundary.
