### PR TITLE
Tighten planner DSL region coverage

### DIFF
--- a/src/planner/dsl/expression/arg.rs
+++ b/src/planner/dsl/expression/arg.rs
@@ -75,11 +75,15 @@ pub(crate) fn tuple_function_arg(local: usize, value: TupleFunction) -> CallArg 
 #[cfg(test)]
 mod tests {
     use super::{
-        bool_arg, bool_function_arg, capture_tuple, float_arg, float_function_arg, int_arg,
-        int_function_arg, int_function_call_arg, nil_arg, nil_function_arg, string_arg,
-        string_function_arg, tuple_arg, tuple_function_arg,
+        bool_arg, bool_function_arg, capture_float, capture_int, capture_tuple, float_arg,
+        float_function_arg, int_arg, int_function_arg, int_function_call_arg, nil_arg,
+        nil_function_arg, string_arg, string_function_arg, tuple_arg, tuple_function_arg,
     };
-    use crate::plan::{CallArgKind, CaptureArgKind, Expr, ParamLocal};
+    use crate::plan::{
+        BoolFunctionLocalId, BoolLocalId, CallArg, CaptureArg, Expr, FloatFunctionLocalId,
+        FloatLocalId, IntFunctionLocalId, IntLocalId, NilFunctionLocalId, NilLocalId, ParamLocal,
+        StringFunctionLocalId, StringLocalId, TupleFunctionLocalId, TupleLocalId,
+    };
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, int, int_function_ref, nil,
         nil_function_ref, string, string_function_ref, tuple, tuple_function_ref,
@@ -87,59 +91,96 @@ mod tests {
 
     #[test]
     fn call_arg_helpers_build_typed_arg_shapes() {
-        assert!(matches!(int_arg(0, int(1)).kind(), CallArgKind::Int { .. },));
-        assert!(matches!(
-            int_function_call_arg(0, int(1)).kind(),
-            CallArgKind::Int { .. },
-        ));
-        assert!(matches!(
-            int_function_arg(0, int_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            CallArgKind::IntFunction { .. },
-        ));
-        assert!(matches!(
-            string_arg(0, string("a")).kind(),
-            CallArgKind::String { .. },
-        ));
-        assert!(matches!(
-            string_function_arg(0, string_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            CallArgKind::StringFunction { .. },
-        ));
-        assert!(matches!(
-            float_arg(0, float(1.0)).kind(),
-            CallArgKind::Float { .. },
-        ));
-        assert!(matches!(
-            float_function_arg(0, float_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            CallArgKind::FloatFunction { .. },
-        ));
-        assert!(matches!(
-            bool_arg(0, bool_(true)).kind(),
-            CallArgKind::Bool { .. },
-        ));
-        assert!(matches!(
-            bool_function_arg(0, bool_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            CallArgKind::BoolFunction { .. },
-        ));
-        assert!(matches!(nil_arg(0, nil()).kind(), CallArgKind::Nil { .. },));
-        assert!(matches!(
-            nil_function_arg(0, nil_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            CallArgKind::NilFunction { .. },
-        ));
-        assert!(matches!(
-            tuple_arg(0, tuple([Expr::from(int(1)), Expr::from(string("one"))])).kind(),
-            CallArgKind::Tuple { .. },
-        ));
-        assert!(matches!(
-            capture_tuple(0, tuple([Expr::from(int(1)), Expr::from(string("one"))])).kind(),
-            CaptureArgKind::Tuple { .. },
-        ));
-        assert!(matches!(
+        assert_eq!(
+            int_arg(0, int(1)),
+            CallArg::int(IntLocalId(0), int(1).into())
+        );
+        assert_eq!(
+            capture_int(1, int(2)),
+            CaptureArg::int(IntLocalId(1), int(2).into()),
+        );
+        assert_eq!(
+            int_function_call_arg(2, int(3)),
+            CallArg::int(IntLocalId(2), int(3).into()),
+        );
+        assert_eq!(
+            int_function_arg(3, int_function_ref(0, Vec::<ParamLocal>::new())),
+            CallArg::int_function(
+                IntFunctionLocalId(3),
+                int_function_ref(0, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
+            string_arg(4, string("a")),
+            CallArg::string(StringLocalId(4), string("a").into()),
+        );
+        assert_eq!(
+            string_function_arg(5, string_function_ref(0, Vec::<ParamLocal>::new())),
+            CallArg::string_function(
+                StringFunctionLocalId(5),
+                string_function_ref(0, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
+            float_arg(6, float(1.0)),
+            CallArg::float(FloatLocalId(6), float(1.0).into()),
+        );
+        assert_eq!(
+            capture_float(7, float(2.0)),
+            CaptureArg::float(FloatLocalId(7), float(2.0).into()),
+        );
+        assert_eq!(
+            float_function_arg(8, float_function_ref(0, Vec::<ParamLocal>::new())),
+            CallArg::float_function(
+                FloatFunctionLocalId(8),
+                float_function_ref(0, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
+            bool_arg(9, bool_(true)),
+            CallArg::bool(BoolLocalId(9), bool_(true).into()),
+        );
+        assert_eq!(
+            bool_function_arg(10, bool_function_ref(0, Vec::<ParamLocal>::new())),
+            CallArg::bool_function(
+                BoolFunctionLocalId(10),
+                bool_function_ref(0, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
+            nil_arg(11, nil()),
+            CallArg::nil(NilLocalId(11), nil().into())
+        );
+        assert_eq!(
+            nil_function_arg(12, nil_function_ref(0, Vec::<ParamLocal>::new())),
+            CallArg::nil_function(
+                NilFunctionLocalId(12),
+                nil_function_ref(0, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+
+        let tuple_value_expr = crate::plan::TupleExpr::value(
+            vec![Expr::from(int(1)), Expr::from(string("one"))],
+            vec![crate::plan::ValueType::Int, crate::plan::ValueType::String],
+        );
+        assert_eq!(
+            tuple_arg(13, tuple([Expr::from(int(1)), Expr::from(string("one"))])),
+            CallArg::tuple(TupleLocalId(13), tuple_value_expr.clone()),
+        );
+        assert_eq!(
+            capture_tuple(14, tuple([Expr::from(int(1)), Expr::from(string("one"))])),
+            CaptureArg::tuple(TupleLocalId(14), tuple_value_expr),
+        );
+        assert_eq!(
             tuple_function_arg(
                 0,
                 tuple_function_ref(0, Vec::<ParamLocal>::new(), [crate::plan::ValueType::Int]),
-            )
-            .kind(),
-            CallArgKind::TupleFunction { .. },
-        ));
+            ),
+            CallArg::tuple_function(
+                TupleFunctionLocalId(0),
+                tuple_function_ref(0, Vec::<ParamLocal>::new(), [crate::plan::ValueType::Int])
+                    .into(),
+            ),
+        );
     }
 }

--- a/src/planner/dsl/expression/block.rs
+++ b/src/planner/dsl/expression/block.rs
@@ -111,10 +111,12 @@ mod tests {
         block_tuple_function,
     };
     use crate::plan::{
-        BoolExprKind, FloatExprKind, FunctionExpr, FunctionExprKind, FunctionFunctionId,
-        FunctionType, IntExprKind, IntFunctionExprKind, IntFunctionFunctionId, ListExprKind,
-        ListFunctionExprKind, NilExprKind, ParamLocal, RuntimeFunctionId, StringExprKind,
-        TupleFunctionExprKind, ValueType,
+        BoolExpr, BoolFunctionId, BoolFunctionValue, FloatExpr, FloatFunctionId,
+        FloatFunctionValue, FunctionExpr, FunctionFunctionExpr, FunctionFunctionId,
+        FunctionFunctionValue, FunctionType, IntExpr, IntFunctionExpr, IntFunctionFunctionId,
+        IntFunctionId, IntFunctionValue, ListExpr, ListFunctionExpr, ListFunctionValue, NilExpr,
+        NilFunctionId, NilFunctionValue, ParamLocal, RuntimeFunctionId, StringExpr,
+        StringFunctionId, StringFunctionValue, TupleFunctionExpr, TupleFunctionValue, ValueType,
     };
     use crate::planner::dsl::expression::{
         Function, bool_, float, function_function_ref, function_ref, int, int_function_ref,
@@ -124,98 +126,121 @@ mod tests {
 
     #[test]
     fn primitive_block_helpers_build_block_shapes() {
-        assert!(matches!(
-            block_int([let_int_step(0, "x", int(1))], local_int(0, "x"))
-                .0
-                .kind(),
-            IntExprKind::Block { .. },
-        ));
-        assert!(matches!(
-            block_string([let_string_step(0, "x", string("a"))], local_string(0, "x"))
-                .0
-                .kind(),
-            StringExprKind::Block { .. },
-        ));
-        assert!(matches!(
-            block_float([], float(1.0)).0.kind(),
-            FloatExprKind::Block { .. },
-        ));
-        assert!(matches!(
-            block_bool([let_bool_step(0, "x", bool_(true))], local_bool(0, "x"))
-                .0
-                .kind(),
-            BoolExprKind::Block { .. },
-        ));
-        assert!(matches!(
-            block_nil([let_nil_step(0, "x", nil())], local_nil(0, "x"))
-                .0
-                .kind(),
-            NilExprKind::Block { .. },
-        ));
-        assert!(matches!(
-            block_list([], list([int(1)], ValueType::Int)).0.kind(),
-            ListExprKind::Block { .. },
-        ));
+        assert_eq!(
+            block_int([let_int_step(0, "x", int(1))], local_int(0, "x")).0,
+            IntExpr::block(vec![let_int_step(0, "x", int(1))], local_int(0, "x").into()),
+        );
+        assert_eq!(
+            block_string([let_string_step(0, "x", string("a"))], local_string(0, "x")).0,
+            StringExpr::block(
+                vec![let_string_step(0, "x", string("a"))],
+                local_string(0, "x").into(),
+            ),
+        );
+        assert_eq!(
+            block_float([], float(1.0)).0,
+            FloatExpr::block(Vec::new(), float(1.0).into()),
+        );
+        assert_eq!(
+            block_bool([let_bool_step(0, "x", bool_(true))], local_bool(0, "x")).0,
+            BoolExpr::block(
+                vec![let_bool_step(0, "x", bool_(true))],
+                local_bool(0, "x").into(),
+            ),
+        );
+        assert_eq!(
+            block_nil([let_nil_step(0, "x", nil())], local_nil(0, "x")).0,
+            NilExpr::block(vec![let_nil_step(0, "x", nil())], local_nil(0, "x").into()),
+        );
+        assert_eq!(
+            block_list([], list([int(1)], ValueType::Int)).0,
+            ListExpr::block(Vec::new(), list([int(1)], ValueType::Int).into()),
+        );
     }
 
     #[test]
     fn function_block_helpers_preserve_return_family() {
-        assert!(matches!(
+        assert_eq!(
             FunctionExpr::from(block_function(
                 vec![],
                 function_ref(
                     RuntimeFunctionId::Int(crate::plan::IntFunctionId(0)),
                     [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
                 ),
-            ))
-            .kind(),
-            FunctionExprKind::Int(_),
-        ));
-        assert!(matches!(
+            )),
+            FunctionExpr::int(IntFunctionExpr::block(
+                Vec::new(),
+                IntFunctionExpr::value(IntFunctionValue::new(
+                    IntFunctionId(0),
+                    vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                )),
+            )),
+        );
+        assert_eq!(
             FunctionExpr::from(block_function(
                 vec![],
                 function_ref(
                     RuntimeFunctionId::String(crate::plan::StringFunctionId(0)),
                     [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
                 ),
-            ))
-            .kind(),
-            FunctionExprKind::String(_),
-        ));
-        assert!(matches!(
+            )),
+            FunctionExpr::string(crate::plan::StringFunctionExpr::block(
+                Vec::new(),
+                crate::plan::StringFunctionExpr::value(StringFunctionValue::new(
+                    StringFunctionId(0),
+                    vec![ParamLocal::string(crate::plan::StringLocalId(0))],
+                )),
+            )),
+        );
+        assert_eq!(
             FunctionExpr::from(block_function(
                 vec![],
                 function_ref(
                     RuntimeFunctionId::Float(crate::plan::FloatFunctionId(0)),
                     [crate::plan::LocalId::Float(crate::plan::FloatLocalId(0))],
                 ),
-            ))
-            .kind(),
-            FunctionExprKind::Float(_),
-        ));
-        assert!(matches!(
+            )),
+            FunctionExpr::float(crate::plan::FloatFunctionExpr::block(
+                Vec::new(),
+                crate::plan::FloatFunctionExpr::value(FloatFunctionValue::new(
+                    FloatFunctionId(0),
+                    vec![ParamLocal::float(crate::plan::FloatLocalId(0))],
+                )),
+            )),
+        );
+        assert_eq!(
             FunctionExpr::from(block_function(
                 vec![],
                 function_ref(
                     RuntimeFunctionId::Bool(crate::plan::BoolFunctionId(0)),
                     [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))],
                 ),
-            ))
-            .kind(),
-            FunctionExprKind::Bool(_),
-        ));
-        assert!(matches!(
+            )),
+            FunctionExpr::bool(crate::plan::BoolFunctionExpr::block(
+                Vec::new(),
+                crate::plan::BoolFunctionExpr::value(BoolFunctionValue::new(
+                    BoolFunctionId(0),
+                    vec![ParamLocal::bool(crate::plan::BoolLocalId(0))],
+                )),
+            )),
+        );
+        assert_eq!(
             FunctionExpr::from(block_function(
                 vec![],
                 function_ref(
                     RuntimeFunctionId::Nil(crate::plan::NilFunctionId(0)),
                     [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))],
                 ),
-            ))
-            .kind(),
-            FunctionExprKind::Nil(_),
-        ));
-        assert!(matches!(
+            )),
+            FunctionExpr::nil(crate::plan::NilFunctionExpr::block(
+                Vec::new(),
+                crate::plan::NilFunctionExpr::value(NilFunctionValue::new(
+                    NilFunctionId(0),
+                    vec![ParamLocal::nil(crate::plan::NilLocalId(0))],
+                )),
+            )),
+        );
+        assert_eq!(
             FunctionExpr::from(block_function(
                 vec![],
                 Function::from(tuple_function_ref(
@@ -223,11 +248,17 @@ mod tests {
                     [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
                     [ValueType::Int, ValueType::String],
                 )),
-            ))
-            .kind(),
-            FunctionExprKind::Tuple(_),
-        ));
-        assert!(matches!(
+            )),
+            FunctionExpr::tuple(TupleFunctionExpr::block(
+                Vec::new(),
+                TupleFunctionExpr::value(TupleFunctionValue::new(
+                    crate::plan::TupleFunctionId(0),
+                    vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                    vec![ValueType::Int, ValueType::String],
+                )),
+            )),
+        );
+        assert_eq!(
             FunctionExpr::from(block_function(
                 vec![],
                 Function::from(list_function_ref(
@@ -235,12 +266,18 @@ mod tests {
                     Vec::<ParamLocal>::new(),
                     ValueType::Int
                 )),
-            ))
-            .kind(),
-            FunctionExprKind::List(_),
-        ));
+            )),
+            FunctionExpr::list(ListFunctionExpr::block(
+                Vec::new(),
+                ListFunctionExpr::value(ListFunctionValue::new(
+                    crate::plan::ListFunctionId(0),
+                    Vec::new(),
+                    ValueType::Int,
+                )),
+            )),
+        );
         let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
-        assert!(matches!(
+        assert_eq!(
             FunctionExpr::from(block_function(
                 vec![],
                 Function::from(function_function_ref(
@@ -248,20 +285,28 @@ mod tests {
                     Vec::<ParamLocal>::new(),
                     returned_function_type.clone(),
                 )),
-            ))
-            .kind(),
-            FunctionExprKind::Function(_),
-        ));
-        assert!(matches!(
+            )),
+            FunctionExpr::function(FunctionFunctionExpr::block(
+                Vec::new(),
+                FunctionFunctionExpr::value(FunctionFunctionValue::new(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                    Vec::new(),
+                    returned_function_type.clone(),
+                )),
+            )),
+        );
+        assert_eq!(
             block_int_function(
                 [],
                 int_function_ref(0, [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))]),
             )
-            .0
-            .kind(),
-            IntFunctionExprKind::Block { .. },
-        ));
-        assert!(matches!(
+            .0,
+            IntFunctionExpr::block(
+                Vec::new(),
+                int_function_ref(0, [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))]).into(),
+            ),
+        );
+        assert_eq!(
             block_tuple_function(
                 [],
                 tuple_function_ref(
@@ -270,19 +315,28 @@ mod tests {
                     [ValueType::Int, ValueType::String],
                 ),
             )
-            .0
-            .kind(),
-            TupleFunctionExprKind::Block { .. },
-        ));
-        assert!(matches!(
+            .0,
+            TupleFunctionExpr::block(
+                Vec::new(),
+                tuple_function_ref(
+                    0,
+                    [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+                    [ValueType::Int, ValueType::String],
+                )
+                .into(),
+            ),
+        );
+        assert_eq!(
             block_list_function(
                 [],
                 list_function_ref(0, Vec::<ParamLocal>::new(), ValueType::Int)
             )
-            .0
-            .kind(),
-            ListFunctionExprKind::Block { .. },
-        ));
+            .0,
+            ListFunctionExpr::block(
+                Vec::new(),
+                list_function_ref(0, Vec::<ParamLocal>::new(), ValueType::Int).into(),
+            ),
+        );
         assert_eq!(
             block_function_function(
                 [],
@@ -292,11 +346,15 @@ mod tests {
                     returned_function_type.clone(),
                 ),
             )
-            .0
-            .type_(),
-            &FunctionType::new(
+            .0,
+            FunctionFunctionExpr::block(
                 Vec::new(),
-                ValueType::Function(Box::new(returned_function_type)),
+                function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                    returned_function_type,
+                )
+                .into(),
             ),
         );
     }

--- a/src/planner/dsl/expression/call.rs
+++ b/src/planner/dsl/expression/call.rs
@@ -81,34 +81,38 @@ mod tests {
         call_nil, call_string,
     };
     use crate::plan::{
-        BoolExprKind, FloatExprKind, FunctionType, IntExprKind, ListExprKind, NilExprKind,
-        ParamLocal, StringExprKind, ValueType,
+        BoolExpr, BoolFunctionId, FloatExpr, FloatFunctionId, FunctionType, IntExpr,
+        IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, ListExpr, ListFunctionId, NilExpr,
+        NilFunctionId, ParamLocal, StringExpr, StringFunctionId, ValueType,
     };
     use crate::planner::dsl::expression::{int, int_arg, int_function_ref, string, string_arg};
 
     #[test]
     fn direct_call_helpers_build_call_shapes() {
-        assert!(matches!(
-            call_int(0, [int_arg(0, int(1))]).0.kind(),
-            IntExprKind::Call { .. },
-        ));
-        assert!(matches!(
-            call_string(0, [string_arg(0, string("a"))]).0.kind(),
-            StringExprKind::Call { .. },
-        ));
-        assert!(matches!(
-            call_float(0, []).0.kind(),
-            FloatExprKind::Call { .. },
-        ));
-        assert!(matches!(
-            call_bool(0, []).0.kind(),
-            BoolExprKind::Call { .. },
-        ));
-        assert!(matches!(call_nil(0, []).0.kind(), NilExprKind::Call { .. },));
-        assert!(matches!(
-            call_list(0, [], ValueType::Int).0.kind(),
-            ListExprKind::Call { .. },
-        ));
+        assert_eq!(
+            call_int(0, [int_arg(0, int(1))]).0,
+            IntExpr::call(IntFunctionId(0), vec![int_arg(0, int(1))]),
+        );
+        assert_eq!(
+            call_string(1, [string_arg(0, string("a"))]).0,
+            StringExpr::call(StringFunctionId(1), vec![string_arg(0, string("a"))]),
+        );
+        assert_eq!(
+            call_float(2, []).0,
+            FloatExpr::call(FloatFunctionId(2), Vec::new()),
+        );
+        assert_eq!(
+            call_bool(3, []).0,
+            BoolExpr::call(BoolFunctionId(3), Vec::new()),
+        );
+        assert_eq!(
+            call_nil(4, []).0,
+            NilExpr::call(NilFunctionId(4), Vec::new()),
+        );
+        assert_eq!(
+            call_list(5, [], ValueType::Int).0,
+            ListExpr::call(ListFunctionId(5), Vec::new(), ValueType::Int),
+        );
     }
 
     #[test]
@@ -116,19 +120,23 @@ mod tests {
         let return_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
 
         assert_eq!(
-            call_int_returning_function(0, [], return_type.clone())
-                .0
-                .type_(),
-            &return_type,
+            call_int_returning_function(6, [int_arg(0, int(1))], return_type.clone()).0,
+            IntFunctionExpr::call(
+                IntFunctionFunctionId(6),
+                vec![int_arg(0, int(1))],
+                return_type,
+            ),
         );
-        assert!(matches!(
+        assert_eq!(
             call_int_function(
                 int_function_ref(0, Vec::<ParamLocal>::new()),
                 [int_arg(0, int(1))],
             )
-            .0
-            .kind(),
-            IntExprKind::FunctionCall { .. },
-        ));
+            .0,
+            IntExpr::function_call(
+                int_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                vec![int_arg(0, int(1))],
+            ),
+        );
     }
 }

--- a/src/planner/dsl/expression/case/bool_.rs
+++ b/src/planner/dsl/expression/case/bool_.rs
@@ -127,10 +127,9 @@ mod tests {
         bool_case_nil_function, bool_case_string, bool_case_string_function,
     };
     use crate::plan::{
-        BoolExprKind, BoolFunctionExprKind, FloatExprKind, FloatFunctionExprKind,
-        FunctionFunctionId, FunctionType, IntExprKind, IntFunctionExprKind, IntFunctionFunctionId,
-        NilExprKind, NilFunctionExprKind, ParamLocal, StringExprKind, StringFunctionExprKind,
-        ValueType,
+        BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr, FunctionFunctionExpr,
+        FunctionFunctionId, FunctionType, IntExpr, IntFunctionExpr, IntFunctionFunctionId, NilExpr,
+        NilFunctionExpr, ParamLocal, StringExpr, StringFunctionExpr, ValueType,
     };
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, function_function_ref, int,
@@ -139,82 +138,91 @@ mod tests {
 
     #[test]
     fn bool_case_helpers_build_result_family_shapes() {
-        assert!(matches!(
-            bool_case_int(bool_(true), int(1), int(0)).0.kind(),
-            IntExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
-            bool_case_string(bool_(true), string("a"), string("b"))
-                .0
-                .kind(),
-            StringExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
-            bool_case_float(bool_(true), float(1.0), float(0.0))
-                .0
-                .kind(),
-            FloatExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
-            bool_case_bool(bool_(true), bool_(true), bool_(false))
-                .0
-                .kind(),
-            BoolExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
-            bool_case_nil(bool_(true), nil(), nil()).0.kind(),
-            NilExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+        assert_eq!(
+            bool_case_int(bool_(true), int(1), int(0)).0,
+            IntExpr::bool_case(bool_(true).into(), int(1).into(), int(0).into()),
+        );
+        assert_eq!(
+            bool_case_string(bool_(true), string("a"), string("b")).0,
+            StringExpr::bool_case(bool_(true).into(), string("a").into(), string("b").into()),
+        );
+        assert_eq!(
+            bool_case_float(bool_(true), float(1.0), float(0.0)).0,
+            FloatExpr::bool_case(bool_(true).into(), float(1.0).into(), float(0.0).into()),
+        );
+        assert_eq!(
+            bool_case_bool(bool_(true), bool_(true), bool_(false)).0,
+            BoolExpr::bool_case(bool_(true).into(), bool_(true).into(), bool_(false).into()),
+        );
+        assert_eq!(
+            bool_case_nil(bool_(true), nil(), nil()).0,
+            NilExpr::bool_case(bool_(true).into(), nil().into(), nil().into()),
+        );
+        assert_eq!(
             bool_case_int_function(
                 bool_(true),
                 int_function_ref(0, Vec::<ParamLocal>::new()),
                 int_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            IntFunctionExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            IntFunctionExpr::bool_case(
+                bool_(true).into(),
+                int_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                int_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             bool_case_string_function(
                 bool_(true),
                 string_function_ref(0, Vec::<ParamLocal>::new()),
                 string_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            StringFunctionExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            StringFunctionExpr::bool_case(
+                bool_(true).into(),
+                string_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                string_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             bool_case_float_function(
                 bool_(true),
                 float_function_ref(0, Vec::<ParamLocal>::new()),
                 float_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            FloatFunctionExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            FloatFunctionExpr::bool_case(
+                bool_(true).into(),
+                float_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                float_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             bool_case_bool_function(
                 bool_(true),
                 bool_function_ref(0, Vec::<ParamLocal>::new()),
                 bool_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            BoolFunctionExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            BoolFunctionExpr::bool_case(
+                bool_(true).into(),
+                bool_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                bool_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             bool_case_nil_function(
                 bool_(true),
                 nil_function_ref(0, Vec::<ParamLocal>::new()),
                 nil_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            NilFunctionExprKind::BoolCase { .. },
-        ));
+            .0,
+            NilFunctionExpr::bool_case(
+                bool_(true).into(),
+                nil_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                nil_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
         assert_eq!(
             bool_case_function_function(
                 bool_(true),
@@ -229,14 +237,21 @@ mod tests {
                     FunctionType::new(vec![ValueType::Int], ValueType::Int),
                 ),
             )
-            .0
-            .type_(),
-            &FunctionType::new(
-                Vec::new(),
-                ValueType::Function(Box::new(FunctionType::new(
-                    vec![ValueType::Int],
-                    ValueType::Int,
-                ))),
+            .0,
+            FunctionFunctionExpr::bool_case(
+                bool_(true).into(),
+                function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                )
+                .into(),
+                function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(1)),
+                    Vec::<ParamLocal>::new(),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                )
+                .into(),
             ),
         );
     }

--- a/src/planner/dsl/expression/case/float.rs
+++ b/src/planner/dsl/expression/case/float.rs
@@ -180,10 +180,9 @@ mod tests {
         float_case_nil_function, float_case_string, float_case_string_function,
     };
     use crate::plan::{
-        BoolExprKind, BoolFunctionExprKind, FloatExprKind, FloatFunctionExprKind,
-        FunctionFunctionId, FunctionType, IntExprKind, IntFunctionExprKind, IntFunctionFunctionId,
-        NilExprKind, NilFunctionExprKind, ParamLocal, StringExprKind, StringFunctionExprKind,
-        ValueType,
+        BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr, FunctionFunctionExpr,
+        FunctionFunctionId, FunctionType, IntExpr, IntFunctionExpr, IntFunctionFunctionId, NilExpr,
+        NilFunctionExpr, ParamLocal, StringExpr, StringFunctionExpr, ValueType,
     };
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, function_function_ref, int,
@@ -192,84 +191,107 @@ mod tests {
 
     #[test]
     fn float_case_helpers_build_result_family_shapes() {
-        assert!(matches!(
-            float_case_int(float(1.0), [(1.0, int(10))], int(0))
-                .0
-                .kind(),
-            IntExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
-            float_case_string(float(1.0), [(1.0, string("hit"))], string("miss"))
-                .0
-                .kind(),
-            StringExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
-            float_case_float(float(1.0), [(1.0, float(10.0))], float(0.0))
-                .0
-                .kind(),
-            FloatExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
-            float_case_bool(float(1.0), [(1.0, bool_(true))], bool_(false))
-                .0
-                .kind(),
-            BoolExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
-            float_case_nil(float(1.0), [(1.0, nil())], nil()).0.kind(),
-            NilExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+        assert_eq!(
+            float_case_int(float(1.0), [(1.0, int(10))], int(0)).0,
+            IntExpr::float_case(
+                float(1.0).into(),
+                vec![(1.0, int(10).into())],
+                int(0).into()
+            ),
+        );
+        assert_eq!(
+            float_case_string(float(1.0), [(1.0, string("hit"))], string("miss")).0,
+            StringExpr::float_case(
+                float(1.0).into(),
+                vec![(1.0, string("hit").into())],
+                string("miss").into(),
+            ),
+        );
+        assert_eq!(
+            float_case_float(float(1.0), [(1.0, float(10.0))], float(0.0)).0,
+            FloatExpr::float_case(
+                float(1.0).into(),
+                vec![(1.0, float(10.0).into())],
+                float(0.0).into(),
+            ),
+        );
+        assert_eq!(
+            float_case_bool(float(1.0), [(1.0, bool_(true))], bool_(false)).0,
+            BoolExpr::float_case(
+                float(1.0).into(),
+                vec![(1.0, bool_(true).into())],
+                bool_(false).into(),
+            ),
+        );
+        assert_eq!(
+            float_case_nil(float(1.0), [(1.0, nil())], nil()).0,
+            NilExpr::float_case(float(1.0).into(), vec![(1.0, nil().into())], nil().into()),
+        );
+        assert_eq!(
             float_case_int_function(
                 float(1.0),
                 [(1.0, int_function_ref(0, Vec::<ParamLocal>::new()))],
                 int_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            IntFunctionExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            IntFunctionExpr::float_case(
+                float(1.0).into(),
+                vec![(1.0, int_function_ref(0, Vec::<ParamLocal>::new()).into())],
+                int_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             float_case_string_function(
                 float(1.0),
                 [(1.0, string_function_ref(0, Vec::<ParamLocal>::new()))],
                 string_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            StringFunctionExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            StringFunctionExpr::float_case(
+                float(1.0).into(),
+                vec![(1.0, string_function_ref(0, Vec::<ParamLocal>::new()).into())],
+                string_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             float_case_float_function(
                 float(1.0),
                 [(1.0, float_function_ref(0, Vec::<ParamLocal>::new()))],
                 float_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            FloatFunctionExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            FloatFunctionExpr::float_case(
+                float(1.0).into(),
+                vec![(1.0, float_function_ref(0, Vec::<ParamLocal>::new()).into())],
+                float_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             float_case_bool_function(
                 float(1.0),
                 [(1.0, bool_function_ref(0, Vec::<ParamLocal>::new()))],
                 bool_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            BoolFunctionExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            BoolFunctionExpr::float_case(
+                float(1.0).into(),
+                vec![(1.0, bool_function_ref(0, Vec::<ParamLocal>::new()).into())],
+                bool_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             float_case_nil_function(
                 float(1.0),
                 [(1.0, nil_function_ref(0, Vec::<ParamLocal>::new()))],
                 nil_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            NilFunctionExprKind::FloatCase { .. },
-        ));
+            .0,
+            NilFunctionExpr::float_case(
+                float(1.0).into(),
+                vec![(1.0, nil_function_ref(0, Vec::<ParamLocal>::new()).into())],
+                nil_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
         assert_eq!(
             float_case_function_function(
                 float(1.0),
@@ -287,14 +309,24 @@ mod tests {
                     FunctionType::new(vec![ValueType::Int], ValueType::Int),
                 ),
             )
-            .0
-            .type_(),
-            &FunctionType::new(
-                Vec::new(),
-                ValueType::Function(Box::new(FunctionType::new(
-                    vec![ValueType::Int],
-                    ValueType::Int,
-                ))),
+            .0,
+            FunctionFunctionExpr::float_case(
+                float(1.0).into(),
+                vec![(
+                    1.0,
+                    function_function_ref(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                        Vec::<ParamLocal>::new(),
+                        FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                    )
+                    .into(),
+                )],
+                function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(1)),
+                    Vec::<ParamLocal>::new(),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                )
+                .into(),
             ),
         );
     }

--- a/src/planner/dsl/expression/case/int.rs
+++ b/src/planner/dsl/expression/case/int.rs
@@ -181,94 +181,138 @@ mod tests {
         int_case_nil_function, int_case_string, int_case_string_function,
     };
     use crate::plan::{
-        BoolExprKind, BoolFunctionExprKind, FloatExprKind, FloatFunctionExprKind,
-        FunctionFunctionId, FunctionType, IntExprKind, IntFunctionExprKind, IntFunctionFunctionId,
-        NilExprKind, NilFunctionExprKind, ParamLocal, StringExprKind, StringFunctionExprKind,
-        ValueType,
+        BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr, FunctionFunctionExpr,
+        FunctionFunctionId, FunctionType, IntExpr, IntFunctionExpr, IntFunctionFunctionId, NilExpr,
+        NilFunctionExpr, ParamLocal, StringExpr, StringFunctionExpr, ValueType,
     };
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, function_function_ref, int,
         int_function_ref, nil, nil_function_ref, string, string_function_ref,
     };
+    use num_bigint::BigInt;
 
     #[test]
     fn int_case_helpers_build_result_family_shapes() {
-        assert!(matches!(
-            int_case_int(int(1), [(1, int(10))], int(0)).0.kind(),
-            IntExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
-            int_case_string(int(1), [(1, string("one"))], string("other"))
-                .0
-                .kind(),
-            StringExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
-            int_case_float(int(1), [(1, float(1.0))], float(0.0))
-                .0
-                .kind(),
-            FloatExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
-            int_case_bool(int(1), [(1, bool_(true))], bool_(false))
-                .0
-                .kind(),
-            BoolExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
-            int_case_nil(int(1), [(1, nil())], nil()).0.kind(),
-            NilExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+        assert_eq!(
+            int_case_int(int(1), [(1, int(10))], int(0)).0,
+            IntExpr::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), int(10).into())],
+                int(0).into(),
+            ),
+        );
+        assert_eq!(
+            int_case_string(int(1), [(1, string("one"))], string("other")).0,
+            StringExpr::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), string("one").into())],
+                string("other").into(),
+            ),
+        );
+        assert_eq!(
+            int_case_float(int(1), [(1, float(1.0))], float(0.0)).0,
+            FloatExpr::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), float(1.0).into())],
+                float(0.0).into(),
+            ),
+        );
+        assert_eq!(
+            int_case_bool(int(1), [(1, bool_(true))], bool_(false)).0,
+            BoolExpr::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), bool_(true).into())],
+                bool_(false).into(),
+            ),
+        );
+        assert_eq!(
+            int_case_nil(int(1), [(1, nil())], nil()).0,
+            NilExpr::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), nil().into())],
+                nil().into(),
+            ),
+        );
+        assert_eq!(
             int_case_int_function(
                 int(1),
                 [(1, int_function_ref(0, Vec::<ParamLocal>::new()))],
                 int_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            IntFunctionExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            IntFunctionExpr::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    int_function_ref(0, Vec::<ParamLocal>::new()).into()
+                )],
+                int_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             int_case_string_function(
                 int(1),
                 [(1, string_function_ref(0, Vec::<ParamLocal>::new()))],
                 string_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            StringFunctionExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            StringFunctionExpr::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    string_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                )],
+                string_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             int_case_float_function(
                 int(1),
                 [(1, float_function_ref(0, Vec::<ParamLocal>::new()))],
                 float_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            FloatFunctionExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            FloatFunctionExpr::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    float_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                )],
+                float_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             int_case_bool_function(
                 int(1),
                 [(1, bool_function_ref(0, Vec::<ParamLocal>::new()))],
                 bool_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            BoolFunctionExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            BoolFunctionExpr::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    bool_function_ref(0, Vec::<ParamLocal>::new()).into()
+                )],
+                bool_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             int_case_nil_function(
                 int(1),
                 [(1, nil_function_ref(0, Vec::<ParamLocal>::new()))],
                 nil_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            NilFunctionExprKind::IntCase { .. },
-        ));
+            .0,
+            NilFunctionExpr::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    nil_function_ref(0, Vec::<ParamLocal>::new()).into()
+                )],
+                nil_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
         assert_eq!(
             int_case_function_function(
                 int(1),
@@ -286,14 +330,24 @@ mod tests {
                     FunctionType::new(vec![ValueType::Int], ValueType::Int),
                 ),
             )
-            .0
-            .type_(),
-            &FunctionType::new(
-                Vec::new(),
-                ValueType::Function(Box::new(FunctionType::new(
-                    vec![ValueType::Int],
-                    ValueType::Int,
-                ))),
+            .0,
+            FunctionFunctionExpr::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    function_function_ref(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                        Vec::<ParamLocal>::new(),
+                        FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                    )
+                    .into(),
+                )],
+                function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(1)),
+                    Vec::<ParamLocal>::new(),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                )
+                .into(),
             ),
         );
     }

