### PR TITLE
Support case variable patterns

### DIFF
--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -418,11 +418,23 @@ impl<'a> PlanContext<'a> {
         local
     }
 
+    pub(super) fn define_internal_int_local(&mut self) -> IntLocalId {
+        let local = IntLocalId(self.next_int_local);
+        self.next_int_local += 1;
+        local
+    }
+
     pub(super) fn define_string_local(&mut self, name: EcoString) -> StringLocalId {
         let local = StringLocalId(self.next_string_local);
         self.next_string_local += 1;
         self.bindings
             .insert(name, LocalBinding::Primitive(LocalId::String(local)));
+        local
+    }
+
+    pub(super) fn define_internal_string_local(&mut self) -> StringLocalId {
+        let local = StringLocalId(self.next_string_local);
+        self.next_string_local += 1;
         local
     }
 
@@ -434,11 +446,23 @@ impl<'a> PlanContext<'a> {
         local
     }
 
+    pub(super) fn define_internal_float_local(&mut self) -> FloatLocalId {
+        let local = FloatLocalId(self.next_float_local);
+        self.next_float_local += 1;
+        local
+    }
+
     pub(super) fn define_bool_local(&mut self, name: EcoString) -> BoolLocalId {
         let local = BoolLocalId(self.next_bool_local);
         self.next_bool_local += 1;
         self.bindings
             .insert(name, LocalBinding::Primitive(LocalId::Bool(local)));
+        local
+    }
+
+    pub(super) fn define_internal_bool_local(&mut self) -> BoolLocalId {
+        let local = BoolLocalId(self.next_bool_local);
+        self.next_bool_local += 1;
         local
     }
 
@@ -1013,12 +1037,13 @@ mod tests {
     use super::FunctionLocalBinding;
     use super::{AnonymousFunctions, FunctionInfo, FunctionRuntimeIds, PlanContext};
     use crate::plan::{
-        BoolFunctionExpr, BoolFunctionLocalId, CaptureArg, FloatFunctionExpr, FloatFunctionId,
-        FloatFunctionLocalId, FunctionFunctionExpr, FunctionFunctionLocalId, FunctionType,
-        FunctionValue, IntFunctionId, IntFunctionLocalId, IntLocalId, ListExpr, ListFunctionExpr,
-        ListFunctionLocalId, ListLocalId, LocalId, NilFunctionExpr, NilFunctionLocalId, ParamLocal,
-        RuntimeFunctionId, StringFunctionExpr, StringFunctionLocalId, TupleFunctionExpr,
-        TupleFunctionLocalId, TupleLocalId, ValueType,
+        BoolFunctionExpr, BoolFunctionLocalId, BoolLocalId, CaptureArg, FloatFunctionExpr,
+        FloatFunctionId, FloatFunctionLocalId, FloatLocalId, FunctionFunctionExpr,
+        FunctionFunctionLocalId, FunctionType, FunctionValue, IntFunctionId, IntFunctionLocalId,
+        IntLocalId, ListExpr, ListFunctionExpr, ListFunctionLocalId, ListLocalId, LocalId,
+        NilFunctionExpr, NilFunctionLocalId, ParamLocal, RuntimeFunctionId, StringFunctionExpr,
+        StringFunctionLocalId, StringLocalId, TupleFunctionExpr, TupleFunctionLocalId,
+        TupleLocalId, ValueType,
     };
     use ecow::EcoString;
     use gleam_core::type_;
@@ -1244,6 +1269,31 @@ mod tests {
             context.lookup_list_local(&"values".into()),
             Some((ListLocalId(1), ValueType::Int)),
         );
+    }
+
+    #[test]
+    fn define_internal_primitive_locals_reserve_ids_without_user_binding() {
+        let module = EcoString::from("main");
+        let functions = HashMap::<EcoString, FunctionInfo>::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+
+        assert_eq!(context.define_internal_int_local(), IntLocalId(0));
+        assert_eq!(context.define_internal_string_local(), StringLocalId(0));
+        assert_eq!(context.define_internal_float_local(), FloatLocalId(0));
+        assert_eq!(context.define_internal_bool_local(), BoolLocalId(0));
+        assert_eq!(context.lookup_local(&"<case:int:0>".into()), None);
+        assert_eq!(context.lookup_local(&"<case:string:0>".into()), None);
+        assert_eq!(context.lookup_local(&"<case:float:0>".into()), None);
+        assert_eq!(context.lookup_local(&"<case:bool:0>".into()), None);
+
+        assert_eq!(context.define_int_local("int".into()), IntLocalId(1));
+        assert_eq!(
+            context.define_string_local("string".into()),
+            StringLocalId(1),
+        );
+        assert_eq!(context.define_float_local("float".into()), FloatLocalId(1));
+        assert_eq!(context.define_bool_local("bool".into()), BoolLocalId(1));
     }
 
     #[test]

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -76,8 +76,6 @@ pub enum UnsupportedCaseReason {
     UnsupportedSubjectType,
     #[error("string prefix patterns are not supported")]
     StringPrefixPattern,
-    #[error("variable patterns are not supported")]
-    VariablePattern,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]

