### PR TITLE
Tighten plan expression region coverage

### DIFF
--- a/src/plan/expression/bool.rs
+++ b/src/plan/expression/bool.rs
@@ -322,92 +322,212 @@ impl BoolExpr {
 #[cfg(test)]
 mod tests {
     use super::{BoolExpr, BoolExprKind};
-    use crate::plan::{BoolFunctionId, BoolFunctionValue, Expr, IntExpr, Step};
+    use crate::plan::{
+        BoolFunctionId, BoolFunctionValue, BoolLocalId, Expr, FloatExpr, IntExpr, Step, TupleExpr,
+        ValueType,
+    };
+    use num_bigint::BigInt;
 
     #[test]
     fn bool_expr_kind_accessors() {
-        assert!(matches!(
-            BoolExpr::value(true).kind(),
-            BoolExprKind::Value(true)
-        ));
-        assert!(matches!(
+        assert_eq!(BoolExpr::value(true).kind(), &BoolExprKind::Value(true),);
+        assert_eq!(
+            BoolExpr::local_get(BoolLocalId(0), "flag".into()).kind(),
+            &BoolExprKind::LocalGet {
+                local: BoolLocalId(0),
+                name: "flag".into(),
+            },
+        );
+        assert_eq!(
+            BoolExpr::call(BoolFunctionId(0), Vec::new()).kind(),
+            &BoolExprKind::Call {
+                function: BoolFunctionId(0),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            BoolExpr::function_call(function_expr(), Vec::new()).kind(),
+            &BoolExprKind::FunctionCall {
+                function: Box::new(function_expr()),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            BoolExpr::tuple_index(tuple_expr(), 0).kind(),
+            &BoolExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+            },
+        );
+        assert_eq!(
+            BoolExpr::not(BoolExpr::value(true)).kind(),
+            &BoolExprKind::Not(Box::new(BoolExpr::value(true))),
+        );
+        assert_eq!(
+            BoolExpr::lt_int(IntExpr::value(1.into()), IntExpr::value(2.into())).kind(),
+            &BoolExprKind::LtInt {
+                left: Box::new(IntExpr::value(1.into())),
+                right: Box::new(IntExpr::value(2.into())),
+            },
+        );
+        assert_eq!(
+            BoolExpr::lte_int(IntExpr::value(1.into()), IntExpr::value(2.into())).kind(),
+            &BoolExprKind::LtEqInt {
+                left: Box::new(IntExpr::value(1.into())),
+                right: Box::new(IntExpr::value(2.into())),
+            },
+        );
+        assert_eq!(
+            BoolExpr::gt_int(IntExpr::value(2.into()), IntExpr::value(1.into())).kind(),
+            &BoolExprKind::GtInt {
+                left: Box::new(IntExpr::value(2.into())),
+                right: Box::new(IntExpr::value(1.into())),
+            },
+        );
+        assert_eq!(
+            BoolExpr::gte_int(IntExpr::value(2.into()), IntExpr::value(1.into())).kind(),
+            &BoolExprKind::GtEqInt {
+                left: Box::new(IntExpr::value(2.into())),
+                right: Box::new(IntExpr::value(1.into())),
+            },
+        );
+        assert_eq!(
+            BoolExpr::lt_float(FloatExpr::value(1.0), FloatExpr::value(2.0)).kind(),
+            &BoolExprKind::LtFloat {
+                left: Box::new(FloatExpr::value(1.0)),
+                right: Box::new(FloatExpr::value(2.0)),
+            },
+        );
+        assert_eq!(
+            BoolExpr::lte_float(FloatExpr::value(1.0), FloatExpr::value(2.0)).kind(),
+            &BoolExprKind::LtEqFloat {
+                left: Box::new(FloatExpr::value(1.0)),
+                right: Box::new(FloatExpr::value(2.0)),
+            },
+        );
+        assert_eq!(
+            BoolExpr::gt_float(FloatExpr::value(2.0), FloatExpr::value(1.0)).kind(),
+            &BoolExprKind::GtFloat {
+                left: Box::new(FloatExpr::value(2.0)),
+                right: Box::new(FloatExpr::value(1.0)),
+            },
+        );
+        assert_eq!(
+            BoolExpr::gte_float(FloatExpr::value(2.0), FloatExpr::value(1.0)).kind(),
+            &BoolExprKind::GtEqFloat {
+                left: Box::new(FloatExpr::value(2.0)),
+                right: Box::new(FloatExpr::value(1.0)),
+            },
+        );
+        assert_eq!(
+            BoolExpr::equal(
+                Expr::int(IntExpr::value(1.into())),
+                Expr::int(IntExpr::value(1.into()))
+            )
+            .kind(),
+            &BoolExprKind::Equal {
+                left: Box::new(Expr::int(IntExpr::value(1.into()))),
+                right: Box::new(Expr::int(IntExpr::value(1.into()))),
+            },
+        );
+        assert_eq!(
+            BoolExpr::not_equal(
+                Expr::bool(BoolExpr::value(true)),
+                Expr::bool(BoolExpr::value(false))
+            )
+            .kind(),
+            &BoolExprKind::NotEqual {
+                left: Box::new(Expr::bool(BoolExpr::value(true))),
+                right: Box::new(Expr::bool(BoolExpr::value(false))),
+            },
+        );
+        assert_eq!(
+            BoolExpr::and(BoolExpr::value(true), BoolExpr::value(false)).kind(),
+            &BoolExprKind::And {
+                left: Box::new(BoolExpr::value(true)),
+                right: Box::new(BoolExpr::value(false)),
+            },
+        );
+        assert_eq!(
+            BoolExpr::or(BoolExpr::value(true), BoolExpr::value(false)).kind(),
+            &BoolExprKind::Or {
+                left: Box::new(BoolExpr::value(true)),
+                right: Box::new(BoolExpr::value(false)),
+            },
+        );
+        assert_eq!(
             BoolExpr::bool_case(
                 BoolExpr::value(true),
                 BoolExpr::value(true),
                 BoolExpr::value(false)
             )
             .kind(),
-            BoolExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
-            BoolExpr::function_call(function_expr(), Vec::new()).kind(),
-            BoolExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
-            BoolExpr::tuple_index(
-                crate::plan::TupleExpr::value(
-                    vec![Expr::bool(BoolExpr::value(true))],
-                    vec![crate::plan::ValueType::Bool],
-                ),
-                0,
-            )
-            .kind(),
-            BoolExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &BoolExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(BoolExpr::value(true)),
+                false_: Box::new(BoolExpr::value(false)),
+            },
+        );
+        assert_eq!(
             BoolExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), BoolExpr::value(true))],
                 BoolExpr::value(false)
             )
             .kind(),
-            BoolExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
+            &BoolExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(BigInt::from(1), BoolExpr::value(true))],
+                fallback: Box::new(BoolExpr::value(false)),
+            },
+        );
+        assert_eq!(
             BoolExpr::string_case(
                 crate::plan::StringExpr::value("a".into()),
                 vec![("a".into(), BoolExpr::value(true))],
                 BoolExpr::value(false)
             )
             .kind(),
-            BoolExprKind::StringCase { .. }
-        ));
-        assert!(matches!(
+            &BoolExprKind::StringCase {
+                subject: Box::new(crate::plan::StringExpr::value("a".into())),
+                clauses: vec![("a".into(), BoolExpr::value(true))],
+                fallback: Box::new(BoolExpr::value(false)),
+            },
+        );
+        assert_eq!(
             BoolExpr::float_case(
-                crate::plan::FloatExpr::value(1.0),
+                FloatExpr::value(1.0),
                 vec![(1.0, BoolExpr::value(true))],
                 BoolExpr::value(false)
             )
             .kind(),
-            BoolExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
-            BoolExpr::lt_float(
-                crate::plan::FloatExpr::value(1.0),
-                crate::plan::FloatExpr::value(2.0)
-            )
-            .kind(),
-            BoolExprKind::LtFloat { .. }
-        ));
-        assert!(matches!(
-            BoolExpr::and(BoolExpr::value(true), BoolExpr::value(false)).kind(),
-            BoolExprKind::And { .. }
-        ));
-        assert!(matches!(
-            BoolExpr::or(BoolExpr::value(true), BoolExpr::value(false)).kind(),
-            BoolExprKind::Or { .. }
-        ));
-        assert!(matches!(
+            &BoolExprKind::FloatCase {
+                subject: Box::new(FloatExpr::value(1.0)),
+                clauses: vec![(1.0, BoolExpr::value(true))],
+                fallback: Box::new(BoolExpr::value(false)),
+            },
+        );
+        assert_eq!(
             BoolExpr::block(
                 vec![Step::evaluate(Expr::bool(BoolExpr::value(false)))],
                 BoolExpr::value(true),
             )
             .kind(),
-            BoolExprKind::Block { .. }
-        ));
+            &BoolExprKind::Block {
+                steps: vec![Step::evaluate(Expr::bool(BoolExpr::value(false)))],
+                return_: Box::new(BoolExpr::value(true)),
+            },
+        );
     }
 
     fn function_expr() -> crate::plan::BoolFunctionExpr {
         crate::plan::BoolFunctionExpr::value(BoolFunctionValue::new(BoolFunctionId(0), Vec::new()))
+    }
+
+    fn tuple_expr() -> TupleExpr {
+        TupleExpr::value(
+            vec![Expr::bool(BoolExpr::value(true))],
+            vec![ValueType::Bool],
+        )
     }
 }

