### PR TITLE
Support assert statements

### DIFF
--- a/src/plan/frame/step.rs
+++ b/src/plan/frame/step.rs
@@ -81,6 +81,12 @@ impl FrameLayout {
                     self.include_string_expr(message);
                 }
             }
+            StepKind::AssertBool { condition, message } => {
+                self.include_bool_expr(condition);
+                if let Some(message) = message {
+                    self.include_string_expr(message);
+                }
+            }
             StepKind::Evaluate(value) => self.include_expr(value),
         }
     }
@@ -286,5 +292,19 @@ mod tests {
         assert_eq!(layout.ints(), 1);
         assert_eq!(layout.strings(), 2);
         assert_eq!(layout.lists(), 2);
+    }
+
+    #[test]
+    fn frame_layout_includes_assert_bool_dependencies() {
+        let steps = [crate::plan::Step::assert_bool(
+            BoolExpr::local_get(BoolLocalId(0), "condition".into()),
+            Some(StringExpr::local_get(StringLocalId(0), "message".into())),
+        )];
+        let return_ = ReturnExpr::int(IntFunctionId(0), IntExpr::value(0.into()));
+
+        let layout = FrameLayout::from_function_parts(&[], &steps, &return_);
+
+        assert_eq!(layout.bools(), 1);
+        assert_eq!(layout.strings(), 1);
     }
 }

--- a/src/plan/step.rs
+++ b/src/plan/step.rs
@@ -136,6 +136,10 @@ pub(crate) enum StepKind {
         pattern: AssertPattern,
         message: Option<StringExpr>,
     },
+    AssertBool {
+        condition: BoolExpr,
+        message: Option<StringExpr>,
+    },
     Evaluate(Expr),
 }
 
@@ -329,6 +333,12 @@ impl Step {
         }
     }
 