--- a/src/planner/expression/case.rs
+++ b/src/planner/expression/case.rs
@@ -3,11 +3,16 @@ mod float_subject;
 mod int_subject;
 mod string_subject;
 
-use crate::plan::{Expr, ValueType};
+use crate::plan::{
+    BoolExpr, BoolLocalId, Expr, FloatExpr, FloatLocalId, IntExpr, IntLocalId, Step, StringExpr,
+    StringLocalId, ValueType,
+};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
     InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
 };
+use crate::planner::statement::plan_variable_runtime_step;
+use ecow::EcoString;
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
@@ -98,6 +103,81 @@ pub(super) fn case_return_type(case_type: &Type) -> Result<ValueType, PlanError>
         .ok_or_else(|| invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch))
 }
 
+pub(super) fn plan_case_branch(
+    case_type: &Type,
+    return_type: &ValueType,
+    then: TypedExpr,
+    variable_binding: Option<(EcoString, Expr)>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    context.with_local_scope(|context| {
+        let steps = variable_binding
+            .map(|(name, value)| vec![plan_variable_runtime_step(name, value, context)])
+            .unwrap_or_default();
+        let branch =
+            super::plan_expr_with_expected_source_stop_type(then, return_type.clone(), context)?;
+        validate_case_branch_type(case_type, &branch)?;
+
+        if steps.is_empty() {
+            Ok(branch)
+        } else {
+            Ok(super::block::block_expr(steps, branch))
+        }
+    })
+}
+
+pub(super) fn bind_int_case_subject(
+    subject: IntExpr,
+    context: &mut PlanContext<'_>,
+) -> (Step, IntExpr) {
+    let local = context.define_internal_int_local();
+    let name = internal_int_case_subject_name(local);
+    (
+        Step::let_int(local, name.clone(), subject),
+        IntExpr::local_get(local, name),
+    )
+}
+
+pub(super) fn bind_string_case_subject(
+    subject: StringExpr,
+    context: &mut PlanContext<'_>,
+) -> (Step, StringExpr) {
+    let local = context.define_internal_string_local();
+    let name = internal_string_case_subject_name(local);
+    (
+        Step::let_string(local, name.clone(), subject),
+        StringExpr::local_get(local, name),
+    )
+}
+
+pub(super) fn bind_float_case_subject(
+    subject: FloatExpr,
+    context: &mut PlanContext<'_>,
+) -> (Step, FloatExpr) {
+    let local = context.define_internal_float_local();
+    let name = internal_float_case_subject_name(local);
+    (
+        Step::let_float(local, name.clone(), subject),
+        FloatExpr::local_get(local, name),
+    )
+}
+
+pub(super) fn bind_bool_case_subject(
+    subject: BoolExpr,
+    context: &mut PlanContext<'_>,
+) -> (Step, BoolExpr) {
+    let local = context.define_internal_bool_local();
+    let name = internal_bool_case_subject_name(local);
+    (
+        Step::let_bool(local, name.clone(), subject),
+        BoolExpr::local_get(local, name),
+    )
+}
+
+pub(super) fn case_subject_block(step: Step, case: Expr) -> Expr {
+    super::block::block_expr(vec![step], case)
+}
+
 pub(super) fn unsupported_case(reason: UnsupportedCaseReason) -> PlanError {
     PlanError::UnsupportedCase { reason }
 }
@@ -106,6 +186,22 @@ pub(super) fn invalid_case_shape(reason: InvalidCaseShapeReason) -> PlanError {
     PlanError::InvalidTypedAst {
         reason: InvalidTypedAstReason::CaseShape { reason },
     }
+}
+
+fn internal_int_case_subject_name(local: IntLocalId) -> EcoString {
+    format!("<case:int:{}>", local.0).into()
+}
+
+fn internal_string_case_subject_name(local: StringLocalId) -> EcoString {
+    format!("<case:string:{}>", local.0).into()
+}
+
+fn internal_float_case_subject_name(local: FloatLocalId) -> EcoString {
+    format!("<case:float:{}>", local.0).into()
+}
+
+fn internal_bool_case_subject_name(local: BoolLocalId) -> EcoString {
+    format!("<case:bool:{}>", local.0).into()
 }
 
 #[cfg(test)]