--- a/src/plan/expression/float.rs
+++ b/src/plan/expression/float.rs
@@ -211,64 +211,134 @@ impl FloatExpr {
 #[cfg(test)]
 mod tests {
     use super::{FloatExpr, FloatExprKind};
-    use crate::plan::{BoolExpr, Expr, FloatFunctionId, FloatFunctionValue, Step};
+    use crate::plan::{
+        BoolExpr, Expr, FloatFunctionId, FloatFunctionValue, FloatLocalId, IntExpr, Step,
+        TupleExpr, ValueType,
+    };
+    use num_bigint::BigInt;
 
     #[test]
     fn float_expr_kind_accessors() {
-        assert!(matches!(
-            FloatExpr::value(1.0).kind(),
-            FloatExprKind::Value(_)
-        ));
-        assert!(matches!(
+        assert_eq!(FloatExpr::value(1.0).kind(), &FloatExprKind::Value(1.0),);
+        assert_eq!(
+            FloatExpr::local_get(FloatLocalId(0), "value".into()).kind(),
+            &FloatExprKind::LocalGet {
+                local: FloatLocalId(0),
+                name: "value".into(),
+            },
+        );
+        assert_eq!(
+            FloatExpr::call(FloatFunctionId(0), Vec::new()).kind(),
+            &FloatExprKind::Call {
+                function: FloatFunctionId(0),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            FloatExpr::function_call(function_expr(), Vec::new()).kind(),
+            &FloatExprKind::FunctionCall {
+                function: Box::new(function_expr()),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            FloatExpr::tuple_index(tuple_expr(), 0).kind(),
+            &FloatExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+            },
+        );
+        assert_eq!(
+            FloatExpr::add(FloatExpr::value(1.0), FloatExpr::value(2.0)).kind(),
+            &FloatExprKind::Add {
+                left: Box::new(FloatExpr::value(1.0)),
+                right: Box::new(FloatExpr::value(2.0)),
+            },
+        );
+        assert_eq!(
+            FloatExpr::sub(FloatExpr::value(1.0), FloatExpr::value(2.0)).kind(),
+            &FloatExprKind::Sub {
+                left: Box::new(FloatExpr::value(1.0)),
+                right: Box::new(FloatExpr::value(2.0)),
+            },
+        );
+        assert_eq!(
+            FloatExpr::mult(FloatExpr::value(1.0), FloatExpr::value(2.0)).kind(),
+            &FloatExprKind::Mult {
+                left: Box::new(FloatExpr::value(1.0)),
+                right: Box::new(FloatExpr::value(2.0)),
+            },
+        );
+        assert_eq!(
+            FloatExpr::div(FloatExpr::value(1.0), FloatExpr::value(2.0)).kind(),
+            &FloatExprKind::Div {
+                left: Box::new(FloatExpr::value(1.0)),
+                right: Box::new(FloatExpr::value(2.0)),
+            },
+        );
+        assert_eq!(
             FloatExpr::bool_case(
                 BoolExpr::value(true),
                 FloatExpr::value(1.0),
                 FloatExpr::value(0.0)
             )
             .kind(),
-            FloatExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
-            FloatExpr::function_call(function_expr(), Vec::new()).kind(),
-            FloatExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
-            FloatExpr::tuple_index(
-                crate::plan::TupleExpr::value(
-                    vec![Expr::float(FloatExpr::value(1.0))],
-                    vec![crate::plan::ValueType::Float],
-                ),
-                0,
+            &FloatExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(FloatExpr::value(1.0)),
+                false_: Box::new(FloatExpr::value(0.0)),
+            },
+        );
+        assert_eq!(
+            FloatExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), FloatExpr::value(10.0))],
+                FloatExpr::value(0.0)
             )
             .kind(),
-            FloatExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &FloatExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(BigInt::from(1), FloatExpr::value(10.0))],
+                fallback: Box::new(FloatExpr::value(0.0)),
+            },
+        );
+        assert_eq!(
             FloatExpr::float_case(
                 FloatExpr::value(1.0),
                 vec![(1.0, FloatExpr::value(10.0))],
                 FloatExpr::value(0.0)
             )
             .kind(),
-            FloatExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &FloatExprKind::FloatCase {
+                subject: Box::new(FloatExpr::value(1.0)),
+                clauses: vec![(1.0, FloatExpr::value(10.0))],
+                fallback: Box::new(FloatExpr::value(0.0)),
+            },
+        );
+        assert_eq!(
             FloatExpr::string_case(
                 crate::plan::StringExpr::value("a".into()),
                 vec![("a".into(), FloatExpr::value(10.0))],
                 FloatExpr::value(0.0)
             )
             .kind(),
-            FloatExprKind::StringCase { .. }
-        ));
-        assert!(matches!(
+            &FloatExprKind::StringCase {
+                subject: Box::new(crate::plan::StringExpr::value("a".into())),
+                clauses: vec![("a".into(), FloatExpr::value(10.0))],
+                fallback: Box::new(FloatExpr::value(0.0)),
+            },
+        );
+        assert_eq!(
             FloatExpr::block(
                 vec![Step::evaluate(Expr::float(FloatExpr::value(1.0)))],
                 FloatExpr::value(2.0),
             )
             .kind(),
-            FloatExprKind::Block { .. }
-        ));
+            &FloatExprKind::Block {
+                steps: vec![Step::evaluate(Expr::float(FloatExpr::value(1.0)))],
+                return_: Box::new(FloatExpr::value(2.0)),
+            },
+        );
     }
 
     fn function_expr() -> crate::plan::FloatFunctionExpr {
@@ -276,5 +346,12 @@ mod tests {
             FloatFunctionId(0),
             Vec::new(),
         ))
+    }
+
+    fn tuple_expr() -> TupleExpr {
+        TupleExpr::value(
+            vec![Expr::float(FloatExpr::value(1.0))],
+            vec![ValueType::Float],
+        )
     }
 }