--- a/src/planner/dsl/expression/case/string.rs
+++ b/src/planner/dsl/expression/case/string.rs
@@ -180,10 +180,9 @@ mod tests {
         string_case_nil_function, string_case_string, string_case_string_function,
     };
     use crate::plan::{
-        BoolExprKind, BoolFunctionExprKind, FloatExprKind, FloatFunctionExprKind,
-        FunctionFunctionId, FunctionType, IntExprKind, IntFunctionExprKind, IntFunctionFunctionId,
-        NilExprKind, NilFunctionExprKind, ParamLocal, StringExprKind, StringFunctionExprKind,
-        ValueType,
+        BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr, FunctionFunctionExpr,
+        FunctionFunctionId, FunctionType, IntExpr, IntFunctionExpr, IntFunctionFunctionId, NilExpr,
+        NilFunctionExpr, ParamLocal, StringExpr, StringFunctionExpr, ValueType,
     };
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, function_function_ref, int,
@@ -192,86 +191,126 @@ mod tests {
 
     #[test]
     fn string_case_helpers_build_result_family_shapes() {
-        assert!(matches!(
-            string_case_int(string("key"), [("one", int(10))], int(0))
-                .0
-                .kind(),
-            IntExprKind::StringCase { .. },
-        ));
-        assert!(matches!(
-            string_case_string(string("key"), [("one", string("hit"))], string("miss"))
-                .0
-                .kind(),
-            StringExprKind::StringCase { .. },
-        ));
-        assert!(matches!(
-            string_case_float(string("key"), [("one", float(1.0))], float(0.0))
-                .0
-                .kind(),
-            FloatExprKind::StringCase { .. },
-        ));
-        assert!(matches!(
-            string_case_bool(string("key"), [("one", bool_(true))], bool_(false))
-                .0
-                .kind(),
-            BoolExprKind::StringCase { .. },
-        ));
-        assert!(matches!(
-            string_case_nil(string("key"), [("one", nil())], nil())
-                .0
-                .kind(),
-            NilExprKind::StringCase { .. },
-        ));
-        assert!(matches!(
+        assert_eq!(
+            string_case_int(string("key"), [("one", int(10))], int(0)).0,
+            IntExpr::string_case(
+                string("key").into(),
+                vec![("one".into(), int(10).into())],
+                int(0).into(),
+            ),
+        );
+        assert_eq!(
+            string_case_string(string("key"), [("one", string("hit"))], string("miss")).0,
+            StringExpr::string_case(
+                string("key").into(),
+                vec![("one".into(), string("hit").into())],
+                string("miss").into(),
+            ),
+        );
+        assert_eq!(
+            string_case_float(string("key"), [("one", float(1.0))], float(0.0)).0,
+            FloatExpr::string_case(
+                string("key").into(),
+                vec![("one".into(), float(1.0).into())],
+                float(0.0).into(),
+            ),
+        );
+        assert_eq!(
+            string_case_bool(string("key"), [("one", bool_(true))], bool_(false)).0,
+            BoolExpr::string_case(
+                string("key").into(),
+                vec![("one".into(), bool_(true).into())],
+                bool_(false).into(),
+            ),
+        );
+        assert_eq!(
+            string_case_nil(string("key"), [("one", nil())], nil()).0,
+            NilExpr::string_case(
+                string("key").into(),
+                vec![("one".into(), nil().into())],
+                nil().into(),
+            ),
+        );
+        assert_eq!(
             string_case_int_function(
                 string("key"),
                 [("one", int_function_ref(0, Vec::<ParamLocal>::new()))],
                 int_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            IntFunctionExprKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            IntFunctionExpr::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    int_function_ref(0, Vec::<ParamLocal>::new()).into()
+                )],
+                int_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             string_case_string_function(
                 string("key"),
                 [("one", string_function_ref(0, Vec::<ParamLocal>::new()))],
                 string_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            StringFunctionExprKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            StringFunctionExpr::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    string_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                )],
+                string_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             string_case_float_function(
                 string("key"),
                 [("one", float_function_ref(0, Vec::<ParamLocal>::new()))],
                 float_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            FloatFunctionExprKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            FloatFunctionExpr::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    float_function_ref(0, Vec::<ParamLocal>::new()).into()
+                )],
+                float_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             string_case_bool_function(
                 string("key"),
                 [("one", bool_function_ref(0, Vec::<ParamLocal>::new()))],
                 bool_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            BoolFunctionExprKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            .0,
+            BoolFunctionExpr::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    bool_function_ref(0, Vec::<ParamLocal>::new()).into()
+                )],
+                bool_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
+        assert_eq!(
             string_case_nil_function(
                 string("key"),
                 [("one", nil_function_ref(0, Vec::<ParamLocal>::new()))],
                 nil_function_ref(1, Vec::<ParamLocal>::new()),
             )
-            .0
-            .kind(),
-            NilFunctionExprKind::StringCase { .. },
-        ));
+            .0,
+            NilFunctionExpr::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    nil_function_ref(0, Vec::<ParamLocal>::new()).into()
+                )],
+                nil_function_ref(1, Vec::<ParamLocal>::new()).into(),
+            ),
+        );
         assert_eq!(
             string_case_function_function(
                 string("key"),
@@ -289,14 +328,24 @@ mod tests {
                     FunctionType::new(vec![ValueType::Int], ValueType::Int),
                 ),
             )
-            .0
-            .type_(),
-            &FunctionType::new(
-                Vec::new(),
-                ValueType::Function(Box::new(FunctionType::new(
-                    vec![ValueType::Int],
-                    ValueType::Int,
-                ))),
+            .0,
+            FunctionFunctionExpr::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    function_function_ref(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                        Vec::<ParamLocal>::new(),
+                        FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                    )
+                    .into(),
+                )],
+                function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(1)),
+                    Vec::<ParamLocal>::new(),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                )
+                .into(),
             ),
         );
     }