--- a/src/planner/expression/case/bool_subject.rs
+++ b/src/planner/expression/case/bool_subject.rs
@@ -34,7 +34,7 @@ pub(super) fn plan(
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_bool_case_pattern(pattern)?;
         let binding = pattern
-            .binding()
+            .bound_name()
             .cloned()
             .map(|name| (name, Expr::bool(subject.clone())));
         let branch =
@@ -67,13 +67,13 @@ pub(super) fn plan(
 enum BoolCasePattern {
     True,
     False,
-    Any { binding: Option<EcoString> },
+    Any { bound_name: Option<EcoString> },
 }
 
 impl BoolCasePattern {
-    fn binding(&self) -> Option<&EcoString> {
+    fn bound_name(&self) -> Option<&EcoString> {
         match self {
-            BoolCasePattern::Any { binding } => binding.as_ref(),
+            BoolCasePattern::Any { bound_name } => bound_name.as_ref(),
             BoolCasePattern::True | BoolCasePattern::False => None,
         }
     }
@@ -95,13 +95,13 @@ fn plan_bool_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<BoolCasePattern
             )),
         },
         Pattern::Variable { name, type_, .. } if type_.is_bool() => Ok(BoolCasePattern::Any {
-            binding: Some(name),
+            bound_name: Some(name),
         }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
         Pattern::Discard { type_, .. } if type_.is_bool() => {
-            Ok(BoolCasePattern::Any { binding: None })
+            Ok(BoolCasePattern::Any { bound_name: None })
         }
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,

--- a/src/planner/expression/case/bool_subject.rs
+++ b/src/planner/expression/case/bool_subject.rs
@@ -1,10 +1,11 @@
 use super::{
     case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
-    validate_case_branch_type, validate_clause_shape,
+    validate_clause_shape,
 };
 use crate::plan::{BoolCaseBranches, BoolExpr, Expr, ExprKind};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
+use ecow::EcoString;
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
@@ -17,23 +18,32 @@ pub(super) fn plan(
 ) -> Result<Expr, PlanError> {
     let subject = super::super::plan_bool_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
+    for clause in &clauses {
+        validate_clause_shape(clause)?;
+    }
+    let needs_subject_binding = clauses.iter().any(clause_has_bool_variable_pattern);
+    let (subject_step, subject) = if needs_subject_binding {
+        let (step, subject) = super::bind_bool_case_subject(subject, context);
+        (Some(step), subject)
+    } else {
+        (None, subject)
+    };
     let mut true_branch = None;
     let mut false_branch = None;
     for clause in clauses {
-        validate_clause_shape(&clause)?;
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_bool_case_pattern(pattern)?;
-        let branch = super::super::plan_expr_with_expected_source_stop_type(
-            clause.then,
-            return_type.clone(),
-            context,
-        )?;
-        validate_case_branch_type(type_.as_ref(), &branch)?;
+        let binding = pattern
+            .binding()
+            .cloned()
+            .map(|name| (name, Expr::bool(subject.clone())));
+        let branch =
+            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, binding, context)?;
 
         match pattern {
             BoolCasePattern::True => set_case_branch(&mut true_branch, branch),
             BoolCasePattern::False => set_case_branch(&mut false_branch, branch),
-            BoolCasePattern::Any => {
+            BoolCasePattern::Any { .. } => {
                 set_case_branch(&mut true_branch, branch.clone());
                 set_case_branch(&mut false_branch, branch);
             }
@@ -47,14 +57,26 @@ pub(super) fn plan(
         InvalidCaseShapeReason::MissingFalsePattern,
     ))?;
 
-    bool_case_expr(subject, true_, false_)
+    bool_case_expr(subject, true_, false_).map(|case| match subject_step {
+        Some(step) => super::case_subject_block(step, case),
+        None => case,
+    })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum BoolCasePattern {
     True,
     False,
-    Any,
+    Any { binding: Option<EcoString> },
+}
+
+impl BoolCasePattern {
+    fn binding(&self) -> Option<&EcoString> {
+        match self {
+            BoolCasePattern::Any { binding } => binding.as_ref(),
+            BoolCasePattern::True | BoolCasePattern::False => None,
+        }
+    }
 }
 
 fn plan_bool_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<BoolCasePattern, PlanError> {
@@ -72,13 +94,15 @@ fn plan_bool_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<BoolCasePattern
                 InvalidCaseShapeReason::PatternTypeMismatch,
             )),
         },
-        Pattern::Variable { type_, .. } if type_.is_bool() => {
-            Err(unsupported_case(UnsupportedCaseReason::VariablePattern))
-        }
+        Pattern::Variable { name, type_, .. } if type_.is_bool() => Ok(BoolCasePattern::Any {
+            binding: Some(name),
+        }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Discard { type_, .. } if type_.is_bool() => Ok(BoolCasePattern::Any),
+        Pattern::Discard { type_, .. } if type_.is_bool() => {
+            Ok(BoolCasePattern::Any { binding: None })
+        }
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
@@ -99,6 +123,15 @@ fn plan_bool_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<BoolCasePattern
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
     }
+}
+
+fn clause_has_bool_variable_pattern(clause: &TypedClause) -> bool {
+    clause.pattern.iter().any(|pattern| {
+        matches!(
+            pattern,
+            Pattern::Variable { type_, .. } if type_.is_bool()
+        )
+    })
 }
 
 fn validate_bool_case_assign_pattern(
@@ -209,10 +242,10 @@ mod tests {
         ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        bool_, bool_return_bool_case, bool_return_expr, call_bool, function, function_ref, int,
-        int_return_bool_case, int_return_expr, list, list_return_bool_case, list_return_expr,
-        local_bool, module, nil, nil_return_bool_case, nil_return_expr, return_list, string,
-        string_return_bool_case, string_return_expr,
+        bool_, bool_return_block, bool_return_bool_case, bool_return_expr, call_bool, function,
+        function_ref, int, int_return_bool_case, int_return_expr, let_bool_step, list,
+        list_return_bool_case, list_return_expr, local_bool, module, nil, nil_return_bool_case,
+        nil_return_expr, return_list, string, string_return_bool_case, string_return_expr,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -314,6 +347,37 @@ pub fn list_case(value: Bool) {
                 )
                 .param_bool(0, "value"),
             ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_bool_case_variable_pattern_binds_subject_once_in_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case True {
+    other -> other
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let branch = bool_return_block(
+            [let_bool_step(1, "other", local_bool(0, "<case:bool:0>"))],
+            bool_return_expr(local_bool(1, "other")),
+        );
+        let expected = module(
+            "main",
+            function(
+                "main",
+                bool_return_block(
+                    [let_bool_step(0, "<case:bool:0>", bool_(true))],
+                    bool_return_bool_case(local_bool(0, "<case:bool:0>"), branch.clone(), branch),
+                ),
+            ),
+            [],
         );
 
         assert_eq!(actual, expected);
@@ -650,10 +714,6 @@ fn duplicate_true(value: Bool) {
     #[test]
     fn reject_profile_bool_case_patterns() {
         let cases = [
-            (
-                r#"pub fn main() { case True { value -> 1 } }"#,
-                UnsupportedCaseReason::VariablePattern,
-            ),
             (
                 r#"
 pub fn main() {

--- a/src/planner/expression/case/float_subject.rs
+++ b/src/planner/expression/case/float_subject.rs
@@ -34,7 +34,7 @@ pub(super) fn plan(
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_float_case_pattern(pattern)?;
         let binding = pattern
-            .binding()
+            .bound_name()
             .cloned()
             .map(|name| (name, Expr::float(subject.clone())));
         let branch =
@@ -71,13 +71,13 @@ pub(super) fn plan(
 #[derive(Debug, Clone, PartialEq)]
 enum FloatCasePattern {
     Literal(f64),
-    Any { binding: Option<EcoString> },
+    Any { bound_name: Option<EcoString> },
 }
 
 impl FloatCasePattern {
-    fn binding(&self) -> Option<&EcoString> {
+    fn bound_name(&self) -> Option<&EcoString> {
         match self {
-            FloatCasePattern::Any { binding } => binding.as_ref(),
+            FloatCasePattern::Any { bound_name } => bound_name.as_ref(),
             FloatCasePattern::Literal(_) => None,
         }
     }
@@ -87,13 +87,13 @@ fn plan_float_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<FloatCasePatte
     match pattern {
         Pattern::Float { float_value, .. } => Ok(FloatCasePattern::Literal(float_value.value())),
         Pattern::Variable { name, type_, .. } if type_.is_float() => Ok(FloatCasePattern::Any {
-            binding: Some(name),
+            bound_name: Some(name),
         }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
         Pattern::Discard { type_, .. } if type_.is_float() => {
-            Ok(FloatCasePattern::Any { binding: None })
+            Ok(FloatCasePattern::Any { bound_name: None })
         }
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,

--- a/src/planner/expression/case/float_subject.rs
+++ b/src/planner/expression/case/float_subject.rs
@@ -1,10 +1,11 @@
 use super::{
     case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
-    validate_case_branch_type, validate_clause_shape,
+    validate_clause_shape,
 };
 use crate::plan::{Expr, ExprKind, FloatCaseBranches, FloatExpr};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
+use ecow::EcoString;
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
@@ -17,18 +18,27 @@ pub(super) fn plan(
 ) -> Result<Expr, PlanError> {
     let subject = super::super::plan_float_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
+    for clause in &clauses {
+        validate_clause_shape(clause)?;
+    }
+    let needs_subject_binding = clauses.iter().any(clause_has_float_variable_pattern);
+    let (subject_step, subject) = if needs_subject_binding {
+        let (step, subject) = super::bind_float_case_subject(subject, context);
+        (Some(step), subject)
+    } else {
+        (None, subject)
+    };
     let mut literal_clauses = Vec::new();
     let mut fallback = None;
     for clause in clauses {
-        validate_clause_shape(&clause)?;
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_float_case_pattern(pattern)?;
-        let branch = super::super::plan_expr_with_expected_source_stop_type(
-            clause.then,
-            return_type.clone(),
-            context,
-        )?;
-        validate_case_branch_type(type_.as_ref(), &branch)?;
+        let binding = pattern
+            .binding()
+            .cloned()
+            .map(|name| (name, Expr::float(subject.clone())));
+        let branch =
+            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, binding, context)?;
 
         match pattern {
             FloatCasePattern::Literal(value) => {
@@ -40,7 +50,7 @@ pub(super) fn plan(
                     literal_clauses.push((value, branch));
                 }
             }
-            FloatCasePattern::Any => {
+            FloatCasePattern::Any { .. } => {
                 if fallback.is_none() {
                     fallback = Some(branch);
                 }
@@ -52,25 +62,39 @@ pub(super) fn plan(
         InvalidCaseShapeReason::MissingFallbackPattern,
     ))?;
 
-    float_case_expr(subject, literal_clauses, fallback)
+    float_case_expr(subject, literal_clauses, fallback).map(|case| match subject_step {
+        Some(step) => super::case_subject_block(step, case),
+        None => case,
+    })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 enum FloatCasePattern {
     Literal(f64),
-    Any,
+    Any { binding: Option<EcoString> },
+}
+
+impl FloatCasePattern {
+    fn binding(&self) -> Option<&EcoString> {
+        match self {
+            FloatCasePattern::Any { binding } => binding.as_ref(),
+            FloatCasePattern::Literal(_) => None,
+        }
+    }
 }
 
 fn plan_float_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<FloatCasePattern, PlanError> {
     match pattern {
         Pattern::Float { float_value, .. } => Ok(FloatCasePattern::Literal(float_value.value())),
-        Pattern::Variable { type_, .. } if type_.is_float() => {
-            Err(unsupported_case(UnsupportedCaseReason::VariablePattern))
-        }
+        Pattern::Variable { name, type_, .. } if type_.is_float() => Ok(FloatCasePattern::Any {
+            binding: Some(name),
+        }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Discard { type_, .. } if type_.is_float() => Ok(FloatCasePattern::Any),
+        Pattern::Discard { type_, .. } if type_.is_float() => {
+            Ok(FloatCasePattern::Any { binding: None })
+        }
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
@@ -90,6 +114,15 @@ fn plan_float_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<FloatCasePatte
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
     }
+}
+
+fn clause_has_float_variable_pattern(clause: &TypedClause) -> bool {
+    clause.pattern.iter().any(|pattern| {
+        matches!(
+            pattern,
+            Pattern::Variable { type_, .. } if type_.is_float()
+        )
+    })
 }
 
 fn validate_float_case_assign_pattern(
@@ -419,11 +452,11 @@ mod tests {
         TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        bool_, bool_return_expr, bool_return_float_case, float, float_return_expr,
-        float_return_float_case, function, function_ref, int, int_return_expr,
-        int_return_float_case, list, list_return_expr, list_return_float_case, local_float, module,
-        nil, nil_return_expr, nil_return_float_case, return_list, string, string_return_expr,
-        string_return_float_case, tuple,
+        bool_, bool_return_expr, bool_return_float_case, float, float_return_block,
+        float_return_expr, float_return_float_case, function, function_ref, int, int_return_expr,
+        int_return_float_case, let_float_step, list, list_return_expr, list_return_float_case,
+        local_float, module, nil, nil_return_expr, nil_return_float_case, return_list, string,
+        string_return_expr, string_return_float_case, tuple,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -543,6 +576,40 @@ pub fn list_case(value: Float) {
                 )
                 .param_float(0, "value"),
             ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_float_case_variable_pattern_binds_subject_once_in_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 1.5 {
+    other -> other
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                float_return_block(
+                    [let_float_step(0, "<case:float:0>", float(1.5))],
+                    float_return_float_case(
+                        local_float(0, "<case:float:0>"),
+                        [],
+                        float_return_block(
+                            [let_float_step(1, "other", local_float(0, "<case:float:0>"))],
+                            float_return_expr(local_float(1, "other")),
+                        ),
+                    ),
+                ),
+            ),
+            [],
         );
 
         assert_eq!(actual, expected);
@@ -806,10 +873,6 @@ fn duplicate_literal(value: Float) {
     #[test]
     fn reject_profile_float_case_patterns() {
         let cases = [
-            (
-                r#"pub fn main() { case 1.0 { value -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::VariablePattern,
-            ),
             (
                 r#"pub fn main() { case 1.0 { 1.0 as value -> 1 _ -> 0 } }"#,
                 UnsupportedCaseReason::AssignPattern,

--- a/src/planner/expression/case/int_subject.rs
+++ b/src/planner/expression/case/int_subject.rs
@@ -1,10 +1,11 @@
 use super::{
     case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
-    validate_case_branch_type, validate_clause_shape,
+    validate_clause_shape,
 };
 use crate::plan::{Expr, ExprKind, IntCaseBranches, IntExpr};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
+use ecow::EcoString;
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
 use num_bigint::BigInt;
@@ -18,18 +19,27 @@ pub(super) fn plan(
 ) -> Result<Expr, PlanError> {
     let subject = super::super::plan_int_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
+    for clause in &clauses {
+        validate_clause_shape(clause)?;
+    }
+    let needs_subject_binding = clauses.iter().any(clause_has_int_variable_pattern);
+    let (subject_step, subject) = if needs_subject_binding {
+        let (step, subject) = super::bind_int_case_subject(subject, context);
+        (Some(step), subject)
+    } else {
+        (None, subject)
+    };
     let mut literal_clauses = Vec::new();
     let mut fallback = None;
     for clause in clauses {
-        validate_clause_shape(&clause)?;
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_int_case_pattern(pattern)?;
-        let branch = super::super::plan_expr_with_expected_source_stop_type(
-            clause.then,
-            return_type.clone(),
-            context,
-        )?;
-        validate_case_branch_type(type_.as_ref(), &branch)?;
+        let binding = pattern
+            .binding()
+            .cloned()
+            .map(|name| (name, Expr::int(subject.clone())));
+        let branch =
+            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, binding, context)?;
 
         match pattern {
             IntCasePattern::Literal(value) => {
@@ -41,7 +51,7 @@ pub(super) fn plan(
                     literal_clauses.push((value, branch));
                 }
             }
-            IntCasePattern::Any => {
+            IntCasePattern::Any { .. } => {
                 if fallback.is_none() {
                     fallback = Some(branch);
                 }
@@ -53,25 +63,39 @@ pub(super) fn plan(
         InvalidCaseShapeReason::MissingFallbackPattern,
     ))?;
 
-    int_case_expr(subject, literal_clauses, fallback)
+    int_case_expr(subject, literal_clauses, fallback).map(|case| match subject_step {
+        Some(step) => super::case_subject_block(step, case),
+        None => case,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum IntCasePattern {
     Literal(BigInt),
-    Any,
+    Any { binding: Option<EcoString> },
+}
+
+impl IntCasePattern {
+    fn binding(&self) -> Option<&EcoString> {
+        match self {
+            IntCasePattern::Any { binding } => binding.as_ref(),
+            IntCasePattern::Literal(_) => None,
+        }
+    }
 }
 
 fn plan_int_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<IntCasePattern, PlanError> {
     match pattern {
         Pattern::Int { int_value, .. } => Ok(IntCasePattern::Literal(int_value)),
-        Pattern::Variable { type_, .. } if type_.is_int() => {
-            Err(unsupported_case(UnsupportedCaseReason::VariablePattern))
-        }
+        Pattern::Variable { name, type_, .. } if type_.is_int() => Ok(IntCasePattern::Any {
+            binding: Some(name),
+        }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Discard { type_, .. } if type_.is_int() => Ok(IntCasePattern::Any),
+        Pattern::Discard { type_, .. } if type_.is_int() => {
+            Ok(IntCasePattern::Any { binding: None })
+        }
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
@@ -91,6 +115,15 @@ fn plan_int_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<IntCasePattern, 
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
     }
+}
+
+fn clause_has_int_variable_pattern(clause: &TypedClause) -> bool {
+    clause.pattern.iter().any(|pattern| {
+        matches!(
+            pattern,
+            Pattern::Variable { type_, .. } if type_.is_int()
+        )
+    })
 }
 
 fn validate_int_case_assign_pattern(
@@ -421,9 +454,10 @@ mod tests {
     };
     use crate::planner::dsl::{
         bool_, bool_return_expr, bool_return_int_case, float, function, function_ref, int,
-        int_return_expr, int_return_int_case, list, list_return_expr, list_return_int_case,
-        local_int, module, nil, nil_return_expr, nil_return_int_case, return_list, string,
-        string_return_expr, string_return_int_case, tuple,
+        int_return_block, int_return_expr, int_return_int_case, let_int_step, list,
+        list_return_expr, list_return_int_case, local_int, module, nil, nil_return_expr,
+        nil_return_int_case, return_list, string, string_return_expr, string_return_int_case,
+        tuple,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -602,6 +636,40 @@ fn duplicate_literal(value: Int) {
                 )
                 .param_int(0, "value"),
             ],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_int_case_variable_pattern_binds_subject_once_in_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 41 {
+    other -> other + 1
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "<case:int:0>", int(41))],
+                    int_return_int_case(
+                        local_int(0, "<case:int:0>"),
+                        [],
+                        int_return_block(
+                            [let_int_step(1, "other", local_int(0, "<case:int:0>"))],
+                            int_return_expr(local_int(1, "other").add_int(int(1))),
+                        ),
+                    ),
+                ),
+            ),
+            [],
         );
 
         assert_eq!(actual, expected);
@@ -889,10 +957,6 @@ fn duplicate_literal(value: Int) {
     #[test]
     fn reject_profile_int_case_patterns() {
         let cases = [
-            (
-                r#"pub fn main() { case 1 { value -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::VariablePattern,
-            ),
             (
                 r#"pub fn main() { case 1 { 1 as value -> 1 _ -> 0 } }"#,
                 UnsupportedCaseReason::AssignPattern,

--- a/src/planner/expression/case/int_subject.rs
+++ b/src/planner/expression/case/int_subject.rs
@@ -35,7 +35,7 @@ pub(super) fn plan(
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_int_case_pattern(pattern)?;
         let binding = pattern
-            .binding()
+            .bound_name()
             .cloned()
             .map(|name| (name, Expr::int(subject.clone())));
         let branch =
@@ -72,13 +72,13 @@ pub(super) fn plan(
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum IntCasePattern {
     Literal(BigInt),
-    Any { binding: Option<EcoString> },
+    Any { bound_name: Option<EcoString> },
 }
 
 impl IntCasePattern {
-    fn binding(&self) -> Option<&EcoString> {
+    fn bound_name(&self) -> Option<&EcoString> {
         match self {
-            IntCasePattern::Any { binding } => binding.as_ref(),
+            IntCasePattern::Any { bound_name } => bound_name.as_ref(),
             IntCasePattern::Literal(_) => None,
         }
     }
@@ -88,13 +88,13 @@ fn plan_int_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<IntCasePattern, 
     match pattern {
         Pattern::Int { int_value, .. } => Ok(IntCasePattern::Literal(int_value)),
         Pattern::Variable { name, type_, .. } if type_.is_int() => Ok(IntCasePattern::Any {
-            binding: Some(name),
+            bound_name: Some(name),
         }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
         Pattern::Discard { type_, .. } if type_.is_int() => {
-            Ok(IntCasePattern::Any { binding: None })
+            Ok(IntCasePattern::Any { bound_name: None })
         }
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,

--- a/src/planner/expression/case/string_subject.rs
+++ b/src/planner/expression/case/string_subject.rs
@@ -34,7 +34,7 @@ pub(super) fn plan(
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_string_case_pattern(pattern)?;
         let binding = pattern
-            .binding()
+            .bound_name()
             .cloned()
             .map(|name| (name, Expr::string(subject.clone())));
         let branch =
@@ -71,13 +71,13 @@ pub(super) fn plan(
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum StringCasePattern {
     Literal(EcoString),
-    Any { binding: Option<EcoString> },
+    Any { bound_name: Option<EcoString> },
 }
 
 impl StringCasePattern {
-    fn binding(&self) -> Option<&EcoString> {
+    fn bound_name(&self) -> Option<&EcoString> {
         match self {
-            StringCasePattern::Any { binding } => binding.as_ref(),
+            StringCasePattern::Any { bound_name } => bound_name.as_ref(),
             StringCasePattern::Literal(_) => None,
         }
     }
@@ -87,13 +87,13 @@ fn plan_string_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<StringCasePat
     match pattern {
         Pattern::String { value, .. } => Ok(StringCasePattern::Literal(value)),
         Pattern::Variable { name, type_, .. } if type_.is_string() => Ok(StringCasePattern::Any {
-            binding: Some(name),
+            bound_name: Some(name),
         }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
         Pattern::Discard { type_, .. } if type_.is_string() => {
-            Ok(StringCasePattern::Any { binding: None })
+            Ok(StringCasePattern::Any { bound_name: None })
         }
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,

--- a/src/planner/expression/case/string_subject.rs
+++ b/src/planner/expression/case/string_subject.rs
@@ -1,6 +1,6 @@
 use super::{
     case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
-    validate_case_branch_type, validate_clause_shape,
+    validate_clause_shape,
 };
 use crate::plan::{Expr, ExprKind, StringCaseBranches, StringExpr};
 use crate::planner::context::PlanContext;
@@ -18,18 +18,27 @@ pub(super) fn plan(
 ) -> Result<Expr, PlanError> {
     let subject = super::super::plan_string_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
+    for clause in &clauses {
+        validate_clause_shape(clause)?;
+    }
+    let needs_subject_binding = clauses.iter().any(clause_has_string_variable_pattern);
+    let (subject_step, subject) = if needs_subject_binding {
+        let (step, subject) = super::bind_string_case_subject(subject, context);
+        (Some(step), subject)
+    } else {
+        (None, subject)
+    };
     let mut literal_clauses = Vec::new();
     let mut fallback = None;
     for clause in clauses {
-        validate_clause_shape(&clause)?;
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_string_case_pattern(pattern)?;
-        let branch = super::super::plan_expr_with_expected_source_stop_type(
-            clause.then,
-            return_type.clone(),
-            context,
-        )?;
-        validate_case_branch_type(type_.as_ref(), &branch)?;
+        let binding = pattern
+            .binding()
+            .cloned()
+            .map(|name| (name, Expr::string(subject.clone())));
+        let branch =
+            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, binding, context)?;
 
         match pattern {
             StringCasePattern::Literal(value) => {
@@ -41,7 +50,7 @@ pub(super) fn plan(
                     literal_clauses.push((value, branch));
                 }
             }
-            StringCasePattern::Any => {
+            StringCasePattern::Any { .. } => {
                 if fallback.is_none() {
                     fallback = Some(branch);
                 }
@@ -53,25 +62,39 @@ pub(super) fn plan(
         InvalidCaseShapeReason::MissingFallbackPattern,
     ))?;
 
-    string_case_expr(subject, literal_clauses, fallback)
+    string_case_expr(subject, literal_clauses, fallback).map(|case| match subject_step {
+        Some(step) => super::case_subject_block(step, case),
+        None => case,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum StringCasePattern {
     Literal(EcoString),
-    Any,
+    Any { binding: Option<EcoString> },
+}
+
+impl StringCasePattern {
+    fn binding(&self) -> Option<&EcoString> {
+        match self {
+            StringCasePattern::Any { binding } => binding.as_ref(),
+            StringCasePattern::Literal(_) => None,
+        }
+    }
 }
 
 fn plan_string_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<StringCasePattern, PlanError> {
     match pattern {
         Pattern::String { value, .. } => Ok(StringCasePattern::Literal(value)),
-        Pattern::Variable { type_, .. } if type_.is_string() => {
-            Err(unsupported_case(UnsupportedCaseReason::VariablePattern))
-        }
+        Pattern::Variable { name, type_, .. } if type_.is_string() => Ok(StringCasePattern::Any {
+            binding: Some(name),
+        }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Discard { type_, .. } if type_.is_string() => Ok(StringCasePattern::Any),
+        Pattern::Discard { type_, .. } if type_.is_string() => {
+            Ok(StringCasePattern::Any { binding: None })
+        }
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
@@ -93,6 +116,15 @@ fn plan_string_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<StringCasePat
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
     }
+}
+
+fn clause_has_string_variable_pattern(clause: &TypedClause) -> bool {
+    clause.pattern.iter().any(|pattern| {
+        matches!(
+            pattern,
+            Pattern::Variable { type_, .. } if type_.is_string()
+        )
+    })
 }
 
 fn validate_string_case_assign_pattern(
@@ -423,9 +455,10 @@ mod tests {
     };
     use crate::planner::dsl::{
         bool_, bool_return_expr, bool_return_string_case, float, function, function_ref, int,
-        int_return_expr, int_return_string_case, list, list_return_expr, list_return_string_case,
-        local_string, module, nil, nil_return_expr, nil_return_string_case, return_list, string,
-        string_return_expr, string_return_string_case, tuple,
+        int_return_expr, int_return_string_case, let_string_step, list, list_return_expr,
+        list_return_string_case, local_string, module, nil, nil_return_expr,
+        nil_return_string_case, return_list, string, string_return_block, string_return_expr,
+        string_return_string_case, tuple,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -539,6 +572,44 @@ pub fn list_case(value: String) {
     }
 
     #[test]
+    fn plan_string_case_variable_pattern_binds_subject_once_in_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case "geam" {
+    other -> other
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                string_return_block(
+                    [let_string_step(0, "<case:string:0>", string("geam"))],
+                    string_return_string_case(
+                        local_string(0, "<case:string:0>"),
+                        [],
+                        string_return_block(
+                            [let_string_step(
+                                1,
+                                "other",
+                                local_string(0, "<case:string:0>"),
+                            )],
+                            string_return_expr(local_string(1, "other")),
+                        ),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_string_case_wildcard_fallbacks() {
         let actual = plan_module(crate::planner::support::compile(
             r#"
@@ -642,10 +713,6 @@ fn duplicate_literal(value: String) {
     #[test]
     fn reject_profile_string_case_patterns() {
         let cases = [
-            (
-                r#"pub fn main() { case "one" { value -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::VariablePattern,
-            ),
             (
                 r#"pub fn main() { case "one" { "one" as value -> 1 _ -> 0 } }"#,
                 UnsupportedCaseReason::AssignPattern,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -134,6 +134,11 @@ mod control_flow {
             tuple_projection_case,
             tuple_case_return_families,
             list_case_return_families,
+            variable_pattern,
+            variable_pattern_ordering,
+            variable_pattern_families,
+            variable_pattern_closure_capture,
+            variable_pattern_scope,
         );
     }
 }
@@ -402,7 +407,6 @@ mod rejection {
             guard,
             alternative_patterns,
             multiple_subjects,
-            variable_pattern,
             tuple_pattern,
             tuple_subject,
             string_prefix_pattern,

--- a/tests/fixtures/execution/control_flow/case/variable_pattern.gleam
+++ b/tests/fixtures/execution/control_flow/case/variable_pattern.gleam
@@ -4,3 +4,5 @@ pub fn main() {
     other -> other
   }
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/control_flow/case/variable_pattern_closure_capture.gleam
+++ b/tests/fixtures/execution/control_flow/case/variable_pattern_closure_capture.gleam
@@ -1,0 +1,7 @@
+pub fn main() {
+  case 41 {
+    other -> fn() { other + 1 }()
+  }
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/control_flow/case/variable_pattern_families.gleam
+++ b/tests/fixtures/execution/control_flow/case/variable_pattern_families.gleam
@@ -1,0 +1,17 @@
+pub fn main() {
+  let bool_value = case True {
+    other -> other
+  }
+
+  let string_value = case "geam" {
+    other -> other
+  }
+
+  let float_value = case 1.5 {
+    other -> other
+  }
+
+  bool_value == True && string_value == "geam" && float_value == 1.5
+}
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/control_flow/case/variable_pattern_ordering.gleam
+++ b/tests/fixtures/execution/control_flow/case/variable_pattern_ordering.gleam
@@ -1,0 +1,15 @@
+pub fn main() {
+  let literal_before_variable = case 2 {
+    1 -> 10
+    other -> other
+  }
+
+  let variable_before_literal = case 1 {
+    other -> other
+    1 -> 999
+  }
+
+  literal_before_variable + variable_before_literal
+}
+
+// geam:expect Int(3)

--- a/tests/fixtures/execution/control_flow/case/variable_pattern_scope.gleam
+++ b/tests/fixtures/execution/control_flow/case/variable_pattern_scope.gleam
@@ -1,0 +1,10 @@
+pub fn main() {
+  let other = 100
+  let selected = case 1 {
+    other -> other
+  }
+
+  other + selected
+}
+
+// geam:expect Int(101)


### PR DESCRIPTION
- Allow Bool/Int/Float/String case branches like `case value { other -> other }`.
- Preserve single subject evaluation through an internal case subject local, then bind branch-local names inside the selected branch.
- Keep alias, tuple, list, guard, alternative, and multiple-subject case boundaries unchanged.
- Move variable-pattern coverage from rejection to execution fixtures, including ordering, family, scope, and closure-capture cases.