--- a/src/plan/expression/function.rs
+++ b/src/plan/expression/function.rs
@@ -246,139 +246,261 @@ mod tests {
 
     #[test]
     fn function_expr_kind_accessors() {
-        assert!(matches!(
-            FunctionExpr::value(function_value()).kind(),
-            FunctionExprKind::Int(_)
-        ));
-        assert!(matches!(
+        assert_eq!(
             FunctionExpr::int(int_function_value()).kind(),
-            FunctionExprKind::Int(_)
-        ));
-        assert!(matches!(
+            &FunctionExprKind::Int(int_function_value()),
+        );
+        assert_eq!(
             FunctionExpr::string(string_function_value()).kind(),
-            FunctionExprKind::String(_)
-        ));
-        assert!(matches!(
+            &FunctionExprKind::String(string_function_value()),
+        );
+        assert_eq!(
             FunctionExpr::float(float_function_value()).kind(),
-            FunctionExprKind::Float(_)
-        ));
-        assert!(matches!(
+            &FunctionExprKind::Float(float_function_value()),
+        );
+        assert_eq!(
             FunctionExpr::bool(bool_function_value()).kind(),
-            FunctionExprKind::Bool(_)
-        ));
-        assert!(matches!(
+            &FunctionExprKind::Bool(bool_function_value()),
+        );
+        assert_eq!(
             FunctionExpr::nil(nil_function_value()).kind(),
-            FunctionExprKind::Nil(_)
-        ));
-        assert!(matches!(
+            &FunctionExprKind::Nil(nil_function_value()),
+        );
+        assert_eq!(
             FunctionExpr::tuple(tuple_function_value()).kind(),
-            FunctionExprKind::Tuple(_)
-        ));
-        assert!(matches!(
+            &FunctionExprKind::Tuple(tuple_function_value()),
+        );
+        assert_eq!(
             FunctionExpr::list(list_function_value()).kind(),
-            FunctionExprKind::List(_)
-        ));
-        assert!(matches!(
+            &FunctionExprKind::List(list_function_value()),
+        );
+        assert_eq!(
             FunctionExpr::function(function_function_value()).kind(),
-            FunctionExprKind::Function(_)
-        ));
+            &FunctionExprKind::Function(function_function_value()),
+        );
+    }
+
+    #[test]
+    fn function_expr_value_preserves_runtime_family() {
+        assert_eq!(
+            FunctionExpr::value(int_runtime_function_value()).kind(),
+            &FunctionExprKind::Int(int_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::value(string_runtime_function_value()).kind(),
+            &FunctionExprKind::String(string_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::value(float_runtime_function_value()).kind(),
+            &FunctionExprKind::Float(float_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::value(bool_runtime_function_value()).kind(),
+            &FunctionExprKind::Bool(bool_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::value(nil_runtime_function_value()).kind(),
+            &FunctionExprKind::Nil(nil_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::value(tuple_runtime_function_value()).kind(),
+            &FunctionExprKind::Tuple(tuple_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::value(list_runtime_function_value()).kind(),
+            &FunctionExprKind::List(list_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::value(function_runtime_function_value()).kind(),
+            &FunctionExprKind::Function(function_function_value()),
+        );
+    }
+
+    #[test]
+    fn function_expr_type_accessors() {
+        assert_eq!(
+            FunctionExpr::int(int_function_value()).type_(),
+            &int_function_type(),
+        );
+        assert_eq!(
+            FunctionExpr::string(string_function_value()).type_(),
+            &string_function_type(),
+        );
+        assert_eq!(
+            FunctionExpr::float(float_function_value()).type_(),
+            &float_function_type(),
+        );
+        assert_eq!(
+            FunctionExpr::bool(bool_function_value()).type_(),
+            &bool_function_type()
+        );
+        assert_eq!(FunctionExpr::nil(nil_function_value()).type_(), &nil_type());
+        assert_eq!(
+            FunctionExpr::tuple(tuple_function_value()).type_(),
+            &tuple_function_type(),
+        );
+        assert_eq!(
+            FunctionExpr::list(list_function_value()).type_(),
+            &list_function_type()
+        );
+        assert_eq!(
+            FunctionExpr::function(function_function_value()).type_(),
+            &function_function_type(),
+        );
     }
 
     #[test]
     fn function_expr_typed_conversions() {
-        assert!(FunctionExpr::int(int_function_value()).into_int().is_some());
-        assert!(
-            FunctionExpr::string(string_function_value())
-                .into_string()
-                .is_some()
+        assert_eq!(
+            FunctionExpr::int(int_function_value()).into_int(),
+            Some(int_function_value()),
         );
-        assert!(
-            FunctionExpr::float(float_function_value())
-                .into_float()
-                .is_some()
+        assert_eq!(
+            FunctionExpr::string(string_function_value()).into_string(),
+            Some(string_function_value()),
         );
-        assert!(
-            FunctionExpr::bool(bool_function_value())
-                .into_bool()
-                .is_some()
+        assert_eq!(
+            FunctionExpr::float(float_function_value()).into_float(),
+            Some(float_function_value()),
         );
-        assert!(FunctionExpr::nil(nil_function_value()).into_nil().is_some());
-        assert!(
-            FunctionExpr::tuple(tuple_function_value())
-                .into_tuple()
-                .is_some()
+        assert_eq!(
+            FunctionExpr::bool(bool_function_value()).into_bool(),
+            Some(bool_function_value()),
         );
-        assert!(
-            FunctionExpr::list(list_function_value())
-                .into_list()
-                .is_some()
+        assert_eq!(
+            FunctionExpr::nil(nil_function_value()).into_nil(),
+            Some(nil_function_value()),
         );
-
-        assert!(
-            FunctionExpr::int(int_function_value())
-                .into_string()
-                .is_none()
+        assert_eq!(
+            FunctionExpr::tuple(tuple_function_value()).into_tuple(),
+            Some(tuple_function_value()),
         );
-        assert!(
-            FunctionExpr::int(int_function_value())
-                .into_float()
-                .is_none()
+        assert_eq!(
+            FunctionExpr::list(list_function_value()).into_list(),
+            Some(list_function_value()),
         );
-        assert!(
-            FunctionExpr::int(int_function_value())
-                .into_bool()
-                .is_none()
-        );
-        assert!(FunctionExpr::int(int_function_value()).into_nil().is_none());
-        assert!(
-            FunctionExpr::int(int_function_value())
-                .into_tuple()
-                .is_none()
-        );
-        assert!(
-            FunctionExpr::int(int_function_value())
-                .into_list()
-                .is_none()
+        assert_eq!(
+            FunctionExpr::function(function_function_value()).into_function(),
+            Some(function_function_value()),
         );
 
-        assert!(matches!(
-            FunctionExpr::from(int_function_value()).kind(),
-            FunctionExprKind::Int(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(string_function_value()).kind(),
-            FunctionExprKind::String(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(float_function_value()).kind(),
-            FunctionExprKind::Float(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(bool_function_value()).kind(),
-            FunctionExprKind::Bool(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(nil_function_value()).kind(),
-            FunctionExprKind::Nil(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(tuple_function_value()).kind(),
-            FunctionExprKind::Tuple(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(list_function_value()).kind(),
-            FunctionExprKind::List(_),
-        ));
-        assert!(matches!(
-            FunctionExpr::from(function_function_value()).kind(),
-            FunctionExprKind::Function(_),
-        ));
+        assert_eq!(
+            FunctionExpr::string(string_function_value()).into_int(),
+            None
+        );
+        assert_eq!(FunctionExpr::int(int_function_value()).into_string(), None,);
+        assert_eq!(FunctionExpr::int(int_function_value()).into_float(), None);
+        assert_eq!(FunctionExpr::int(int_function_value()).into_bool(), None);
+        assert_eq!(FunctionExpr::int(int_function_value()).into_nil(), None);
+        assert_eq!(FunctionExpr::int(int_function_value()).into_tuple(), None);
+        assert_eq!(FunctionExpr::int(int_function_value()).into_list(), None);
+        assert_eq!(
+            FunctionExpr::int(int_function_value()).into_function(),
+            None,
+        );
+
+        assert_eq!(
+            FunctionExpr::from(int_function_value()),
+            FunctionExpr::int(int_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::from(string_function_value()),
+            FunctionExpr::string(string_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::from(float_function_value()),
+            FunctionExpr::float(float_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::from(bool_function_value()),
+            FunctionExpr::bool(bool_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::from(nil_function_value()),
+            FunctionExpr::nil(nil_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::from(tuple_function_value()),
+            FunctionExpr::tuple(tuple_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::from(list_function_value()),
+            FunctionExpr::list(list_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::from(function_function_value()),
+            FunctionExpr::function(function_function_value()),
+        );
     }
 
-    fn function_value() -> FunctionValue {
+    fn int_runtime_function_value() -> FunctionValue {
         FunctionValue::new(
             RuntimeFunctionId::Int(IntFunctionId(0)),
             vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+        )
+    }
+
+    fn string_runtime_function_value() -> FunctionValue {
+        FunctionValue::new(
+            RuntimeFunctionId::String(StringFunctionId(0)),
+            vec![ParamLocal::string(crate::plan::StringLocalId(0))],
+        )
+    }
+
+    fn float_runtime_function_value() -> FunctionValue {
+        FunctionValue::new(
+            RuntimeFunctionId::Float(FloatFunctionId(0)),
+            vec![ParamLocal::float(crate::plan::FloatLocalId(0))],
+        )
+    }
+
+    fn bool_runtime_function_value() -> FunctionValue {
+        FunctionValue::new(
+            RuntimeFunctionId::Bool(BoolFunctionId(0)),
+            vec![ParamLocal::bool(crate::plan::BoolLocalId(0))],
+        )
+    }
+
+    fn nil_runtime_function_value() -> FunctionValue {
+        FunctionValue::new(
+            RuntimeFunctionId::Nil(NilFunctionId(0)),
+            vec![ParamLocal::nil(crate::plan::NilLocalId(0))],
+        )
+    }
+
+    fn tuple_runtime_function_value() -> FunctionValue {
+        FunctionValue::new(
+            RuntimeFunctionId::Tuple {
+                id: TupleFunctionId(0),
+                return_type: vec![ValueType::Int],
+            },
+            vec![ParamLocal::tuple(
+                crate::plan::TupleLocalId(0),
+                vec![ValueType::Int],
+            )],
+        )
+    }
+
+    fn list_runtime_function_value() -> FunctionValue {
+        FunctionValue::new(
+            RuntimeFunctionId::List {
+                id: ListFunctionId(0),
+                return_type: Box::new(ValueType::Int),
+            },
+            vec![ParamLocal::list(
+                crate::plan::ListLocalId(0),
+                ValueType::Int,
+            )],
+        )
+    }
+
+    fn function_runtime_function_value() -> FunctionValue {
+        FunctionValue::new(
+            RuntimeFunctionId::Function {
+                id: FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                return_type: FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            },
+            Vec::new(),
         )
     }
 
@@ -443,7 +565,51 @@ mod tests {
         FunctionFunctionExpr::value(FunctionFunctionValue::new(
             FunctionFunctionId::Int(IntFunctionFunctionId(0)),
             Vec::new(),
-            FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            int_function_type(),
         ))
+    }
+
+    fn int_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Int], ValueType::Int)
+    }
+
+    fn string_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::String], ValueType::String)
+    }
+
+    fn float_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Float], ValueType::Float)
+    }
+
+    fn bool_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Bool], ValueType::Bool)
+    }
+
+    fn nil_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Nil], ValueType::Nil)
+    }
+
+    fn tuple_function_type() -> FunctionType {
+        FunctionType::new(
+            vec![ValueType::Tuple(vec![ValueType::Int])],
+            ValueType::Tuple(vec![ValueType::Int]),
+        )
+    }
+
+    fn list_function_type() -> FunctionType {
+        FunctionType::new(
+            vec![ValueType::List(Box::new(ValueType::Int))],
+            ValueType::List(Box::new(ValueType::Int)),
+        )
+    }
+
+    fn function_function_type() -> FunctionType {
+        FunctionType::new(
+            Vec::new(),
+            ValueType::Function(Box::new(FunctionType::new(
+                vec![ValueType::Int],
+                ValueType::Int,
+            ))),
+        )
     }
 }

--- a/src/plan/expression/function/bool.rs
+++ b/src/plan/expression/function/bool.rs
@@ -226,59 +226,123 @@ mod tests {
     use crate::plan::{
         BoolExpr, BoolFunctionFunctionId, BoolFunctionId, BoolFunctionLocalId, BoolFunctionValue,
         BoolLocalId, Expr, FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionValue,
-        FunctionType, IntExpr, ParamLocal, Step, ValueType,
+        FunctionType, IntExpr, ParamLocal, Step, StringExpr, ValueType,
     };
 
     #[test]
     fn bool_function_expr_kind_accessors() {
-        assert!(matches!(
+        assert_eq!(
+            function_value().kind(),
+            &BoolFunctionExprKind::Value(BoolFunctionValue::new(
+                BoolFunctionId(0),
+                vec![ParamLocal::bool(BoolLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            BoolFunctionExpr::closure(
+                BoolFunctionId(0),
+                vec![ParamLocal::bool(BoolLocalId(0))],
+                Vec::new(),
+                function_type(),
+            )
+            .kind(),
+            &BoolFunctionExprKind::Closure {
+                runtime_id: BoolFunctionId(0),
+                params: vec![ParamLocal::bool(BoolLocalId(0))],
+                captures: Vec::new(),
+            },
+        );
+        assert_eq!(
             BoolFunctionExpr::local_get(BoolFunctionLocalId(0), "f".into(), function_type()).kind(),
-            BoolFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
+            &BoolFunctionExprKind::LocalGet {
+                local: BoolFunctionLocalId(0),
+                name: "f".into(),
+            },
+        );
+        assert_eq!(
             BoolFunctionExpr::call(BoolFunctionFunctionId(0), Vec::new(), function_type()).kind(),
-            BoolFunctionExprKind::Call { .. },
-        ));
-        assert!(matches!(
+            &BoolFunctionExprKind::Call {
+                function: BoolFunctionFunctionId(0),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             BoolFunctionExpr::function_call(function_function_value(), Vec::new(), function_type())
                 .kind(),
-            BoolFunctionExprKind::FunctionCall { .. },
-        ));
-        assert!(matches!(
+            &BoolFunctionExprKind::FunctionCall {
+                function: Box::new(function_function_value()),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             BoolFunctionExpr::tuple_index(tuple_expr(), 0, function_type()).kind(),
-            BoolFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
+            &BoolFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             BoolFunctionExpr::bool_case(BoolExpr::value(true), function_value(), function_value(),)
                 .kind(),
-            BoolFunctionExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            &BoolFunctionExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(function_value()),
+                false_: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             BoolFunctionExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), function_value())],
                 function_value(),
             )
             .kind(),
-            BoolFunctionExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            &BoolFunctionExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
+            BoolFunctionExpr::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), function_value())],
+                function_value(),
+            )
+            .kind(),
+            &BoolFunctionExprKind::StringCase {
+                subject: Box::new(StringExpr::value("one".into())),
+                clauses: vec![("one".into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             BoolFunctionExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, function_value())],
                 function_value(),
             )
             .kind(),
-            BoolFunctionExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            &BoolFunctionExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             BoolFunctionExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 function_value(),
             )
             .kind(),
-            BoolFunctionExprKind::Block { .. },
-        ));
+            &BoolFunctionExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(function_value()),
+            },
+        );
     }
 
     #[test]

--- a/src/plan/expression/function/float.rs
+++ b/src/plan/expression/function/float.rs
@@ -226,7 +226,7 @@ mod tests {
     use crate::plan::{
         BoolExpr, Expr, FloatExpr, FloatFunctionFunctionId, FloatFunctionId, FloatFunctionLocalId,
         FloatFunctionValue, FloatLocalId, FunctionFunctionExpr, FunctionFunctionId,
-        FunctionFunctionValue, FunctionType, ParamLocal, Step, ValueType,
+        FunctionFunctionValue, FunctionType, IntExpr, ParamLocal, Step, StringExpr, ValueType,
     };
 
     #[test]
@@ -235,54 +235,136 @@ mod tests {
             float_function_type(),
             FunctionType::new(vec![ValueType::Float], ValueType::Float),
         );
-        assert!(matches!(
+        assert_eq!(
+            float_function_value().kind(),
+            &FloatFunctionExprKind::Value(FloatFunctionValue::new(
+                FloatFunctionId(0),
+                vec![ParamLocal::float(FloatLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            FloatFunctionExpr::closure(
+                FloatFunctionId(0),
+                vec![ParamLocal::float(FloatLocalId(0))],
+                Vec::new(),
+                float_function_type(),
+            )
+            .kind(),
+            &FloatFunctionExprKind::Closure {
+                runtime_id: FloatFunctionId(0),
+                params: vec![ParamLocal::float(FloatLocalId(0))],
+                captures: Vec::new(),
+            },
+        );
+        assert_eq!(
             FloatFunctionExpr::local_get(
                 FloatFunctionLocalId(0),
                 "f".into(),
                 float_function_type(),
             )
             .kind(),
-            FloatFunctionExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
+            &FloatFunctionExprKind::LocalGet {
+                local: FloatFunctionLocalId(0),
+                name: "f".into(),
+            },
+        );
+        assert_eq!(
             FloatFunctionExpr::call(
                 FloatFunctionFunctionId(0),
                 Vec::new(),
                 float_function_type()
             )
             .kind(),
-            FloatFunctionExprKind::Call { .. }
-        ));
-        assert!(matches!(
+            &FloatFunctionExprKind::Call {
+                function: FloatFunctionFunctionId(0),
+                args: Vec::new(),
+                type_: float_function_type(),
+            },
+        );
+        assert_eq!(
             FloatFunctionExpr::function_call(
                 function_function_value(),
                 Vec::new(),
                 float_function_type(),
             )
             .kind(),
-            FloatFunctionExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
+            &FloatFunctionExprKind::FunctionCall {
+                function: Box::new(function_function_value()),
+                args: Vec::new(),
+                type_: float_function_type(),
+            },
+        );
+        assert_eq!(
             FloatFunctionExpr::tuple_index(tuple_expr(), 0, float_function_type()).kind(),
-            FloatFunctionExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &FloatFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+                type_: float_function_type(),
+            },
+        );
+        assert_eq!(
+            FloatFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                float_function_value(),
+                float_function_value(),
+            )
+            .kind(),
+            &FloatFunctionExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(float_function_value()),
+                false_: Box::new(float_function_value()),
+            },
+        );
+        assert_eq!(
+            FloatFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), float_function_value())],
+                float_function_value(),
+            )
+            .kind(),
+            &FloatFunctionExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), float_function_value())],
+                fallback: Box::new(float_function_value()),
+            },
+        );
+        assert_eq!(
+            FloatFunctionExpr::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), float_function_value())],
+                float_function_value(),
+            )
+            .kind(),
+            &FloatFunctionExprKind::StringCase {
+                subject: Box::new(StringExpr::value("one".into())),
+                clauses: vec![("one".into(), float_function_value())],
+                fallback: Box::new(float_function_value()),
+            },
+        );
+        assert_eq!(
             FloatFunctionExpr::float_case(
                 FloatExpr::value(1.0),
                 vec![(1.0, float_function_value())],
                 float_function_value(),
             )
             .kind(),
-            FloatFunctionExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &FloatFunctionExprKind::FloatCase {
+                subject: Box::new(FloatExpr::value(1.0)),
+                clauses: vec![(1.0, float_function_value())],
+                fallback: Box::new(float_function_value()),
+            },
+        );
+        assert_eq!(
             FloatFunctionExpr::block(
                 vec![Step::evaluate(Expr::float(FloatExpr::value(1.0)))],
                 float_function_value(),
             )
             .kind(),
-            FloatFunctionExprKind::Block { .. }
-        ));
+            &FloatFunctionExprKind::Block {
+                steps: vec![Step::evaluate(Expr::float(FloatExpr::value(1.0)))],
+                return_: Box::new(float_function_value()),
+            },
+        );
     }
 
     #[test]

