### PR TITLE
Tighten runtime function region coverage

### DIFF
--- a/src/runtime/function.rs
+++ b/src/runtime/function.rs
@@ -1445,6 +1445,116 @@ pub fn main() {
         ));
     }
 
+    #[test]
+    fn primitive_function_value_calls_propagate_frame_binding_errors() {
+        let plan = primitive_function_plan();
+
+        assert_expected_function_got_int(run_int_function_call(
+            &plan,
+            &IntFunctionExpr::value(IntFunctionValue::new(IntFunctionId(0), Vec::new())),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_string_function_call(
+            &plan,
+            &StringFunctionExpr::value(StringFunctionValue::new(StringFunctionId(0), Vec::new())),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_float_function_call(
+            &plan,
+            &FloatFunctionExpr::value(FloatFunctionValue::new(FloatFunctionId(0), Vec::new())),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_bool_function_call(
+            &plan,
+            &BoolFunctionExpr::value(BoolFunctionValue::new(BoolFunctionId(0), Vec::new())),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_nil_function_call(
+            &plan,
+            &NilFunctionExpr::value(NilFunctionValue::new(NilFunctionId(0), Vec::new())),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_tuple_function_call(
+            &plan,
+            &TupleFunctionExpr::value(TupleFunctionValue::new(
+                TupleFunctionId(0),
+                Vec::new(),
+                vec![ValueType::Int],
+            )),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_list_function_call(
+            &plan,
+            &ListFunctionExpr::value(ListFunctionValue::new(
+                ListFunctionId(0),
+                Vec::new(),
+                ValueType::Int,
+            )),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+    }
+
+    #[test]
+    fn function_function_calls_propagate_frame_binding_errors() {
+        let plan = plan_with_function_function_steps(Vec::new());
+
+        assert_expected_function_got_int(run_int_function_function_call(
+            &plan,
+            &function_function_expr(FunctionFunctionId::Int(IntFunctionFunctionId(0))),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_string_function_function_call(
+            &plan,
+            &function_function_expr(FunctionFunctionId::String(StringFunctionFunctionId(0))),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_float_function_function_call(
+            &plan,
+            &function_function_expr(FunctionFunctionId::Float(FloatFunctionFunctionId(0))),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_bool_function_function_call(
+            &plan,
+            &function_function_expr(FunctionFunctionId::Bool(BoolFunctionFunctionId(0))),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_nil_function_function_call(
+            &plan,
+            &function_function_expr(FunctionFunctionId::Nil(NilFunctionFunctionId(0))),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_tuple_function_function_call(
+            &plan,
+            &function_function_expr(FunctionFunctionId::Tuple(TupleFunctionFunctionId(0))),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_list_function_function_call(
+            &plan,
+            &function_function_expr(FunctionFunctionId::List(ListFunctionFunctionId(0))),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+        assert_expected_function_got_int(run_function_function_function_call(
+            &plan,
+            &function_function_expr(FunctionFunctionId::Function(FunctionFunctionFunctionId(0))),
+            &[failing_function_function_arg()],
+            &mut Frame::default(),
+        ));
+    }
+
     fn assert_expected_function_got_int<T>(actual: Result<T, ExecutionError>) {
         assert_function_return_family_mismatch(
             actual,

--- a/src/runtime/function/bind.rs
+++ b/src/runtime/function/bind.rs
@@ -416,42 +416,56 @@ mod tests {
     }
 
     #[test]
-    fn float_function_captures_are_evaluated_and_bound() {
+    fn eval_capture_args_evaluates_all_capture_families() {
         let plan = plan();
         let captures = eval_capture_args(
             &plan,
             &mut Frame::default(),
             &[
+                CaptureArg::int(IntLocalId(0), IntExpr::value(1.into())),
+                CaptureArg::string(StringLocalId(0), StringExpr::value("one".into())),
+                CaptureArg::float(FloatLocalId(0), FloatExpr::value(1.5)),
+                CaptureArg::bool(BoolLocalId(0), BoolExpr::value(true)),
+                CaptureArg::nil(NilLocalId(0), NilExpr::value()),
+                CaptureArg::tuple(TupleLocalId(0), tuple_expr()),
+                CaptureArg::list(ListLocalId(0), list_expr()),
+                CaptureArg::int_function(IntFunctionLocalId(0), int_function_expr()),
+                CaptureArg::string_function(StringFunctionLocalId(0), string_function_expr()),
                 CaptureArg::float_function(FloatFunctionLocalId(0), float_function_expr()),
+                CaptureArg::bool_function(BoolFunctionLocalId(0), bool_function_expr()),
+                CaptureArg::nil_function(NilFunctionLocalId(0), nil_function_expr()),
                 CaptureArg::tuple_function(TupleFunctionLocalId(0), tuple_function_expr()),
                 CaptureArg::list_function(ListFunctionLocalId(0), list_function_expr()),
+                CaptureArg::function_function(FunctionFunctionLocalId(0), function_function_expr()),
             ],
         )
         .expect("capture args should evaluate");
-        let frame = bind_function_value_arguments(
-            &plan,
-            &[],
-            &mut Frame::default(),
-            FrameLayout::default(),
-            &captures,
-        )
-        .expect("captures should bind");
 
         assert_eq!(
-            frame
-                .get_float_function(FloatFunctionLocalId(0))
-                .runtime_id(),
-            FloatFunctionId(0),
-        );
-        assert_eq!(
-            frame
-                .get_tuple_function(TupleFunctionLocalId(0))
-                .runtime_id(),
-            TupleFunctionId(0),
-        );
-        assert_eq!(
-            frame.get_list_function(ListFunctionLocalId(0)).runtime_id(),
-            ListFunctionId(0),
+            captures,
+            vec![
+                CaptureValue::int(IntLocalId(0), 1.into()),
+                CaptureValue::string(StringLocalId(0), "one".into()),
+                CaptureValue::float(FloatLocalId(0), 1.5),
+                CaptureValue::bool(BoolLocalId(0), true),
+                CaptureValue::nil(NilLocalId(0)),
+                CaptureValue::tuple(TupleLocalId(0), vec![Value::Int(1.into())]),
+                CaptureValue::list(
+                    ListLocalId(0),
+                    ListValue::new(ValueType::Int, vec![Value::Int(1.into())]),
+                ),
+                CaptureValue::int_function(IntFunctionLocalId(0), int_function_value()),
+                CaptureValue::string_function(StringFunctionLocalId(0), string_function_value()),
+                CaptureValue::float_function(FloatFunctionLocalId(0), float_function_value()),
+                CaptureValue::bool_function(BoolFunctionLocalId(0), bool_function_value()),
+                CaptureValue::nil_function(NilFunctionLocalId(0), nil_function_value()),
+                CaptureValue::tuple_function(TupleFunctionLocalId(0), tuple_function_value()),
+                CaptureValue::list_function(ListFunctionLocalId(0), list_function_value()),
+                CaptureValue::function_function(
+                    FunctionFunctionLocalId(0),
+                    function_function_value(),
+                ),
+            ],
         );
     }
 

--- a/src/runtime/function/return_body.rs
+++ b/src/runtime/function/return_body.rs
@@ -470,19 +470,20 @@ mod tests {
     };
     use crate::plan::{
         BoolExpr, BoolFunctionExpr, BoolFunctionFunctionId, BoolFunctionId, BoolFunctionValue,
-        ExecutionPlan, Expr, FloatExpr, FloatFunctionExpr, FloatFunctionFunctionId,
+        CallArg, ExecutionPlan, Expr, FloatExpr, FloatFunctionExpr, FloatFunctionFunctionId,
         FloatFunctionId, FloatFunctionValue, FunctionExpr, FunctionExprKind, FunctionFunctionExpr,
-        FunctionFunctionFunctionId, FunctionFunctionId, FunctionFunctionValue, FunctionId,
-        FunctionPlan, FunctionReturnFamily, FunctionType, IntExpr, IntFunctionExpr,
-        IntFunctionFunctionId, IntFunctionId, IntFunctionValue, ListExpr, ListFunctionExpr,
-        ListFunctionFunctionId, ListFunctionId, ListFunctionValue, NilExpr, NilFunctionExpr,
-        NilFunctionFunctionId, NilFunctionId, NilFunctionValue, ReturnBody, ReturnExpr, Step,
-        StringExpr, StringFunctionExpr, StringFunctionFunctionId, StringFunctionId,
-        StringFunctionValue, TupleExpr, TupleFunctionExpr, TupleFunctionFunctionId,
-        TupleFunctionId, TupleFunctionValue, ValueType,
+        FunctionFunctionFunctionId, FunctionFunctionId, FunctionFunctionLocalId,
+        FunctionFunctionValue, FunctionId, FunctionPlan, FunctionReturnFamily, FunctionType,
+        IntExpr, IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, IntFunctionValue, ListExpr,
+        ListFunctionExpr, ListFunctionFunctionId, ListFunctionId, ListFunctionValue, ListValue,
+        NilExpr, NilFunctionExpr, NilFunctionFunctionId, NilFunctionId, NilFunctionValue,
+        ReturnBody, ReturnExpr, Step, StringExpr, StringFunctionExpr, StringFunctionFunctionId,
+        StringFunctionId, StringFunctionValue, TupleExpr, TupleFunctionExpr,
+        TupleFunctionFunctionId, TupleFunctionId, TupleFunctionValue, Value, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
+    use num_bigint::BigInt;
 
     #[test]
     fn primitive_return_loops_propagate_step_errors() {
@@ -556,25 +557,384 @@ mod tests {
     }
 
     #[test]
-    fn float_function_return_loop_follows_tail_call() {
-        let plan = float_function_tail_call_plan();
+    fn return_body_cases_and_block_choose_expected_branches() {
+        assert_eq!(
+            run_int_loop(
+                &int_return_body_plan(ReturnBody::bool_case(
+                    BoolExpr::value(true),
+                    ReturnBody::expr(IntExpr::value(1.into())),
+                    ReturnBody::expr(IntExpr::value(2.into())),
+                )),
+                IntFunctionId(0),
+                Frame::default(),
+            ),
+            Ok(1.into()),
+        );
+        assert_eq!(
+            run_int_loop(
+                &int_return_body_plan(ReturnBody::bool_case(
+                    BoolExpr::value(false),
+                    ReturnBody::expr(IntExpr::value(1.into())),
+                    ReturnBody::expr(IntExpr::value(2.into())),
+                )),
+                IntFunctionId(0),
+                Frame::default(),
+            ),
+            Ok(2.into()),
+        );
+        assert_eq!(
+            run_int_loop(
+                &int_return_body_plan(ReturnBody::int_case(
+                    IntExpr::value(2.into()),
+                    vec![(BigInt::from(2), ReturnBody::expr(IntExpr::value(3.into())))],
+                    ReturnBody::expr(IntExpr::value(4.into())),
+                )),
+                IntFunctionId(0),
+                Frame::default(),
+            ),
+            Ok(3.into()),
+        );
+        assert_eq!(
+            run_int_loop(
+                &int_return_body_plan(ReturnBody::int_case(
+                    IntExpr::value(5.into()),
+                    vec![(BigInt::from(2), ReturnBody::expr(IntExpr::value(3.into())))],
+                    ReturnBody::expr(IntExpr::value(4.into())),
+                )),
+                IntFunctionId(0),
+                Frame::default(),
+            ),
+            Ok(4.into()),
+        );
+        assert_eq!(
+            run_int_loop(
+                &int_return_body_plan(ReturnBody::float_case(
+                    FloatExpr::value(1.5),
+                    vec![(1.5, ReturnBody::expr(IntExpr::value(5.into())))],
+                    ReturnBody::expr(IntExpr::value(6.into())),
+                )),
+                IntFunctionId(0),
+                Frame::default(),
+            ),
+            Ok(5.into()),
+        );
+        assert_eq!(
+            run_int_loop(
+                &int_return_body_plan(ReturnBody::float_case(
+                    FloatExpr::value(2.5),
+                    vec![(1.5, ReturnBody::expr(IntExpr::value(5.into())))],
+                    ReturnBody::expr(IntExpr::value(6.into())),
+                )),
+                IntFunctionId(0),
+                Frame::default(),
+            ),
+            Ok(6.into()),
+        );
+        assert_eq!(
+            run_int_loop(
+                &int_return_body_plan(ReturnBody::string_case(
+                    StringExpr::value("hit".into()),
+                    vec![("hit".into(), ReturnBody::expr(IntExpr::value(7.into())))],
+                    ReturnBody::expr(IntExpr::value(8.into())),
+                )),
+                IntFunctionId(0),
+                Frame::default(),
+            ),
+            Ok(7.into()),
+        );
+        assert_eq!(
+            run_int_loop(
+                &int_return_body_plan(ReturnBody::string_case(
+                    StringExpr::value("miss".into()),
+                    vec![("hit".into(), ReturnBody::expr(IntExpr::value(7.into())))],
+                    ReturnBody::expr(IntExpr::value(8.into())),
+                )),
+                IntFunctionId(0),
+                Frame::default(),
+            ),
+            Ok(8.into()),
+        );
+        assert_eq!(
+            run_int_loop(
+                &int_return_body_plan(ReturnBody::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::value(0.into())))],
+                    ReturnBody::expr(IntExpr::value(9.into())),
+                )),
+                IntFunctionId(0),
+                Frame::default(),
+            ),
+            Ok(9.into()),
+        );
+        assert_expected_function_got_int(run_int_loop(
+            &int_return_body_plan(ReturnBody::block(
+                vec![failing_step()],
+                ReturnBody::expr(IntExpr::value(10.into())),
+            )),
+            IntFunctionId(0),
+            Frame::default(),
+        ));
+    }
 
+    #[test]
+    fn return_body_case_subject_errors_propagate() {
+        assert_expected_function_got_int(run_int_loop(
+            &int_return_body_plan(ReturnBody::bool_case(
+                failing_bool_expr(),
+                ReturnBody::expr(IntExpr::value(1.into())),
+                ReturnBody::expr(IntExpr::value(2.into())),
+            )),
+            IntFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_int_loop(
+            &int_return_body_plan(ReturnBody::int_case(
+                failing_int_expr(),
+                vec![(BigInt::from(1), ReturnBody::expr(IntExpr::value(1.into())))],
+                ReturnBody::expr(IntExpr::value(2.into())),
+            )),
+            IntFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_int_loop(
+            &int_return_body_plan(ReturnBody::float_case(
+                failing_float_expr(),
+                vec![(1.5, ReturnBody::expr(IntExpr::value(1.into())))],
+                ReturnBody::expr(IntExpr::value(2.into())),
+            )),
+            IntFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_int_loop(
+            &int_return_body_plan(ReturnBody::string_case(
+                failing_string_expr(),
+                vec![("hit".into(), ReturnBody::expr(IntExpr::value(1.into())))],
+                ReturnBody::expr(IntExpr::value(2.into())),
+            )),
+            IntFunctionId(0),
+            Frame::default(),
+        ));
+    }
+
+    #[test]
+    fn primitive_return_loops_propagate_return_body_errors() {
+        let plan = primitive_function_plan_with_return_body_errors();
+
+        assert_expected_function_got_int(run_int_loop(&plan, IntFunctionId(0), Frame::default()));
+        assert_expected_function_got_int(run_string_loop(
+            &plan,
+            StringFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_float_loop(
+            &plan,
+            FloatFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_bool_loop(&plan, BoolFunctionId(0), Frame::default()));
+        assert_expected_function_got_int(run_nil_loop(&plan, NilFunctionId(0), Frame::default()));
+        assert_expected_function_got_int(run_tuple_loop(
+            &plan,
+            TupleFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_list_loop(&plan, ListFunctionId(0), Frame::default()));
+    }
+
+    #[test]
+    fn function_return_loops_propagate_return_body_errors() {
+        let plan = function_function_plan_with_return_body_errors();
+
+        assert_expected_function_got_int(run_int_function_loop(
+            &plan,
+            IntFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_string_function_loop(
+            &plan,
+            StringFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_float_function_loop(
+            &plan,
+            FloatFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_bool_function_loop(
+            &plan,
+            BoolFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_nil_function_loop(
+            &plan,
+            NilFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_tuple_function_loop(
+            &plan,
+            TupleFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_list_function_loop(
+            &plan,
+            ListFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_function_function_loop(
+            &plan,
+            FunctionFunctionFunctionId(0),
+            Frame::default(),
+        ));
+    }
+
+    #[test]
+    fn primitive_return_loops_follow_tail_calls() {
+        let plan = primitive_tail_call_plan(Vec::new());
+
+        assert_eq!(
+            run_int_loop(&plan, IntFunctionId(0), Frame::default()),
+            Ok(2.into()),
+        );
+        assert_eq!(
+            run_string_loop(&plan, StringFunctionId(0), Frame::default()),
+            Ok("done".into()),
+        );
+        assert_eq!(
+            run_float_loop(&plan, FloatFunctionId(0), Frame::default()),
+            Ok(2.5),
+        );
+        assert_eq!(
+            run_bool_loop(&plan, BoolFunctionId(0), Frame::default()),
+            Ok(false),
+        );
+        assert_eq!(
+            run_nil_loop(&plan, NilFunctionId(0), Frame::default()),
+            Ok(())
+        );
+        assert_eq!(
+            run_tuple_loop(&plan, TupleFunctionId(0), Frame::default()),
+            Ok(vec![Value::Int(2.into())]),
+        );
+        assert_eq!(
+            run_list_loop(&plan, ListFunctionId(0), Frame::default()),
+            Ok(ListValue::new(ValueType::Int, vec![Value::Int(2.into())])),
+        );
+    }
+
+    #[test]
+    fn function_return_loops_follow_tail_calls() {
+        let plan = function_tail_call_plan(Vec::new());
+
+        assert_eq!(
+            run_int_function_loop(&plan, IntFunctionFunctionId(0), Frame::default())
+                .map(|value| value.runtime_id()),
+            Ok(IntFunctionId(0)),
+        );
+        assert_eq!(
+            run_string_function_loop(&plan, StringFunctionFunctionId(0), Frame::default())
+                .map(|value| value.runtime_id()),
+            Ok(StringFunctionId(0)),
+        );
         assert_eq!(
             run_float_function_loop(&plan, FloatFunctionFunctionId(0), Frame::default())
                 .map(|value| value.runtime_id()),
             Ok(FloatFunctionId(0)),
         );
-    }
-
-    #[test]
-    fn list_function_return_loop_follows_tail_call() {
-        let plan = list_function_tail_call_plan();
-
+        assert_eq!(
+            run_bool_function_loop(&plan, BoolFunctionFunctionId(0), Frame::default())
+                .map(|value| value.runtime_id()),
+            Ok(BoolFunctionId(0)),
+        );
+        assert_eq!(
+            run_nil_function_loop(&plan, NilFunctionFunctionId(0), Frame::default())
+                .map(|value| value.runtime_id()),
+            Ok(NilFunctionId(0)),
+        );
+        assert_eq!(
+            run_tuple_function_loop(&plan, TupleFunctionFunctionId(0), Frame::default())
+                .map(|value| value.runtime_id()),
+            Ok(TupleFunctionId(0)),
+        );
         assert_eq!(
             run_list_function_loop(&plan, ListFunctionFunctionId(0), Frame::default())
                 .map(|value| value.runtime_id()),
             Ok(ListFunctionId(0)),
         );
+        assert_eq!(
+            run_function_function_loop(&plan, FunctionFunctionFunctionId(0), Frame::default())
+                .map(|value| value.runtime_id()),
+            Ok(FunctionFunctionId::Int(IntFunctionFunctionId(0))),
+        );
+    }
+
+    #[test]
+    fn primitive_return_loops_propagate_tail_call_binding_errors() {
+        let plan = primitive_tail_call_binding_error_plan();
+
+        assert_expected_function_got_int(run_int_loop(&plan, IntFunctionId(0), Frame::default()));
+        assert_expected_function_got_int(run_string_loop(
+            &plan,
+            StringFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_float_loop(
+            &plan,
+            FloatFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_bool_loop(&plan, BoolFunctionId(0), Frame::default()));
+        assert_expected_function_got_int(run_nil_loop(&plan, NilFunctionId(0), Frame::default()));
+        assert_expected_function_got_int(run_tuple_loop(
+            &plan,
+            TupleFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_list_loop(&plan, ListFunctionId(0), Frame::default()));
+    }
+
+    #[test]
+    fn function_return_loops_propagate_tail_call_binding_errors() {
+        let plan = function_tail_call_binding_error_plan();
+
+        assert_expected_function_got_int(run_int_function_loop(
+            &plan,
+            IntFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_string_function_loop(
+            &plan,
+            StringFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_float_function_loop(
+            &plan,
+            FloatFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_bool_function_loop(
+            &plan,
+            BoolFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_nil_function_loop(
+            &plan,
+            NilFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_tuple_function_loop(
+            &plan,
+            TupleFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_list_function_loop(
+            &plan,
+            ListFunctionFunctionId(0),
+            Frame::default(),
+        ));
+        assert_expected_function_got_int(run_function_function_loop(
+            &plan,
+            FunctionFunctionFunctionId(0),
+            Frame::default(),
+        ));
     }
 
     fn assert_expected_function_got_int<T>(actual: Result<T, ExecutionError>) {
@@ -604,6 +964,24 @@ mod tests {
         Step::evaluate(Expr::function(FunctionExpr::function(
             failing_function_function_expr(),
         )))
+    }
+
+    fn failing_function_function_arg() -> CallArg {
+        CallArg::function_function(FunctionFunctionLocalId(0), failing_function_function_expr())
+    }
+
+    fn int_return_body_plan(body: ReturnBody<IntExpr, IntFunctionId>) -> ExecutionPlan {
+        ExecutionPlan::new(
+            "main".into(),
+            FunctionPlan::new(
+                FunctionId::new(0),
+                "main".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int_body(IntFunctionId(0), body),
+            ),
+            Vec::new(),
+        )
     }
 
     fn plan_with_function_function_steps(steps: Vec<Step>) -> ExecutionPlan {
@@ -704,7 +1082,7 @@ mod tests {
         )
     }
 
-    fn float_function_tail_call_plan() -> ExecutionPlan {
+    fn primitive_function_plan_with_return_body_errors() -> ExecutionPlan {
         ExecutionPlan::new(
             "main".into(),
             FunctionPlan::new(
@@ -712,38 +1090,64 @@ mod tests {
                 "main".into(),
                 Vec::new(),
                 Vec::new(),
-                ReturnExpr::int(IntFunctionId(0), IntExpr::value(1.into())),
+                ReturnExpr::int_body(IntFunctionId(0), failing_int_return_body()),
             ),
             vec![
                 FunctionPlan::new(
                     FunctionId::new(1),
-                    "tail".into(),
+                    "string".into(),
                     Vec::new(),
                     Vec::new(),
-                    ReturnExpr::float_function_body(
-                        FloatFunctionFunctionId(0),
-                        FunctionType::new(Vec::new(), ValueType::Float),
-                        ReturnBody::tail_call(FloatFunctionFunctionId(1), Vec::new()),
-                    ),
+                    ReturnExpr::string_body(StringFunctionId(0), failing_string_return_body()),
                 ),
                 FunctionPlan::new(
                     FunctionId::new(2),
-                    "done".into(),
+                    "float".into(),
                     Vec::new(),
                     Vec::new(),
-                    ReturnExpr::float_function(
-                        FloatFunctionFunctionId(1),
-                        FloatFunctionExpr::value(FloatFunctionValue::new(
-                            FloatFunctionId(0),
-                            Vec::new(),
-                        )),
+                    ReturnExpr::float_body(FloatFunctionId(0), failing_float_return_body()),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(3),
+                    "bool".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::bool_body(BoolFunctionId(0), failing_bool_return_body()),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(4),
+                    "nil".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::nil_body(NilFunctionId(0), failing_nil_return_body()),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(5),
+                    "tuple".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::tuple_body(
+                        TupleFunctionId(0),
+                        vec![ValueType::Int],
+                        failing_tuple_return_body(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(6),
+                    "list".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::list_body(
+                        ListFunctionId(0),
+                        ValueType::Int,
+                        failing_list_return_body(),
                     ),
                 ),
             ],
         )
     }
 
-    fn list_function_tail_call_plan() -> ExecutionPlan {
+    fn function_function_plan_with_return_body_errors() -> ExecutionPlan {
         ExecutionPlan::new(
             "main".into(),
             FunctionPlan::new(
@@ -756,31 +1160,597 @@ mod tests {
             vec![
                 FunctionPlan::new(
                     FunctionId::new(1),
-                    "tail".into(),
+                    "int_function".into(),
                     Vec::new(),
                     Vec::new(),
-                    ReturnExpr::list_function_body(
-                        ListFunctionFunctionId(0),
-                        FunctionType::new(Vec::new(), ValueType::List(Box::new(ValueType::Int))),
-                        ReturnBody::tail_call(ListFunctionFunctionId(1), Vec::new()),
+                    ReturnExpr::int_function_body(
+                        IntFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Int),
+                        failing_int_function_return_body(),
                     ),
                 ),
                 FunctionPlan::new(
                     FunctionId::new(2),
-                    "done".into(),
+                    "string_function".into(),
                     Vec::new(),
                     Vec::new(),
-                    ReturnExpr::list_function(
-                        ListFunctionFunctionId(1),
-                        ListFunctionExpr::value(ListFunctionValue::new(
-                            ListFunctionId(0),
-                            Vec::new(),
-                            ValueType::Int,
-                        )),
+                    ReturnExpr::string_function_body(
+                        StringFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::String),
+                        failing_string_function_return_body(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(3),
+                    "float_function".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::float_function_body(
+                        FloatFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Float),
+                        failing_float_function_return_body(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(4),
+                    "bool_function".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::bool_function_body(
+                        BoolFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Bool),
+                        failing_bool_function_return_body(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(5),
+                    "nil_function".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::nil_function_body(
+                        NilFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Nil),
+                        failing_nil_function_return_body(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(6),
+                    "tuple_function".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::tuple_function_body(
+                        TupleFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Tuple(vec![ValueType::Int])),
+                        failing_tuple_function_return_body(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(7),
+                    "list_function".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::list_function_body(
+                        ListFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::List(Box::new(ValueType::Int))),
+                        failing_list_function_return_body(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(8),
+                    "function_function".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::function_function_body(
+                        FunctionFunctionFunctionId(0),
+                        function_function_type(),
+                        failing_function_function_return_body(),
                     ),
                 ),
             ],
         )
+    }
+
+    fn primitive_tail_call_binding_error_plan() -> ExecutionPlan {
+        primitive_tail_call_plan(vec![failing_function_function_arg()])
+    }
+
+    fn primitive_tail_call_plan(args: Vec<CallArg>) -> ExecutionPlan {
+        ExecutionPlan::new(
+            "main".into(),
+            FunctionPlan::new(
+                FunctionId::new(0),
+                "main".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int_body(
+                    IntFunctionId(0),
+                    ReturnBody::tail_call(IntFunctionId(1), args.clone()),
+                ),
+            ),
+            vec![
+                FunctionPlan::new(
+                    FunctionId::new(1),
+                    "int_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::int(IntFunctionId(1), IntExpr::value(2.into())),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(2),
+                    "string_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::string_body(
+                        StringFunctionId(0),
+                        ReturnBody::tail_call(StringFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(3),
+                    "string_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::string(StringFunctionId(1), StringExpr::value("done".into())),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(4),
+                    "float_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::float_body(
+                        FloatFunctionId(0),
+                        ReturnBody::tail_call(FloatFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(5),
+                    "float_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::float(FloatFunctionId(1), FloatExpr::value(2.5)),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(6),
+                    "bool_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::bool_body(
+                        BoolFunctionId(0),
+                        ReturnBody::tail_call(BoolFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(7),
+                    "bool_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::bool(BoolFunctionId(1), BoolExpr::value(false)),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(8),
+                    "nil_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::nil_body(
+                        NilFunctionId(0),
+                        ReturnBody::tail_call(NilFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(9),
+                    "nil_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::nil(NilFunctionId(1), NilExpr::value()),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(10),
+                    "tuple_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::tuple_body(
+                        TupleFunctionId(0),
+                        vec![ValueType::Int],
+                        ReturnBody::tail_call(TupleFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(11),
+                    "tuple_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::tuple(TupleFunctionId(1), tuple_value_expr_with_int(2)),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(12),
+                    "list_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::list_body(
+                        ListFunctionId(0),
+                        ValueType::Int,
+                        ReturnBody::tail_call(ListFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(13),
+                    "list_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::list_body(
+                        ListFunctionId(1),
+                        ValueType::Int,
+                        ReturnBody::expr(list_value_expr_with_int(2)),
+                    ),
+                ),
+            ],
+        )
+    }
+
+    fn function_tail_call_binding_error_plan() -> ExecutionPlan {
+        function_tail_call_plan(vec![failing_function_function_arg()])
+    }
+
+    fn function_tail_call_plan(args: Vec<CallArg>) -> ExecutionPlan {
+        ExecutionPlan::new(
+            "main".into(),
+            FunctionPlan::new(
+                FunctionId::new(0),
+                "main".into(),
+                Vec::new(),
+                Vec::new(),
+                ReturnExpr::int(IntFunctionId(0), IntExpr::value(1.into())),
+            ),
+            vec![
+                FunctionPlan::new(
+                    FunctionId::new(1),
+                    "int_function_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::int_function_body(
+                        IntFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Int),
+                        ReturnBody::tail_call(IntFunctionFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(2),
+                    "int_function_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::int_function(IntFunctionFunctionId(1), int_function_value_expr()),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(3),
+                    "string_function_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::string_function_body(
+                        StringFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::String),
+                        ReturnBody::tail_call(StringFunctionFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(4),
+                    "string_function_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::string_function(
+                        StringFunctionFunctionId(1),
+                        string_function_value_expr(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(5),
+                    "float_function_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::float_function_body(
+                        FloatFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Float),
+                        ReturnBody::tail_call(FloatFunctionFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(6),
+                    "float_function_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::float_function(
+                        FloatFunctionFunctionId(1),
+                        float_function_value_expr(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(7),
+                    "bool_function_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::bool_function_body(
+                        BoolFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Bool),
+                        ReturnBody::tail_call(BoolFunctionFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(8),
+                    "bool_function_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::bool_function(
+                        BoolFunctionFunctionId(1),
+                        bool_function_value_expr(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(9),
+                    "nil_function_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::nil_function_body(
+                        NilFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Nil),
+                        ReturnBody::tail_call(NilFunctionFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(10),
+                    "nil_function_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::nil_function(NilFunctionFunctionId(1), nil_function_value_expr()),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(11),
+                    "tuple_function_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::tuple_function_body(
+                        TupleFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::Tuple(vec![ValueType::Int])),
+                        ReturnBody::tail_call(TupleFunctionFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(12),
+                    "tuple_function_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::tuple_function(
+                        TupleFunctionFunctionId(1),
+                        tuple_function_value_expr(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(13),
+                    "list_function_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::list_function_body(
+                        ListFunctionFunctionId(0),
+                        zero_arg_function_type(ValueType::List(Box::new(ValueType::Int))),
+                        ReturnBody::tail_call(ListFunctionFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(14),
+                    "list_function_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::list_function(
+                        ListFunctionFunctionId(1),
+                        list_function_value_expr(),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(15),
+                    "function_function_tail".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::function_function_body(
+                        FunctionFunctionFunctionId(0),
+                        function_function_type(),
+                        ReturnBody::tail_call(FunctionFunctionFunctionId(1), args.clone()),
+                    ),
+                ),
+                FunctionPlan::new(
+                    FunctionId::new(16),
+                    "function_function_done".into(),
+                    Vec::new(),
+                    Vec::new(),
+                    ReturnExpr::function_function(
+                        FunctionFunctionFunctionId(1),
+                        function_function_value_expr_typed(),
+                    ),
+                ),
+            ],
+        )
+    }
+
+    fn failing_int_return_body() -> ReturnBody<IntExpr, IntFunctionId> {
+        ReturnBody::expr(IntExpr::block(
+            vec![failing_step()],
+            IntExpr::value(1.into()),
+        ))
+    }
+
+    fn failing_string_return_body() -> ReturnBody<StringExpr, StringFunctionId> {
+        ReturnBody::expr(StringExpr::block(
+            vec![failing_step()],
+            StringExpr::value("geam".into()),
+        ))
+    }
+
+    fn failing_float_return_body() -> ReturnBody<FloatExpr, FloatFunctionId> {
+        ReturnBody::expr(FloatExpr::block(
+            vec![failing_step()],
+            FloatExpr::value(1.5),
+        ))
+    }
+
+    fn failing_bool_return_body() -> ReturnBody<BoolExpr, BoolFunctionId> {
+        ReturnBody::expr(BoolExpr::block(vec![failing_step()], BoolExpr::value(true)))
+    }
+
+    fn failing_nil_return_body() -> ReturnBody<NilExpr, NilFunctionId> {
+        ReturnBody::expr(NilExpr::block(vec![failing_step()], NilExpr::value()))
+    }
+
+    fn failing_tuple_return_body() -> ReturnBody<TupleExpr, TupleFunctionId> {
+        ReturnBody::expr(TupleExpr::block(vec![failing_step()], tuple_value_expr()))
+    }
+
+    fn failing_list_return_body() -> ReturnBody<ListExpr, ListFunctionId> {
+        ReturnBody::expr(ListExpr::block(vec![failing_step()], list_value_expr()))
+    }
+
+    fn failing_int_function_return_body() -> ReturnBody<IntFunctionExpr, IntFunctionFunctionId> {
+        ReturnBody::expr(IntFunctionExpr::block(
+            vec![failing_step()],
+            int_function_value_expr(),
+        ))
+    }
+
+    fn failing_string_function_return_body()
+    -> ReturnBody<StringFunctionExpr, StringFunctionFunctionId> {
+        ReturnBody::expr(StringFunctionExpr::block(
+            vec![failing_step()],
+            string_function_value_expr(),
+        ))
+    }
+
+    fn failing_float_function_return_body() -> ReturnBody<FloatFunctionExpr, FloatFunctionFunctionId>
+    {
+        ReturnBody::expr(FloatFunctionExpr::block(
+            vec![failing_step()],
+            float_function_value_expr(),
+        ))
+    }
+
+    fn failing_bool_function_return_body() -> ReturnBody<BoolFunctionExpr, BoolFunctionFunctionId> {
+        ReturnBody::expr(BoolFunctionExpr::block(
+            vec![failing_step()],
+            bool_function_value_expr(),
+        ))
+    }
+
+    fn failing_nil_function_return_body() -> ReturnBody<NilFunctionExpr, NilFunctionFunctionId> {
+        ReturnBody::expr(NilFunctionExpr::block(
+            vec![failing_step()],
+            nil_function_value_expr(),
+        ))
+    }
+
+    fn failing_tuple_function_return_body() -> ReturnBody<TupleFunctionExpr, TupleFunctionFunctionId>
+    {
+        ReturnBody::expr(TupleFunctionExpr::block(
+            vec![failing_step()],
+            tuple_function_value_expr(),
+        ))
+    }
+
+    fn failing_list_function_return_body() -> ReturnBody<ListFunctionExpr, ListFunctionFunctionId> {
+        ReturnBody::expr(ListFunctionExpr::block(
+            vec![failing_step()],
+            list_function_value_expr(),
+        ))
+    }
+
+    fn failing_function_function_return_body()
+    -> ReturnBody<FunctionFunctionExpr, FunctionFunctionFunctionId> {
+        ReturnBody::expr(FunctionFunctionExpr::block(
+            vec![failing_step()],
+            function_function_value_expr_typed(),
+        ))
+    }
+
+    fn failing_int_expr() -> IntExpr {
+        IntExpr::block(vec![failing_step()], IntExpr::value(1.into()))
+    }
+
+    fn failing_string_expr() -> StringExpr {
+        StringExpr::block(vec![failing_step()], StringExpr::value("geam".into()))
+    }
+
+    fn failing_float_expr() -> FloatExpr {
+        FloatExpr::block(vec![failing_step()], FloatExpr::value(1.5))
+    }
+
+    fn failing_bool_expr() -> BoolExpr {
+        BoolExpr::block(vec![failing_step()], BoolExpr::value(true))
+    }
+
+    fn tuple_value_expr() -> TupleExpr {
+        tuple_value_expr_with_int(1)
+    }
+
+    fn tuple_value_expr_with_int(value: i64) -> TupleExpr {
+        TupleExpr::value(
+            vec![Expr::int(IntExpr::value(value.into()))],
+            vec![ValueType::Int],
+        )
+    }
+
+    fn list_value_expr() -> ListExpr {
+        list_value_expr_with_int(1)
+    }
+
+    fn list_value_expr_with_int(value: i64) -> ListExpr {
+        ListExpr::value(
+            vec![Expr::int(IntExpr::value(value.into()))],
+            ValueType::Int,
+        )
+    }
+
+    fn int_function_value_expr() -> IntFunctionExpr {
+        IntFunctionExpr::value(IntFunctionValue::new(IntFunctionId(0), Vec::new()))
+    }
+
+    fn string_function_value_expr() -> StringFunctionExpr {
+        StringFunctionExpr::value(StringFunctionValue::new(StringFunctionId(0), Vec::new()))
+    }
+
+    fn float_function_value_expr() -> FloatFunctionExpr {
+        FloatFunctionExpr::value(FloatFunctionValue::new(FloatFunctionId(0), Vec::new()))
+    }
+
+    fn bool_function_value_expr() -> BoolFunctionExpr {
+        BoolFunctionExpr::value(BoolFunctionValue::new(BoolFunctionId(0), Vec::new()))
+    }
+
+    fn nil_function_value_expr() -> NilFunctionExpr {
+        NilFunctionExpr::value(NilFunctionValue::new(NilFunctionId(0), Vec::new()))
+    }
+
+    fn tuple_function_value_expr() -> TupleFunctionExpr {
+        TupleFunctionExpr::value(TupleFunctionValue::new(
+            TupleFunctionId(0),
+            Vec::new(),
+            vec![ValueType::Int],
+        ))
+    }
+
+    fn list_function_value_expr() -> ListFunctionExpr {
+        ListFunctionExpr::value(ListFunctionValue::new(
+            ListFunctionId(0),
+            Vec::new(),
+            ValueType::Int,
+        ))
+    }
+
+    fn function_function_value_expr_typed() -> FunctionFunctionExpr {
+        function_function_expr(FunctionFunctionId::Int(IntFunctionFunctionId(0)))
+    }
+
+    fn zero_arg_function_type(return_: ValueType) -> FunctionType {
+        FunctionType::new(Vec::new(), return_)
+    }
+
+    fn function_function_type() -> FunctionType {
+        zero_arg_function_type(ValueType::Function(Box::new(zero_arg_function_type(
+            ValueType::Int,
+        ))))
     }
 
     fn function_plan(

--- a/src/runtime/function/steps.rs
+++ b/src/runtime/function/steps.rs
@@ -94,10 +94,12 @@ mod tests {
         FunctionFunctionId, FunctionFunctionLocalId, FunctionFunctionValue, FunctionId,
         FunctionPlan, FunctionReturnFamily, FunctionType, IntExpr, IntFunctionExpr,
         IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId, IntFunctionValue, IntLocalId,
-        NilExpr, NilFunctionExpr, NilFunctionId, NilFunctionLocalId, NilFunctionValue, NilLocalId,
-        ReturnExpr, Step, StringExpr, StringFunctionExpr, StringFunctionId, StringFunctionLocalId,
-        StringFunctionValue, StringLocalId, TupleExpr, TupleFunctionExpr, TupleFunctionId,
-        TupleFunctionLocalId, TupleFunctionValue, TupleLocalId, Value, ValueType,
+        ListExpr, ListFunctionExpr, ListFunctionId, ListFunctionLocalId, ListFunctionValue,
+        ListLocalId, ListValue, NilExpr, NilFunctionExpr, NilFunctionId, NilFunctionLocalId,
+        NilFunctionValue, NilLocalId, ReturnExpr, Step, StringExpr, StringFunctionExpr,
+        StringFunctionId, StringFunctionLocalId, StringFunctionValue, StringLocalId, TupleExpr,
+        TupleFunctionExpr, TupleFunctionId, TupleFunctionLocalId, TupleFunctionValue, TupleLocalId,
+        Value, ValueType,
     };
     use crate::runtime::ExecutionError;
     use crate::runtime::frame::Frame;
@@ -113,6 +115,7 @@ mod tests {
             Step::let_bool(BoolLocalId(0), "x".into(), failing_bool_expr()),
             Step::let_nil(NilLocalId(0), "x".into(), failing_nil_expr()),
             Step::let_tuple(TupleLocalId(0), "x".into(), failing_tuple_expr()),
+            Step::let_list(ListLocalId(0), "x".into(), failing_list_expr()),
             Step::let_int_function(
                 IntFunctionLocalId(0),
                 "x".into(),
@@ -143,6 +146,11 @@ mod tests {
                 "x".into(),
                 failing_tuple_function_expr(),
             ),
+            Step::let_list_function(
+                ListFunctionLocalId(0),
+                "x".into(),
+                failing_list_function_expr(),
+            ),
             Step::let_function_function(
                 FunctionFunctionLocalId(0),
                 "x".into(),
@@ -170,12 +178,14 @@ mod tests {
             Step::let_bool(BoolLocalId(0), "x".into(), BoolExpr::value(true)),
             Step::let_nil(NilLocalId(0), "x".into(), NilExpr::value()),
             Step::let_tuple(TupleLocalId(0), "x".into(), tuple_expr()),
+            Step::let_list(ListLocalId(0), "x".into(), list_expr()),
             Step::let_int_function(IntFunctionLocalId(0), "x".into(), int_function_expr()),
             Step::let_string_function(StringFunctionLocalId(0), "x".into(), string_function_expr()),
             Step::let_float_function(FloatFunctionLocalId(0), "x".into(), float_function_expr()),
             Step::let_bool_function(BoolFunctionLocalId(0), "x".into(), bool_function_expr()),
             Step::let_nil_function(NilFunctionLocalId(0), "x".into(), nil_function_expr()),
             Step::let_tuple_function(TupleFunctionLocalId(0), "x".into(), tuple_function_expr()),
+            Step::let_list_function(ListFunctionLocalId(0), "x".into(), list_function_expr()),
             Step::let_function_function(
                 FunctionFunctionLocalId(0),
                 "x".into(),
@@ -191,6 +201,10 @@ mod tests {
         assert!(frame.get_bool(BoolLocalId(0)));
         assert_eq!(frame.get_nil(NilLocalId(0)), ());
         assert_eq!(frame.get_tuple(TupleLocalId(0)), vec![Value::Int(1.into())]);
+        assert_eq!(
+            frame.get_list(ListLocalId(0)),
+            ListValue::new(ValueType::Int, vec![Value::Int(1.into())]),
+        );
         assert_eq!(
             frame.get_int_function(IntFunctionLocalId(0)).runtime_id(),
             IntFunctionId(0),
@@ -220,6 +234,10 @@ mod tests {
                 .get_tuple_function(TupleFunctionLocalId(0))
                 .runtime_id(),
             TupleFunctionId(0),
+        );
+        assert_eq!(
+            frame.get_list_function(ListFunctionLocalId(0)).runtime_id(),
+            ListFunctionId(0),
         );
         assert_eq!(
             frame
@@ -291,6 +309,14 @@ mod tests {
         )
     }
 
+    fn failing_list_expr() -> ListExpr {
+        ListExpr::function_call(failing_list_function_expr(), Vec::new(), ValueType::Int)
+    }
+
+    fn list_expr() -> ListExpr {
+        ListExpr::value(vec![Expr::int(IntExpr::value(1.into()))], ValueType::Int)
+    }
+
     fn int_function_expr() -> IntFunctionExpr {
         IntFunctionExpr::value(IntFunctionValue::new(IntFunctionId(0), Vec::new()))
     }
@@ -316,6 +342,14 @@ mod tests {
             TupleFunctionId(0),
             Vec::new(),
             vec![ValueType::Int],
+        ))
+    }
+
+    fn list_function_expr() -> ListFunctionExpr {
+        ListFunctionExpr::value(ListFunctionValue::new(
+            ListFunctionId(0),
+            Vec::new(),
+            ValueType::Int,
         ))
     }
 
@@ -375,6 +409,14 @@ mod tests {
         )
     }
 
+    fn failing_list_function_expr() -> ListFunctionExpr {
+        ListFunctionExpr::function_call(
+            failing_function_function_expr(),
+            Vec::new(),
+            FunctionType::new(Vec::new(), ValueType::List(Box::new(ValueType::Int))),
+        )
+    }
+
     fn plan() -> ExecutionPlan {
         ExecutionPlan::new(
             "main".into(),
@@ -397,12 +439,14 @@ mod tests {
         layout.include_bool(BoolLocalId(0));
         layout.include_nil(NilLocalId(0));
         layout.include_tuple(TupleLocalId(0));
+        layout.include_list(ListLocalId(0));
         layout.include_int_function(IntFunctionLocalId(0));
         layout.include_string_function(StringFunctionLocalId(0));
         layout.include_float_function(FloatFunctionLocalId(0));
         layout.include_bool_function(BoolFunctionLocalId(0));
         layout.include_nil_function(NilFunctionLocalId(0));
         layout.include_tuple_function(TupleFunctionLocalId(0));
+        layout.include_list_function(ListFunctionLocalId(0));
         layout.include_function_function(FunctionFunctionLocalId(0));
         layout
     }


### PR DESCRIPTION
- Bring all `src/runtime/function/**` files to 100% region coverage.
- Cover runtime function step, bind, call wrapper, and return-loop branches with owning unit tests.
- Keep coverage focused on runtime internals without adding execution fixtures.