+    pub(crate) fn assert_bool(condition: BoolExpr, message: Option<StringExpr>) -> Self {
+        Self {
+            kind: StepKind::AssertBool { condition, message },
+        }
+    }
+
     pub(crate) fn assert_list(
         local: ListLocalId,
         pattern: AssertPattern,
@@ -352,8 +362,9 @@ impl Step {
 mod tests {
     use super::{Step, StepKind};
     use crate::plan::{
-        AssertPattern, Expr, IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionValue,
-        IntLocalId, ListAssertPattern, ListAssertTail, ListLocalId, ParamLocal, ValueType,
+        AssertPattern, BoolExpr, Expr, IntExpr, IntFunctionId, IntFunctionLocalId,
+        IntFunctionValue, IntLocalId, ListAssertPattern, ListAssertTail, ListLocalId, ParamLocal,
+        StringExpr, ValueType,
     };
     use num_bigint::BigInt;
 
@@ -378,6 +389,17 @@ mod tests {
         assert_eq!(
             Step::evaluate(Expr::int(IntExpr::value(BigInt::from(1)))).kind(),
             &StepKind::Evaluate(Expr::int(IntExpr::value(BigInt::from(1)))),
+        );
+        assert_eq!(
+            Step::assert_bool(
+                BoolExpr::value(false),
+                Some(StringExpr::value("nope".into()))
+            )
+            .kind(),
+            &StepKind::AssertBool {
+                condition: BoolExpr::value(false),
+                message: Some(StringExpr::value("nope".into())),
+            },
         );
         assert_eq!(
             Step::assert_list(

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -13,7 +13,7 @@ pub use error::{
     InvalidTypedAstReason, InvalidUseShapeReason, PlanError, UnsupportedArgumentReason,
     UnsupportedBinOpKind, UnsupportedCaseReason, UnsupportedExpressionKind,
     UnsupportedFunctionReason, UnsupportedPatternKind, UnsupportedPipelineReason,
-    UnsupportedStatementKind, UnsupportedTopLevelKind,
+    UnsupportedTopLevelKind,
 };
 pub use module::plan_module;
 

--- a/src/planner/error.rs
+++ b/src/planner/error.rs
@@ -12,7 +12,7 @@ pub use invalid::{
 pub use unsupported::{
     UnsupportedArgumentReason, UnsupportedBinOpKind, UnsupportedCaseReason,
     UnsupportedExpressionKind, UnsupportedFunctionReason, UnsupportedPatternKind,
-    UnsupportedPipelineReason, UnsupportedStatementKind, UnsupportedTopLevelKind,
+    UnsupportedPipelineReason, UnsupportedTopLevelKind,
 };
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -31,9 +31,6 @@ pub enum PlanError {
         function: EcoString,
         reason: UnsupportedArgumentReason,
     },
-
-    #[error("unsupported statement: {kind}")]
-    UnsupportedStatement { kind: UnsupportedStatementKind },
 
     #[error("unsupported pattern: {kind}")]
     UnsupportedPattern { kind: UnsupportedPatternKind },

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -27,14 +27,6 @@ pub enum UnsupportedArgumentReason {
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
-pub enum UnsupportedStatementKind {
-    #[error("assert")]
-    Assert,
-    #[error("assert as final statement")]
-    AssertAsFinalStatement,
-}
-
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedPatternKind {
     #[error("list")]
     List,

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -499,7 +499,7 @@ fn plan_int_expr(
         .ok_or_else(|| invalid_expression_type(InvalidExpressionType::Int, actual))
 }
 
-fn plan_string_expr(
+pub(super) fn plan_string_expr(
     expression: TypedExpr,
     context: &mut PlanContext<'_>,
 ) -> Result<StringExpr, PlanError> {
@@ -523,7 +523,7 @@ fn plan_float_expr(
         .ok_or_else(|| invalid_expression_type(InvalidExpressionType::Float, actual))
 }
 
-fn plan_bool_expr(
+pub(super) fn plan_bool_expr(
     expression: TypedExpr,
     context: &mut PlanContext<'_>,
 ) -> Result<BoolExpr, PlanError> {

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -310,7 +310,7 @@ mod tests {
     use crate::planner::error::{
         InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
         InvalidPipelineShapeReason, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
-        UnsupportedPatternKind, UnsupportedStatementKind,
+        UnsupportedPatternKind,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, dummy_span};
@@ -963,26 +963,6 @@ pub fn main() {
                 reason: InvalidTypedAstReason::PipelineShape {
                     reason: InvalidPipelineShapeReason::NonCallStep,
                 },
-            }),
-        );
-    }
-
-    #[test]
-    fn reject_profile_anonymous_function_assert_statement() {
-        assert_eq!(
-            plan_module(compile(
-                r#"
-pub fn main() {
-  fn() {
-    assert True
-    1
-  }
-  1
-}
-"#,
-            )),
-            Err(PlanError::UnsupportedStatement {
-                kind: UnsupportedStatementKind::Assert,
             }),
         );
     }

--- a/src/planner/expression/function/free_variables.rs
+++ b/src/planner/expression/function/free_variables.rs
@@ -77,7 +77,12 @@ fn collect_statement(
         Statement::Use(use_) => {
             collect_expr(&use_.call, bound, free);
         }
-        Statement::Assert(_) => {}
+        Statement::Assert(assert) => {
+            collect_expr(&assert.value, bound, free);
+            if let Some(message) = &assert.message {
+                collect_expr(message, bound, free);
+            }
+        }
     }
 }
 
@@ -273,6 +278,9 @@ pub fn main() {
   let list_tail_value = [7]
   let panic_message = "boom"
   let todo_message = "later"
+  let assert_condition = True
+  let assert_message = "failed"
+  let plain_assert_condition = True
   fn() {
     {
       block_value
@@ -296,6 +304,8 @@ pub fn main() {
     [0, ..list_tail_value]
     panic as panic_message
     todo as todo_message
+    assert assert_condition as assert_message
+    assert plain_assert_condition
   }
   1
 }
@@ -314,6 +324,9 @@ pub fn main() {
                 "list_tail_value".to_string(),
                 "panic_message".to_string(),
                 "todo_message".to_string(),
+                "assert_condition".to_string(),
+                "assert_message".to_string(),
+                "plain_assert_condition".to_string(),
             ],
         );
     }

--- a/src/planner/statement.rs
+++ b/src/planner/statement.rs
@@ -3,11 +3,13 @@ mod use_;
 
 pub(in crate::planner) use assignment::plan_variable_runtime_step;
 
-use crate::plan::{Step, ValueType};
+use crate::plan::{Expr, NilExpr, Step, ValueType};
 use crate::planner::context::PlanContext;
-use crate::planner::error::{InvalidTypedAstReason, PlanError, UnsupportedStatementKind};
-use crate::planner::expression::{plan_expr, plan_expr_with_expected_source_stop_type};
-use gleam_core::ast::Statement;
+use crate::planner::error::{InvalidTypedAstReason, PlanError};
+use crate::planner::expression::{
+    plan_bool_expr, plan_expr, plan_expr_with_expected_source_stop_type, plan_string_expr,
+};
+use gleam_core::ast::{Statement, TypedAssert};
 use vec1::Vec1;
 
 pub(super) struct PlannedStatements {
@@ -62,10 +64,9 @@ fn plan_ordered_steps_and_return(
             planned.value
         }
         Statement::Use(use_) => use_::plan_use_statement(use_, context)?,
-        Statement::Assert(_) => {
-            return Err(PlanError::UnsupportedStatement {
-                kind: UnsupportedStatementKind::AssertAsFinalStatement,
-            });
+        Statement::Assert(assert) => {
+            steps.push(plan_assert_step(assert, context)?);
+            Expr::nil(NilExpr::value())
         }
     };
 
@@ -84,20 +85,29 @@ pub(super) fn plan_runtime_steps(
         Statement::Use(_) => Err(PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::UseStatement,
         }),
-        Statement::Assert(_) => Err(PlanError::UnsupportedStatement {
-            kind: UnsupportedStatementKind::Assert,
-        }),
+        Statement::Assert(assert) => Ok(vec![plan_assert_step(assert, context)?]),
     }
+}
+
+fn plan_assert_step(assert: TypedAssert, context: &mut PlanContext<'_>) -> Result<Step, PlanError> {
+    let message = assert
+        .message
+        .map(|message| plan_string_expr(message, context))
+        .transpose()?;
+    let condition = plan_bool_expr(assert.value, context)?;
+
+    Ok(Step::assert_bool(condition, message))
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::plan::{BoolExpr, Step, StringExpr};
     use crate::planner::context::{AnonymousFunctions, PlanContext};
-    use crate::planner::dsl::{function, int, module};
+    use crate::planner::dsl::{function, int, module, nil};
     use crate::planner::plan_module;
-    use crate::planner::support::{compile, compile_minimal_module, dummy_span, expect_plan_error};
+    use crate::planner::support::{compile, compile_minimal_module, dummy_span};
     use crate::planner::{
-        InvalidTypedAstReason, PlanError, UnsupportedExpressionKind, UnsupportedStatementKind,
+        InvalidExpressionType, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
     };
     use gleam_core::ast::{Statement, TypedExpr};
     use gleam_core::type_;
@@ -159,35 +169,173 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_assert_statement() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+    fn plan_assert_statement_steps() {
+        let actual = plan_module(compile(
+            r#"
 pub fn main() {
   assert True
   1
 }
 "#,
-            ),
-            PlanError::UnsupportedStatement {
-                kind: UnsupportedStatementKind::Assert,
-            },
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", int(1)).step(Step::assert_bool(BoolExpr::value(true), None)),
+            [],
         );
+
+        assert_eq!(actual, expected);
     }
 
     #[test]
-    fn reject_profile_final_assert_statement() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+    fn plan_final_assert_statement_returns_nil() {
+        let actual = plan_module(compile(
+            r#"
 pub fn main() {
   assert True
 }
 "#,
-            ),
-            PlanError::UnsupportedStatement {
-                kind: UnsupportedStatementKind::AssertAsFinalStatement,
-            },
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", nil()).step(Step::assert_bool(BoolExpr::value(true), None)),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_assert_statement_with_message() {
+        let actual = plan_module(compile(
+            r#"
+pub fn main() {
+  assert True as "ok"
+  1
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", int(1)).step(Step::assert_bool(
+                BoolExpr::value(true),
+                Some(StringExpr::value("ok".into())),
+            )),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_margin_assert_condition_type_mismatch() {
+        let mut module = compile_minimal_module();
+        module.definitions.functions[0].body = vec![
+            Statement::Assert(gleam_core::ast::Assert {
+                location: dummy_span(),
+                value: typed_int_expr(1),
+                message: None,
+            }),
+            Statement::Expression(typed_int_expr(1)),
+        ];
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Bool,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_assert_message_type_mismatch() {
+        let mut module = compile_minimal_module();
+        module.definitions.functions[0].body = vec![
+            Statement::Assert(gleam_core::ast::Assert {
+                location: dummy_span(),
+                value: typed_bool_expr(false),
+                message: Some(typed_int_expr(1)),
+            }),
+            Statement::Expression(typed_int_expr(1)),
+        ];
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::String,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_assert_message_type_takes_precedence_over_condition_type() {
+        let mut module = compile_minimal_module();
+        module.definitions.functions[0].body = vec![
+            Statement::Assert(gleam_core::ast::Assert {
+                location: dummy_span(),
+                value: typed_int_expr(1),
+                message: Some(typed_int_expr(2)),
+            }),
+            Statement::Expression(typed_int_expr(3)),
+        ];
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::String,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_final_assert_condition_type_mismatch() {
+        let mut module = compile_minimal_module();
+        module.definitions.functions[0].body = vec![Statement::Assert(gleam_core::ast::Assert {
+            location: dummy_span(),
+            value: typed_int_expr(1),
+            message: None,
+        })];
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Bool,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_final_assert_message_type_mismatch() {
+        let mut module = compile_minimal_module();
+        module.definitions.functions[0].body = vec![Statement::Assert(gleam_core::ast::Assert {
+            location: dummy_span(),
+            value: typed_bool_expr(true),
+            message: Some(typed_int_expr(1)),
+        })];
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::String,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
         );
     }
 
@@ -218,6 +366,32 @@ pub fn main() {
             type_: type_::int(),
             value: value.to_string().into(),
             int_value: BigInt::from(value),
+        }
+    }
+
+    fn typed_bool_expr(value: bool) -> TypedExpr {
+        use gleam_core::ast::Publicity;
+        use gleam_core::type_::{Deprecation, ValueConstructor, ValueConstructorVariant};
+
+        let name = if value { "True" } else { "False" };
+        TypedExpr::Var {
+            location: dummy_span(),
+            name: name.into(),
+            constructor: ValueConstructor {
+                publicity: Publicity::Private,
+                deprecation: Deprecation::NotDeprecated,
+                type_: type_::bool(),
+                variant: ValueConstructorVariant::Record {
+                    name: name.into(),
+                    arity: 0,
+                    field_map: None,
+                    location: dummy_span(),
+                    module: type_::PRELUDE_MODULE_NAME.into(),
+                    variants_count: 1,
+                    variant_index: 0,
+                    documentation: None,
+                },
+            },
         }
     }
 }

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -24,6 +24,7 @@ pub enum ExecutionError {
 pub enum PanicKind {
     Panic { message: Option<EcoString> },
     Todo { message: Option<EcoString> },
+    Assert { message: Option<EcoString> },
     LetAssert { message: Option<EcoString> },
     EmptyFunction,
     EmptyBlock,
@@ -35,6 +36,7 @@ impl fmt::Display for PanicKind {
         match self {
             PanicKind::Panic { message } => write_panic_message(f, "panic", message.as_deref()),
             PanicKind::Todo { message } => write_panic_message(f, "todo", message.as_deref()),
+            PanicKind::Assert { message } => write_panic_message(f, "assert", message.as_deref()),
             PanicKind::LetAssert { message } => {
                 write_panic_message(f, "let assert", message.as_deref())
             }
@@ -96,6 +98,13 @@ mod tests {
                     message: Some("later".into()),
                 },
                 "todo as \"later\"",
+            ),
+            (PanicKind::Assert { message: None }, "assert"),
+            (
+                PanicKind::Assert {
+                    message: Some("nope".into()),
+                },
+                "assert as \"nope\"",
             ),
             (PanicKind::LetAssert { message: None }, "let assert"),
             (

--- a/src/runtime/function/steps.rs
+++ b/src/runtime/function/steps.rs
@@ -104,6 +104,15 @@ pub(in crate::runtime) fn execute_steps(
                     frame_set_binding(frame, binding);
                 }
             }
+            StepKind::AssertBool { condition, message } => {
+                let message = match message {
+                    Some(message) => Some(eval_string_expr(plan, frame, message)?),
+                    None => None,
+                };
+                if !eval_bool_expr(plan, frame, condition)? {
+                    return Err(ExecutionError::panic(PanicKind::Assert { message }));
+                }
+            }
             StepKind::Evaluate(expression) => {
                 let _ = eval_expr(plan, frame, expression)?;
             }
@@ -310,9 +319,10 @@ mod tests {
         IntFunctionValue, IntLocalId, ListAssertPattern, ListAssertTail, ListExpr,
         ListFunctionExpr, ListFunctionId, ListFunctionLocalId, ListFunctionValue, ListLocalId,
         ListValue, NilExpr, NilFunctionExpr, NilFunctionId, NilFunctionLocalId, NilFunctionValue,
-        NilLocalId, ParamLocal, ReturnExpr, Step, StringExpr, StringFunctionExpr, StringFunctionId,
-        StringFunctionLocalId, StringFunctionValue, StringLocalId, TupleExpr, TupleFunctionExpr,
-        TupleFunctionId, TupleFunctionLocalId, TupleFunctionValue, TupleLocalId, Value, ValueType,
+        NilLocalId, PanicExpr, ParamLocal, ReturnExpr, Step, StringExpr, StringFunctionExpr,
+        StringFunctionId, StringFunctionLocalId, StringFunctionValue, StringLocalId, TupleExpr,
+        TupleFunctionExpr, TupleFunctionId, TupleFunctionLocalId, TupleFunctionValue, TupleLocalId,
+        Value, ValueType,
     };
     use crate::runtime::frame::Frame;
     use crate::runtime::{ExecutionError, PanicKind};
@@ -484,6 +494,95 @@ mod tests {
             frame.get_list(ListLocalId(1)),
             ListValue::new(ValueType::Int, vec![Value::Int(2.into())]),
         );
+    }
+
+    #[test]
+    fn execute_steps_assert_bool_continues_after_true_condition() {
+        let plan = plan();
+
+        assert_eq!(
+            execute_steps(
+                &plan,
+                &[Step::assert_bool(
+                    BoolExpr::value(true),
+                    Some(StringExpr::value("ok".into())),
+                )],
+                &mut Frame::default(),
+            ),
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn execute_steps_assert_bool_returns_assert_panic_after_false_condition() {
+        let plan = plan();
+
+        assert_eq!(
+            execute_steps(
+                &plan,
+                &[Step::assert_bool(BoolExpr::value(false), None)],
+                &mut Frame::default(),
+            ),
+            Err(ExecutionError::panic(PanicKind::Assert { message: None })),
+        );
+        assert_eq!(
+            execute_steps(
+                &plan,
+                &[Step::assert_bool(
+                    BoolExpr::value(false),
+                    Some(StringExpr::value("nope".into())),
+                )],
+                &mut Frame::default(),
+            ),
+            Err(ExecutionError::panic(PanicKind::Assert {
+                message: Some("nope".into()),
+            })),
+        );
+    }
+
+    #[test]
+    fn execute_steps_assert_bool_evaluates_message_before_condition() {
+        let plan = plan();
+
+        assert_eq!(
+            execute_steps(
+                &plan,
+                &[Step::assert_bool(
+                    BoolExpr::panic(PanicExpr::todo(None)),
+                    Some(StringExpr::panic(PanicExpr::panic(None))),
+                )],
+                &mut Frame::default(),
+            ),
+            Err(ExecutionError::panic(PanicKind::Panic { message: None })),
+        );
+    }
+
+    #[test]
+    fn execute_steps_assert_bool_propagates_message_error_before_condition() {
+        let plan = plan();
+
+        assert_expected_function_got_int(execute_steps(
+            &plan,
+            &[Step::assert_bool(
+                failing_bool_expr(),
+                Some(failing_string_expr()),
+            )],
+            &mut Frame::default(),
+        ));
+    }
+
+    #[test]
+    fn execute_steps_assert_bool_propagates_condition_error_after_message() {
+        let plan = plan();
+
+        assert_expected_function_got_int(execute_steps(
+            &plan,
+            &[Step::assert_bool(
+                failing_bool_expr(),
+                Some(StringExpr::value("checked".into())),
+            )],
+            &mut Frame::default(),
+        ));
     }
 
     #[test]

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -88,6 +88,8 @@ mod statements {
         final_discard_assignment,
         final_tuple_destructuring,
         final_pattern_alias_assignment,
+        assert_statement,
+        final_assert,
     );
 }
 
@@ -241,6 +243,7 @@ mod functions {
             anonymous_function_returning_function,
             anonymous_float_function,
             anonymous_list_function,
+            anonymous_assert_statement,
             anonymous_function_main_returning_function,
             anonymous_todo_body_not_called,
             function_capture_literal,
@@ -328,6 +331,15 @@ mod execution_errors {
             let_assert_message,
         );
     }
+
+    mod statements {
+        execution_error_cases!("statements";
+            assert_statement,
+            assert_message,
+            assert_message_before_condition,
+            assert_condition_error_after_message,
+        );
+    }
 }
 
 mod rejection {
@@ -359,7 +371,6 @@ mod rejection {
             unsupported_list_return_type,
             unsupported_body_before_main,
             unsupported_body_after_main,
-            anonymous_assert_statement,
             anonymous_unsupported_argument_type,
             anonymous_unsupported_return_type,
         );
@@ -379,13 +390,6 @@ mod rejection {
             function_equality,
             tuple_function_equality,
             list_function_equality,
-        );
-    }
-
-    mod statements {
-        rejection_cases!("statements";
-            assert_statement,
-            final_assert,
         );
     }
 
@@ -469,6 +473,7 @@ fn render_panic_kind(kind: &PanicKind) -> String {
     match kind {
         PanicKind::Panic { message } => render_panic_message("panic", message.as_deref()),
         PanicKind::Todo { message } => render_panic_message("todo", message.as_deref()),
+        PanicKind::Assert { message } => render_panic_message("assert", message.as_deref()),
         PanicKind::LetAssert { message } => render_panic_message("let_assert", message.as_deref()),
         PanicKind::EmptyFunction => "empty_function".into(),
         PanicKind::EmptyBlock => "empty_block".into(),

--- a/tests/fixtures/execution/functions/anonymous/anonymous_assert_statement.gleam
+++ b/tests/fixtures/execution/functions/anonymous/anonymous_assert_statement.gleam
@@ -1,0 +1,10 @@
+pub fn main() {
+  let run = fn() {
+    assert True
+    1
+  }
+
+  run()
+}
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/statements/assert_statement.gleam
+++ b/tests/fixtures/execution/statements/assert_statement.gleam
@@ -1,3 +1,6 @@
 pub fn main() {
   assert True
+  1
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/statements/final_assert.gleam
+++ b/tests/fixtures/execution/statements/final_assert.gleam
@@ -1,4 +1,5 @@
 pub fn main() {
   assert True
-  1
 }
+
+// geam:expect Nil

--- a/tests/fixtures/execution_errors/statements/assert_condition_error_after_message.gleam
+++ b/tests/fixtures/execution_errors/statements/assert_condition_error_after_message.gleam
@@ -1,0 +1,10 @@
+fn fail_condition() -> Bool {
+  panic as "condition"
+}
+
+pub fn main() {
+  assert fail_condition() as "checked"
+  1
+}
+
+// geam:expect-error Panic(panic, "condition")

--- a/tests/fixtures/execution_errors/statements/assert_message.gleam
+++ b/tests/fixtures/execution_errors/statements/assert_message.gleam
@@ -1,0 +1,6 @@
+pub fn main() {
+  assert False as "nope"
+  1
+}
+
+// geam:expect-error Panic(assert, "nope")

--- a/tests/fixtures/execution_errors/statements/assert_message_before_condition.gleam
+++ b/tests/fixtures/execution_errors/statements/assert_message_before_condition.gleam
@@ -1,0 +1,10 @@
+fn fail_message() -> String {
+  panic as "message"
+}
+
+pub fn main() {
+  assert True as fail_message()
+  1
+}
+
+// geam:expect-error Panic(panic, "message")

--- a/tests/fixtures/execution_errors/statements/assert_statement.gleam
+++ b/tests/fixtures/execution_errors/statements/assert_statement.gleam
@@ -1,0 +1,6 @@
+pub fn main() {
+  assert False
+  1
+}
+
+// geam:expect-error Panic(assert)

--- a/tests/fixtures/rejection/functions/anonymous_assert_statement.gleam
+++ b/tests/fixtures/rejection/functions/anonymous_assert_statement.gleam
@@ -1,7 +1,0 @@
-pub fn main() {
-  fn() {
-    assert True
-    1
-  }
-  1
-}


### PR DESCRIPTION
- Accept `assert value > 0` as a normal statement and final `assert True` as a Nil return.
- Return `Panic(assert)` for failed assertions, including `assert False as "nope"`.
- Move accepted assert fixtures out of rejection coverage.