--- a/src/plan/expression/function/int.rs
+++ b/src/plan/expression/function/int.rs
@@ -226,7 +226,7 @@ mod tests {
     use crate::plan::{
         BoolExpr, Expr, FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionValue,
         FunctionType, IntExpr, IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId,
-        IntFunctionValue, IntLocalId, ParamLocal, Step, ValueType,
+        IntFunctionValue, IntLocalId, ParamLocal, Step, StringExpr, ValueType,
     };
 
     #[test]
@@ -235,54 +235,127 @@ mod tests {
             int_function_type(),
             FunctionType::new(vec![ValueType::Int], ValueType::Int),
         );
-        assert!(matches!(
+        assert_eq!(
+            int_function_value().kind(),
+            &IntFunctionExprKind::Value(IntFunctionValue::new(
+                IntFunctionId(0),
+                vec![ParamLocal::int(IntLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            IntFunctionExpr::closure(
+                IntFunctionId(0),
+                vec![ParamLocal::int(IntLocalId(0))],
+                Vec::new(),
+                int_function_type(),
+            )
+            .kind(),
+            &IntFunctionExprKind::Closure {
+                runtime_id: IntFunctionId(0),
+                params: vec![ParamLocal::int(IntLocalId(0))],
+                captures: Vec::new(),
+            },
+        );
+        assert_eq!(
             IntFunctionExpr::local_get(IntFunctionLocalId(0), "f".into(), int_function_type(),)
                 .kind(),
-            IntFunctionExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
+            &IntFunctionExprKind::LocalGet {
+                local: IntFunctionLocalId(0),
+                name: "f".into(),
+            },
+        );
+        assert_eq!(
             IntFunctionExpr::call(IntFunctionFunctionId(0), Vec::new(), int_function_type()).kind(),
-            IntFunctionExprKind::Call { .. }
-        ));
-        assert!(matches!(
+            &IntFunctionExprKind::Call {
+                function: IntFunctionFunctionId(0),
+                args: Vec::new(),
+                type_: int_function_type(),
+            },
+        );
+        assert_eq!(
             IntFunctionExpr::function_call(
                 function_function_value(),
                 Vec::new(),
                 int_function_type(),
             )
             .kind(),
-            IntFunctionExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
+            &IntFunctionExprKind::FunctionCall {
+                function: Box::new(function_function_value()),
+                args: Vec::new(),
+                type_: int_function_type(),
+            },
+        );
+        assert_eq!(
             IntFunctionExpr::tuple_index(tuple_expr(), 0, int_function_type()).kind(),
-            IntFunctionExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &IntFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+                type_: int_function_type(),
+            },
+        );
+        assert_eq!(
+            IntFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                int_function_value(),
+                int_function_value(),
+            )
+            .kind(),
+            &IntFunctionExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(int_function_value()),
+                false_: Box::new(int_function_value()),
+            },
+        );
+        assert_eq!(
             IntFunctionExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), int_function_value())],
                 int_function_value(),
             )
             .kind(),
-            IntFunctionExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
+            &IntFunctionExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), int_function_value())],
+                fallback: Box::new(int_function_value()),
+            },
+        );
+        assert_eq!(
+            IntFunctionExpr::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), int_function_value())],
+                int_function_value(),
+            )
+            .kind(),
+            &IntFunctionExprKind::StringCase {
+                subject: Box::new(StringExpr::value("one".into())),
+                clauses: vec![("one".into(), int_function_value())],
+                fallback: Box::new(int_function_value()),
+            },
+        );
+        assert_eq!(
             IntFunctionExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, int_function_value())],
                 int_function_value(),
             )
             .kind(),
-            IntFunctionExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &IntFunctionExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, int_function_value())],
+                fallback: Box::new(int_function_value()),
+            },
+        );
+        assert_eq!(
             IntFunctionExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 int_function_value(),
             )
             .kind(),
-            IntFunctionExprKind::Block { .. }
-        ));
+            &IntFunctionExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(int_function_value()),
+            },
+        );
     }
 
     #[test]