--- a/src/planner/dsl/expression/conversion.rs
+++ b/src/planner/dsl/expression/conversion.rs
@@ -308,13 +308,17 @@ impl IntoParamLocal for ParamLocal {
 mod tests {
     use super::{IntoParamLocal, IntoValueType};
     use crate::plan::{
-        Expr, ExprKind, FunctionExpr, FunctionExprKind, FunctionFunctionId, FunctionType,
-        IntFunctionFunctionId, ParamLocal, ValueType,
+        BoolExpr, Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr, FunctionFunctionId,
+        FunctionFunctionValue, FunctionType, IntExpr, IntFunctionExpr, IntFunctionFunctionId,
+        IntFunctionId, IntFunctionValue, ListExpr, ListFunctionExpr, ListFunctionId,
+        ListFunctionValue, NilExpr, ParamLocal, StringExpr, TupleExpr, TupleFunctionExpr,
+        TupleFunctionId, TupleFunctionValue, ValueType,
     };
     use crate::planner::dsl::expression::{
         Function, bool_, float, float_function_ref, function_function_ref, int, int_function_ref,
         list, list_function_ref, nil, string, tuple, tuple_function_ref,
     };
+    use num_bigint::BigInt;
 
     #[test]
     fn value_type_conversions() {
@@ -323,115 +327,172 @@ mod tests {
             ParamLocal::int(crate::plan::IntLocalId(0)).into_value_type(),
             ValueType::Int,
         );
+
         assert_eq!(
             crate::plan::LocalId::Int(crate::plan::IntLocalId(0)).into_value_type(),
             ValueType::Int,
         );
         assert_eq!(
-            crate::plan::LocalId::Float(crate::plan::FloatLocalId(0)).into_value_type(),
+            crate::plan::LocalId::String(crate::plan::StringLocalId(1)).into_value_type(),
+            ValueType::String,
+        );
+        assert_eq!(
+            crate::plan::LocalId::Float(crate::plan::FloatLocalId(2)).into_value_type(),
             ValueType::Float,
         );
+        assert_eq!(
+            crate::plan::LocalId::Bool(crate::plan::BoolLocalId(3)).into_value_type(),
+            ValueType::Bool,
+        );
+        assert_eq!(
+            crate::plan::LocalId::Nil(crate::plan::NilLocalId(4)).into_value_type(),
+            ValueType::Nil,
+        );
+
         assert_eq!(
             crate::plan::LocalId::Int(crate::plan::IntLocalId(0)).into_param_local(),
             ParamLocal::int(crate::plan::IntLocalId(0)),
         );
         assert_eq!(
-            crate::plan::LocalId::Float(crate::plan::FloatLocalId(0)).into_param_local(),
-            ParamLocal::float(crate::plan::FloatLocalId(0)),
+            crate::plan::LocalId::String(crate::plan::StringLocalId(1)).into_param_local(),
+            ParamLocal::string(crate::plan::StringLocalId(1)),
+        );
+        assert_eq!(
+            crate::plan::LocalId::Float(crate::plan::FloatLocalId(2)).into_param_local(),
+            ParamLocal::float(crate::plan::FloatLocalId(2)),
+        );
+        assert_eq!(
+            crate::plan::LocalId::Bool(crate::plan::BoolLocalId(3)).into_param_local(),
+            ParamLocal::bool(crate::plan::BoolLocalId(3)),
+        );
+        assert_eq!(
+            crate::plan::LocalId::Nil(crate::plan::NilLocalId(4)).into_param_local(),
+            ParamLocal::nil(crate::plan::NilLocalId(4)),
         );
     }
 
     #[test]
     fn wrapper_conversions_preserve_result_families() {
-        assert!(matches!(Expr::from(int(1)).kind(), ExprKind::Int(_)));
-        assert!(matches!(
-            Expr::from(string("a")).kind(),
-            ExprKind::String(_)
-        ));
-        assert!(matches!(Expr::from(float(1.5)).kind(), ExprKind::Float(_)));
-        assert!(matches!(Expr::from(bool_(true)).kind(), ExprKind::Bool(_)));
-        assert!(matches!(Expr::from(nil()).kind(), ExprKind::Nil(_)));
-        assert!(matches!(
-            Expr::from(tuple([Expr::from(int(1)), Expr::from(string("one"))])).kind(),
-            ExprKind::Tuple(_),
-        ));
-        assert!(matches!(
-            Expr::from(list([int(1)], ValueType::Int)).kind(),
-            ExprKind::List(_),
-        ));
-        assert!(matches!(
-            Expr::from(int_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            ExprKind::Function(_),
-        ));
-        assert!(matches!(
+        assert_eq!(
+            Expr::from(int(1)),
+            Expr::int(IntExpr::value(BigInt::from(1)))
+        );
+        assert_eq!(
+            Expr::from(string("a")),
+            Expr::string(StringExpr::value("a".into())),
+        );
+        assert_eq!(Expr::from(float(1.5)), Expr::float(FloatExpr::value(1.5)));
+        assert_eq!(Expr::from(bool_(true)), Expr::bool(BoolExpr::value(true)));
+        assert_eq!(Expr::from(nil()), Expr::nil(NilExpr::value()));
+        assert_eq!(
+            Expr::from(tuple([Expr::from(int(1)), Expr::from(string("one"))])),
+            Expr::tuple(TupleExpr::value(
+                vec![Expr::from(int(1)), Expr::from(string("one"))],
+                vec![ValueType::Int, ValueType::String],
+            )),
+        );
+        assert_eq!(
+            Expr::from(list([int(1)], ValueType::Int)),
+            Expr::list(ListExpr::value(vec![Expr::from(int(1))], ValueType::Int)),
+        );
+
+        assert_eq!(
+            Expr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
+            Expr::function(FunctionExpr::int(IntFunctionExpr::value(
+                IntFunctionValue::new(IntFunctionId(0), Vec::new()),
+            ))),
+        );
+        assert_eq!(
             Expr::from(list_function_ref(
                 0,
                 Vec::<ParamLocal>::new(),
                 ValueType::Int
-            ))
-            .kind(),
-            ExprKind::Function(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            FunctionExprKind::Int(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(float_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            FunctionExprKind::Float(_),
-        ));
-        assert!(matches!(
+            )),
+            Expr::function(FunctionExpr::list(ListFunctionExpr::value(
+                ListFunctionValue::new(ListFunctionId(0), Vec::new(), ValueType::Int),
+            ))),
+        );
+        assert_eq!(
+            FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
+            FunctionExpr::int(IntFunctionExpr::value(IntFunctionValue::new(
+                IntFunctionId(0),
+                Vec::new(),
+            ))),
+        );
+        assert_eq!(
+            FunctionExpr::from(float_function_ref(0, Vec::<ParamLocal>::new())),
+            FunctionExpr::float(crate::plan::FloatFunctionExpr::value(
+                crate::plan::FloatFunctionValue::new(crate::plan::FloatFunctionId(0), Vec::new()),
+            )),
+        );
+        assert_eq!(
             FunctionExpr::from(tuple_function_ref(
                 0,
                 Vec::<ParamLocal>::new(),
-                [ValueType::Int],
-            ))
-            .kind(),
-            FunctionExprKind::Tuple(_),
-        ));
-        assert!(matches!(
+                [ValueType::Int]
+            )),
+            FunctionExpr::tuple(TupleFunctionExpr::value(TupleFunctionValue::new(
+                TupleFunctionId(0),
+                Vec::new(),
+                vec![ValueType::Int],
+            ))),
+        );
+        assert_eq!(
             FunctionExpr::from(list_function_ref(
                 0,
                 Vec::<ParamLocal>::new(),
                 ValueType::Int
-            ))
-            .kind(),
-            FunctionExprKind::List(_),
-        ));
-        assert!(matches!(
+            )),
+            FunctionExpr::list(ListFunctionExpr::value(ListFunctionValue::new(
+                ListFunctionId(0),
+                Vec::new(),
+                ValueType::Int,
+            ))),
+        );
+        assert_eq!(
             FunctionExpr::from(Function::from(float_function_ref(
                 0,
                 Vec::<ParamLocal>::new()
-            )))
-            .kind(),
-            FunctionExprKind::Float(_),
-        ));
-        assert!(matches!(
+            ))),
+            FunctionExpr::float(crate::plan::FloatFunctionExpr::value(
+                crate::plan::FloatFunctionValue::new(crate::plan::FloatFunctionId(0), Vec::new()),
+            )),
+        );
+        assert_eq!(
             FunctionExpr::from(Function::from(tuple_function_ref(
                 0,
                 Vec::<ParamLocal>::new(),
                 [ValueType::Int],
-            )))
-            .kind(),
-            FunctionExprKind::Tuple(_),
-        ));
-        assert!(matches!(
+            ))),
+            FunctionExpr::tuple(TupleFunctionExpr::value(TupleFunctionValue::new(
+                TupleFunctionId(0),
+                Vec::new(),
+                vec![ValueType::Int],
+            ))),
+        );
+        assert_eq!(
             FunctionExpr::from(Function::from(list_function_ref(
                 0,
                 Vec::<ParamLocal>::new(),
                 ValueType::Int,
-            )))
-            .kind(),
-            FunctionExprKind::List(_),
-        ));
-        assert!(matches!(
+            ))),
+            FunctionExpr::list(ListFunctionExpr::value(ListFunctionValue::new(
+                ListFunctionId(0),
+                Vec::new(),
+                ValueType::Int,
+            ))),
+        );
+        assert_eq!(
             FunctionExpr::from(Function::from(function_function_ref(
                 FunctionFunctionId::Int(IntFunctionFunctionId(0)),
                 Vec::<ParamLocal>::new(),
                 FunctionType::new(vec![ValueType::Int], ValueType::Int),
-            )))
-            .kind(),
-            FunctionExprKind::Function(_),
-        ));
+            ))),
+            FunctionExpr::function(FunctionFunctionExpr::value(FunctionFunctionValue::new(
+                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                Vec::new(),
+                FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            ))),
+        );
     }
 }

