### PR TITLE
Add main verification workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: Verify
+name: Checks
 
 on:
   push:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  # Temporary trigger for validating this workflow before the first merge.
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,48 @@
+name: Verify
+
+on:
+  push:
+    branches:
+      - main
+  # Temporary trigger for validating this workflow before the first merge.
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify:
+    name: fmt, clippy, test, coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, llvm-tools-preview, rustfmt
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --version 0.8.7 --locked
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Run locked tests
+        run: cargo test --locked
+
+      - name: Check coverage
+        run: cargo llvm-cov --summary-only --fail-under-lines 100 --fail-under-regions 100

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,7 +30,9 @@ jobs:
           components: clippy, llvm-tools-preview, rustfmt
 
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --version 0.8.7 --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov@0.8.7
 
       - name: Check formatting
         run: cargo fmt --check

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,35 +16,90 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  verify:
-    name: fmt, clippy, test, coverage
+  fmt:
+    name: fmt
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: clippy, llvm-tools-preview, rustfmt
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov@0.8.7
+          components: rustfmt
+          cache: false
+          rustflags: ""
 
       - name: Check formatting
         run: cargo fmt --check
 
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+          cache: false
+          rustflags: ""
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          rustflags: ""
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
 
       - name: Run tests
         run: cargo test
 
       - name: Run locked tests
         run: cargo test --locked
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: llvm-tools-preview
+          cache: false
+          rustflags: ""
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov@0.8.7
 
       - name: Check coverage
         run: cargo llvm-cov --summary-only --fail-under-lines 100 --fail-under-regions 100

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96"
+profile = "minimal"


### PR DESCRIPTION
- Run fmt, clippy, tests, locked tests, and line/region coverage in GitHub Actions.
- Trigger on pushes to `main`, with a temporary PR trigger for workflow validation.
- Install stable Rust plus cargo-llvm-cov 0.8.7 for the CI coverage gate.