--- a/src/plan/expression/function/list.rs
+++ b/src/plan/expression/function/list.rs
@@ -234,88 +234,131 @@ mod tests {
 
     #[test]
     fn list_function_expr_kind_accessors() {
-        assert!(matches!(
+        assert_eq!(
             list_function_value().kind(),
-            ListFunctionExprKind::Value(_)
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::Value(ListFunctionValue::new(
+                ListFunctionId(0),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                element_type(),
+            )),
+        );
+        assert_eq!(
             ListFunctionExpr::closure(
                 ListFunctionId(0),
-                Vec::new(),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
                 Vec::new(),
                 list_function_type(),
                 element_type(),
             )
             .kind(),
-            ListFunctionExprKind::Closure { .. }
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::Closure {
+                runtime_id: ListFunctionId(0),
+                params: vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                captures: Vec::new(),
+                return_type: element_type(),
+            },
+        );
+        assert_eq!(
             ListFunctionExpr::local_get(ListFunctionLocalId(0), "f".into(), list_function_type(),)
                 .kind(),
-            ListFunctionExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::LocalGet {
+                local: ListFunctionLocalId(0),
+                name: "f".into(),
+            },
+        );
+        assert_eq!(
             ListFunctionExpr::call(ListFunctionFunctionId(0), Vec::new(), list_function_type(),)
                 .kind(),
-            ListFunctionExprKind::Call { .. }
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::Call {
+                function: ListFunctionFunctionId(0),
+                args: Vec::new(),
+                type_: list_function_type(),
+            },
+        );
+        assert_eq!(
             ListFunctionExpr::function_call(
                 function_function_value(),
                 Vec::new(),
                 list_function_type(),
             )
             .kind(),
-            ListFunctionExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::FunctionCall {
+                function: Box::new(function_function_value()),
+                args: Vec::new(),
+                type_: list_function_type(),
+            },
+        );
+        assert_eq!(
             ListFunctionExpr::tuple_index(tuple_expr(), 0, list_function_type()).kind(),
-            ListFunctionExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+                type_: list_function_type(),
+            },
+        );
+        assert_eq!(
             ListFunctionExpr::bool_case(
                 BoolExpr::value(true),
                 list_function_value(),
                 list_function_value(),
             )
             .kind(),
-            ListFunctionExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(list_function_value()),
+                false_: Box::new(list_function_value()),
+            },
+        );
+        assert_eq!(
             ListFunctionExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), list_function_value())],
                 list_function_value(),
             )
             .kind(),
-            ListFunctionExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), list_function_value())],
+                fallback: Box::new(list_function_value()),
+            },
+        );
+        assert_eq!(
             ListFunctionExpr::string_case(
                 crate::plan::StringExpr::value("one".into()),
                 vec![("one".into(), list_function_value())],
                 list_function_value(),
             )
             .kind(),
-            ListFunctionExprKind::StringCase { .. }
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::StringCase {
+                subject: Box::new(crate::plan::StringExpr::value("one".into())),
+                clauses: vec![("one".into(), list_function_value())],
+                fallback: Box::new(list_function_value()),
+            },
+        );
+        assert_eq!(
             ListFunctionExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, list_function_value())],
                 list_function_value(),
             )
             .kind(),
-            ListFunctionExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &ListFunctionExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, list_function_value())],
+                fallback: Box::new(list_function_value()),
+            },
+        );
+        assert_eq!(
             ListFunctionExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 list_function_value(),
             )
             .kind(),
-            ListFunctionExprKind::Block { .. }
-        ));
+            &ListFunctionExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(list_function_value()),
+            },
+        );
     }
 
     #[test]

--- a/src/plan/expression/function/nil.rs
+++ b/src/plan/expression/function/nil.rs
@@ -226,59 +226,123 @@ mod tests {
     use crate::plan::{
         BoolExpr, Expr, FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionValue,
         FunctionType, IntExpr, NilFunctionFunctionId, NilFunctionId, NilFunctionLocalId,
-        NilFunctionValue, NilLocalId, ParamLocal, Step, ValueType,
+        NilFunctionValue, NilLocalId, ParamLocal, Step, StringExpr, ValueType,
     };
 
     #[test]
     fn nil_function_expr_kind_accessors() {
-        assert!(matches!(
+        assert_eq!(
+            function_value().kind(),
+            &NilFunctionExprKind::Value(NilFunctionValue::new(
+                NilFunctionId(0),
+                vec![ParamLocal::nil(NilLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            NilFunctionExpr::closure(
+                NilFunctionId(0),
+                vec![ParamLocal::nil(NilLocalId(0))],
+                Vec::new(),
+                function_type(),
+            )
+            .kind(),
+            &NilFunctionExprKind::Closure {
+                runtime_id: NilFunctionId(0),
+                params: vec![ParamLocal::nil(NilLocalId(0))],
+                captures: Vec::new(),
+            },
+        );
+        assert_eq!(
             NilFunctionExpr::local_get(NilFunctionLocalId(0), "f".into(), function_type()).kind(),
-            NilFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
+            &NilFunctionExprKind::LocalGet {
+                local: NilFunctionLocalId(0),
+                name: "f".into(),
+            },
+        );
+        assert_eq!(
             NilFunctionExpr::call(NilFunctionFunctionId(0), Vec::new(), function_type()).kind(),
-            NilFunctionExprKind::Call { .. },
-        ));
-        assert!(matches!(
+            &NilFunctionExprKind::Call {
+                function: NilFunctionFunctionId(0),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             NilFunctionExpr::function_call(function_function_value(), Vec::new(), function_type())
                 .kind(),
-            NilFunctionExprKind::FunctionCall { .. },
-        ));
-        assert!(matches!(
+            &NilFunctionExprKind::FunctionCall {
+                function: Box::new(function_function_value()),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             NilFunctionExpr::tuple_index(tuple_expr(), 0, function_type()).kind(),
-            NilFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
+            &NilFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             NilFunctionExpr::bool_case(BoolExpr::value(true), function_value(), function_value(),)
                 .kind(),
-            NilFunctionExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            &NilFunctionExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(function_value()),
+                false_: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             NilFunctionExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), function_value())],
                 function_value(),
             )
             .kind(),
-            NilFunctionExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            &NilFunctionExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
+            NilFunctionExpr::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), function_value())],
+                function_value(),
+            )
+            .kind(),
+            &NilFunctionExprKind::StringCase {
+                subject: Box::new(StringExpr::value("one".into())),
+                clauses: vec![("one".into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             NilFunctionExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, function_value())],
                 function_value(),
             )
             .kind(),
-            NilFunctionExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            &NilFunctionExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             NilFunctionExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 function_value(),
             )
             .kind(),
-            NilFunctionExprKind::Block { .. },
-        ));
+            &NilFunctionExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(function_value()),
+            },
+        );
     }
 
     #[test]

--- a/src/plan/expression/function/returning_function.rs
+++ b/src/plan/expression/function/returning_function.rs
@@ -229,64 +229,141 @@ mod tests {
     use super::{FunctionFunctionExpr, FunctionFunctionExprKind};
     use crate::plan::{
         BoolExpr, Expr, FunctionFunctionId, FunctionFunctionLocalId, FunctionFunctionValue,
-        FunctionType, IntExpr, IntFunctionFunctionId, ParamLocal, Step, ValueType,
+        FunctionType, IntExpr, IntFunctionFunctionId, ParamLocal, Step, StringExpr, ValueType,
     };
 
     #[test]
     fn function_function_expr_kind_accessors() {
-        assert!(matches!(
+        assert_eq!(
+            function_value().kind(),
+            &FunctionFunctionExprKind::Value(FunctionFunctionValue::new(
+                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                FunctionType::new(vec![ValueType::Int], ValueType::Int),
+            )),
+        );
+        assert_eq!(
+            FunctionFunctionExpr::closure(
+                FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                Vec::new(),
+                function_type(),
+                returned_function_type(),
+            )
+            .kind(),
+            &FunctionFunctionExprKind::Closure {
+                runtime_id: FunctionFunctionId::Int(IntFunctionFunctionId(0)),
+                params: vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                captures: Vec::new(),
+                return_type: returned_function_type(),
+            },
+        );
+        assert_eq!(
             FunctionFunctionExpr::local_get(
                 FunctionFunctionLocalId(0),
                 "f".into(),
                 function_type(),
             )
             .kind(),
-            FunctionFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
+            &FunctionFunctionExprKind::LocalGet {
+                local: FunctionFunctionLocalId(0),
+                name: "f".into(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             FunctionFunctionExpr::call(
                 crate::plan::FunctionFunctionFunctionId(0),
                 Vec::new(),
                 function_type(),
             )
             .kind(),
-            FunctionFunctionExprKind::Call { .. },
-        ));
-        assert!(matches!(
+            &FunctionFunctionExprKind::Call {
+                function: crate::plan::FunctionFunctionFunctionId(0),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             FunctionFunctionExpr::function_call(function_value(), Vec::new(), function_type())
                 .kind(),
-            FunctionFunctionExprKind::FunctionCall { .. },
-        ));
-        assert!(matches!(
+            &FunctionFunctionExprKind::FunctionCall {
+                function: Box::new(function_value()),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             FunctionFunctionExpr::tuple_index(tuple_expr(), 0, function_type()).kind(),
-            FunctionFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
+            &FunctionFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
+            FunctionFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                function_value(),
+                function_value(),
+            )
+            .kind(),
+            &FunctionFunctionExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(function_value()),
+                false_: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             FunctionFunctionExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), function_value())],
                 function_value(),
             )
             .kind(),
-            FunctionFunctionExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            &FunctionFunctionExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
+            FunctionFunctionExpr::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), function_value())],
+                function_value(),
+            )
+            .kind(),
+            &FunctionFunctionExprKind::StringCase {
+                subject: Box::new(StringExpr::value("one".into())),
+                clauses: vec![("one".into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             FunctionFunctionExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, function_value())],
                 function_value(),
             )
             .kind(),