--- a/src/planner/dsl/expression/function_value.rs
+++ b/src/planner/dsl/expression/function_value.rs
@@ -400,160 +400,199 @@ mod tests {
         tuple_function_closure, tuple_function_ref,
     };
     use crate::plan::{
-        BoolFunctionExprKind, Expr, ExprKind, FloatFunctionExprKind, FunctionExpr,
-        FunctionExprKind, FunctionFunctionId, FunctionType, IntFunctionExprKind,
-        IntFunctionFunctionId, ListFunctionExprKind, NilFunctionExprKind, ParamLocal,
-        RuntimeFunctionId, StringFunctionExprKind, TupleFunctionExprKind, ValueType,
+        BoolFunctionExpr, BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue,
+        FloatFunctionExpr, FloatFunctionId, FloatFunctionLocalId, FloatFunctionValue, FunctionExpr,
+        FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionLocalId, FunctionType,
+        FunctionValue, IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId,
+        IntFunctionValue, ListFunctionExpr, ListFunctionId, ListFunctionLocalId, ListFunctionValue,
+        NilFunctionExpr, NilFunctionId, NilFunctionLocalId, NilFunctionValue, ParamLocal,
+        RuntimeFunctionId, StringFunctionExpr, StringFunctionId, StringFunctionLocalId,
+        StringFunctionValue, TupleFunctionExpr, TupleFunctionId, TupleFunctionLocalId,
+        TupleFunctionValue, ValueType,
     };
     use crate::planner::dsl::expression::{Function, float, int};
 
     #[test]
     fn function_ref_helpers_build_function_values() {
-        assert!(matches!(
-            Expr::from(function_ref(
-                RuntimeFunctionId::Int(crate::plan::IntFunctionId(0)),
-                [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
-            ))
-            .kind(),
-            ExprKind::Function(_),
-        ));
-        assert!(matches!(
-            Expr::from(string_function_ref(
-                0,
-                [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
-            ))
-            .kind(),
-            ExprKind::Function(_),
-        ));
-        assert!(matches!(
-            Expr::from(float_function_ref(
-                0,
-                [crate::plan::LocalId::Float(crate::plan::FloatLocalId(0))],
-            ))
-            .kind(),
-            ExprKind::Function(_),
-        ));
-        assert!(matches!(
-            Expr::from(bool_function_ref(
-                0,
-                [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))],
-            ))
-            .kind(),
-            ExprKind::Function(_),
-        ));
-        assert!(matches!(
-            Expr::from(nil_function_ref(
-                0,
-                [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))],
-            ))
-            .kind(),
-            ExprKind::Function(_),
-        ));
-        assert!(matches!(
-            Expr::from(tuple_function_ref(
-                0,
-                [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
-                [ValueType::Int, ValueType::String],
-            ))
-            .kind(),
-            ExprKind::Function(_),
-        ));
-        assert!(matches!(
-            Expr::from(list_function_ref(
-                0,
-                [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
-                ValueType::Int,
-            ))
-            .kind(),
-            ExprKind::Function(_),
-        ));
-        assert!(matches!(
+        assert_eq!(
             FunctionExpr::from(function_ref(
                 RuntimeFunctionId::Int(crate::plan::IntFunctionId(0)),
                 [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
-            ))
-            .kind(),
-            FunctionExprKind::Int(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(Function::from(int_function_ref(
-                0,
+            )),
+            FunctionExpr::value(FunctionValue::new(
+                RuntimeFunctionId::Int(IntFunctionId(0)),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            string_function_ref(
+                1,
+                [crate::plan::LocalId::String(crate::plan::StringLocalId(0))]
+            )
+            .0,
+            StringFunctionExpr::value(StringFunctionValue::new(
+                StringFunctionId(1),
+                vec![ParamLocal::string(crate::plan::StringLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            float_function_ref(
+                2,
+                [crate::plan::LocalId::Float(crate::plan::FloatLocalId(0))]
+            )
+            .0,
+            FloatFunctionExpr::value(FloatFunctionValue::new(
+                FloatFunctionId(2),
+                vec![ParamLocal::float(crate::plan::FloatLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            bool_function_ref(3, [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))]).0,
+            BoolFunctionExpr::value(BoolFunctionValue::new(
+                BoolFunctionId(3),
+                vec![ParamLocal::bool(crate::plan::BoolLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            nil_function_ref(4, [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))]).0,
+            NilFunctionExpr::value(NilFunctionValue::new(
+                NilFunctionId(4),
+                vec![ParamLocal::nil(crate::plan::NilLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            tuple_function_ref(
+                5,
                 [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
-            )))
-            .kind(),
-            FunctionExprKind::Int(_),
-        ));
+                [ValueType::Int, ValueType::String],
+            )
+            .0,
+            TupleFunctionExpr::value(TupleFunctionValue::new(
+                TupleFunctionId(5),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                vec![ValueType::Int, ValueType::String],
+            )),
+        );
+        assert_eq!(
+            list_function_ref(
+                6,
+                [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+                ValueType::Int,
+            )
+            .0,
+            ListFunctionExpr::value(ListFunctionValue::new(
+                ListFunctionId(6),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                ValueType::Int,
+            )),
+        );
+        assert_eq!(
+            FunctionExpr::from(Function::from(int_function_ref(
+                7,
+                [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))],
+            ))),
+            FunctionExpr::int(IntFunctionExpr::value(IntFunctionValue::new(
+                IntFunctionId(7),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+            ))),
+        );
     }
 
     #[test]
     fn function_local_helpers_build_local_get_shapes() {
-        assert!(matches!(
+        assert_eq!(
             local_int_function(
                 0,
                 "f",
                 [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))]
             )
-            .0
-            .kind(),
-            IntFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
+            .0,
+            IntFunctionExpr::local_get(
+                IntFunctionLocalId(0),
+                "f".into(),
+                FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            ),
+        );
+        assert_eq!(
             local_string_function(
                 0,
                 "f",
                 [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
             )
-            .0
-            .kind(),
-            StringFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
+            .0,
+            StringFunctionExpr::local_get(
+                StringFunctionLocalId(0),
+                "f".into(),
+                FunctionType::new(vec![ValueType::String], ValueType::String),
+            ),
+        );
+        assert_eq!(
             local_float_function(
                 0,
                 "f",
                 [crate::plan::LocalId::Float(crate::plan::FloatLocalId(0))],
             )
-            .0
-            .kind(),
-            FloatFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
+            .0,
+            FloatFunctionExpr::local_get(
+                FloatFunctionLocalId(0),
+                "f".into(),
+                FunctionType::new(vec![ValueType::Float], ValueType::Float),
+            ),
+        );
+        assert_eq!(
             local_bool_function(
                 0,
                 "f",
                 [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))],
             )
-            .0
-            .kind(),
-            BoolFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
+            .0,
+            BoolFunctionExpr::local_get(
+                BoolFunctionLocalId(0),
+                "f".into(),
+                FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
+            ),
+        );
+        assert_eq!(
             local_nil_function(
                 0,
                 "f",
                 [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))],
             )
-            .0
-            .kind(),
-            NilFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
+            .0,
+            NilFunctionExpr::local_get(
+                NilFunctionLocalId(0),
+                "f".into(),
+                FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+            ),
+        );
+        assert_eq!(
             local_tuple_function(
                 0,
                 "f",
                 [ValueType::Int],
                 [ValueType::Int, ValueType::String]
             )
-            .0
-            .kind(),
-            TupleFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
-            local_list_function(0, "f", [ValueType::Int], ValueType::String)
-                .0
-                .kind(),
-            ListFunctionExprKind::LocalGet { .. },
-        ));
+            .0,
+            TupleFunctionExpr::local_get(
+                TupleFunctionLocalId(0),
+                "f".into(),
+                FunctionType::new(
+                    vec![ValueType::Int],
+                    ValueType::Tuple(vec![ValueType::Int, ValueType::String]),
+                ),
+            ),
+        );
+        assert_eq!(
+            local_list_function(0, "f", [ValueType::Int], ValueType::String).0,
+            ListFunctionExpr::local_get(
+                ListFunctionLocalId(0),
+                "f".into(),
+                FunctionType::new(
+                    vec![ValueType::Int],
+                    ValueType::List(Box::new(ValueType::String)),
+                ),
+            ),
+        );
         assert_eq!(
             local_function_function(
                 0,
@@ -566,14 +605,17 @@ mod tests {
                     ))),
                 ),
             )
-            .0
-            .type_(),
-            &FunctionType::new(
-                Vec::new(),
-                ValueType::Function(Box::new(FunctionType::new(
-                    vec![ValueType::Int],
-                    ValueType::Int,
-                ))),
+            .0,
+            FunctionFunctionExpr::local_get(
+                FunctionFunctionLocalId(0),
+                "f".into(),
+                FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(FunctionType::new(
+                        vec![ValueType::Int],
+                        ValueType::Int,
+                    ))),
+                ),
             ),
         );
     }
@@ -581,10 +623,13 @@ mod tests {
     #[test]
     fn function_closure_helpers_build_function_values() {
         assert_eq!(
-            int_function_closure(0, [ParamLocal::int(crate::plan::IntLocalId(0))], [])
-                .0
-                .type_(),
-            &FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            int_function_closure(0, [ParamLocal::int(crate::plan::IntLocalId(0))], []).0,
+            IntFunctionExpr::closure(
+                IntFunctionId(0),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                Vec::new(),
+                FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            ),
         );
         assert_eq!(
             float_function_closure(
@@ -595,9 +640,16 @@ mod tests {
                     float(1.0)
                 )],
             )
-            .0
-            .type_(),
-            &FunctionType::new(vec![ValueType::Float], ValueType::Float),
+            .0,
+            FloatFunctionExpr::closure(
+                FloatFunctionId(0),
+                vec![ParamLocal::float(crate::plan::FloatLocalId(0))],
+                vec![crate::planner::dsl::expression::capture_float(
+                    0,
+                    float(1.0)
+                )],
+                FunctionType::new(vec![ValueType::Float], ValueType::Float),
+            ),
         );
         assert_eq!(
             function_function_closure(
@@ -606,14 +658,19 @@ mod tests {
                 [crate::planner::dsl::expression::capture_int(0, int(1))],
                 FunctionType::new(vec![ValueType::Int], ValueType::Int),
             )
-            .0
-            .type_(),
-            &FunctionType::new(
+            .0,
+            FunctionFunctionExpr::closure(
+                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
                 Vec::new(),
-                ValueType::Function(Box::new(FunctionType::new(
-                    vec![ValueType::Int],
-                    ValueType::Int,
-                ))),
+                vec![crate::planner::dsl::expression::capture_int(0, int(1))],
+                FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(FunctionType::new(
+                        vec![ValueType::Int],
+                        ValueType::Int,
+                    ))),
+                ),
+                FunctionType::new(vec![ValueType::Int], ValueType::Int),
             ),
         );
         assert_eq!(
@@ -623,11 +680,16 @@ mod tests {
                 [crate::planner::dsl::expression::capture_int(0, int(1))],
                 [ValueType::Int, ValueType::String],
             )
-            .0
-            .type_(),
-            &FunctionType::new(
-                vec![ValueType::Int],
-                ValueType::Tuple(vec![ValueType::Int, ValueType::String]),
+            .0,
+            TupleFunctionExpr::closure(
+                TupleFunctionId(0),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                vec![crate::planner::dsl::expression::capture_int(0, int(1))],
+                FunctionType::new(
+                    vec![ValueType::Int],
+                    ValueType::Tuple(vec![ValueType::Int, ValueType::String]),
+                ),
+                vec![ValueType::Int, ValueType::String],
             ),
         );
         assert_eq!(
@@ -637,11 +699,16 @@ mod tests {
                 [crate::planner::dsl::expression::capture_int(0, int(1))],
                 ValueType::String,
             )
-            .0
-            .type_(),
-            &FunctionType::new(
-                vec![ValueType::Int],
-                ValueType::List(Box::new(ValueType::String)),
+            .0,
+            ListFunctionExpr::closure(
+                ListFunctionId(0),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                vec![crate::planner::dsl::expression::capture_int(0, int(1))],
+                FunctionType::new(
+                    vec![ValueType::Int],
+                    ValueType::List(Box::new(ValueType::String)),
+                ),
+                ValueType::String,
             ),
         );
     }

--- a/src/planner/dsl/expression/local.rs
+++ b/src/planner/dsl/expression/local.rs
@@ -55,39 +55,43 @@ mod tests {
         local_bool, local_float, local_int, local_list, local_nil, local_string, local_tuple,
     };
     use crate::plan::{
-        BoolExprKind, FloatExprKind, IntExprKind, ListExprKind, NilExprKind, StringExprKind,
-        TupleExprKind, ValueType,
+        BoolExpr, BoolLocalId, FloatExpr, FloatLocalId, IntExpr, IntLocalId, ListExpr, ListLocalId,
+        NilExpr, NilLocalId, StringExpr, StringLocalId, TupleExpr, TupleLocalId, ValueType,
     };
 
     #[test]
     fn local_helpers_build_local_get_shapes() {
-        assert!(matches!(
-            local_int(0, "x").0.kind(),
-            IntExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
-            local_string(0, "x").0.kind(),
-            StringExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
-            local_float(0, "x").0.kind(),
-            FloatExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
-            local_bool(0, "x").0.kind(),
-            BoolExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
-            local_nil(0, "x").0.kind(),
-            NilExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
-            local_tuple(0, "x", [ValueType::Int]).0.kind(),
-            TupleExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
-            local_list(0, "x", ValueType::Int).0.kind(),
-            ListExprKind::LocalGet { .. },
-        ));
+        assert_eq!(
+            local_int(0, "x").0,
+            IntExpr::local_get(IntLocalId(0), "x".into()),
+        );
+        assert_eq!(
+            local_string(1, "name").0,
+            StringExpr::local_get(StringLocalId(1), "name".into()),
+        );
+        assert_eq!(
+            local_float(2, "ratio").0,
+            FloatExpr::local_get(FloatLocalId(2), "ratio".into()),
+        );
+        assert_eq!(
+            local_bool(3, "ok").0,
+            BoolExpr::local_get(BoolLocalId(3), "ok".into()),
+        );
+        assert_eq!(
+            local_nil(4, "done").0,
+            NilExpr::local_get(NilLocalId(4), "done".into()),
+        );
+        assert_eq!(
+            local_tuple(5, "pair", [ValueType::Int, ValueType::String]).0,
+            TupleExpr::local_get(
+                TupleLocalId(5),
+                "pair".into(),
+                vec![ValueType::Int, ValueType::String],
+            ),
+        );
+        assert_eq!(
+            local_list(6, "values", ValueType::Int).0,
+            ListExpr::local_get(ListLocalId(6), "values".into(), ValueType::Int),
+        );
     }
 }

--- a/src/planner/dsl/expression/operator.rs
+++ b/src/planner/dsl/expression/operator.rs
@@ -296,280 +296,342 @@ impl Bool {
 mod tests {
     use super::{equal, not_equal};
     use crate::plan::{
-        BoolExprKind, BoolFunctionExprKind, FloatExprKind, FloatFunctionExprKind,
-        FunctionFunctionExprKind, FunctionType, IntExprKind, IntFunctionExprKind, ListExprKind,
-        ListFunctionExprKind, NilExprKind, NilFunctionExprKind, StringExprKind,
-        StringFunctionExprKind, TupleExprKind, TupleFunctionExprKind, ValueType,
+        BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr, FunctionFunctionExpr,
+        FunctionType, IntExpr, IntFunctionExpr, ListExpr, ListFunctionExpr, NilExpr,
+        NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr, TupleFunctionExpr, ValueType,
     };
     use crate::planner::dsl::expression::{bool_, float, int, local_tuple, string};
 
     #[test]
     fn int_operator_helpers_build_operator_shapes() {
-        assert!(matches!(
-            int(1).add_int(int(2)).0.kind(),
-            IntExprKind::Add { .. },
-        ));
-        assert!(matches!(
-            int(1).sub_int(int(2)).0.kind(),
-            IntExprKind::Sub { .. },
-        ));
-        assert!(matches!(
-            int(1).mult_int(int(2)).0.kind(),
-            IntExprKind::Mult { .. },
-        ));
-        assert!(matches!(
-            int(1).div_int(int(2)).0.kind(),
-            IntExprKind::Div { .. },
-        ));
-        assert!(matches!(
-            int(1).remainder_int(int(2)).0.kind(),
-            IntExprKind::Remainder { .. },
-        ));
-        assert!(matches!(
-            int(1).negate_int().0.kind(),
-            IntExprKind::Negate(_)
-        ));
+        assert_eq!(
+            int(1).add_int(int(2)).0,
+            IntExpr::add(int(1).into(), int(2).into())
+        );
+        assert_eq!(
+            int(1).sub_int(int(2)).0,
+            IntExpr::sub(int(1).into(), int(2).into())
+        );
+        assert_eq!(
+            int(1).mult_int(int(2)).0,
+            IntExpr::mult(int(1).into(), int(2).into()),
+        );
+        assert_eq!(
+            int(1).div_int(int(2)).0,
+            IntExpr::div(int(1).into(), int(2).into())
+        );
+        assert_eq!(
+            int(1).remainder_int(int(2)).0,
+            IntExpr::remainder(int(1).into(), int(2).into()),
+        );
+        assert_eq!(int(1).negate_int().0, IntExpr::negate(int(1).into()));
     }
 
     #[test]
     fn float_operator_helpers_build_operator_shapes() {
-        assert!(matches!(
-            float(1.0).add_float(float(2.0)).0.kind(),
-            FloatExprKind::Add { .. },
-        ));
-        assert!(matches!(
-            float(1.0).sub_float(float(2.0)).0.kind(),
-            FloatExprKind::Sub { .. },
-        ));
-        assert!(matches!(
-            float(1.0).mult_float(float(2.0)).0.kind(),
-            FloatExprKind::Mult { .. },
-        ));
-        assert!(matches!(
-            float(1.0).div_float(float(2.0)).0.kind(),
-            FloatExprKind::Div { .. },
-        ));
+        assert_eq!(
+            float(1.0).add_float(float(2.0)).0,
+            FloatExpr::add(float(1.0).into(), float(2.0).into()),
+        );
+        assert_eq!(
+            float(1.0).sub_float(float(2.0)).0,
+            FloatExpr::sub(float(1.0).into(), float(2.0).into()),
+        );
+        assert_eq!(
+            float(1.0).mult_float(float(2.0)).0,
+            FloatExpr::mult(float(1.0).into(), float(2.0).into()),
+        );
+        assert_eq!(
+            float(1.0).div_float(float(2.0)).0,
+            FloatExpr::div(float(1.0).into(), float(2.0).into()),
+        );
     }
 
     #[test]
     fn bool_operator_helpers_build_operator_shapes() {
-        assert!(matches!(
-            int(1).lt_int(int(2)).0.kind(),
-            BoolExprKind::LtInt { .. },
-        ));
-        assert!(matches!(
-            int(1).lte_int(int(2)).0.kind(),
-            BoolExprKind::LtEqInt { .. },
-        ));
-        assert!(matches!(
-            int(2).gt_int(int(1)).0.kind(),
-            BoolExprKind::GtInt { .. },
-        ));
-        assert!(matches!(
-            int(2).gte_int(int(1)).0.kind(),
-            BoolExprKind::GtEqInt { .. },
-        ));
-        assert!(matches!(
-            float(1.0).lt_float(float(2.0)).0.kind(),
-            BoolExprKind::LtFloat { .. },
-        ));
-        assert!(matches!(
-            float(1.0).lte_float(float(2.0)).0.kind(),
-            BoolExprKind::LtEqFloat { .. },
-        ));
-        assert!(matches!(
-            float(2.0).gt_float(float(1.0)).0.kind(),
-            BoolExprKind::GtFloat { .. },
-        ));
-        assert!(matches!(
-            float(2.0).gte_float(float(1.0)).0.kind(),
-            BoolExprKind::GtEqFloat { .. },
-        ));
-        assert!(matches!(
-            equal(int(1), int(1)).0.kind(),
-            BoolExprKind::Equal { .. },
-        ));
-        assert!(matches!(
-            not_equal(bool_(true), bool_(false)).0.kind(),
-            BoolExprKind::NotEqual { .. },
-        ));
-        assert!(matches!(
-            bool_(true).and_bool(bool_(false)).0.kind(),
-            BoolExprKind::And { .. },
-        ));
-        assert!(matches!(
-            bool_(true).or_bool(bool_(false)).0.kind(),
-            BoolExprKind::Or { .. },
-        ));
-        assert!(matches!(
-            bool_(true).negate_bool().0.kind(),
-            BoolExprKind::Not(_)
-        ));
+        assert_eq!(
+            int(1).lt_int(int(2)).0,
+            BoolExpr::lt_int(int(1).into(), int(2).into())
+        );
+        assert_eq!(
+            int(1).lte_int(int(2)).0,
+            BoolExpr::lte_int(int(1).into(), int(2).into()),
+        );
+        assert_eq!(
+            int(2).gt_int(int(1)).0,
+            BoolExpr::gt_int(int(2).into(), int(1).into())
+        );
+        assert_eq!(
+            int(2).gte_int(int(1)).0,
+            BoolExpr::gte_int(int(2).into(), int(1).into()),
+        );
+        assert_eq!(
+            float(1.0).lt_float(float(2.0)).0,
+            BoolExpr::lt_float(float(1.0).into(), float(2.0).into()),
+        );
+        assert_eq!(
+            float(1.0).lte_float(float(2.0)).0,
+            BoolExpr::lte_float(float(1.0).into(), float(2.0).into()),
+        );
+        assert_eq!(
+            float(2.0).gt_float(float(1.0)).0,
+            BoolExpr::gt_float(float(2.0).into(), float(1.0).into()),
+        );
+        assert_eq!(
+            float(2.0).gte_float(float(1.0)).0,
+            BoolExpr::gte_float(float(2.0).into(), float(1.0).into()),
+        );
+        assert_eq!(
+            equal(int(1), int(1)).0,
+            BoolExpr::equal(int(1).into(), int(1).into())
+        );
+        assert_eq!(
+            not_equal(bool_(true), bool_(false)).0,
+            BoolExpr::not_equal(bool_(true).into(), bool_(false).into()),
+        );
+        assert_eq!(
+            bool_(true).and_bool(bool_(false)).0,
+            BoolExpr::and(bool_(true).into(), bool_(false).into()),
+        );
+        assert_eq!(
+            bool_(true).or_bool(bool_(false)).0,
+            BoolExpr::or(bool_(true).into(), bool_(false).into()),
+        );
+        assert_eq!(
+            bool_(true).negate_bool().0,
+            BoolExpr::not(bool_(true).into())
+        );
     }
 
     #[test]
     fn string_operator_helpers_build_operator_shapes() {
-        assert!(matches!(
-            string("a").concatenate(string("b")).0.kind(),
-            StringExprKind::Concatenate { .. },
-        ));
+        assert_eq!(
+            string("a").concatenate(string("b")).0,
+            StringExpr::concatenate(string("a").into(), string("b").into()),
+        );
     }
 
     #[test]
     fn tuple_projection_helpers_build_projection_shapes() {
-        assert!(matches!(
-            local_tuple(0, "pair", [ValueType::Int])
-                .index_int(0)
-                .0
-                .kind(),
-            IntExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(0, "pair", [ValueType::String])
-                .index_string(0)
-                .0
-                .kind(),
-            StringExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(0, "pair", [ValueType::Float])
-                .index_float(0)
-                .0
-                .kind(),
-            FloatExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(0, "pair", [ValueType::Bool])
-                .index_bool(0)
-                .0
-                .kind(),
-            BoolExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(0, "pair", [ValueType::Nil])
-                .index_nil(0)
-                .0
-                .kind(),
-            NilExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(0, "pair", [ValueType::Tuple(vec![ValueType::Int])])
-                .index_tuple(0, [ValueType::Int])
-                .0
-                .kind(),
-            TupleExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(0, "pair", [ValueType::List(Box::new(ValueType::Int))])
-                .index_list(0, ValueType::Int)
-                .0
-                .kind(),
-            ListExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(
-                0,
-                "pair",
-                [function_value_type([ValueType::Int], ValueType::Int)]
-            )
-            .index_int_function(0, [ValueType::Int])
-            .0
-            .kind(),
-            IntFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(
-                0,
-                "pair",
-                [function_value_type([ValueType::String], ValueType::String)]
-            )
-            .index_string_function(0, [ValueType::String])
-            .0
-            .kind(),
-            StringFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(
-                0,
-                "pair",
-                [function_value_type([ValueType::Float], ValueType::Float)]
-            )
-            .index_float_function(0, [ValueType::Float])
-            .0
-            .kind(),
-            FloatFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(
-                0,
-                "pair",
-                [function_value_type([ValueType::Bool], ValueType::Bool)]
-            )
-            .index_bool_function(0, [ValueType::Bool])
-            .0
-            .kind(),
-            BoolFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(
-                0,
-                "pair",
-                [function_value_type([ValueType::Nil], ValueType::Nil)]
-            )
-            .index_nil_function(0, [ValueType::Nil])
-            .0
-            .kind(),
-            NilFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(
-                0,
-                "pair",
-                [function_value_type(
-                    [ValueType::Int],
-                    ValueType::Tuple(vec![ValueType::Int])
-                )]
-            )
-            .index_tuple_function(0, [ValueType::Int], [ValueType::Int])
-            .0
-            .kind(),
-            TupleFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(
-                0,
-                "pair",
-                [function_value_type(
-                    [ValueType::Int],
-                    ValueType::List(Box::new(ValueType::Int))
-                )]
-            )
-            .index_list_function(0, [ValueType::Int], ValueType::Int)
-            .0
-            .kind(),
-            ListFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
-            local_tuple(
-                0,
-                "pair",
-                [function_value_type(
-                    [ValueType::Int],
-                    ValueType::Function(Box::new(FunctionType::new(
-                        vec![ValueType::Int],
-                        ValueType::Int
-                    )))
-                )]
-            )
-            .index_function_function(
-                0,
-                [ValueType::Int],
+        let pair = local_tuple(0, "pair", [ValueType::Int]);
+        assert_eq!(
+            pair.index_int(0).0,
+            IntExpr::tuple_index(local_tuple(0, "pair", [ValueType::Int]).into(), 0)
+        );
+
+        let pair = local_tuple(0, "pair", [ValueType::String]);
+        assert_eq!(
+            pair.index_string(1).0,
+            StringExpr::tuple_index(local_tuple(0, "pair", [ValueType::String]).into(), 1)
+        );
+
+        let pair = local_tuple(0, "pair", [ValueType::Float]);
+        assert_eq!(
+            pair.index_float(2).0,
+            FloatExpr::tuple_index(local_tuple(0, "pair", [ValueType::Float]).into(), 2)
+        );
+
+        let pair = local_tuple(0, "pair", [ValueType::Bool]);
+        assert_eq!(
+            pair.index_bool(3).0,
+            BoolExpr::tuple_index(local_tuple(0, "pair", [ValueType::Bool]).into(), 3)
+        );
+
+        let pair = local_tuple(0, "pair", [ValueType::Nil]);
+        assert_eq!(
+            pair.index_nil(4).0,
+            NilExpr::tuple_index(local_tuple(0, "pair", [ValueType::Nil]).into(), 4)
+        );
+
+        let pair = local_tuple(0, "pair", [ValueType::Tuple(vec![ValueType::Int])]);
+        assert_eq!(
+            pair.index_tuple(5, [ValueType::Int]).0,
+            TupleExpr::tuple_index(
+                local_tuple(0, "pair", [ValueType::Tuple(vec![ValueType::Int])]).into(),
+                5,
+                vec![ValueType::Int],
+            ),
+        );
+
+        let pair = local_tuple(0, "pair", [ValueType::List(Box::new(ValueType::Int))]);
+        assert_eq!(
+            pair.index_list(6, ValueType::Int).0,
+            ListExpr::tuple_index(
+                local_tuple(0, "pair", [ValueType::List(Box::new(ValueType::Int))]).into(),
+                6,
+                ValueType::Int,
+            ),
+        );
+
+        let pair = local_tuple(
+            0,
+            "pair",
+            [function_value_type([ValueType::Int], ValueType::Int)],
+        );
+        assert_eq!(
+            pair.index_int_function(7, [ValueType::Int]).0,
+            IntFunctionExpr::tuple_index(
+                local_tuple(
+                    0,
+                    "pair",
+                    [function_value_type([ValueType::Int], ValueType::Int)]
+                )
+                .into(),
+                7,
                 FunctionType::new(vec![ValueType::Int], ValueType::Int),
-            )
-            .0
-            .kind(),
-            FunctionFunctionExprKind::TupleIndex { .. },
-        ));
+            ),
+        );
+
+        let pair = local_tuple(
+            0,
+            "pair",
+            [function_value_type([ValueType::String], ValueType::String)],
+        );
+        assert_eq!(
+            pair.index_string_function(8, [ValueType::String]).0,
+            StringFunctionExpr::tuple_index(
+                local_tuple(
+                    0,
+                    "pair",
+                    [function_value_type([ValueType::String], ValueType::String)]
+                )
+                .into(),
+                8,
+                FunctionType::new(vec![ValueType::String], ValueType::String),
+            ),
+        );
+
+        let pair = local_tuple(
+            0,
+            "pair",
+            [function_value_type([ValueType::Float], ValueType::Float)],
+        );
+        assert_eq!(
+            pair.index_float_function(9, [ValueType::Float]).0,
+            FloatFunctionExpr::tuple_index(
+                local_tuple(
+                    0,
+                    "pair",
+                    [function_value_type([ValueType::Float], ValueType::Float)]
+                )
+                .into(),
+                9,
+                FunctionType::new(vec![ValueType::Float], ValueType::Float),
+            ),
+        );
+
+        let pair = local_tuple(
+            0,
+            "pair",
+            [function_value_type([ValueType::Bool], ValueType::Bool)],
+        );
+        assert_eq!(
+            pair.index_bool_function(10, [ValueType::Bool]).0,
+            BoolFunctionExpr::tuple_index(
+                local_tuple(
+                    0,
+                    "pair",
+                    [function_value_type([ValueType::Bool], ValueType::Bool)]
+                )
+                .into(),
+                10,
+                FunctionType::new(vec![ValueType::Bool], ValueType::Bool),
+            ),
+        );
+
+        let pair = local_tuple(
+            0,
+            "pair",
+            [function_value_type([ValueType::Nil], ValueType::Nil)],
+        );
+        assert_eq!(
+            pair.index_nil_function(11, [ValueType::Nil]).0,
+            NilFunctionExpr::tuple_index(
+                local_tuple(
+                    0,
+                    "pair",
+                    [function_value_type([ValueType::Nil], ValueType::Nil)]
+                )
+                .into(),
+                11,
+                FunctionType::new(vec![ValueType::Nil], ValueType::Nil),
+            ),
+        );
+
+        let tuple_return = ValueType::Tuple(vec![ValueType::Int]);
+        let pair = local_tuple(
+            0,
+            "pair",
+            [function_value_type([ValueType::Int], tuple_return.clone())],
+        );
+        assert_eq!(
+            pair.index_tuple_function(12, [ValueType::Int], [ValueType::Int])
+                .0,
+            TupleFunctionExpr::tuple_index(
+                local_tuple(
+                    0,
+                    "pair",
+                    [function_value_type([ValueType::Int], tuple_return)]
+                )
+                .into(),
+                12,
+                FunctionType::new(vec![ValueType::Int], ValueType::Tuple(vec![ValueType::Int])),
+            ),
+        );
+
+        let list_return = ValueType::List(Box::new(ValueType::Int));
+        let pair = local_tuple(
+            0,
+            "pair",
+            [function_value_type([ValueType::Int], list_return.clone())],
+        );
+        assert_eq!(
+            pair.index_list_function(13, [ValueType::Int], ValueType::Int)
+                .0,
+            ListFunctionExpr::tuple_index(
+                local_tuple(
+                    0,
+                    "pair",
+                    [function_value_type([ValueType::Int], list_return)]
+                )
+                .into(),
+                13,
+                FunctionType::new(
+                    vec![ValueType::Int],
+                    ValueType::List(Box::new(ValueType::Int)),
+                ),
+            ),
+        );
+
+        let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
+        let pair = local_tuple(
+            0,
+            "pair",
+            [function_value_type(
+                [ValueType::Int],
+                ValueType::Function(Box::new(returned_function_type.clone())),
+            )],
+        );
+        assert_eq!(
+            pair.index_function_function(14, [ValueType::Int], returned_function_type.clone())
+                .0,
+            FunctionFunctionExpr::tuple_index(
+                local_tuple(
+                    0,
+                    "pair",
+                    [function_value_type(
+                        [ValueType::Int],
+                        ValueType::Function(Box::new(returned_function_type.clone())),
+                    )]
+                )
+                .into(),
+                14,
+                FunctionType::new(
+                    vec![ValueType::Int],
+                    ValueType::Function(Box::new(returned_function_type)),
+                ),
+            ),
+        );
     }
 
     fn function_value_type(

--- a/src/planner/dsl/expression/step.rs
+++ b/src/planner/dsl/expression/step.rs
@@ -88,8 +88,11 @@ mod tests {
         let_float_step, let_int_function_step, let_int_step, let_list_step, let_nil_function_step,
         let_nil_step, let_string_function_step, let_string_step, let_tuple_step,
     };
-    use crate::plan::Expr;
-    use crate::plan::StepKind;
+    use crate::plan::{
+        BoolFunctionLocalId, BoolLocalId, Expr, FloatFunctionLocalId, FloatLocalId,
+        IntFunctionLocalId, IntLocalId, ListLocalId, NilFunctionLocalId, NilLocalId, Step,
+        StringFunctionLocalId, StringLocalId, TupleLocalId,
+    };
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, int, int_function_ref, list, nil,
         nil_function_ref, string, string_function_ref, tuple,
@@ -97,93 +100,121 @@ mod tests {
 
     #[test]
     fn step_helpers_build_step_shapes() {
-        assert!(matches!(
-            let_int_step(0, "x", int(1)).kind(),
-            StepKind::LetInt { .. },
-        ));
-        assert!(matches!(
-            let_string_step(0, "x", string("a")).kind(),
-            StepKind::LetString { .. },
-        ));
-        assert!(matches!(
-            let_float_step(0, "x", float(1.0)).kind(),
-            StepKind::LetFloat { .. },
-        ));
-        assert!(matches!(
-            let_bool_step(0, "x", bool_(true)).kind(),
-            StepKind::LetBool { .. },
-        ));
-        assert!(matches!(
-            let_nil_step(0, "x", nil()).kind(),
-            StepKind::LetNil { .. },
-        ));
-        assert!(matches!(
+        assert_eq!(
+            let_int_step(0, "x", int(1)),
+            Step::let_int(IntLocalId(0), "x".into(), int(1).into()),
+        );
+        assert_eq!(
+            let_string_step(1, "name", string("a")),
+            Step::let_string(StringLocalId(1), "name".into(), string("a").into()),
+        );
+        assert_eq!(
+            let_float_step(2, "ratio", float(1.0)),
+            Step::let_float(FloatLocalId(2), "ratio".into(), float(1.0).into()),
+        );
+        assert_eq!(
+            let_bool_step(3, "ok", bool_(true)),
+            Step::let_bool(BoolLocalId(3), "ok".into(), bool_(true).into()),
+        );
+        assert_eq!(
+            let_nil_step(4, "done", nil()),
+            Step::let_nil(NilLocalId(4), "done".into(), nil().into()),
+        );
+        assert_eq!(
             let_tuple_step(
-                0,
-                "x",
+                5,
+                "pair",
                 tuple([Expr::from(int(1)), Expr::from(string("one"))])
-            )
-            .kind(),
-            StepKind::LetTuple { .. },
-        ));
-        assert!(matches!(
-            let_list_step(0, "x", list([int(1)], crate::plan::ValueType::Int)).kind(),
-            StepKind::LetList { .. },
-        ));
-        assert!(matches!(
+            ),
+            Step::let_tuple(
+                TupleLocalId(5),
+                "pair".into(),
+                tuple([Expr::from(int(1)), Expr::from(string("one"))]).into(),
+            ),
+        );
+        assert_eq!(
+            let_list_step(6, "values", list([int(1)], crate::plan::ValueType::Int)),
+            Step::let_list(
+                ListLocalId(6),
+                "values".into(),
+                list([int(1)], crate::plan::ValueType::Int).into(),
+            ),
+        );
+        assert_eq!(
             let_int_function_step(
                 0,
                 "f",
                 int_function_ref(0, [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))]),
-            )
-            .kind(),
-            StepKind::LetIntFunction { .. },
-        ));
-        assert!(matches!(
+            ),
+            Step::let_int_function(
+                IntFunctionLocalId(0),
+                "f".into(),
+                int_function_ref(0, [crate::plan::LocalId::Int(crate::plan::IntLocalId(0))]).into(),
+            ),
+        );
+        assert_eq!(
             let_string_function_step(
-                0,
+                1,
                 "f",
                 string_function_ref(
                     0,
                     [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
                 ),
-            )
-            .kind(),
-            StepKind::LetStringFunction { .. },
-        ));
-        assert!(matches!(
+            ),
+            Step::let_string_function(
+                StringFunctionLocalId(1),
+                "f".into(),
+                string_function_ref(
+                    0,
+                    [crate::plan::LocalId::String(crate::plan::StringLocalId(0))],
+                )
+                .into(),
+            ),
+        );
+        assert_eq!(
             let_float_function_step(
-                0,
+                2,
                 "f",
                 float_function_ref(
                     0,
                     [crate::plan::LocalId::Float(crate::plan::FloatLocalId(0))]
                 ),
-            )
-            .kind(),
-            StepKind::LetFloatFunction { .. },
-        ));
-        assert!(matches!(
+            ),
+            Step::let_float_function(
+                FloatFunctionLocalId(2),
+                "f".into(),
+                float_function_ref(
+                    0,
+                    [crate::plan::LocalId::Float(crate::plan::FloatLocalId(0))]
+                )
+                .into(),
+            ),
+        );
+        assert_eq!(
             let_bool_function_step(
-                0,
+                3,
                 "f",
                 bool_function_ref(0, [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))]),
-            )
-            .kind(),
-            StepKind::LetBoolFunction { .. },
-        ));
-        assert!(matches!(
+            ),
+            Step::let_bool_function(
+                BoolFunctionLocalId(3),
+                "f".into(),
+                bool_function_ref(0, [crate::plan::LocalId::Bool(crate::plan::BoolLocalId(0))])
+                    .into(),
+            ),
+        );
+        assert_eq!(
             let_nil_function_step(
-                0,
+                4,
                 "f",
                 nil_function_ref(0, [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))]),
-            )
-            .kind(),
-            StepKind::LetNilFunction { .. },
-        ));
-        assert!(matches!(
-            evaluate_step(int(1)).kind(),
-            StepKind::Evaluate(_),
-        ));
+            ),
+            Step::let_nil_function(
+                NilFunctionLocalId(4),
+                "f".into(),
+                nil_function_ref(0, [crate::plan::LocalId::Nil(crate::plan::NilLocalId(0))]).into(),
+            ),
+        );
+        assert_eq!(evaluate_step(int(1)), Step::evaluate(Expr::from(int(1))));
     }
 }