-            FunctionFunctionExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            &FunctionFunctionExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             FunctionFunctionExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 function_value(),
             )
             .kind(),
-            FunctionFunctionExprKind::Block { .. },
-        ));
+            &FunctionFunctionExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(function_value()),
+            },
+        );
     }
 
     #[test]
@@ -319,6 +396,10 @@ mod tests {
                 ValueType::Int,
             ))),
         )
+    }
+
+    fn returned_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::Int], ValueType::Int)
     }
 
     fn tuple_expr() -> crate::plan::TupleExpr {

--- a/src/plan/expression/function/string.rs
+++ b/src/plan/expression/function/string.rs
@@ -225,70 +225,134 @@ mod tests {
     use super::{StringFunctionExpr, StringFunctionExprKind};
     use crate::plan::{
         BoolExpr, Expr, FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionValue,
-        FunctionType, IntExpr, ParamLocal, Step, StringFunctionFunctionId, StringFunctionId,
-        StringFunctionLocalId, StringFunctionValue, StringLocalId, ValueType,
+        FunctionType, IntExpr, ParamLocal, Step, StringExpr, StringFunctionFunctionId,
+        StringFunctionId, StringFunctionLocalId, StringFunctionValue, StringLocalId, ValueType,
     };
 
     #[test]
     fn string_function_expr_kind_accessors() {
-        assert!(matches!(
+        assert_eq!(
+            function_value().kind(),
+            &StringFunctionExprKind::Value(StringFunctionValue::new(
+                StringFunctionId(0),
+                vec![ParamLocal::string(StringLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            StringFunctionExpr::closure(
+                StringFunctionId(0),
+                vec![ParamLocal::string(StringLocalId(0))],
+                Vec::new(),
+                function_type(),
+            )
+            .kind(),
+            &StringFunctionExprKind::Closure {
+                runtime_id: StringFunctionId(0),
+                params: vec![ParamLocal::string(StringLocalId(0))],
+                captures: Vec::new(),
+            },
+        );
+        assert_eq!(
             StringFunctionExpr::local_get(StringFunctionLocalId(0), "f".into(), function_type())
                 .kind(),
-            StringFunctionExprKind::LocalGet { .. },
-        ));
-        assert!(matches!(
+            &StringFunctionExprKind::LocalGet {
+                local: StringFunctionLocalId(0),
+                name: "f".into(),
+            },
+        );
+        assert_eq!(
             StringFunctionExpr::call(StringFunctionFunctionId(0), Vec::new(), function_type())
                 .kind(),
-            StringFunctionExprKind::Call { .. },
-        ));
-        assert!(matches!(
+            &StringFunctionExprKind::Call {
+                function: StringFunctionFunctionId(0),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             StringFunctionExpr::function_call(
                 function_function_value(),
                 Vec::new(),
                 function_type(),
             )
             .kind(),
-            StringFunctionExprKind::FunctionCall { .. },
-        ));
-        assert!(matches!(
+            &StringFunctionExprKind::FunctionCall {
+                function: Box::new(function_function_value()),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             StringFunctionExpr::tuple_index(tuple_expr(), 0, function_type()).kind(),
-            StringFunctionExprKind::TupleIndex { .. },
-        ));
-        assert!(matches!(
+            &StringFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
             StringFunctionExpr::bool_case(
                 BoolExpr::value(true),
                 function_value(),
                 function_value(),
             )
             .kind(),
-            StringFunctionExprKind::BoolCase { .. },
-        ));
-        assert!(matches!(
+            &StringFunctionExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(function_value()),
+                false_: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             StringFunctionExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), function_value())],
                 function_value(),
             )
             .kind(),
-            StringFunctionExprKind::IntCase { .. },
-        ));
-        assert!(matches!(
+            &StringFunctionExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
+            StringFunctionExpr::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), function_value())],
+                function_value(),
+            )
+            .kind(),
+            &StringFunctionExprKind::StringCase {
+                subject: Box::new(StringExpr::value("one".into())),
+                clauses: vec![("one".into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             StringFunctionExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, function_value())],
                 function_value(),
             )
             .kind(),
-            StringFunctionExprKind::FloatCase { .. },
-        ));
-        assert!(matches!(
+            &StringFunctionExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
             StringFunctionExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 function_value(),
             )
             .kind(),
-            StringFunctionExprKind::Block { .. },
-        ));
+            &StringFunctionExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(function_value()),
+            },
+        );
     }
 
     #[test]

--- a/src/plan/expression/function/tuple.rs
+++ b/src/plan/expression/function/tuple.rs
@@ -234,96 +234,139 @@ mod tests {
 
     #[test]
     fn tuple_function_expr_kind_accessors() {
-        assert!(matches!(
+        assert_eq!(
             tuple_function_value().kind(),
-            TupleFunctionExprKind::Value(_)
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::Value(TupleFunctionValue::new(
+                TupleFunctionId(0),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                tuple_type(),
+            )),
+        );
+        assert_eq!(
             TupleFunctionExpr::closure(
                 TupleFunctionId(0),
-                Vec::new(),
+                vec![ParamLocal::int(crate::plan::IntLocalId(0))],
                 Vec::new(),
                 tuple_function_type(),
                 tuple_type(),
             )
             .kind(),
-            TupleFunctionExprKind::Closure { .. }
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::Closure {
+                runtime_id: TupleFunctionId(0),
+                params: vec![ParamLocal::int(crate::plan::IntLocalId(0))],
+                captures: Vec::new(),
+                return_type: tuple_type(),
+            },
+        );
+        assert_eq!(
             TupleFunctionExpr::local_get(
                 TupleFunctionLocalId(0),
                 "f".into(),
                 tuple_function_type(),
             )
             .kind(),
-            TupleFunctionExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::LocalGet {
+                local: TupleFunctionLocalId(0),
+                name: "f".into(),
+            },
+        );
+        assert_eq!(
             TupleFunctionExpr::call(
                 TupleFunctionFunctionId(0),
                 Vec::new(),
                 tuple_function_type(),
             )
             .kind(),
-            TupleFunctionExprKind::Call { .. }
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::Call {
+                function: TupleFunctionFunctionId(0),
+                args: Vec::new(),
+                type_: tuple_function_type(),
+            },
+        );
+        assert_eq!(
             TupleFunctionExpr::function_call(
                 function_function_value(),
                 Vec::new(),
                 tuple_function_type(),
             )
             .kind(),
-            TupleFunctionExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::FunctionCall {
+                function: Box::new(function_function_value()),
+                args: Vec::new(),
+                type_: tuple_function_type(),
+            },
+        );
+        assert_eq!(
             TupleFunctionExpr::tuple_index(tuple_expr(), 0, tuple_function_type()).kind(),
-            TupleFunctionExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+                type_: tuple_function_type(),
+            },
+        );
+        assert_eq!(
             TupleFunctionExpr::bool_case(
                 BoolExpr::value(true),
                 tuple_function_value(),
                 tuple_function_value(),
             )
             .kind(),
-            TupleFunctionExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(tuple_function_value()),
+                false_: Box::new(tuple_function_value()),
+            },
+        );
+        assert_eq!(
             TupleFunctionExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), tuple_function_value())],
                 tuple_function_value(),
             )
             .kind(),
-            TupleFunctionExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), tuple_function_value())],
+                fallback: Box::new(tuple_function_value()),
+            },
+        );
+        assert_eq!(
             TupleFunctionExpr::string_case(
                 crate::plan::StringExpr::value("one".into()),
                 vec![("one".into(), tuple_function_value())],
                 tuple_function_value(),
             )
             .kind(),
-            TupleFunctionExprKind::StringCase { .. }
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::StringCase {
+                subject: Box::new(crate::plan::StringExpr::value("one".into())),
+                clauses: vec![("one".into(), tuple_function_value())],
+                fallback: Box::new(tuple_function_value()),
+            },
+        );
+        assert_eq!(
             TupleFunctionExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, tuple_function_value())],
                 tuple_function_value(),
             )
             .kind(),
-            TupleFunctionExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &TupleFunctionExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, tuple_function_value())],
+                fallback: Box::new(tuple_function_value()),
+            },
+        );
+        assert_eq!(
             TupleFunctionExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 tuple_function_value(),
             )
             .kind(),
-            TupleFunctionExprKind::Block { .. }
-        ));
+            &TupleFunctionExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(tuple_function_value()),
+            },
+        );
     }
 
     #[test]