--- a/src/planner/dsl/expression/value.rs
+++ b/src/planner/dsl/expression/value.rs
@@ -56,35 +56,39 @@ pub(crate) fn list_spread(
 #[cfg(test)]
 mod tests {
     use super::{bool_, float, int, list, list_spread, nil, string, tuple};
-    use crate::plan::ValueType;
-    use crate::plan::{Expr, ExprKind};
+    use crate::plan::{
+        BoolExpr, Expr, FloatExpr, IntExpr, ListExpr, NilExpr, StringExpr, TupleExpr, ValueType,
+    };
+    use num_bigint::BigInt;
 
     #[test]
     fn value_helpers_build_typed_exprs() {
-        assert!(matches!(Expr::from(int(1)).kind(), ExprKind::Int(_)));
-        assert!(matches!(
-            Expr::from(string("a")).kind(),
-            ExprKind::String(_),
-        ));
-        assert!(matches!(Expr::from(float(1.0)).kind(), ExprKind::Float(_)));
-        assert!(matches!(Expr::from(bool_(true)).kind(), ExprKind::Bool(_)));
-        assert!(matches!(Expr::from(nil()).kind(), ExprKind::Nil(_)));
-        assert!(matches!(
-            Expr::from(tuple([Expr::from(int(1)), Expr::from(string("one"))])).kind(),
-            ExprKind::Tuple(_),
-        ));
-        assert!(matches!(
-            Expr::from(list([int(1)], ValueType::Int)).kind(),
-            ExprKind::List(_),
-        ));
-        assert!(matches!(
-            Expr::from(list_spread(
-                [int(1)],
-                list([int(2)], ValueType::Int),
+        assert_eq!(int(1).0, IntExpr::value(BigInt::from(1)));
+        assert_eq!(string("a").0, StringExpr::value("a".into()));
+        assert_eq!(float(1.0).0, FloatExpr::value(1.0));
+        assert_eq!(bool_(true).0, BoolExpr::value(true));
+        assert_eq!(nil().0, NilExpr::value());
+
+        let tuple_elements = [Expr::from(int(1)), Expr::from(string("one"))];
+        assert_eq!(
+            tuple(tuple_elements.clone()).0,
+            TupleExpr::value(
+                tuple_elements.to_vec(),
+                vec![ValueType::Int, ValueType::String]
+            ),
+        );
+
+        assert_eq!(
+            list([int(1)], ValueType::Int).0,
+            ListExpr::value(vec![Expr::from(int(1))], ValueType::Int),
+        );
+        assert_eq!(
+            list_spread([int(1)], list([int(2)], ValueType::Int), ValueType::Int).0,
+            ListExpr::spread(
+                vec![Expr::from(int(1))],
+                ListExpr::value(vec![Expr::from(int(2))], ValueType::Int),
                 ValueType::Int,
-            ))
-            .kind(),
-            ExprKind::List(_),
-        ));
+            ),
+        );
     }
 }

--- a/src/planner/dsl/function/return_body.rs
+++ b/src/planner/dsl/function/return_body.rs
@@ -13,6 +13,7 @@ use crate::planner::context::FunctionRuntimeIds;
 pub(crate) use function::*;
 pub(crate) use primitive::*;
 
+#[derive(Debug, PartialEq)]
 pub(crate) enum FunctionReturn {
     Int(IntReturn),
     String(StringReturn),
@@ -111,142 +112,161 @@ mod tests {
     use crate::plan::{
         BoolFunctionFunctionId, BoolFunctionId, Expr, FloatFunctionFunctionId, FloatFunctionId,
         FunctionFunctionFunctionId, FunctionFunctionId, FunctionType, IntFunctionFunctionId,
-        IntFunctionId, NilFunctionFunctionId, NilFunctionId, ParamLocal, ReturnExprKind,
-        StringFunctionFunctionId, StringFunctionId, TupleFunctionFunctionId, TupleFunctionId,
-        ValueType,
+        IntFunctionId, ListFunctionFunctionId, ListFunctionId, NilFunctionFunctionId,
+        NilFunctionId, ParamLocal, ReturnBody, ReturnExpr, StringFunctionFunctionId,
+        StringFunctionId, TupleFunctionFunctionId, TupleFunctionId, ValueType,
     };
     use crate::planner::context::FunctionRuntimeIds;
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, float, float_function_ref, function_function_ref, int,
-        int_function_ref, nil, nil_function_ref, string, string_function_ref, tuple,
-        tuple_function_ref,
+        int_function_ref, list, list_function_ref, nil, nil_function_ref, string,
+        string_function_ref, tuple, tuple_function_ref,
     };
 
     #[test]
     fn function_return_build_allocates_runtime_ids_by_return_family() {
         let mut runtime_ids = FunctionRuntimeIds::default();
 
-        assert!(matches!(
-            FunctionReturn::from(int(1)).build(&mut runtime_ids).kind(),
-            ReturnExprKind::Int {
-                runtime_id: IntFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
-            FunctionReturn::from(string("value"))
-                .build(&mut runtime_ids)
-                .kind(),
-            ReturnExprKind::String {
-                runtime_id: StringFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
-            FunctionReturn::from(float(1.5))
-                .build(&mut runtime_ids)
-                .kind(),
-            ReturnExprKind::Float {
-                runtime_id: FloatFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
-            FunctionReturn::from(bool_(true))
-                .build(&mut runtime_ids)
-                .kind(),
-            ReturnExprKind::Bool {
-                runtime_id: BoolFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
-            FunctionReturn::from(nil()).build(&mut runtime_ids).kind(),
-            ReturnExprKind::Nil {
-                runtime_id: NilFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
-            FunctionReturn::from(tuple([Expr::from(int(1))]))
-                .build(&mut runtime_ids)
-                .kind(),
-            ReturnExprKind::Tuple {
-                runtime_id: TupleFunctionId(0),
-                ..
-            },
-        ));
+        assert_eq!(
+            FunctionReturn::from(int(1)).build(&mut runtime_ids),
+            ReturnExpr::int_body(IntFunctionId(0), ReturnBody::expr(int(1).into())),
+        );
+        assert_eq!(
+            FunctionReturn::from(string("value")).build(&mut runtime_ids),
+            ReturnExpr::string_body(
+                StringFunctionId(0),
+                ReturnBody::expr(string("value").into()),
+            ),
+        );
+        assert_eq!(
+            FunctionReturn::from(float(1.5)).build(&mut runtime_ids),
+            ReturnExpr::float_body(FloatFunctionId(0), ReturnBody::expr(float(1.5).into())),
+        );
+        assert_eq!(
+            FunctionReturn::from(bool_(true)).build(&mut runtime_ids),
+            ReturnExpr::bool_body(BoolFunctionId(0), ReturnBody::expr(bool_(true).into())),
+        );
+        assert_eq!(
+            FunctionReturn::from(nil()).build(&mut runtime_ids),
+            ReturnExpr::nil_body(NilFunctionId(0), ReturnBody::expr(nil().into())),
+        );
+        assert_eq!(
+            FunctionReturn::from(tuple([Expr::from(int(1))])).build(&mut runtime_ids),
+            ReturnExpr::tuple_body(
+                TupleFunctionId(0),
+                vec![ValueType::Int],
+                ReturnBody::expr(tuple([Expr::from(int(1))]).into()),
+            ),
+        );
+        assert_eq!(
+            FunctionReturn::from(list([int(1)], ValueType::Int)).build(&mut runtime_ids),
+            ReturnExpr::list_body(
+                ListFunctionId(0),
+                ValueType::Int,
+                ReturnBody::expr(list([int(1)], ValueType::Int).into()),
+            ),
+        );
 
-        assert!(matches!(
+        assert_eq!(
             FunctionReturn::from(int_function_ref(0, Vec::<ParamLocal>::new()))
-                .build(&mut runtime_ids)
-                .kind(),
-            ReturnExprKind::IntFunction {
-                runtime_id: IntFunctionFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
+                .build(&mut runtime_ids),
+            ReturnExpr::int_function_body(
+                IntFunctionFunctionId(0),
+                FunctionType::new(Vec::new(), ValueType::Int),
+                ReturnBody::expr(int_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            ),
+        );
+        assert_eq!(
             FunctionReturn::from(string_function_ref(0, Vec::<ParamLocal>::new()))
-                .build(&mut runtime_ids)
-                .kind(),
-            ReturnExprKind::StringFunction {
-                runtime_id: StringFunctionFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
+                .build(&mut runtime_ids),
+            ReturnExpr::string_function_body(
+                StringFunctionFunctionId(0),
+                FunctionType::new(Vec::new(), ValueType::String),
+                ReturnBody::expr(string_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            ),
+        );
+        assert_eq!(
             FunctionReturn::from(float_function_ref(0, Vec::<ParamLocal>::new()))
-                .build(&mut runtime_ids)
-                .kind(),
-            ReturnExprKind::FloatFunction {
-                runtime_id: FloatFunctionFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
+                .build(&mut runtime_ids),
+            ReturnExpr::float_function_body(
+                FloatFunctionFunctionId(0),
+                FunctionType::new(Vec::new(), ValueType::Float),
+                ReturnBody::expr(float_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            ),
+        );
+        assert_eq!(
             FunctionReturn::from(bool_function_ref(0, Vec::<ParamLocal>::new()))
-                .build(&mut runtime_ids)
-                .kind(),
-            ReturnExprKind::BoolFunction {
-                runtime_id: BoolFunctionFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
+                .build(&mut runtime_ids),
+            ReturnExpr::bool_function_body(
+                BoolFunctionFunctionId(0),
+                FunctionType::new(Vec::new(), ValueType::Bool),
+                ReturnBody::expr(bool_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            ),
+        );
+        assert_eq!(
             FunctionReturn::from(nil_function_ref(0, Vec::<ParamLocal>::new()))
-                .build(&mut runtime_ids)
-                .kind(),
-            ReturnExprKind::NilFunction {
-                runtime_id: NilFunctionFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
+                .build(&mut runtime_ids),
+            ReturnExpr::nil_function_body(
+                NilFunctionFunctionId(0),
+                FunctionType::new(Vec::new(), ValueType::Nil),
+                ReturnBody::expr(nil_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            ),
+        );
+        assert_eq!(
             FunctionReturn::from(tuple_function_ref(
                 0,
                 Vec::<ParamLocal>::new(),
                 [ValueType::Int],
             ))
-            .build(&mut runtime_ids)
-            .kind(),
-            ReturnExprKind::TupleFunction {
-                runtime_id: TupleFunctionFunctionId(0),
-                ..
-            },
-        ));
-        assert!(matches!(
+            .build(&mut runtime_ids),
+            ReturnExpr::tuple_function_body(
+                TupleFunctionFunctionId(0),
+                FunctionType::new(Vec::new(), ValueType::Tuple(vec![ValueType::Int])),
+                ReturnBody::expr(
+                    tuple_function_ref(0, Vec::<ParamLocal>::new(), [ValueType::Int]).into(),
+                ),
+            ),
+        );
+        assert_eq!(
+            FunctionReturn::from(list_function_ref(
+                0,
+                Vec::<ParamLocal>::new(),
+                ValueType::Int
+            ))
+            .build(&mut runtime_ids),
+            ReturnExpr::list_function_body(
+                ListFunctionFunctionId(0),
+                FunctionType::new(Vec::new(), ValueType::List(Box::new(ValueType::Int))),
+                ReturnBody::expr(
+                    list_function_ref(0, Vec::<ParamLocal>::new(), ValueType::Int).into(),
+                ),
+            ),
+        );
+        assert_eq!(
             FunctionReturn::from(function_function_ref(
                 FunctionFunctionId::Int(IntFunctionFunctionId(1)),
                 Vec::<ParamLocal>::new(),
                 FunctionType::new(vec![ValueType::Int], ValueType::Int),
             ))
-            .build(&mut runtime_ids)
-            .kind(),
-            ReturnExprKind::FunctionFunction {
-                runtime_id: FunctionFunctionFunctionId(0),
-                ..
-            },
-        ));
+            .build(&mut runtime_ids),
+            ReturnExpr::function_function_body(
+                FunctionFunctionFunctionId(0),
+                FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(FunctionType::new(
+                        vec![ValueType::Int],
+                        ValueType::Int,
+                    ))),
+                ),
+                ReturnBody::expr(
+                    function_function_ref(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(1)),
+                        Vec::<ParamLocal>::new(),
+                        FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                    )
+                    .into(),
+                ),
+            ),
+        );
     }
 }

--- a/src/planner/dsl/function/return_body/conversion.rs
+++ b/src/planner/dsl/function/return_body/conversion.rs
@@ -213,106 +213,197 @@ impl From<NilReturn> for FunctionReturn {
 mod tests {
     use super::FunctionReturn;
     use crate::plan::{
-        BoolFunctionId, BoolReturn, Expr, FunctionFunctionId, FunctionType, IntFunctionFunctionId,
-        IntFunctionId, IntReturn, NilFunctionId, NilReturn, ParamLocal, ReturnBodyKind,
-        RuntimeFunctionId, StringFunctionId, StringReturn, TupleFunctionId, ValueType,
+        BoolFunctionId, BoolReturn, Expr, FloatFunctionId, FloatReturn, FunctionFunctionId,
+        FunctionType, IntFunctionFunctionId, IntFunctionId, IntReturn, ListFunctionId,
+        NilFunctionId, NilReturn, ParamLocal, ReturnBody, RuntimeFunctionId, StringFunctionId,
+        StringReturn, TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::expression::{
-        bool_, bool_function_ref, function_function_ref, function_ref, int, int_function_ref, nil,
-        nil_function_ref, string, string_function_ref, tuple, tuple_function_ref,
+        bool_, bool_function_ref, float, float_function_ref, function_function_ref, function_ref,
+        int, int_function_ref, list, list_function_ref, nil, nil_function_ref, string,
+        string_function_ref, tuple, tuple_function_ref,
     };
 
     #[test]
     fn value_conversions_build_function_return_families() {
-        assert!(matches!(
+        assert_eq!(
             FunctionReturn::from(int(1)),
-            FunctionReturn::Int(_),
-        ));
-        assert!(matches!(
+            FunctionReturn::Int(ReturnBody::expr(int(1).into())),
+        );
+        assert_eq!(
             FunctionReturn::from(string("value")),
-            FunctionReturn::String(_),
-        ));
-        assert!(matches!(
+            FunctionReturn::String(ReturnBody::expr(string("value").into())),
+        );
+        assert_eq!(
+            FunctionReturn::from(float(1.5)),
+            FunctionReturn::Float(ReturnBody::expr(float(1.5).into())),
+        );
+        assert_eq!(
             FunctionReturn::from(bool_(true)),
-            FunctionReturn::Bool(_),
-        ));
-        assert!(matches!(
+            FunctionReturn::Bool(ReturnBody::expr(bool_(true).into())),
+        );
+        assert_eq!(
             FunctionReturn::from(nil()),
-            FunctionReturn::Nil(_),
-        ));
-        assert!(matches!(
+            FunctionReturn::Nil(ReturnBody::expr(nil().into())),
+        );
+        assert_eq!(
             FunctionReturn::from(tuple([Expr::from(int(1))])),
-            FunctionReturn::Tuple { .. },
-        ));
+            FunctionReturn::Tuple {
+                type_: vec![ValueType::Int],
+                body: ReturnBody::expr(tuple([Expr::from(int(1))]).into()),
+            },
+        );
+        assert_eq!(
+            FunctionReturn::from(list([int(1)], ValueType::Int)),
+            FunctionReturn::List {
+                element_type: ValueType::Int,
+                body: ReturnBody::expr(list([int(1)], ValueType::Int).into()),
+            },
+        );
     }
 
     #[test]
     fn function_value_conversions_preserve_return_family() {
-        assert!(matches!(
+        assert_eq!(
             FunctionReturn::from(int_function_ref(0, Vec::<ParamLocal>::new())),
-            FunctionReturn::IntFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::IntFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Int),
+                body: ReturnBody::expr(int_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(string_function_ref(0, Vec::<ParamLocal>::new())),
-            FunctionReturn::StringFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::StringFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::String),
+                body: ReturnBody::expr(string_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            },
+        );
+        assert_eq!(
+            FunctionReturn::from(float_function_ref(0, Vec::<ParamLocal>::new())),
+            FunctionReturn::FloatFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Float),
+                body: ReturnBody::expr(float_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(bool_function_ref(0, Vec::<ParamLocal>::new())),
-            FunctionReturn::BoolFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::BoolFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Bool),
+                body: ReturnBody::expr(bool_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(nil_function_ref(0, Vec::<ParamLocal>::new())),
-            FunctionReturn::NilFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::NilFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Nil),
+                body: ReturnBody::expr(nil_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(tuple_function_ref(
                 0,
                 Vec::<ParamLocal>::new(),
                 [ValueType::Int],
             )),
-            FunctionReturn::TupleFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::TupleFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Tuple(vec![ValueType::Int])),
+                body: ReturnBody::expr(
+                    tuple_function_ref(0, Vec::<ParamLocal>::new(), [ValueType::Int]).into(),
+                ),
+            },
+        );
+        assert_eq!(
+            FunctionReturn::from(list_function_ref(
+                0,
+                Vec::<ParamLocal>::new(),
+                ValueType::Int
+            )),
+            FunctionReturn::ListFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::List(Box::new(ValueType::Int))),
+                body: ReturnBody::expr(
+                    list_function_ref(0, Vec::<ParamLocal>::new(), ValueType::Int).into(),
+                ),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(function_function_ref(
                 FunctionFunctionId::Int(IntFunctionFunctionId(0)),
                 Vec::<ParamLocal>::new(),
                 FunctionType::new(vec![ValueType::Int], ValueType::Int),
             )),
-            FunctionReturn::FunctionFunction { .. },
-        ));
+            FunctionReturn::FunctionFunction {
+                type_: FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(FunctionType::new(
+                        vec![ValueType::Int],
+                        ValueType::Int,
+                    ))),
+                ),
+                body: ReturnBody::expr(
+                    function_function_ref(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                        Vec::<ParamLocal>::new(),
+                        FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                    )
+                    .into(),
+                ),
+            },
+        );
     }
 
     #[test]
     fn erased_function_value_conversion_preserves_return_family() {
-        assert!(matches!(
+        assert_eq!(
             FunctionReturn::from(function_ref(
                 RuntimeFunctionId::Int(IntFunctionId(0)),
                 Vec::<ParamLocal>::new(),
             )),
-            FunctionReturn::IntFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::IntFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Int),
+                body: ReturnBody::expr(int_function_ref(0, Vec::<ParamLocal>::new()).into(),),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(function_ref(
                 RuntimeFunctionId::String(StringFunctionId(0)),
                 Vec::<ParamLocal>::new(),
             )),
-            FunctionReturn::StringFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::StringFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::String),
+                body: ReturnBody::expr(string_function_ref(0, Vec::<ParamLocal>::new()).into(),),
+            },
+        );
+        assert_eq!(
+            FunctionReturn::from(function_ref(
+                RuntimeFunctionId::Float(FloatFunctionId(0)),
+                Vec::<ParamLocal>::new(),
+            )),
+            FunctionReturn::FloatFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Float),
+                body: ReturnBody::expr(float_function_ref(0, Vec::<ParamLocal>::new()).into(),),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(function_ref(
                 RuntimeFunctionId::Bool(BoolFunctionId(0)),
                 Vec::<ParamLocal>::new(),
             )),
-            FunctionReturn::BoolFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::BoolFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Bool),
+                body: ReturnBody::expr(bool_function_ref(0, Vec::<ParamLocal>::new()).into(),),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(function_ref(
                 RuntimeFunctionId::Nil(NilFunctionId(0)),
                 Vec::<ParamLocal>::new(),
             )),
-            FunctionReturn::NilFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::NilFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Nil),
+                body: ReturnBody::expr(nil_function_ref(0, Vec::<ParamLocal>::new()).into(),),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(function_ref(
                 RuntimeFunctionId::Tuple {
                     id: TupleFunctionId(0),
@@ -320,9 +411,29 @@ mod tests {
                 },
                 Vec::<ParamLocal>::new(),
             )),
-            FunctionReturn::TupleFunction { .. },
-        ));
-        assert!(matches!(
+            FunctionReturn::TupleFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::Tuple(vec![ValueType::Int])),
+                body: ReturnBody::expr(
+                    tuple_function_ref(0, Vec::<ParamLocal>::new(), [ValueType::Int]).into(),
+                ),
+            },
+        );
+        assert_eq!(
+            FunctionReturn::from(function_ref(
+                RuntimeFunctionId::List {
+                    id: ListFunctionId(0),
+                    return_type: Box::new(ValueType::Int),
+                },
+                Vec::<ParamLocal>::new(),
+            )),
+            FunctionReturn::ListFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::List(Box::new(ValueType::Int))),
+                body: ReturnBody::expr(
+                    list_function_ref(0, Vec::<ParamLocal>::new(), ValueType::Int).into(),
+                ),
+            },
+        );
+        assert_eq!(
             FunctionReturn::from(function_ref(
                 RuntimeFunctionId::Function {
                     id: FunctionFunctionId::Int(IntFunctionFunctionId(0)),
@@ -330,27 +441,47 @@ mod tests {
                 },
                 Vec::<ParamLocal>::new(),
             )),
-            FunctionReturn::FunctionFunction { .. },
-        ));
+            FunctionReturn::FunctionFunction {
+                type_: FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(FunctionType::new(
+                        vec![ValueType::Int],
+                        ValueType::Int,
+                    ))),
+                ),
+                body: ReturnBody::expr(
+                    function_function_ref(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                        Vec::<ParamLocal>::new(),
+                        FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                    )
+                    .into(),
+                ),
+            },
+        );
     }
 
     #[test]
     fn return_body_conversions_keep_existing_body_family() {
-        assert!(matches!(
+        assert_eq!(
             FunctionReturn::from(IntReturn::expr(int(1).into())),
-            FunctionReturn::Int(body) if matches!(body.kind(), ReturnBodyKind::Expr(_)),
-        ));
-        assert!(matches!(
+            FunctionReturn::Int(IntReturn::expr(int(1).into())),
+        );
+        assert_eq!(
             FunctionReturn::from(StringReturn::expr(string("value").into())),
-            FunctionReturn::String(body) if matches!(body.kind(), ReturnBodyKind::Expr(_)),
-        ));
-        assert!(matches!(
+            FunctionReturn::String(StringReturn::expr(string("value").into())),
+        );
+        assert_eq!(
+            FunctionReturn::from(FloatReturn::expr(float(1.0).into())),
+            FunctionReturn::Float(FloatReturn::expr(float(1.0).into())),
+        );
+        assert_eq!(
             FunctionReturn::from(BoolReturn::expr(bool_(true).into())),
-            FunctionReturn::Bool(body) if matches!(body.kind(), ReturnBodyKind::Expr(_)),
-        ));
-        assert!(matches!(
+            FunctionReturn::Bool(BoolReturn::expr(bool_(true).into())),
+        );
+        assert_eq!(
             FunctionReturn::from(NilReturn::expr(nil().into())),
-            FunctionReturn::Nil(body) if matches!(body.kind(), ReturnBodyKind::Expr(_)),
-        ));
+            FunctionReturn::Nil(NilReturn::expr(nil().into())),
+        );
     }
 }

--- a/src/planner/dsl/function/return_body/function.rs
+++ b/src/planner/dsl/function/return_body/function.rs
@@ -338,109 +338,129 @@ mod tests {
         string_function_return_string_case, string_function_return_tail_call,
     };
     use crate::plan::{
-        CallArg, FunctionFunctionFunctionId, FunctionFunctionId, FunctionType,
-        IntFunctionFunctionId, ParamLocal, ReturnBodyKind, Step, ValueType,
+        BoolFunctionFunctionId, CallArg, FunctionFunctionFunctionId, FunctionFunctionId,
+        FunctionType, IntFunctionFunctionId, NilFunctionFunctionId, ParamLocal, ReturnBody, Step,
+        StringFunctionFunctionId, ValueType,
     };
     use crate::planner::dsl::expression::{
         bool_, bool_function_ref, function_function_ref, int, int_function_ref, nil_function_ref,
         string, string_function_ref,
     };
+    use num_bigint::BigInt;
 
     #[test]
     fn function_return_expr_helpers_build_return_body_shapes() {
         let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
 
-        assert!(matches!(
-            int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
-        assert!(matches!(
-            string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
-        assert!(matches!(
-            bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
-        assert!(matches!(
-            nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
-        assert!(matches!(
+        assert_eq!(
+            int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
+            ReturnBody::expr(int_function_ref(0, Vec::<ParamLocal>::new()).into()),
+        );
+        assert_eq!(
+            string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
+            ReturnBody::expr(string_function_ref(0, Vec::<ParamLocal>::new()).into()),
+        );
+        assert_eq!(
+            bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
+            ReturnBody::expr(bool_function_ref(0, Vec::<ParamLocal>::new()).into()),
+        );
+        assert_eq!(
+            nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
+            ReturnBody::expr(nil_function_ref(0, Vec::<ParamLocal>::new()).into()),
+        );
+        assert_eq!(
             function_function_return_expr(function_function_ref(
                 FunctionFunctionId::Int(IntFunctionFunctionId(0)),
                 Vec::<ParamLocal>::new(),
                 returned_function_type,
-            ))
-            .kind(),
-            ReturnBodyKind::Expr(_),
-        ));
+            )),
+            ReturnBody::expr(
+                function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                )
+                .into(),
+            ),
+        );
     }
 
     #[test]
     fn function_return_tail_call_helpers_build_return_body_shapes() {
-        assert!(matches!(
-            int_function_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
-        assert!(matches!(
-            string_function_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
-        assert!(matches!(
-            bool_function_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
-        assert!(matches!(
-            nil_function_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
-        assert!(matches!(
-            function_function_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
+        assert_eq!(
+            int_function_return_tail_call(0, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(IntFunctionFunctionId(0), Vec::new()),
+        );
+        assert_eq!(
+            string_function_return_tail_call(1, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(StringFunctionFunctionId(1), Vec::new()),
+        );
+        assert_eq!(
+            bool_function_return_tail_call(2, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(BoolFunctionFunctionId(2), Vec::new()),
+        );
+        assert_eq!(
+            nil_function_return_tail_call(3, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(NilFunctionFunctionId(3), Vec::new()),
+        );
+        assert_eq!(
+            function_function_return_tail_call(4, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(FunctionFunctionFunctionId(4), Vec::new()),
+        );
     }
 
     #[test]
     fn function_return_case_helpers_build_return_body_shapes() {
-        assert!(matches!(
+        assert_eq!(
             int_function_return_bool_case(
                 bool_(true),
                 int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
                 int_function_return_expr(int_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
+                int_function_return_expr(int_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             string_function_return_bool_case(
                 bool_(true),
                 string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
                 string_function_return_expr(string_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
+                string_function_return_expr(string_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             bool_function_return_bool_case(
                 bool_(true),
                 bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
                 bool_function_return_expr(bool_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
+                bool_function_return_expr(bool_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             nil_function_return_bool_case(
                 bool_(true),
                 nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
                 nil_function_return_expr(nil_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
+            ),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
+                nil_function_return_expr(nil_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
 
-        assert!(matches!(
+        assert_eq!(
             int_function_return_int_case(
                 int(1),
                 [(
@@ -448,11 +468,17 @@ mod tests {
                     int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
                 )],
                 int_function_return_expr(int_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
+                )],
+                int_function_return_expr(int_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             string_function_return_int_case(
                 int(1),
                 [(
@@ -460,11 +486,17 @@ mod tests {
                     string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
                 )],
                 string_function_return_expr(string_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
+                )],
+                string_function_return_expr(string_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             bool_function_return_int_case(
                 int(1),
                 [(
@@ -472,11 +504,17 @@ mod tests {
                     bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
                 )],
                 bool_function_return_expr(bool_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
+                )],
+                bool_function_return_expr(bool_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             nil_function_return_int_case(
                 int(1),
                 [(
@@ -484,11 +522,17 @@ mod tests {
                     nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
                 )],
                 nil_function_return_expr(nil_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
+                )],
+                nil_function_return_expr(nil_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             function_function_return_int_case(
                 int(1),
                 [(
@@ -504,12 +548,26 @@ mod tests {
                     Vec::<ParamLocal>::new(),
                     FunctionType::new(vec![ValueType::Int], ValueType::Int),
                 )),
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    function_function_return_expr(function_function_ref(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                        Vec::<ParamLocal>::new(),
+                        FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                    )),
+                )],
+                function_function_return_expr(function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(1)),
+                    Vec::<ParamLocal>::new(),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                )),
+            ),
+        );
 
-        assert!(matches!(
+        assert_eq!(
             int_function_return_string_case(
                 string("key"),
                 [(
@@ -517,11 +575,17 @@ mod tests {
                     int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
                 )],
                 int_function_return_expr(int_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
+                )],
+                int_function_return_expr(int_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             string_function_return_string_case(
                 string("key"),
                 [(
@@ -529,11 +593,17 @@ mod tests {
                     string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
                 )],
                 string_function_return_expr(string_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
+                )],
+                string_function_return_expr(string_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             bool_function_return_string_case(
                 string("key"),
                 [(
@@ -541,11 +611,17 @@ mod tests {
                     bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
                 )],
                 bool_function_return_expr(bool_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
+                )],
+                bool_function_return_expr(bool_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             nil_function_return_string_case(
                 string("key"),
                 [(
@@ -553,14 +629,20 @@ mod tests {
                     nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
                 )],
                 nil_function_return_expr(nil_function_ref(1, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
+                )],
+                nil_function_return_expr(nil_function_ref(1, Vec::<ParamLocal>::new())),
+            ),
+        );
 
         let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
 
-        assert!(matches!(
+        assert_eq!(
             function_function_return_string_case(
                 string("key"),
                 [(
@@ -576,13 +658,30 @@ mod tests {
                     Vec::<ParamLocal>::new(),
                     FunctionType::new(
                         Vec::new(),
+                        ValueType::Function(Box::new(returned_function_type.clone())),
+                    ),
+                )),
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    function_function_return_expr(function_function_ref(
+                        FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                        Vec::<ParamLocal>::new(),
+                        returned_function_type.clone(),
+                    )),
+                )],
+                function_function_return_expr(function_function_ref(
+                    FunctionFunctionId::Function(FunctionFunctionFunctionId(1)),
+                    Vec::<ParamLocal>::new(),
+                    FunctionType::new(
+                        Vec::new(),
                         ValueType::Function(Box::new(returned_function_type)),
                     ),
                 )),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
+            ),
+        );
     }
 
     #[test]
@@ -590,85 +689,111 @@ mod tests {
         let step = Step::evaluate(int(0).into());
         let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
 
-        assert!(matches!(
+        assert_eq!(
             int_function_return_block(
                 [step.clone()],
                 int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::Block { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::block(
+                vec![step.clone()],
+                int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             string_function_return_block(
                 [step.clone()],
                 string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::Block { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::block(
+                vec![step.clone()],
+                string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             bool_function_return_block(
                 [step.clone()],
                 bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::Block { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::block(
+                vec![step.clone()],
+                bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             nil_function_return_block(
                 [step.clone()],
                 nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
-            )
-            .kind(),
-            ReturnBodyKind::Block { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::block(
+                vec![step.clone()],
+                nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
+            ),
+        );
+        assert_eq!(
             function_function_return_block(
                 [step],
                 function_function_return_expr(function_function_ref(
                     FunctionFunctionId::Int(IntFunctionFunctionId(0)),
                     Vec::<ParamLocal>::new(),
-                    returned_function_type,
+                    returned_function_type.clone(),
                 )),
-            )
-            .kind(),
-            ReturnBodyKind::Block { .. },
-        ));
+            ),
+            ReturnBody::block(
+                vec![Step::evaluate(int(0).into())],
+                function_function_return_expr(function_function_ref(
+                    FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                )),
+            ),
+        );
     }
 
     #[test]
     fn function_return_wrapper_helpers_build_return_families() {
         let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
 
-        assert!(matches!(
+        assert_eq!(
             return_int_function(
                 returned_function_type.clone(),
                 int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
             ),
-            super::super::FunctionReturn::IntFunction { .. },
-        ));
-        assert!(matches!(
+            super::super::FunctionReturn::IntFunction {
+                type_: returned_function_type.clone(),
+                body: int_function_return_expr(int_function_ref(0, Vec::<ParamLocal>::new())),
+            },
+        );
+        assert_eq!(
             return_string_function(
                 returned_function_type.clone(),
                 string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
             ),
-            super::super::FunctionReturn::StringFunction { .. },
-        ));
-        assert!(matches!(
+            super::super::FunctionReturn::StringFunction {
+                type_: returned_function_type.clone(),
+                body: string_function_return_expr(string_function_ref(0, Vec::<ParamLocal>::new())),
+            },
+        );
+        assert_eq!(
             return_bool_function(
                 returned_function_type.clone(),
                 bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
             ),
-            super::super::FunctionReturn::BoolFunction { .. },
-        ));
-        assert!(matches!(
+            super::super::FunctionReturn::BoolFunction {
+                type_: returned_function_type.clone(),
+                body: bool_function_return_expr(bool_function_ref(0, Vec::<ParamLocal>::new())),
+            },
+        );
+        assert_eq!(
             return_nil_function(
                 returned_function_type.clone(),
                 nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
             ),
-            super::super::FunctionReturn::NilFunction { .. },
-        ));
-        assert!(matches!(
+            super::super::FunctionReturn::NilFunction {
+                type_: returned_function_type.clone(),
+                body: nil_function_return_expr(nil_function_ref(0, Vec::<ParamLocal>::new())),
+            },
+        );
+        assert_eq!(
             return_function_function(
                 FunctionType::new(
                     Vec::new(),
@@ -677,10 +802,20 @@ mod tests {
                 function_function_return_expr(function_function_ref(
                     FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),
                     Vec::<ParamLocal>::new(),
-                    returned_function_type,
+                    returned_function_type.clone(),
                 )),
             ),
-            super::super::FunctionReturn::FunctionFunction { .. },
-        ));
+            super::super::FunctionReturn::FunctionFunction {
+                type_: FunctionType::new(
+                    Vec::new(),
+                    ValueType::Function(Box::new(returned_function_type.clone())),
+                ),
+                body: function_function_return_expr(function_function_ref(
+                    FunctionFunctionId::Function(FunctionFunctionFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                    returned_function_type,
+                )),
+            },
+        );
     }
 }

--- a/src/planner/dsl/function/return_body/primitive.rs
+++ b/src/planner/dsl/function/return_body/primitive.rs
@@ -410,164 +410,195 @@ mod tests {
         string_return_block, string_return_bool_case, string_return_expr, string_return_float_case,
         string_return_int_case, string_return_string_case, string_return_tail_call,
     };
-    use crate::plan::{CallArg, ReturnBodyKind, Step};
+    use crate::plan::{
+        BoolFunctionId, CallArg, FloatFunctionId, IntFunctionId, ListFunctionId, NilFunctionId,
+        ReturnBody, Step, StringFunctionId,
+    };
     use crate::planner::dsl::expression::{bool_, float, int, list, nil, string};
+    use num_bigint::BigInt;
 
     #[test]
     fn primitive_return_expr_helpers_build_expr_shapes() {
-        assert!(matches!(
-            int_return_expr(int(1)).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
-        assert!(matches!(
-            string_return_expr(string("value")).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
-        assert!(matches!(
-            float_return_expr(float(1.0)).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
-        assert!(matches!(
-            bool_return_expr(bool_(true)).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
-        assert!(matches!(
-            nil_return_expr(nil()).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
-        assert!(matches!(
-            list_return_expr(list([int(1)], crate::plan::ValueType::Int)).kind(),
-            ReturnBodyKind::Expr(_),
-        ));
+        assert_eq!(int_return_expr(int(1)), ReturnBody::expr(int(1).into()));
+        assert_eq!(
+            string_return_expr(string("value")),
+            ReturnBody::expr(string("value").into()),
+        );
+        assert_eq!(
+            float_return_expr(float(1.0)),
+            ReturnBody::expr(float(1.0).into())
+        );
+        assert_eq!(
+            bool_return_expr(bool_(true)),
+            ReturnBody::expr(bool_(true).into()),
+        );
+        assert_eq!(nil_return_expr(nil()), ReturnBody::expr(nil().into()));
+        assert_eq!(
+            list_return_expr(list([int(1)], crate::plan::ValueType::Int)),
+            ReturnBody::expr(list([int(1)], crate::plan::ValueType::Int).into()),
+        );
     }
 
     #[test]
     fn primitive_return_tail_call_helpers_build_tail_call_shapes() {
-        assert!(matches!(
-            int_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
-        assert!(matches!(
-            string_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
-        assert!(matches!(
-            float_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
-        assert!(matches!(
-            bool_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
-        assert!(matches!(
-            nil_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
-        assert!(matches!(
-            list_return_tail_call(0, Vec::<CallArg>::new()).kind(),
-            ReturnBodyKind::TailCall { .. },
-        ));
+        assert_eq!(
+            int_return_tail_call(0, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(IntFunctionId(0), Vec::new()),
+        );
+        assert_eq!(
+            string_return_tail_call(1, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(StringFunctionId(1), Vec::new()),
+        );
+        assert_eq!(
+            float_return_tail_call(2, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(FloatFunctionId(2), Vec::new()),
+        );
+        assert_eq!(
+            bool_return_tail_call(3, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(BoolFunctionId(3), Vec::new()),
+        );
+        assert_eq!(
+            nil_return_tail_call(4, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(NilFunctionId(4), Vec::new()),
+        );
+        assert_eq!(
+            list_return_tail_call(5, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(ListFunctionId(5), Vec::new()),
+        );
     }
 
     #[test]
     fn primitive_return_case_helpers_build_case_shapes() {
-        assert!(matches!(
+        assert_eq!(
             int_return_bool_case(
                 bool_(true),
                 int_return_expr(int(1)),
                 int_return_expr(int(0)),
-            )
-            .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                int_return_expr(int(1)),
+                int_return_expr(int(0)),
+            ),
+        );
+        assert_eq!(
             string_return_bool_case(
                 bool_(true),
                 string_return_expr(string("true")),
                 string_return_expr(string("false")),
-            )
-            .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                string_return_expr(string("true")),
+                string_return_expr(string("false")),
+            ),
+        );
+        assert_eq!(
             float_return_bool_case(
                 bool_(true),
                 float_return_expr(float(1.0)),
                 float_return_expr(float(0.0)),
-            )
-            .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                float_return_expr(float(1.0)),
+                float_return_expr(float(0.0)),
+            ),
+        );
+        assert_eq!(
             bool_return_bool_case(
                 bool_(true),
                 bool_return_expr(bool_(true)),
                 bool_return_expr(bool_(false)),
-            )
-            .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
-        assert!(matches!(
-            nil_return_bool_case(bool_(true), nil_return_expr(nil()), nil_return_expr(nil()))
-                .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                bool_return_expr(bool_(true)),
+                bool_return_expr(bool_(false)),
+            ),
+        );
+        assert_eq!(
+            nil_return_bool_case(bool_(true), nil_return_expr(nil()), nil_return_expr(nil())),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                nil_return_expr(nil()),
+                nil_return_expr(nil()),
+            ),
+        );
+        assert_eq!(
             list_return_bool_case(
                 bool_(true),
                 list_return_expr(list([int(1)], crate::plan::ValueType::Int)),
                 list_return_expr(list([int(0)], crate::plan::ValueType::Int)),
-            )
-            .kind(),
-            ReturnBodyKind::BoolCase { .. },
-        ));
+            ),
+            ReturnBody::bool_case(
+                bool_(true).into(),
+                list_return_expr(list([int(1)], crate::plan::ValueType::Int)),
+                list_return_expr(list([int(0)], crate::plan::ValueType::Int)),
+            ),
+        );
 
-        assert!(matches!(
+        assert_eq!(
             int_return_int_case(
                 int(1),
                 [(1, int_return_expr(int(1)))],
                 int_return_expr(int(0))
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), int_return_expr(int(1)))],
+                int_return_expr(int(0)),
+            ),
+        );
+        assert_eq!(
             string_return_int_case(
                 int(1),
                 [(1, string_return_expr(string("one")))],
                 string_return_expr(string("other")),
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), string_return_expr(string("one")))],
+                string_return_expr(string("other")),
+            ),
+        );
+        assert_eq!(
             float_return_int_case(
                 int(1),
                 [(1, float_return_expr(float(1.0)))],
                 float_return_expr(float(0.0)),
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), float_return_expr(float(1.0)))],
+                float_return_expr(float(0.0)),
+            ),
+        );
+        assert_eq!(
             bool_return_int_case(
                 int(1),
                 [(1, bool_return_expr(bool_(true)))],
                 bool_return_expr(bool_(false)),
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), bool_return_expr(bool_(true)))],
+                bool_return_expr(bool_(false)),
+            ),
+        );
+        assert_eq!(
             nil_return_int_case(
                 int(1),
                 [(1, nil_return_expr(nil()))],
                 nil_return_expr(nil())
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), nil_return_expr(nil()))],
+                nil_return_expr(nil()),
+            ),
+        );
+        assert_eq!(
             list_return_int_case(
                 int(1),
                 [(
@@ -575,84 +606,114 @@ mod tests {
                     list_return_expr(list([int(1)], crate::plan::ValueType::Int))
                 )],
                 list_return_expr(list([int(0)], crate::plan::ValueType::Int)),
-            )
-            .kind(),
-            ReturnBodyKind::IntCase { .. },
-        ));
+            ),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(
+                    BigInt::from(1),
+                    list_return_expr(list([int(1)], crate::plan::ValueType::Int)),
+                )],
+                list_return_expr(list([int(0)], crate::plan::ValueType::Int)),
+            ),
+        );
 
-        assert!(matches!(
+        assert_eq!(
             int_return_string_case(
                 string("key"),
                 [("one", int_return_expr(int(1)))],
                 int_return_expr(int(0)),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![("one".into(), int_return_expr(int(1)))],
+                int_return_expr(int(0)),
+            ),
+        );
+        assert_eq!(
             int_return_float_case(
                 float(1.0),
                 [(1.0, int_return_expr(int(1)))],
                 int_return_expr(int(0)),
-            )
-            .kind(),
-            ReturnBodyKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::float_case(
+                float(1.0).into(),
+                vec![(1.0, int_return_expr(int(1)))],
+                int_return_expr(int(0)),
+            ),
+        );
+        assert_eq!(
             string_return_string_case(
                 string("key"),
                 [("one", string_return_expr(string("one")))],
                 string_return_expr(string("other")),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![("one".into(), string_return_expr(string("one")))],
+                string_return_expr(string("other")),
+            ),
+        );
+        assert_eq!(
             float_return_string_case(
                 string("key"),
                 [("one", float_return_expr(float(1.0)))],
                 float_return_expr(float(0.0)),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![("one".into(), float_return_expr(float(1.0)))],
+                float_return_expr(float(0.0)),
+            ),
+        );
+        assert_eq!(
             bool_return_string_case(
                 string("key"),
                 [("one", bool_return_expr(bool_(true)))],
                 bool_return_expr(bool_(false)),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![("one".into(), bool_return_expr(bool_(true)))],
+                bool_return_expr(bool_(false)),
+            ),
+        );
+        assert_eq!(
             bool_return_float_case(
                 float(1.0),
                 [(1.0, bool_return_expr(bool_(true)))],
                 bool_return_expr(bool_(false)),
-            )
-            .kind(),
-            ReturnBodyKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::float_case(
+                float(1.0).into(),
+                vec![(1.0, bool_return_expr(bool_(true)))],
+                bool_return_expr(bool_(false)),
+            ),
+        );
+        assert_eq!(
             string_return_float_case(
                 float(1.0),
                 [(1.0, string_return_expr(string("one")))],
                 string_return_expr(string("other")),
-            )
-            .kind(),
-            ReturnBodyKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::float_case(
+                float(1.0).into(),
+                vec![(1.0, string_return_expr(string("one")))],
+                string_return_expr(string("other")),
+            ),
+        );
+        assert_eq!(
             nil_return_string_case(
                 string("key"),
                 [("one", nil_return_expr(nil()))],
                 nil_return_expr(nil()),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![("one".into(), nil_return_expr(nil()))],
+                nil_return_expr(nil()),
+            ),
+        );
+        assert_eq!(
             list_return_string_case(
                 string("key"),
                 [(
@@ -660,29 +721,41 @@ mod tests {
                     list_return_expr(list([int(1)], crate::plan::ValueType::Int))
                 )],
                 list_return_expr(list([int(0)], crate::plan::ValueType::Int)),
-            )
-            .kind(),
-            ReturnBodyKind::StringCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![(
+                    "one".into(),
+                    list_return_expr(list([int(1)], crate::plan::ValueType::Int)),
+                )],
+                list_return_expr(list([int(0)], crate::plan::ValueType::Int)),
+            ),
+        );
+        assert_eq!(
             nil_return_float_case(
                 float(1.0),
                 [(1.0, nil_return_expr(nil()))],
                 nil_return_expr(nil()),
-            )
-            .kind(),
-            ReturnBodyKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::float_case(
+                float(1.0).into(),
+                vec![(1.0, nil_return_expr(nil()))],
+                nil_return_expr(nil()),
+            ),
+        );
+        assert_eq!(
             float_return_float_case(
                 float(1.0),
                 [(1.0, float_return_expr(float(1.0)))],
                 float_return_expr(float(0.0)),
-            )
-            .kind(),
-            ReturnBodyKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            ),
+            ReturnBody::float_case(
+                float(1.0).into(),
+                vec![(1.0, float_return_expr(float(1.0)))],
+                float_return_expr(float(0.0)),
+            ),
+        );
+        assert_eq!(
             list_return_float_case(
                 float(1.0),
                 [(
@@ -690,43 +763,51 @@ mod tests {
                     list_return_expr(list([int(1)], crate::plan::ValueType::Int))
                 )],
                 list_return_expr(list([int(0)], crate::plan::ValueType::Int)),
-            )
-            .kind(),
-            ReturnBodyKind::FloatCase { .. },
-        ));
+            ),
+            ReturnBody::float_case(
+                float(1.0).into(),
+                vec![(
+                    1.0,
+                    list_return_expr(list([int(1)], crate::plan::ValueType::Int)),
+                )],
+                list_return_expr(list([int(0)], crate::plan::ValueType::Int)),
+            ),
+        );
     }
 
     #[test]
     fn primitive_return_block_helpers_build_block_shapes() {
         let step = Step::evaluate(int(0).into());
 
-        assert!(matches!(
-            int_return_block([step.clone()], int_return_expr(int(1))).kind(),
-            ReturnBodyKind::Block { .. },
-        ));
-        assert!(matches!(
-            string_return_block([step.clone()], string_return_expr(string("value"))).kind(),
-            ReturnBodyKind::Block { .. },
-        ));
-        assert!(matches!(
-            float_return_block([step.clone()], float_return_expr(float(1.0))).kind(),
-            ReturnBodyKind::Block { .. },
-        ));
-        assert!(matches!(
-            bool_return_block([step.clone()], bool_return_expr(bool_(true))).kind(),
-            ReturnBodyKind::Block { .. },
-        ));
-        assert!(matches!(
-            nil_return_block([step], nil_return_expr(nil())).kind(),
-            ReturnBodyKind::Block { .. },
-        ));
-        assert!(matches!(
+        assert_eq!(
+            int_return_block([step.clone()], int_return_expr(int(1))),
+            ReturnBody::block(vec![step.clone()], int_return_expr(int(1))),
+        );
+        assert_eq!(
+            string_return_block([step.clone()], string_return_expr(string("value"))),
+            ReturnBody::block(vec![step.clone()], string_return_expr(string("value"))),
+        );
+        assert_eq!(
+            float_return_block([step.clone()], float_return_expr(float(1.0))),
+            ReturnBody::block(vec![step.clone()], float_return_expr(float(1.0))),
+        );
+        assert_eq!(
+            bool_return_block([step.clone()], bool_return_expr(bool_(true))),
+            ReturnBody::block(vec![step.clone()], bool_return_expr(bool_(true))),
+        );
+        assert_eq!(
+            nil_return_block([step.clone()], nil_return_expr(nil())),
+            ReturnBody::block(vec![step], nil_return_expr(nil())),
+        );
+        assert_eq!(
             list_return_block(
                 Vec::<Step>::new(),
                 list_return_expr(list([int(1)], crate::plan::ValueType::Int)),
-            )
-            .kind(),
-            ReturnBodyKind::Block { .. },
-        ));
+            ),
+            ReturnBody::block(
+                Vec::new(),
+                list_return_expr(list([int(1)], crate::plan::ValueType::Int)),
+            ),
+        );
     }
 }


### PR DESCRIPTION
- Bring all `src/planner/dsl/**` files to 100% region coverage.
- Replace broad `matches!` checks with exact DSL output shape assertions.
- Update region coverage notes with the remaining non-DSL candidates.