--- a/src/plan/expression/int.rs
+++ b/src/plan/expression/int.rs
@@ -231,76 +231,157 @@ impl IntExpr {
 #[cfg(test)]
 mod tests {
     use super::{IntExpr, IntExprKind};
-    use crate::plan::{BoolExpr, Expr, IntFunctionId, IntFunctionValue, Step};
+    use crate::plan::{
+        BoolExpr, Expr, IntFunctionId, IntFunctionValue, IntLocalId, Step, TupleExpr, ValueType,
+    };
+    use num_bigint::BigInt;
 
     #[test]
     fn int_expr_kind_accessors() {
-        assert!(matches!(
+        assert_eq!(
             IntExpr::value(1.into()).kind(),
-            IntExprKind::Value(_)
-        ));
-        assert!(matches!(
+            &IntExprKind::Value(BigInt::from(1)),
+        );
+        assert_eq!(
+            IntExpr::local_get(IntLocalId(0), "value".into()).kind(),
+            &IntExprKind::LocalGet {
+                local: IntLocalId(0),
+                name: "value".into(),
+            },
+        );
+        assert_eq!(
+            IntExpr::call(IntFunctionId(0), Vec::new()).kind(),
+            &IntExprKind::Call {
+                function: IntFunctionId(0),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            IntExpr::function_call(function_expr(), Vec::new()).kind(),
+            &IntExprKind::FunctionCall {
+                function: Box::new(function_expr()),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            IntExpr::tuple_index(tuple_expr(), 0).kind(),
+            &IntExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+            },
+        );
+        assert_eq!(
+            IntExpr::add(IntExpr::value(1.into()), IntExpr::value(2.into())).kind(),
+            &IntExprKind::Add {
+                left: Box::new(IntExpr::value(1.into())),
+                right: Box::new(IntExpr::value(2.into())),
+            },
+        );
+        assert_eq!(
+            IntExpr::sub(IntExpr::value(1.into()), IntExpr::value(2.into())).kind(),
+            &IntExprKind::Sub {
+                left: Box::new(IntExpr::value(1.into())),
+                right: Box::new(IntExpr::value(2.into())),
+            },
+        );
+        assert_eq!(
+            IntExpr::mult(IntExpr::value(1.into()), IntExpr::value(2.into())).kind(),
+            &IntExprKind::Mult {
+                left: Box::new(IntExpr::value(1.into())),
+                right: Box::new(IntExpr::value(2.into())),
+            },
+        );
+        assert_eq!(
+            IntExpr::div(IntExpr::value(1.into()), IntExpr::value(2.into())).kind(),
+            &IntExprKind::Div {
+                left: Box::new(IntExpr::value(1.into())),
+                right: Box::new(IntExpr::value(2.into())),
+            },
+        );
+        assert_eq!(
+            IntExpr::remainder(IntExpr::value(1.into()), IntExpr::value(2.into())).kind(),
+            &IntExprKind::Remainder {
+                left: Box::new(IntExpr::value(1.into())),
+                right: Box::new(IntExpr::value(2.into())),
+            },
+        );
+        assert_eq!(
+            IntExpr::negate(IntExpr::value(1.into())).kind(),
+            &IntExprKind::Negate(Box::new(IntExpr::value(1.into()))),
+        );
+        assert_eq!(
             IntExpr::bool_case(
                 BoolExpr::value(true),
                 IntExpr::value(1.into()),
                 IntExpr::value(0.into())
             )
             .kind(),
-            IntExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
-            IntExpr::function_call(function_expr(), Vec::new()).kind(),
-            IntExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
-            IntExpr::tuple_index(
-                crate::plan::TupleExpr::value(
-                    vec![Expr::int(IntExpr::value(1.into()))],
-                    vec![crate::plan::ValueType::Int],
-                ),
-                0,
-            )
-            .kind(),
-            IntExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &IntExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(IntExpr::value(1.into())),
+                false_: Box::new(IntExpr::value(0.into())),
+            },
+        );
+        assert_eq!(
             IntExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), IntExpr::value(10.into()))],
                 IntExpr::value(0.into())
             )
             .kind(),
-            IntExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
+            &IntExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(BigInt::from(1), IntExpr::value(10.into()))],
+                fallback: Box::new(IntExpr::value(0.into())),
+            },
+        );
+        assert_eq!(
             IntExpr::string_case(
                 crate::plan::StringExpr::value("a".into()),
                 vec![("a".into(), IntExpr::value(10.into()))],
                 IntExpr::value(0.into())
             )
             .kind(),
-            IntExprKind::StringCase { .. }
-        ));
-        assert!(matches!(
+            &IntExprKind::StringCase {
+                subject: Box::new(crate::plan::StringExpr::value("a".into())),
+                clauses: vec![("a".into(), IntExpr::value(10.into()))],
+                fallback: Box::new(IntExpr::value(0.into())),
+            },
+        );
+        assert_eq!(
             IntExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, IntExpr::value(10.into()))],
                 IntExpr::value(0.into())
             )
             .kind(),
-            IntExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &IntExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, IntExpr::value(10.into()))],
+                fallback: Box::new(IntExpr::value(0.into())),
+            },
+        );
+        assert_eq!(
             IntExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 IntExpr::value(2.into()),
             )
             .kind(),
-            IntExprKind::Block { .. }
-        ));
+            &IntExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(IntExpr::value(2.into())),
+            },
+        );
     }
 
     fn function_expr() -> crate::plan::IntFunctionExpr {
         crate::plan::IntFunctionExpr::value(IntFunctionValue::new(IntFunctionId(0), Vec::new()))
+    }
+
+    fn tuple_expr() -> TupleExpr {
+        TupleExpr::value(
+            vec![Expr::int(IntExpr::value(1.into()))],
+            vec![ValueType::Int],
+        )
     }
 }

--- a/src/plan/expression/list.rs
+++ b/src/plan/expression/list.rs
@@ -207,71 +207,108 @@ mod tests {
 
     #[test]
     fn list_expr_kind_accessors() {
-        assert!(matches!(list_value().kind(), ListExprKind::Value(_)));
-        assert!(matches!(
+        assert_eq!(
+            list_value().kind(),
+            &ListExprKind::Value(vec![Expr::int(IntExpr::value(1.into()))]),
+        );
+        assert_eq!(
             ListExpr::spread(
                 vec![Expr::int(IntExpr::value(0.into()))],
                 list_value(),
                 element_type()
             )
             .kind(),
-            ListExprKind::Spread { .. }
-        ));
-        assert!(matches!(
+            &ListExprKind::Spread {
+                elements: vec![Expr::int(IntExpr::value(0.into()))],
+                tail: Box::new(list_value()),
+            },
+        );
+        assert_eq!(
             ListExpr::local_get(ListLocalId(0), "values".into(), element_type()).kind(),
-            ListExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
+            &ListExprKind::LocalGet {
+                local: ListLocalId(0),
+                name: "values".into(),
+            },
+        );
+        assert_eq!(
             ListExpr::call(ListFunctionId(0), Vec::new(), element_type()).kind(),
-            ListExprKind::Call { .. }
-        ));
-        assert!(matches!(
+            &ListExprKind::Call {
+                function: ListFunctionId(0),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
             ListExpr::function_call(list_function_expr(), Vec::new(), element_type()).kind(),
-            ListExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
+            &ListExprKind::FunctionCall {
+                function: Box::new(list_function_expr()),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
             ListExpr::tuple_index(tuple_expr(), 0, element_type()).kind(),
-            ListExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &ListExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+            },
+        );
+        assert_eq!(
             ListExpr::bool_case(BoolExpr::value(true), list_value(), list_value()).kind(),
-            ListExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
+            &ListExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(list_value()),
+                false_: Box::new(list_value()),
+            },
+        );
+        assert_eq!(
             ListExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), list_value())],
                 list_value(),
             )
             .kind(),
-            ListExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
+            &ListExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), list_value())],
+                fallback: Box::new(list_value()),
+            },
+        );
+        assert_eq!(
             ListExpr::string_case(
                 crate::plan::StringExpr::value("one".into()),
                 vec![("one".into(), list_value())],
                 list_value(),
             )
             .kind(),
-            ListExprKind::StringCase { .. }
-        ));
-        assert!(matches!(
+            &ListExprKind::StringCase {
+                subject: Box::new(crate::plan::StringExpr::value("one".into())),
+                clauses: vec![("one".into(), list_value())],
+                fallback: Box::new(list_value()),
+            },
+        );
+        assert_eq!(
             ListExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, list_value())],
                 list_value(),
             )
             .kind(),
-            ListExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &ListExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, list_value())],
+                fallback: Box::new(list_value()),
+            },
+        );
+        assert_eq!(
             ListExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 list_value(),
             )
             .kind(),
-            ListExprKind::Block { .. }
-        ));
+            &ListExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(list_value()),
+            },
+        );
     }
 
     #[test]

--- a/src/plan/expression/nil.rs
+++ b/src/plan/expression/nil.rs
@@ -159,68 +159,108 @@ impl NilExpr {
 #[cfg(test)]
 mod tests {
     use super::{NilExpr, NilExprKind};
-    use crate::plan::{BoolExpr, Expr, IntExpr, NilFunctionId, NilFunctionValue, Step};
+    use crate::plan::{
+        BoolExpr, Expr, IntExpr, NilFunctionId, NilFunctionValue, NilLocalId, Step, TupleExpr,
+        ValueType,
+    };
+    use num_bigint::BigInt;
 
     #[test]
     fn nil_expr_kind_accessors() {
-        assert!(matches!(NilExpr::value().kind(), NilExprKind::Value));
-        assert!(matches!(
+        assert_eq!(NilExpr::value().kind(), &NilExprKind::Value);
+        assert_eq!(
+            NilExpr::local_get(NilLocalId(0), "unit".into()).kind(),
+            &NilExprKind::LocalGet {
+                local: NilLocalId(0),
+                name: "unit".into(),
+            },
+        );
+        assert_eq!(
+            NilExpr::call(NilFunctionId(0), Vec::new()).kind(),
+            &NilExprKind::Call {
+                function: NilFunctionId(0),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
             NilExpr::function_call(function_expr(), Vec::new()).kind(),
-            NilExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
-            NilExpr::tuple_index(
-                crate::plan::TupleExpr::value(
-                    vec![Expr::nil(NilExpr::value())],
-                    vec![crate::plan::ValueType::Nil],
-                ),
-                0,
-            )
-            .kind(),
-            NilExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &NilExprKind::FunctionCall {
+                function: Box::new(function_expr()),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            NilExpr::tuple_index(tuple_expr(), 0).kind(),
+            &NilExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+            },
+        );
+        assert_eq!(
             NilExpr::bool_case(BoolExpr::value(true), NilExpr::value(), NilExpr::value()).kind(),
-            NilExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
+            &NilExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(NilExpr::value()),
+                false_: Box::new(NilExpr::value()),
+            },
+        );
+        assert_eq!(
             NilExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), NilExpr::value())],
                 NilExpr::value()
             )
             .kind(),
-            NilExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
+            &NilExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(BigInt::from(1), NilExpr::value())],
+                fallback: Box::new(NilExpr::value()),
+            },
+        );
+        assert_eq!(
             NilExpr::string_case(
                 crate::plan::StringExpr::value("a".into()),
                 vec![("a".into(), NilExpr::value())],
                 NilExpr::value()
             )
             .kind(),
-            NilExprKind::StringCase { .. }
-        ));
-        assert!(matches!(
+            &NilExprKind::StringCase {
+                subject: Box::new(crate::plan::StringExpr::value("a".into())),
+                clauses: vec![("a".into(), NilExpr::value())],
+                fallback: Box::new(NilExpr::value()),
+            },
+        );
+        assert_eq!(
             NilExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, NilExpr::value())],
                 NilExpr::value()
             )
             .kind(),
-            NilExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &NilExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, NilExpr::value())],
+                fallback: Box::new(NilExpr::value()),
+            },
+        );
+        assert_eq!(
             NilExpr::block(
                 vec![Step::evaluate(Expr::nil(NilExpr::value()))],
                 NilExpr::value(),
             )
             .kind(),
-            NilExprKind::Block { .. }
-        ));
+            &NilExprKind::Block {
+                steps: vec![Step::evaluate(Expr::nil(NilExpr::value()))],
+                return_: Box::new(NilExpr::value()),
+            },
+        );
     }
 
     fn function_expr() -> crate::plan::NilFunctionExpr {
         crate::plan::NilFunctionExpr::value(NilFunctionValue::new(NilFunctionId(0), Vec::new()))
+    }
+
+    fn tuple_expr() -> TupleExpr {
+        TupleExpr::value(vec![Expr::nil(NilExpr::value())], vec![ValueType::Nil])
     }
 }

--- a/src/plan/expression/string.rs
+++ b/src/plan/expression/string.rs
@@ -172,73 +172,117 @@ impl StringExpr {
 #[cfg(test)]
 mod tests {
     use super::{StringExpr, StringExprKind};
-    use crate::plan::{BoolExpr, Expr, IntExpr, Step, StringFunctionId, StringFunctionValue};
+    use crate::plan::{
+        BoolExpr, Expr, IntExpr, Step, StringFunctionId, StringFunctionValue, StringLocalId,
+        TupleExpr, ValueType,
+    };
+    use num_bigint::BigInt;
 
     #[test]
     fn string_expr_kind_accessors() {
-        assert!(matches!(
+        assert_eq!(
             StringExpr::value("geam".into()).kind(),
-            StringExprKind::Value(_)
-        ));
-        assert!(matches!(
+            &StringExprKind::Value("geam".into()),
+        );
+        assert_eq!(
+            StringExpr::local_get(StringLocalId(0), "value".into()).kind(),
+            &StringExprKind::LocalGet {
+                local: StringLocalId(0),
+                name: "value".into(),
+            },
+        );
+        assert_eq!(
+            StringExpr::call(StringFunctionId(0), Vec::new()).kind(),
+            &StringExprKind::Call {
+                function: StringFunctionId(0),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            StringExpr::function_call(function_expr(), Vec::new()).kind(),
+            &StringExprKind::FunctionCall {
+                function: Box::new(function_expr()),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            StringExpr::tuple_index(tuple_expr(), 0).kind(),
+            &StringExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+            },
+        );
+        assert_eq!(
+            StringExpr::concatenate(StringExpr::value("a".into()), StringExpr::value("b".into()))
+                .kind(),
+            &StringExprKind::Concatenate {
+                left: Box::new(StringExpr::value("a".into())),
+                right: Box::new(StringExpr::value("b".into())),
+            },
+        );
+        assert_eq!(
             StringExpr::bool_case(
                 BoolExpr::value(true),
                 StringExpr::value("yes".into()),
                 StringExpr::value("no".into())
             )
             .kind(),
-            StringExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
-            StringExpr::function_call(function_expr(), Vec::new()).kind(),
-            StringExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
-            StringExpr::tuple_index(
-                crate::plan::TupleExpr::value(
-                    vec![Expr::string(StringExpr::value("geam".into()))],
-                    vec![crate::plan::ValueType::String],
-                ),
-                0,
-            )
-            .kind(),
-            StringExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &StringExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(StringExpr::value("yes".into())),
+                false_: Box::new(StringExpr::value("no".into())),
+            },
+        );
+        assert_eq!(
             StringExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), StringExpr::value("one".into()))],
                 StringExpr::value("other".into())
             )
             .kind(),
-            StringExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
+            &StringExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(BigInt::from(1), StringExpr::value("one".into()))],
+                fallback: Box::new(StringExpr::value("other".into())),
+            },
+        );
+        assert_eq!(
             StringExpr::string_case(
                 StringExpr::value("a".into()),
                 vec![("a".into(), StringExpr::value("hit".into()))],
                 StringExpr::value("miss".into())
             )
             .kind(),
-            StringExprKind::StringCase { .. }
-        ));
-        assert!(matches!(
+            &StringExprKind::StringCase {
+                subject: Box::new(StringExpr::value("a".into())),
+                clauses: vec![("a".into(), StringExpr::value("hit".into()))],
+                fallback: Box::new(StringExpr::value("miss".into())),
+            },
+        );
+        assert_eq!(
             StringExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, StringExpr::value("hit".into()))],
                 StringExpr::value("miss".into())
             )
             .kind(),
-            StringExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &StringExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, StringExpr::value("hit".into()))],
+                fallback: Box::new(StringExpr::value("miss".into())),
+            },
+        );
+        assert_eq!(
             StringExpr::block(
                 vec![Step::evaluate(Expr::string(StringExpr::value("a".into())))],
                 StringExpr::value("b".into()),
             )
             .kind(),
-            StringExprKind::Block { .. }
-        ));
+            &StringExprKind::Block {
+                steps: vec![Step::evaluate(Expr::string(StringExpr::value("a".into())))],
+                return_: Box::new(StringExpr::value("b".into())),
+            },
+        );
     }
 
     fn function_expr() -> crate::plan::StringFunctionExpr {
@@ -246,5 +290,12 @@ mod tests {
             StringFunctionId(0),
             Vec::new(),
         ))
+    }
+
+    fn tuple_expr() -> TupleExpr {
+        TupleExpr::value(
+            vec![Expr::string(StringExpr::value("geam".into()))],
+            vec![ValueType::String],
+        )
     }
 }

--- a/src/plan/expression/tuple.rs
+++ b/src/plan/expression/tuple.rs
@@ -189,62 +189,96 @@ mod tests {
 
     #[test]
     fn tuple_expr_kind_accessors() {
-        assert!(matches!(tuple_value().kind(), TupleExprKind::Value(_)));
-        assert!(matches!(
+        assert_eq!(
+            tuple_value().kind(),
+            &TupleExprKind::Value(vec![Expr::int(IntExpr::value(1.into()))]),
+        );
+        assert_eq!(
             TupleExpr::local_get(TupleLocalId(0), "pair".into(), tuple_type()).kind(),
-            TupleExprKind::LocalGet { .. }
-        ));
-        assert!(matches!(
+            &TupleExprKind::LocalGet {
+                local: TupleLocalId(0),
+                name: "pair".into(),
+            },
+        );
+        assert_eq!(
             TupleExpr::call(TupleFunctionId(0), Vec::new(), tuple_type()).kind(),
-            TupleExprKind::Call { .. }
-        ));
-        assert!(matches!(
+            &TupleExprKind::Call {
+                function: TupleFunctionId(0),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
             TupleExpr::function_call(tuple_function_expr(), Vec::new(), tuple_type()).kind(),
-            TupleExprKind::FunctionCall { .. }
-        ));
-        assert!(matches!(
+            &TupleExprKind::FunctionCall {
+                function: Box::new(tuple_function_expr()),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
             TupleExpr::tuple_index(tuple_value(), 0, tuple_type()).kind(),
-            TupleExprKind::TupleIndex { .. }
-        ));
-        assert!(matches!(
+            &TupleExprKind::TupleIndex {
+                tuple: Box::new(tuple_value()),
+                index: 0,
+            },
+        );
+        assert_eq!(
             TupleExpr::bool_case(BoolExpr::value(true), tuple_value(), tuple_value()).kind(),
-            TupleExprKind::BoolCase { .. }
-        ));
-        assert!(matches!(
+            &TupleExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(tuple_value()),
+                false_: Box::new(tuple_value()),
+            },
+        );
+        assert_eq!(
             TupleExpr::int_case(
                 IntExpr::value(1.into()),
                 vec![(1.into(), tuple_value())],
                 tuple_value(),
             )
             .kind(),
-            TupleExprKind::IntCase { .. }
-        ));
-        assert!(matches!(
+            &TupleExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), tuple_value())],
+                fallback: Box::new(tuple_value()),
+            },
+        );
+        assert_eq!(
             TupleExpr::string_case(
                 crate::plan::StringExpr::value("one".into()),
                 vec![("one".into(), tuple_value())],
                 tuple_value(),
             )
             .kind(),
-            TupleExprKind::StringCase { .. }
-        ));
-        assert!(matches!(
+            &TupleExprKind::StringCase {
+                subject: Box::new(crate::plan::StringExpr::value("one".into())),
+                clauses: vec![("one".into(), tuple_value())],
+                fallback: Box::new(tuple_value()),
+            },
+        );
+        assert_eq!(
             TupleExpr::float_case(
                 crate::plan::FloatExpr::value(1.0),
                 vec![(1.0, tuple_value())],
                 tuple_value(),
             )
             .kind(),
-            TupleExprKind::FloatCase { .. }
-        ));
-        assert!(matches!(
+            &TupleExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, tuple_value())],
+                fallback: Box::new(tuple_value()),
+            },
+        );
+        assert_eq!(
             TupleExpr::block(
                 vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
                 tuple_value(),
             )
             .kind(),
-            TupleExprKind::Block { .. }
-        ));
+            &TupleExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(tuple_value()),
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Bring all `src/plan/expression/**` files to 100% region coverage.
- Replace broad `matches!` and option checks with exact expression shape assertions.
- Update region coverage notes with the remaining runtime and frontend candidates.
