### PR TITLE
Add case guard support

### DIFF
--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -68,8 +68,6 @@ pub enum UnsupportedCaseReason {
     AlternativePatterns,
     #[error("assign patterns are not supported")]
     AssignPattern,
-    #[error("guards are not supported")]
-    Guard,
     #[error("multiple subjects are not supported")]
     MultipleSubjects,
     #[error("case subject type is not supported")]

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -1,6 +1,7 @@
 mod block;
 mod call;
 mod case;
+mod constant;
 mod function;
 mod operator;
 mod pipeline;

--- a/src/planner/expression/case.rs
+++ b/src/planner/expression/case.rs
@@ -1,11 +1,12 @@
 mod bool_subject;
 mod float_subject;
+mod guard;
 mod int_subject;
 mod string_subject;
 
 use crate::plan::{
-    BoolExpr, BoolLocalId, Expr, FloatExpr, FloatLocalId, IntExpr, IntLocalId, Step, StringExpr,
-    StringLocalId, ValueType,
+    BoolCaseBranches, BoolExpr, BoolLocalId, Expr, ExprKind, FloatExpr, FloatLocalId,
+    FunctionExprKind, IntExpr, IntLocalId, Step, StringExpr, StringLocalId, ValueType,
 };
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
@@ -13,7 +14,7 @@ use crate::planner::error::{
 };
 use crate::planner::statement::plan_variable_runtime_step;
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{Pattern, TypedClause, TypedClauseGuard, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
@@ -52,9 +53,6 @@ pub(super) fn plan_case(
 pub(super) fn validate_clause_shape(clause: &TypedClause) -> Result<(), PlanError> {
     if !clause.alternative_patterns.is_empty() {
         return Err(unsupported_case(UnsupportedCaseReason::AlternativePatterns));
-    }
-    if clause.guard.is_some() {
-        return Err(unsupported_case(UnsupportedCaseReason::Guard));
     }
 
     Ok(())
@@ -98,6 +96,75 @@ pub(super) fn validate_case_branch_type(case_type: &Type, branch: &Expr) -> Resu
     ))
 }
 
+pub(super) fn bool_case_expr(
+    subject: BoolExpr,
+    true_: Expr,
+    false_: Expr,
+) -> Result<Expr, PlanError> {
+    let branches = match (true_.into_kind(), false_.into_kind()) {
+        (ExprKind::Int(true_), ExprKind::Int(false_)) => BoolCaseBranches::Int { true_, false_ },
+        (ExprKind::String(true_), ExprKind::String(false_)) => {
+            BoolCaseBranches::String { true_, false_ }
+        }
+        (ExprKind::Float(true_), ExprKind::Float(false_)) => {
+            BoolCaseBranches::Float { true_, false_ }
+        }
+        (ExprKind::Bool(true_), ExprKind::Bool(false_)) => BoolCaseBranches::Bool { true_, false_ },
+        (ExprKind::Nil(true_), ExprKind::Nil(false_)) => BoolCaseBranches::Nil { true_, false_ },
+        (ExprKind::Tuple(true_), ExprKind::Tuple(false_)) => {
+            BoolCaseBranches::Tuple { true_, false_ }
+        }
+        (ExprKind::List(true_), ExprKind::List(false_)) => BoolCaseBranches::List { true_, false_ },
+        (ExprKind::Function(true_), ExprKind::Function(false_)) => {
+            bool_function_case_branches(true_, false_)?
+        }
+        _ => {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        }
+    };
+
+    Ok(Expr::bool_case(subject, branches))
+}
+
+fn bool_function_case_branches(
+    true_: crate::plan::FunctionExpr,
+    false_: crate::plan::FunctionExpr,
+) -> Result<BoolCaseBranches, PlanError> {
+    Ok(match (true_.into_kind(), false_.into_kind()) {
+        (FunctionExprKind::Int(true_), FunctionExprKind::Int(false_)) => {
+            BoolCaseBranches::IntFunction { true_, false_ }
+        }
+        (FunctionExprKind::String(true_), FunctionExprKind::String(false_)) => {
+            BoolCaseBranches::StringFunction { true_, false_ }
+        }
+        (FunctionExprKind::Float(true_), FunctionExprKind::Float(false_)) => {
+            BoolCaseBranches::FloatFunction { true_, false_ }
+        }
+        (FunctionExprKind::Bool(true_), FunctionExprKind::Bool(false_)) => {
+            BoolCaseBranches::BoolFunction { true_, false_ }
+        }
+        (FunctionExprKind::Nil(true_), FunctionExprKind::Nil(false_)) => {
+            BoolCaseBranches::NilFunction { true_, false_ }
+        }
+        (FunctionExprKind::Tuple(true_), FunctionExprKind::Tuple(false_)) => {
+            BoolCaseBranches::TupleFunction { true_, false_ }
+        }
+        (FunctionExprKind::List(true_), FunctionExprKind::List(false_)) => {
+            BoolCaseBranches::ListFunction { true_, false_ }
+        }
+        (FunctionExprKind::Function(true_), FunctionExprKind::Function(false_)) => {
+            BoolCaseBranches::FunctionFunction { true_, false_ }
+        }
+        _ => {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        }
+    })
+}
+
 pub(super) fn case_return_type(case_type: &Type) -> Result<ValueType, PlanError> {
     ValueType::from_gleam(case_type)
         .ok_or_else(|| invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch))
@@ -124,6 +191,98 @@ pub(super) fn plan_case_branch(
             Ok(super::block::block_expr(steps, branch))
         }
     })
+}
+
+#[derive(Clone)]
+pub(super) struct OrderedCaseClause {
+    pub(super) condition: BoolExpr,
+    pub(super) branch: Expr,
+    pub(super) is_total: bool,
+}
+
+pub(super) struct OrderedCaseClauseInput<'a> {
+    pub(super) case_type: &'a Type,
+    pub(super) return_type: &'a ValueType,
+    pub(super) then: TypedExpr,
+    pub(super) variable_binding: Option<(EcoString, Expr)>,
+    pub(super) guard: Option<TypedClauseGuard>,
+    pub(super) match_condition: BoolExpr,
+    pub(super) is_total: bool,
+}
+
+pub(super) fn plan_ordered_case_clause(
+    input: OrderedCaseClauseInput<'_>,
+    context: &mut PlanContext<'_>,
+) -> Result<OrderedCaseClause, PlanError> {
+    let OrderedCaseClauseInput {
+        case_type,
+        return_type,
+        then,
+        variable_binding,
+        guard,
+        match_condition,
+        is_total,
+    } = input;
+
+    context.with_local_scope(|context| {
+        let binding_step =
+            variable_binding.map(|(name, value)| plan_variable_runtime_step(name, value, context));
+        let guard_condition = guard
+            .map(|guard| guard::plan_bool(guard, context))
+            .transpose()?;
+        let condition = match guard_condition {
+            Some(guard_condition) => BoolExpr::and(match_condition, guard_condition),
+            None => match_condition,
+        };
+        let condition = match &binding_step {
+            Some(step) => BoolExpr::block(vec![step.clone()], condition),
+            None => condition,
+        };
+
+        let branch =
+            super::plan_expr_with_expected_source_stop_type(then, return_type.clone(), context)?;
+        validate_case_branch_type(case_type, &branch)?;
+        let branch = if let Some(step) = binding_step {
+            super::block::block_expr(vec![step], branch)
+        } else {
+            branch
+        };
+
+        Ok(OrderedCaseClause {
+            condition,
+            branch,
+            is_total,
+        })
+    })
+}
+
+pub(super) fn ordered_case_expr(clauses: Vec<OrderedCaseClause>) -> Result<Expr, PlanError> {
+    let mut reachable_clauses = Vec::new();
+    for clause in clauses {
+        let is_total = clause.is_total;
+        reachable_clauses.push(clause);
+        if is_total {
+            break;
+        }
+    }
+
+    let Some(last_clause) = reachable_clauses.pop() else {
+        return Err(invalid_case_shape(
+            InvalidCaseShapeReason::MissingFallbackPattern,
+        ));
+    };
+    if !last_clause.is_total {
+        return Err(invalid_case_shape(
+            InvalidCaseShapeReason::MissingFallbackPattern,
+        ));
+    }
+
+    let mut next = last_clause.branch;
+    for clause in reachable_clauses.into_iter().rev() {
+        next = bool_case_expr(clause.condition, clause.branch, next)?;
+    }
+
+    Ok(next)
 }
 
 pub(super) fn bind_int_case_subject(
@@ -271,14 +430,18 @@ pub(super) fn expect_expression_statement(statement: &TypedStatement) -> &TypedE
 
 #[cfg(test)]
 mod tests {
+    use crate::plan::{BoolExpr, Expr, IntExpr};
+    use crate::planner::context::{AnonymousFunctions, PlanContext};
     use crate::planner::plan_module;
     use crate::planner::support::{compile_minimal_module, dummy_span, expect_plan_error};
     use crate::planner::{
         InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
         UnsupportedExpressionKind,
     };
+    use ecow::EcoString;
     use gleam_core::ast::TypedExpr;
     use gleam_core::type_;
+    use std::collections::HashMap;
 
     #[test]
     fn reject_profile_case_expressions() {
@@ -293,18 +456,6 @@ pub fn main() {
 }
 "#,
                 UnsupportedCaseReason::MultipleSubjects,
-            ),
-            (
-                r#"
-pub fn main() {
-  case True {
-    True if True -> 1
-    False -> 0
-    _ -> 2
-  }
-}
-"#,
-                UnsupportedCaseReason::Guard,
             ),
             (
                 r#"pub fn main() { case True { True | False -> 1 } }"#,
@@ -353,6 +504,22 @@ pub fn main() {
   case 1 {
     _ -> 1
     1 -> echo 2
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Echo,
+            },
+        );
+
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case 1 {
+    value if value > 0 -> echo value
+    _ -> 0
   }
 }
 "#,
@@ -449,6 +616,109 @@ pub fn main() {
                     reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
                 },
             }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_ordered_case_expr_requires_total_fallback() {
+        assert_eq!(
+            super::ordered_case_expr(Vec::new()),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::MissingFallbackPattern,
+                },
+            }),
+        );
+        assert_eq!(
+            super::ordered_case_expr(vec![super::OrderedCaseClause {
+                condition: BoolExpr::value(false),
+                branch: Expr::int(IntExpr::value(1.into())),
+                is_total: false,
+            }]),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::MissingFallbackPattern,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn ordered_case_expr_preserves_source_ordered_fallthrough_shape() {
+        assert_eq!(
+            super::ordered_case_expr(vec![super::OrderedCaseClause {
+                condition: BoolExpr::value(true),
+                branch: Expr::int(IntExpr::value(1.into())),
+                is_total: true,
+            }]),
+            Ok(Expr::int(IntExpr::value(1.into()))),
+        );
+        assert_eq!(
+            super::ordered_case_expr(vec![
+                super::OrderedCaseClause {
+                    condition: BoolExpr::value(false),
+                    branch: Expr::int(IntExpr::value(1.into())),
+                    is_total: false,
+                },
+                super::OrderedCaseClause {
+                    condition: BoolExpr::value(true),
+                    branch: Expr::int(IntExpr::value(0.into())),
+                    is_total: true,
+                }
+            ]),
+            Ok(Expr::int(IntExpr::bool_case(
+                BoolExpr::value(false),
+                IntExpr::value(1.into()),
+                IntExpr::value(0.into()),
+            ))),
+        );
+        assert_eq!(
+            super::ordered_case_expr(vec![
+                super::OrderedCaseClause {
+                    condition: BoolExpr::value(true),
+                    branch: Expr::int(IntExpr::value(10.into())),
+                    is_total: true,
+                },
+                super::OrderedCaseClause {
+                    condition: BoolExpr::value(true),
+                    branch: Expr::int(IntExpr::value(999.into())),
+                    is_total: false,
+                },
+            ]),
+            Ok(Expr::int(IntExpr::value(10.into()))),
+        );
+    }
+
+    #[test]
+    fn reject_margin_ordered_case_clause_branch_type_mismatch() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        let case_type = type_::string();
+
+        let actual = super::plan_ordered_case_clause(
+            super::OrderedCaseClauseInput {
+                case_type: case_type.as_ref(),
+                return_type: &crate::plan::ValueType::String,
+                then: super::super::typed_int_expr(1),
+                variable_binding: None,
+                guard: None,
+                match_condition: BoolExpr::value(true),
+                is_total: true,
+            },
+            &mut context,
+        );
+        let error = actual
+            .map(|_| ())
+            .expect_err("branch type mismatch should reject ordered case clause");
+        assert_eq!(
+            error,
+            PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            },
         );
     }
 

--- a/src/planner/expression/case/bool_subject.rs
+++ b/src/planner/expression/case/bool_subject.rs
@@ -2,9 +2,11 @@ use super::{
     case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
     validate_clause_shape,
 };
-use crate::plan::{BoolCaseBranches, BoolExpr, Expr, ExprKind};
+use crate::plan::{BoolExpr, Expr, ValueType};
 use crate::planner::context::PlanContext;
-use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
+use crate::planner::error::{
+    InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
+};
 use ecow::EcoString;
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
@@ -20,6 +22,11 @@ pub(super) fn plan(
     let return_type = case_return_type(type_.as_ref())?;
     for clause in &clauses {
         validate_clause_shape(clause)?;
+    }
+    if clauses.iter().any(|clause| clause.guard.is_some()) {
+        let (subject_step, subject) = super::bind_bool_case_subject(subject, context);
+        let case = plan_guarded_bool_case(type_.as_ref(), return_type, subject, clauses, context)?;
+        return Ok(super::case_subject_block(subject_step, case));
     }
     let needs_subject_binding = clauses.iter().any(clause_has_bool_variable_pattern);
     let (subject_step, subject) = if needs_subject_binding {
@@ -57,9 +64,71 @@ pub(super) fn plan(
         InvalidCaseShapeReason::MissingFalsePattern,
     ))?;
 
-    bool_case_expr(subject, true_, false_).map(|case| match subject_step {
+    super::bool_case_expr(subject, true_, false_).map(|case| match subject_step {
         Some(step) => super::case_subject_block(step, case),
         None => case,
+    })
+}
+
+fn plan_guarded_bool_case(
+    case_type: &Type,
+    return_type: ValueType,
+    subject: BoolExpr,
+    clauses: Vec<TypedClause>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let mut true_clauses = Vec::with_capacity(clauses.len());
+    let mut false_clauses = Vec::with_capacity(clauses.len());
+    for clause in clauses {
+        let pattern = single_case_pattern(clause.pattern)?;
+        let pattern = plan_bool_case_pattern(pattern)?;
+        let binding = pattern
+            .bound_name()
+            .cloned()
+            .map(|name| (name, Expr::bool(subject.clone())));
+        let is_total = clause.guard.is_none();
+        let ordered_clause = super::plan_ordered_case_clause(
+            super::OrderedCaseClauseInput {
+                case_type,
+                return_type: &return_type,
+                then: clause.then,
+                variable_binding: binding,
+                guard: clause.guard,
+                match_condition: BoolExpr::value(true),
+                is_total,
+            },
+            context,
+        )?;
+
+        match pattern {
+            BoolCasePattern::True => true_clauses.push(ordered_clause),
+            BoolCasePattern::False => false_clauses.push(ordered_clause),
+            BoolCasePattern::Any { .. } => {
+                true_clauses.push(ordered_clause.clone());
+                false_clauses.push(ordered_clause);
+            }
+        }
+    }
+
+    let true_ = ordered_bool_case_branch(true_clauses, InvalidCaseShapeReason::MissingTruePattern)?;
+    let false_ =
+        ordered_bool_case_branch(false_clauses, InvalidCaseShapeReason::MissingFalsePattern)?;
+
+    super::bool_case_expr(subject, true_, false_)
+}
+
+fn ordered_bool_case_branch(
+    clauses: Vec<super::OrderedCaseClause>,
+    missing_reason: InvalidCaseShapeReason,
+) -> Result<Expr, PlanError> {
+    super::ordered_case_expr(clauses).map_err(|error| match error {
+        PlanError::InvalidTypedAst {
+            reason:
+                InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::MissingFallbackPattern,
+                },
+        } => invalid_case_shape(missing_reason),
+        error => error,
     })
 }
 
@@ -165,87 +234,20 @@ fn set_case_branch(branch: &mut Option<Expr>, value: Expr) {
     }
 }
 
-fn bool_case_expr(subject: BoolExpr, true_: Expr, false_: Expr) -> Result<Expr, PlanError> {
-    let branches = match (true_.into_kind(), false_.into_kind()) {
-        (ExprKind::Int(true_), ExprKind::Int(false_)) => BoolCaseBranches::Int { true_, false_ },
-        (ExprKind::String(true_), ExprKind::String(false_)) => {
-            BoolCaseBranches::String { true_, false_ }
-        }
-        (ExprKind::Float(true_), ExprKind::Float(false_)) => {
-            BoolCaseBranches::Float { true_, false_ }
-        }
-        (ExprKind::Bool(true_), ExprKind::Bool(false_)) => BoolCaseBranches::Bool { true_, false_ },
-        (ExprKind::Nil(true_), ExprKind::Nil(false_)) => BoolCaseBranches::Nil { true_, false_ },
-        (ExprKind::Tuple(true_), ExprKind::Tuple(false_)) => {
-            BoolCaseBranches::Tuple { true_, false_ }
-        }
-        (ExprKind::List(true_), ExprKind::List(false_)) => BoolCaseBranches::List { true_, false_ },
-        (ExprKind::Function(true_), ExprKind::Function(false_)) => {
-            bool_function_case_branches(true_, false_)?
-        }
-        _ => {
-            return Err(invalid_case_shape(
-                InvalidCaseShapeReason::BranchReturnTypeMismatch,
-            ));
-        }
-    };
-
-    Ok(Expr::bool_case(subject, branches))
-}
-
-fn bool_function_case_branches(
-    true_: crate::plan::FunctionExpr,
-    false_: crate::plan::FunctionExpr,
-) -> Result<BoolCaseBranches, PlanError> {
-    match (true_.into_kind(), false_.into_kind()) {
-        (crate::plan::FunctionExprKind::Int(true_), crate::plan::FunctionExprKind::Int(false_)) => {
-            Ok(BoolCaseBranches::IntFunction { true_, false_ })
-        }
-        (
-            crate::plan::FunctionExprKind::String(true_),
-            crate::plan::FunctionExprKind::String(false_),
-        ) => Ok(BoolCaseBranches::StringFunction { true_, false_ }),
-        (
-            crate::plan::FunctionExprKind::Float(true_),
-            crate::plan::FunctionExprKind::Float(false_),
-        ) => Ok(BoolCaseBranches::FloatFunction { true_, false_ }),
-        (
-            crate::plan::FunctionExprKind::Bool(true_),
-            crate::plan::FunctionExprKind::Bool(false_),
-        ) => Ok(BoolCaseBranches::BoolFunction { true_, false_ }),
-        (crate::plan::FunctionExprKind::Nil(true_), crate::plan::FunctionExprKind::Nil(false_)) => {
-            Ok(BoolCaseBranches::NilFunction { true_, false_ })
-        }
-        (
-            crate::plan::FunctionExprKind::Tuple(true_),
-            crate::plan::FunctionExprKind::Tuple(false_),
-        ) => Ok(BoolCaseBranches::TupleFunction { true_, false_ }),
-        (
-            crate::plan::FunctionExprKind::List(true_),
-            crate::plan::FunctionExprKind::List(false_),
-        ) => Ok(BoolCaseBranches::ListFunction { true_, false_ }),
-        (
-            crate::plan::FunctionExprKind::Function(true_),
-            crate::plan::FunctionExprKind::Function(false_),
-        ) => Ok(BoolCaseBranches::FunctionFunction { true_, false_ }),
-        _ => Err(invalid_case_shape(
-            InvalidCaseShapeReason::BranchReturnTypeMismatch,
-        )),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::plan::{
         BoolExpr, BoolFunctionId, Expr, FloatExpr, FloatFunctionId, FunctionExpr,
         FunctionFunctionId, FunctionType, IntFunctionFunctionId, IntFunctionId, IntLocalId,
-        ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringFunctionId, ValueType,
+        IntReturn, ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringFunctionId,
+        ValueType,
     };
     use crate::planner::dsl::{
         bool_, bool_return_block, bool_return_bool_case, bool_return_expr, call_bool, function,
-        function_ref, int, int_return_bool_case, int_return_expr, let_bool_step, list,
-        list_return_bool_case, list_return_expr, local_bool, module, nil, nil_return_bool_case,
-        nil_return_expr, return_list, string, string_return_bool_case, string_return_expr,
+        function_ref, int, int_return_block, int_return_bool_case, int_return_expr, let_bool_step,
+        list, list_return_bool_case, list_return_expr, local_bool, module, nil,
+        nil_return_bool_case, nil_return_expr, return_list, string, string_return_bool_case,
+        string_return_expr,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -253,7 +255,7 @@ mod tests {
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
         UnsupportedCaseReason, UnsupportedExpressionKind,
     };
-    use gleam_core::ast::Pattern;
+    use gleam_core::ast::{BinOp, ClauseGuard, Constant, Pattern};
     use gleam_core::type_::{self, error::VariableOrigin};
     use num_bigint::BigInt;
 
@@ -375,6 +377,45 @@ pub fn main() {
                 bool_return_block(
                     [let_bool_step(0, "<case:bool:0>", bool_(true))],
                     bool_return_bool_case(local_bool(0, "<case:bool:0>"), branch.clone(), branch),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_bool_case_guard_binds_subject_once_and_falls_through() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case True {
+    other if other -> 1
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let bind_other = let_bool_step(1, "other", local_bool(0, "<case:bool:0>"));
+        let condition = BoolExpr::block(
+            vec![bind_other.clone()],
+            BoolExpr::and(BoolExpr::value(true), local_bool(1, "other").into()),
+        );
+        let guarded_branch = int_return_block([bind_other], int_return_expr(int(1)));
+        let guarded_case = IntReturn::bool_case(condition, guarded_branch, int_return_expr(int(0)));
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_bool_step(0, "<case:bool:0>", bool_(true))],
+                    int_return_bool_case(
+                        local_bool(0, "<case:bool:0>"),
+                        guarded_case.clone(),
+                        guarded_case,
+                    ),
                 ),
             ),
             [],
@@ -530,7 +571,7 @@ fn duplicate_true(value: Bool) {
     #[test]
     fn reject_margin_bool_case_function_branch_type_mismatch_direct() {
         assert_eq!(
-            (super::bool_function_case_branches(
+            (super::super::bool_function_case_branches(
                 FunctionExpr::from(function_ref(
                     RuntimeFunctionId::Int(IntFunctionId(0)),
                     [LocalId::Int(IntLocalId(0))],
@@ -548,7 +589,7 @@ fn duplicate_true(value: Bool) {
             }),
         );
         assert_eq!(
-            (super::bool_function_case_branches(
+            (super::super::bool_function_case_branches(
                 FunctionExpr::from(function_ref(
                     RuntimeFunctionId::Bool(BoolFunctionId(0)),
                     [LocalId::Int(IntLocalId(0))],
@@ -570,21 +611,21 @@ fn duplicate_true(value: Bool) {
     #[test]
     fn plan_bool_case_function_branch_return_families_direct() {
         assert_eq!(
-            super::bool_case_expr(
+            super::super::bool_case_expr(
                 BoolExpr::value(true),
                 Expr::float(FloatExpr::value(1.0)),
                 Expr::float(FloatExpr::value(0.0)),
             ),
             Ok(Expr::bool_case(
                 BoolExpr::value(true),
-                super::BoolCaseBranches::Float {
+                crate::plan::BoolCaseBranches::Float {
                     true_: FloatExpr::value(1.0),
                     false_: FloatExpr::value(0.0),
                 },
             )),
         );
 
-        let string_branches = super::bool_function_case_branches(
+        let string_branches = super::super::bool_function_case_branches(
             FunctionExpr::from(function_ref(
                 RuntimeFunctionId::String(StringFunctionId(0)),
                 [LocalId::String(crate::plan::StringLocalId(0))],
@@ -603,7 +644,7 @@ fn duplicate_true(value: Bool) {
             ))),
         );
 
-        let float_branches = super::bool_function_case_branches(
+        let float_branches = super::super::bool_function_case_branches(
             FunctionExpr::from(function_ref(
                 RuntimeFunctionId::Float(FloatFunctionId(0)),
                 [LocalId::Float(crate::plan::FloatLocalId(0))],
@@ -622,7 +663,7 @@ fn duplicate_true(value: Bool) {
             ))),
         );
 
-        let bool_branches = super::bool_function_case_branches(
+        let bool_branches = super::super::bool_function_case_branches(
             FunctionExpr::from(function_ref(
                 RuntimeFunctionId::Bool(BoolFunctionId(0)),
                 [LocalId::Bool(crate::plan::BoolLocalId(0))],
@@ -641,7 +682,7 @@ fn duplicate_true(value: Bool) {
             ))),
         );
 
-        let nil_branches = super::bool_function_case_branches(
+        let nil_branches = super::super::bool_function_case_branches(
             FunctionExpr::from(function_ref(
                 RuntimeFunctionId::Nil(NilFunctionId(0)),
                 [LocalId::Nil(crate::plan::NilLocalId(0))],
@@ -660,7 +701,7 @@ fn duplicate_true(value: Bool) {
             ))),
         );
 
-        let list_branches = super::bool_function_case_branches(
+        let list_branches = super::super::bool_function_case_branches(
             FunctionExpr::from(function_ref(
                 RuntimeFunctionId::List {
                     id: ListFunctionId(0),
@@ -686,7 +727,7 @@ fn duplicate_true(value: Bool) {
         );
 
         let returned_function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
-        let function_branches = super::bool_function_case_branches(
+        let function_branches = super::super::bool_function_case_branches(
             FunctionExpr::from(function_ref(
                 RuntimeFunctionId::Function {
                     id: FunctionFunctionId::Int(IntFunctionFunctionId(0)),
@@ -995,6 +1036,112 @@ pub fn main() {
     }
 
     #[test]
+    fn reject_margin_guarded_bool_case_pattern_shapes() {
+        let mut empty_pattern = super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut empty_pattern.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(bool_true_guard());
+        clauses[0].pattern.clear();
+        assert_eq!(
+            plan_module(empty_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
+                },
+            }),
+        );
+
+        let mut pattern_type_mismatch = super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut pattern_type_mismatch.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(bool_true_guard());
+        clauses[0].pattern[0] = Pattern::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        };
+        assert_eq!(
+            plan_module(pattern_type_mismatch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_guarded_bool_case_missing_patterns() {
+        let mut missing_true_pattern = super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut missing_true_pattern.definitions.functions[0].body[0],
+        );
+        clauses.remove(0);
+        clauses[0].guard = Some(bool_true_guard());
+        assert_eq!(
+            plan_module(missing_true_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::MissingTruePattern,
+                },
+            }),
+        );
+
+        let mut missing_false_pattern = super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut missing_false_pattern.definitions.functions[0].body[0],
+        );
+        clauses.pop();
+        clauses.push(gleam_core::ast::Clause {
+            location: dummy_span(),
+            pattern: vec![Pattern::Discard {
+                name: "_".into(),
+                location: dummy_span(),
+                type_: type_::bool(),
+            }],
+            alternative_patterns: Vec::new(),
+            guard: Some(bool_true_guard()),
+            then: crate::planner::expression::typed_int_expr(0),
+        });
+        assert_eq!(
+            plan_module(missing_false_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::MissingFalsePattern,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_ordered_bool_case_branch_preserves_non_fallback_errors() {
+        assert_eq!(
+            super::ordered_bool_case_branch(
+                vec![
+                    super::super::OrderedCaseClause {
+                        condition: BoolExpr::value(true),
+                        branch: int(1).into(),
+                        is_total: false,
+                    },
+                    super::super::OrderedCaseClause {
+                        condition: BoolExpr::value(true),
+                        branch: bool_(true).into(),
+                        is_total: true,
+                    },
+                ],
+                InvalidCaseShapeReason::MissingTruePattern,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
     fn reject_margin_bool_case_subject_type_mismatch() {
         let mut module = super::super::compile_bool_case_module();
         let (_, subjects, _) =
@@ -1034,9 +1181,31 @@ pub fn main() {
     }
 
     #[test]
+    fn reject_margin_bool_case_guard_must_be_bool() {
+        let mut module = super::super::compile_bool_case_module();
+        let (_, _, clauses) =
+            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Bool,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+    }
+
+    #[test]
     fn reject_margin_bool_case_expr_type_mismatch() {
         assert_eq!(
-            super::bool_case_expr(bool_(true).into(), int(1).into(), bool_(false).into()),
+            super::super::bool_case_expr(bool_(true).into(), int(1).into(), bool_(false).into()),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CaseShape {
                     reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
@@ -1048,7 +1217,7 @@ pub fn main() {
     #[test]
     fn reject_margin_bool_case_function_expr_type_mismatch_direct() {
         assert_eq!(
-            super::bool_case_expr(
+            super::super::bool_case_expr(
                 BoolExpr::value(true),
                 Expr::from(function_ref(
                     RuntimeFunctionId::Int(IntFunctionId(0)),
@@ -1113,5 +1282,23 @@ fn stringify(value: Int) {
                 },
             }),
         );
+    }
+
+    fn bool_true_guard() -> ClauseGuard<std::sync::Arc<gleam_core::type_::Type>> {
+        ClauseGuard::BinaryOperator {
+            location: dummy_span(),
+            operator: BinOp::Eq,
+            operator_start: 0,
+            left: Box::new(ClauseGuard::Constant(Constant::Int {
+                location: dummy_span(),
+                value: "1".into(),
+                int_value: BigInt::from(1),
+            })),
+            right: Box::new(ClauseGuard::Constant(Constant::Int {
+                location: dummy_span(),
+                value: "1".into(),
+                int_value: BigInt::from(1),
+            })),
+        }
     }
 }

--- a/src/planner/expression/case/float_subject.rs
+++ b/src/planner/expression/case/float_subject.rs
@@ -2,7 +2,7 @@ use super::{
     case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
     validate_clause_shape,
 };
-use crate::plan::{Expr, ExprKind, FloatCaseBranches, FloatExpr};
+use crate::plan::{BoolExpr, Expr, ExprKind, FloatCaseBranches, FloatExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use ecow::EcoString;
@@ -20,6 +20,11 @@ pub(super) fn plan(
     let return_type = case_return_type(type_.as_ref())?;
     for clause in &clauses {
         validate_clause_shape(clause)?;
+    }
+    if clauses.iter().any(|clause| clause.guard.is_some()) {
+        let (subject_step, subject) = super::bind_float_case_subject(subject, context);
+        let case = plan_guarded_float_case(type_.as_ref(), return_type, subject, clauses, context)?;
+        return Ok(super::case_subject_block(subject_step, case));
     }
     let needs_subject_binding = clauses.iter().any(clause_has_float_variable_pattern);
     let (subject_step, subject) = if needs_subject_binding {
@@ -66,6 +71,46 @@ pub(super) fn plan(
         Some(step) => super::case_subject_block(step, case),
         None => case,
     })
+}
+
+fn plan_guarded_float_case(
+    case_type: &Type,
+    return_type: ValueType,
+    subject: FloatExpr,
+    clauses: Vec<TypedClause>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    for clause in clauses {
+        let pattern = single_case_pattern(clause.pattern)?;
+        let pattern = plan_float_case_pattern(pattern)?;
+        let binding = pattern
+            .bound_name()
+            .cloned()
+            .map(|name| (name, Expr::float(subject.clone())));
+        let is_total = matches!(pattern, FloatCasePattern::Any { .. }) && clause.guard.is_none();
+        let match_condition = match pattern {
+            FloatCasePattern::Literal(value) => BoolExpr::equal(
+                Expr::float(subject.clone()),
+                Expr::float(FloatExpr::value(value)),
+            ),
+            FloatCasePattern::Any { .. } => BoolExpr::value(true),
+        };
+        ordered_clauses.push(super::plan_ordered_case_clause(
+            super::OrderedCaseClauseInput {
+                case_type,
+                return_type: &return_type,
+                then: clause.then,
+                variable_binding: binding,
+                guard: clause.guard,
+                match_condition,
+                is_total,
+            },
+            context,
+        )?);
+    }
+
+    super::ordered_case_expr(ordered_clauses)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -184,7 +229,9 @@ fn int_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Int(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -197,7 +244,9 @@ fn string_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::String(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -210,7 +259,9 @@ fn float_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Float(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -223,7 +274,9 @@ fn bool_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Bool(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -236,7 +289,9 @@ fn nil_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Nil(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -249,7 +304,9 @@ fn tuple_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Tuple(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -262,7 +319,9 @@ fn list_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::List(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -317,10 +376,14 @@ fn int_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_int() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -333,10 +396,14 @@ fn string_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_string() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -349,10 +416,14 @@ fn float_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_float() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -365,10 +436,14 @@ fn bool_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_bool() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -381,10 +456,14 @@ fn nil_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_nil() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -397,10 +476,14 @@ fn tuple_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_tuple() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -413,10 +496,14 @@ fn list_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_list() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -429,27 +516,27 @@ fn function_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_function() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
     Ok(typed_clauses)
 }
 
-fn branch_return_type_mismatch() -> PlanError {
-    invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch)
-}
-
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        BoolFunctionId, Expr, FloatCaseBranches, FloatFunctionFunctionId, FloatFunctionId,
-        FunctionExpr, FunctionFunctionId, FunctionType, IntFunctionExpr, IntFunctionId, IntLocalId,
-        ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringFunctionId,
-        TupleFunctionId, ValueType,
+        BoolExpr, BoolFunctionId, Expr, FloatCaseBranches, FloatFunctionFunctionId,
+        FloatFunctionId, FloatReturn, FunctionExpr, FunctionFunctionId, FunctionType,
+        IntFunctionExpr, IntFunctionId, IntLocalId, ListFunctionId, LocalId, NilFunctionId,
+        RuntimeFunctionId, StringFunctionId, TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
         bool_, bool_return_expr, bool_return_float_case, float, float_return_block,
@@ -464,9 +551,10 @@ mod tests {
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
         UnsupportedCaseReason, UnsupportedExpressionKind,
     };
-    use gleam_core::ast::{Pattern, TypedModule};
+    use gleam_core::ast::{ClauseGuard, Constant, Pattern, TypedModule};
     use gleam_core::parse::LiteralFloatValue;
     use gleam_core::type_::{self, error::VariableOrigin};
+    use num_bigint::BigInt;
 
     #[test]
     fn plan_float_case_expressions() {
@@ -606,6 +694,48 @@ pub fn main() {
                             [let_float_step(1, "other", local_float(0, "<case:float:0>"))],
                             float_return_expr(local_float(1, "other")),
                         ),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_float_case_guard_binds_subject_once_and_falls_through() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 1.5 {
+    other if other >. 1.0 -> other
+    _ -> 0.0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let bind_other = let_float_step(1, "other", local_float(0, "<case:float:0>"));
+        let condition = BoolExpr::block(
+            vec![bind_other.clone()],
+            BoolExpr::and(
+                BoolExpr::value(true),
+                BoolExpr::gt_float(local_float(1, "other").into(), float(1.0).into()),
+            ),
+        );
+        let guarded_branch =
+            float_return_block([bind_other], float_return_expr(local_float(1, "other")));
+        let expected = module(
+            "main",
+            function(
+                "main",
+                float_return_block(
+                    [let_float_step(0, "<case:float:0>", float(1.5))],
+                    FloatReturn::bool_case(
+                        condition,
+                        guarded_branch,
+                        float_return_expr(float(0.0)),
                     ),
                 ),
             ),
@@ -885,10 +1015,6 @@ fn duplicate_literal(value: Float) {
                 r#"pub fn main() { case 1.0 { _ as alias -> 1 } }"#,
                 UnsupportedCaseReason::AssignPattern,
             ),
-            (
-                r#"pub fn main() { case 1.0 { 1.0 if True -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::Guard,
-            ),
         ];
 
         for (src, reason) in cases {
@@ -921,6 +1047,22 @@ pub fn main() {
 
     #[test]
     fn reject_margin_float_case_pattern_shapes() {
+        let mut alternative_pattern = compile_float_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut alternative_pattern.definitions.functions[0].body[0],
+        );
+        clauses[0].alternative_patterns.push(vec![Pattern::Float {
+            location: dummy_span(),
+            value: "2.0".into(),
+            float_value: LiteralFloatValue::ONE,
+        }]);
+        assert_eq!(
+            plan_module(alternative_pattern),
+            Err(PlanError::UnsupportedCase {
+                reason: UnsupportedCaseReason::AlternativePatterns,
+            }),
+        );
+
         let mut variable_type_mismatch = compile_float_case_module();
         let (_, _, clauses) = super::super::expect_case_statement_mut(
             &mut variable_type_mismatch.definitions.functions[0].body[0],
@@ -1110,6 +1252,72 @@ fn add_one(value: Float) {
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CaseShape {
                     reason: InvalidCaseShapeReason::MissingFallbackPattern,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_guarded_float_case_pattern_shapes() {
+        let mut empty_pattern = compile_float_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut empty_pattern.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+        clauses[0].pattern.clear();
+        assert_eq!(
+            plan_module(empty_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
+                },
+            }),
+        );
+
+        let mut pattern_type_mismatch = compile_float_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut pattern_type_mismatch.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+        clauses[0].pattern[0] = Pattern::String {
+            location: dummy_span(),
+            value: "one".into(),
+        };
+        assert_eq!(
+            plan_module(pattern_type_mismatch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_float_case_guard_must_be_bool() {
+        let mut module = compile_float_case_module();
+        let (_, _, clauses) =
+            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Bool,
+                    actual: InvalidExpressionType::Int,
                 },
             }),
         );

--- a/src/planner/expression/case/guard.rs
+++ b/src/planner/expression/case/guard.rs
@@ -1,0 +1,1431 @@
+use crate::plan::{
+    BoolExpr, BoolFunctionExpr, Expr, FloatExpr, FloatFunctionExpr, FunctionExpr,
+    FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr, ListFunctionExpr, LocalId, NilExpr,
+    NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr, TupleFunctionExpr, ValueType,
+};
+use crate::planner::context::{FunctionLocalBinding, PlanContext};
+use crate::planner::error::{
+    InvalidExpressionShapeKind, InvalidExpressionType, InvalidTypedAstReason, PlanError,
+    UnsupportedBinOpKind,
+};
+use ecow::EcoString;
+use gleam_core::ast::{BinOp, ClauseGuard};
+use gleam_core::type_::Type;
+use std::sync::Arc;
+
+pub(super) fn plan_bool(
+    guard: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<BoolExpr, PlanError> {
+    let expression = plan_expr(guard, context)?;
+    let actual = expression.value_type();
+    expression
+        .into_bool()
+        .ok_or_else(|| invalid_expression_type_for_value(ValueType::Bool, actual))
+}
+
+fn plan_expr(
+    guard: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    match guard {
+        ClauseGuard::Constant(constant) => super::super::constant::plan(constant, context),
+        ClauseGuard::Block { value, .. } => plan_expr(*value, context),
+        ClauseGuard::Var { name, .. } => plan_local(name, context),
+        ClauseGuard::TupleIndex {
+            tuple,
+            index,
+            type_,
+            ..
+        } => plan_tuple_index(*tuple, index, type_, context),
+        ClauseGuard::Not { expression, .. } => {
+            Ok(Expr::bool(BoolExpr::not(plan_bool(*expression, context)?)))
+        }
+        ClauseGuard::BinaryOperator {
+            operator,
+            left,
+            right,
+            ..
+        } => plan_binary_operator(operator, *left, *right, context),
+        ClauseGuard::ModuleSelect {
+            module_name,
+            literal,
+            ..
+        } if module_name == *context.module_name => super::super::constant::plan(literal, context),
+        ClauseGuard::ModuleSelect { .. } => {
+            invalid_expression_shape(InvalidExpressionShapeKind::ModuleSelect)
+        }
+        ClauseGuard::FieldAccess { .. } => {
+            invalid_expression_shape(InvalidExpressionShapeKind::RecordAccess)
+        }
+        ClauseGuard::Invalid { .. } => {
+            invalid_expression_shape(InvalidExpressionShapeKind::Invalid)
+        }
+    }
+}
+
+fn plan_binary_operator(
+    operator: BinOp,
+    left: ClauseGuard<Arc<Type>>,
+    right: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    match operator {
+        BinOp::And => bool_binary_operator(left, right, context, BoolExpr::and),
+        BinOp::Or => bool_binary_operator(left, right, context, BoolExpr::or),
+        BinOp::Eq => equality(
+            left,
+            right,
+            context,
+            UnsupportedBinOpKind::EqFunction,
+            false,
+        ),
+        BinOp::NotEq => equality(
+            left,
+            right,
+            context,
+            UnsupportedBinOpKind::NotEqFunction,
+            true,
+        ),
+        BinOp::GtInt => int_comparison_operator(left, right, context, BoolExpr::gt_int),
+        BinOp::GtEqInt => int_comparison_operator(left, right, context, BoolExpr::gte_int),
+        BinOp::LtInt => int_comparison_operator(left, right, context, BoolExpr::lt_int),
+        BinOp::LtEqInt => int_comparison_operator(left, right, context, BoolExpr::lte_int),
+        BinOp::GtFloat => float_comparison_operator(left, right, context, BoolExpr::gt_float),
+        BinOp::GtEqFloat => float_comparison_operator(left, right, context, BoolExpr::gte_float),
+        BinOp::LtFloat => float_comparison_operator(left, right, context, BoolExpr::lt_float),
+        BinOp::LtEqFloat => float_comparison_operator(left, right, context, BoolExpr::lte_float),
+        BinOp::AddInt => int_binary_operator(left, right, context, IntExpr::add),
+        BinOp::SubInt => int_binary_operator(left, right, context, IntExpr::sub),
+        BinOp::MultInt => int_binary_operator(left, right, context, IntExpr::mult),
+        BinOp::DivInt => int_binary_operator(left, right, context, IntExpr::div),
+        BinOp::RemainderInt => int_binary_operator(left, right, context, IntExpr::remainder),
+        BinOp::AddFloat => float_binary_operator(left, right, context, FloatExpr::add),
+        BinOp::SubFloat => float_binary_operator(left, right, context, FloatExpr::sub),
+        BinOp::MultFloat => float_binary_operator(left, right, context, FloatExpr::mult),
+        BinOp::DivFloat => float_binary_operator(left, right, context, FloatExpr::div),
+        BinOp::Concatenate => string_binary_operator(left, right, context, StringExpr::concatenate),
+    }
+}
+
+fn bool_binary_operator(
+    left: ClauseGuard<Arc<Type>>,
+    right: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+    operator: fn(BoolExpr, BoolExpr) -> BoolExpr,
+) -> Result<Expr, PlanError> {
+    let left = plan_bool(left, context)?;
+    let right = plan_bool(right, context)?;
+    Ok(Expr::bool(operator(left, right)))
+}
+
+fn int_comparison_operator(
+    left: ClauseGuard<Arc<Type>>,
+    right: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+    operator: fn(IntExpr, IntExpr) -> BoolExpr,
+) -> Result<Expr, PlanError> {
+    let left = plan_int(left, context)?;
+    let right = plan_int(right, context)?;
+    Ok(Expr::bool(operator(left, right)))
+}
+
+fn float_comparison_operator(
+    left: ClauseGuard<Arc<Type>>,
+    right: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+    operator: fn(FloatExpr, FloatExpr) -> BoolExpr,
+) -> Result<Expr, PlanError> {
+    let left = plan_float(left, context)?;
+    let right = plan_float(right, context)?;
+    Ok(Expr::bool(operator(left, right)))
+}
+
+fn int_binary_operator(
+    left: ClauseGuard<Arc<Type>>,
+    right: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+    operator: fn(IntExpr, IntExpr) -> IntExpr,
+) -> Result<Expr, PlanError> {
+    let left = plan_int(left, context)?;
+    let right = plan_int(right, context)?;
+    Ok(Expr::int(operator(left, right)))
+}
+
+fn float_binary_operator(
+    left: ClauseGuard<Arc<Type>>,
+    right: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+    operator: fn(FloatExpr, FloatExpr) -> FloatExpr,
+) -> Result<Expr, PlanError> {
+    let left = plan_float(left, context)?;
+    let right = plan_float(right, context)?;
+    Ok(Expr::float(operator(left, right)))
+}
+
+fn string_binary_operator(
+    left: ClauseGuard<Arc<Type>>,
+    right: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+    operator: fn(StringExpr, StringExpr) -> StringExpr,
+) -> Result<Expr, PlanError> {
+    let left = plan_string(left, context)?;
+    let right = plan_string(right, context)?;
+    Ok(Expr::string(operator(left, right)))
+}
+
+fn equality(
+    left: ClauseGuard<Arc<Type>>,
+    right: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+    operator: UnsupportedBinOpKind,
+    negated: bool,
+) -> Result<Expr, PlanError> {
+    let left = plan_expr(left, context)?;
+    let right = plan_expr(right, context)?;
+    if contains_function_value(&left.value_type()) || contains_function_value(&right.value_type()) {
+        return Err(PlanError::UnsupportedBinOp { operator });
+    }
+
+    let expression = if negated {
+        BoolExpr::not_equal(left, right)
+    } else {
+        BoolExpr::equal(left, right)
+    };
+    Ok(Expr::bool(expression))
+}
+
+fn plan_int(
+    guard: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<IntExpr, PlanError> {
+    let expression = plan_expr(guard, context)?;
+    let actual = expression.value_type();
+    expression
+        .into_int()
+        .ok_or_else(|| invalid_expression_type_for_value(ValueType::Int, actual))
+}
+
+fn plan_float(
+    guard: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<FloatExpr, PlanError> {
+    let expression = plan_expr(guard, context)?;
+    let actual = expression.value_type();
+    expression
+        .into_float()
+        .ok_or_else(|| invalid_expression_type_for_value(ValueType::Float, actual))
+}
+
+fn plan_string(
+    guard: ClauseGuard<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<StringExpr, PlanError> {
+    let expression = plan_expr(guard, context)?;
+    let actual = expression.value_type();
+    expression
+        .into_string()
+        .ok_or_else(|| invalid_expression_type_for_value(ValueType::String, actual))
+}
+
+fn plan_tuple_index(
+    tuple: ClauseGuard<Arc<Type>>,
+    index: u64,
+    type_: Arc<Type>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    #[cfg(target_pointer_width = "64")]
+    let index = index as usize;
+    #[cfg(not(target_pointer_width = "64"))]
+    let index = usize::try_from(index).map_err(|_| PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionType {
+            expected: InvalidExpressionType::Tuple,
+            actual: InvalidExpressionType::Tuple,
+        },
+    })?;
+    let tuple = plan_expr(tuple, context)?;
+    let actual = tuple.value_type();
+    let Some(tuple) = tuple.into_tuple() else {
+        return Err(invalid_expression_type_for_value(
+            ValueType::Tuple(Vec::new()),
+            actual,
+        ));
+    };
+    let expected =
+        ValueType::from_gleam(type_.as_ref()).ok_or_else(|| PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionType {
+                expected: InvalidExpressionType::Unsupported,
+                actual: InvalidExpressionType::Tuple,
+            },
+        })?;
+    let actual = tuple.type_().get(index).cloned().ok_or_else(|| {
+        invalid_expression_type_for_value(expected.clone(), ValueType::Tuple(Vec::new()))
+    })?;
+    if actual != expected {
+        return Err(invalid_expression_type_for_value(expected.clone(), actual));
+    }
+
+    Ok(super::super::tuple_index_expr(tuple, index, expected))
+}
+
+fn plan_local(name: EcoString, context: &PlanContext<'_>) -> Result<Expr, PlanError> {
+    if let Some((local, type_)) = context.lookup_local(&name) {
+        return local_get(local, name, type_);
+    }
+    if let Some((local, type_)) = context.lookup_tuple_local(&name) {
+        return Ok(Expr::tuple(TupleExpr::local_get(local, name, type_)));
+    }
+    if let Some((local, element_type)) = context.lookup_list_local(&name) {
+        return Ok(Expr::list(ListExpr::local_get(local, name, element_type)));
+    }
+    if let Some(binding) = context.lookup_function_local(&name) {
+        return Ok(function_local_get(binding, name));
+    }
+
+    Err(PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::UnknownLocal { name },
+    })
+}
+
+fn local_get(local: LocalId, name: EcoString, type_: ValueType) -> Result<Expr, PlanError> {
+    match (local, type_) {
+        (LocalId::Int(local), ValueType::Int) => Ok(Expr::int(IntExpr::local_get(local, name))),
+        (LocalId::Float(local), ValueType::Float) => {
+            Ok(Expr::float(FloatExpr::local_get(local, name)))
+        }
+        (LocalId::String(local), ValueType::String) => {
+            Ok(Expr::string(StringExpr::local_get(local, name)))
+        }
+        (LocalId::Bool(local), ValueType::Bool) => Ok(Expr::bool(BoolExpr::local_get(local, name))),
+        (LocalId::Nil(local), ValueType::Nil) => Ok(Expr::nil(NilExpr::local_get(local, name))),
+        _ => invalid_expression_shape(InvalidExpressionShapeKind::Invalid),
+    }
+}
+
+fn function_local_get(binding: FunctionLocalBinding, name: EcoString) -> Expr {
+    match binding {
+        FunctionLocalBinding::Int { local, type_ } => Expr::function(FunctionExpr::int(
+            IntFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::String { local, type_ } => Expr::function(FunctionExpr::string(
+            StringFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::Float { local, type_ } => Expr::function(FunctionExpr::float(
+            FloatFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::Bool { local, type_ } => Expr::function(FunctionExpr::bool(
+            BoolFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::Nil { local, type_ } => Expr::function(FunctionExpr::nil(
+            NilFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::Tuple { local, type_ } => Expr::function(FunctionExpr::tuple(
+            TupleFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::List { local, type_ } => Expr::function(FunctionExpr::list(
+            ListFunctionExpr::local_get(local, name, type_),
+        )),
+        FunctionLocalBinding::Function { local, type_ } => Expr::function(FunctionExpr::function(
+            FunctionFunctionExpr::local_get(local, name, type_),
+        )),
+    }
+}
+
+fn contains_function_value(type_: &ValueType) -> bool {
+    match type_ {
+        ValueType::Function(_) => true,
+        ValueType::Tuple(elements) => elements.iter().any(contains_function_value),
+        ValueType::List(element) => contains_function_value(element),
+        ValueType::Int
+        | ValueType::Float
+        | ValueType::String
+        | ValueType::Bool
+        | ValueType::Nil => false,
+    }
+}
+
+fn invalid_expression_type_for_value(expected: ValueType, actual: ValueType) -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionType {
+            expected: invalid_expression_type(expected),
+            actual: invalid_expression_type(actual),
+        },
+    }
+}
+
+fn invalid_expression_type(type_: ValueType) -> InvalidExpressionType {
+    match type_ {
+        ValueType::Int => InvalidExpressionType::Int,
+        ValueType::Float => InvalidExpressionType::Float,
+        ValueType::String => InvalidExpressionType::String,
+        ValueType::Bool => InvalidExpressionType::Bool,
+        ValueType::Nil => InvalidExpressionType::Nil,
+        ValueType::Tuple(_) => InvalidExpressionType::Tuple,
+        ValueType::List(_) => InvalidExpressionType::List,
+        ValueType::Function(_) => InvalidExpressionType::Function,
+    }
+}
+
+fn invalid_expression_shape(kind: InvalidExpressionShapeKind) -> Result<Expr, PlanError> {
+    Err(PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionShape { kind },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{contains_function_value, function_local_get, invalid_expression_type, plan_expr};
+    use crate::plan::{
+        BoolExpr, BoolFunctionExpr, BoolFunctionLocalId, BoolLocalId, Expr, FloatExpr,
+        FloatFunctionExpr, FloatFunctionLocalId, FunctionExpr, FunctionFunctionExpr,
+        FunctionFunctionLocalId, FunctionType, IntExpr, IntFunctionExpr, IntFunctionLocalId,
+        IntLocalId, ListExpr, ListFunctionExpr, ListFunctionLocalId, ListLocalId, LocalId, NilExpr,
+        NilFunctionExpr, NilFunctionLocalId, NilLocalId, StringExpr, StringFunctionExpr,
+        StringFunctionLocalId, TupleExpr, TupleFunctionExpr, TupleFunctionLocalId, TupleLocalId,
+        ValueType,
+    };
+    use crate::planner::context::{AnonymousFunctions, FunctionLocalBinding, PlanContext};
+    use crate::planner::support::dummy_span;
+    use crate::planner::{
+        InvalidExpressionShapeKind, InvalidExpressionType, InvalidTypedAstReason, PlanError,
+        UnsupportedBinOpKind,
+    };
+    use ecow::EcoString;
+    use gleam_core::ast::{BinOp, ClauseGuard, Constant};
+    use gleam_core::parse::LiteralFloatValue;
+    use gleam_core::type_::{self, Type, error::VariableOrigin};
+    use num_bigint::BigInt;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    #[test]
+    fn plan_expr_handles_non_operator_guard_shapes() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        context.define_bool_local("flag".into());
+        context.define_tuple_local("pair".into(), vec![ValueType::Int, ValueType::String]);
+
+        assert_eq!(
+            plan_expr(int_constant(1), &mut context),
+            Ok(Expr::int(IntExpr::value(1.into()))),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::Block {
+                    location: dummy_span(),
+                    value: Box::new(int_constant(2)),
+                },
+                &mut context,
+            ),
+            Ok(Expr::int(IntExpr::value(2.into()))),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::Not {
+                    location: dummy_span(),
+                    expression: Box::new(var("flag", type_::bool())),
+                },
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::not(BoolExpr::local_get(
+                crate::plan::BoolLocalId(0),
+                "flag".into(),
+            )))),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::TupleIndex {
+                    location: dummy_span(),
+                    index: 1,
+                    type_: type_::string(),
+                    tuple: Box::new(var(
+                        "pair",
+                        type_::tuple(vec![type_::int(), type_::string()]),
+                    )),
+                },
+                &mut context,
+            ),
+            Ok(Expr::string(StringExpr::tuple_index(
+                TupleExpr::local_get(
+                    TupleLocalId(0),
+                    "pair".into(),
+                    vec![ValueType::Int, ValueType::String],
+                ),
+                1,
+            ))),
+        );
+        assert_eq!(
+            plan_expr(module_select("main", int_constant_literal(3)), &mut context),
+            Ok(Expr::int(IntExpr::value(3.into()))),
+        );
+    }
+
+    #[test]
+    fn plan_expr_rejects_invalid_guard_shapes() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+
+        assert_eq!(
+            plan_expr(
+                module_select("other", int_constant_literal(1)),
+                &mut context
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::ModuleSelect
+            )),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::FieldAccess {
+                    label_location: dummy_span(),
+                    index: Some(0),
+                    label: "field".into(),
+                    type_: type_::int(),
+                    container: Box::new(int_constant(1)),
+                },
+                &mut context,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::RecordAccess
+            )),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                },
+                &mut context,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+    }
+
+    #[test]
+    fn binary_operators_preserve_success_shapes() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        context.define_bool_local("flag".into());
+
+        let flag = BoolExpr::local_get(BoolLocalId(0), "flag".into());
+        let int_one = IntExpr::value(1.into());
+        let int_two = IntExpr::value(2.into());
+        let float_one = FloatExpr::value(1.0);
+        let float_two = FloatExpr::value(1.0);
+        let string_left = StringExpr::value("ge".into());
+        let string_right = StringExpr::value("am".into());
+
+        assert_eq!(
+            plan_expr(
+                binary(
+                    BinOp::And,
+                    var("flag", type_::bool()),
+                    var("flag", type_::bool())
+                ),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::and(flag.clone(), flag.clone()))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(
+                    BinOp::Or,
+                    var("flag", type_::bool()),
+                    var("flag", type_::bool())
+                ),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::or(flag.clone(), flag.clone()))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::Eq, int_constant(1), int_constant(2)),
+                &mut context
+            ),
+            Ok(Expr::bool(BoolExpr::equal(
+                Expr::int(int_one.clone()),
+                Expr::int(int_two.clone()),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::NotEq, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::not_equal(
+                Expr::int(int_one.clone()),
+                Expr::int(int_two.clone()),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::GtInt, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::gt_int(
+                int_one.clone(),
+                int_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::GtEqInt, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::gte_int(
+                int_one.clone(),
+                int_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::LtInt, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::lt_int(
+                int_one.clone(),
+                int_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::LtEqInt, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::lte_int(
+                int_one.clone(),
+                int_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::GtFloat, float_constant(), float_constant()),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::gt_float(
+                float_one.clone(),
+                float_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::GtEqFloat, float_constant(), float_constant()),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::gte_float(
+                float_one.clone(),
+                float_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::LtFloat, float_constant(), float_constant()),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::lt_float(
+                float_one.clone(),
+                float_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::LtEqFloat, float_constant(), float_constant()),
+                &mut context,
+            ),
+            Ok(Expr::bool(BoolExpr::lte_float(
+                float_one.clone(),
+                float_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::AddInt, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::int(IntExpr::add(int_one.clone(), int_two.clone()))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::SubInt, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::int(IntExpr::sub(int_one.clone(), int_two.clone()))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::MultInt, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::int(IntExpr::mult(int_one.clone(), int_two.clone()))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::DivInt, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::int(IntExpr::div(int_one.clone(), int_two.clone()))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::RemainderInt, int_constant(1), int_constant(2)),
+                &mut context,
+            ),
+            Ok(Expr::int(IntExpr::remainder(
+                int_one.clone(),
+                int_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::AddFloat, float_constant(), float_constant()),
+                &mut context,
+            ),
+            Ok(Expr::float(FloatExpr::add(
+                float_one.clone(),
+                float_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::SubFloat, float_constant(), float_constant()),
+                &mut context,
+            ),
+            Ok(Expr::float(FloatExpr::sub(
+                float_one.clone(),
+                float_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::MultFloat, float_constant(), float_constant()),
+                &mut context,
+            ),
+            Ok(Expr::float(FloatExpr::mult(
+                float_one.clone(),
+                float_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(BinOp::DivFloat, float_constant(), float_constant()),
+                &mut context,
+            ),
+            Ok(Expr::float(FloatExpr::div(
+                float_one.clone(),
+                float_two.clone(),
+            ))),
+        );
+        assert_eq!(
+            plan_expr(
+                binary(
+                    BinOp::Concatenate,
+                    string_constant("ge"),
+                    string_constant("am")
+                ),
+                &mut context,
+            ),
+            Ok(Expr::string(StringExpr::concatenate(
+                string_left,
+                string_right,
+            ))),
+        );
+    }
+
+    #[test]
+    fn not_guard_rejects_non_bool_expression() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::Not {
+                    location: dummy_span(),
+                    expression: Box::new(int_constant(1)),
+                },
+                &mut context,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Bool,
+                InvalidExpressionType::Int,
+            )),
+        );
+    }
+
+    #[test]
+    fn binary_operator_helpers_reject_operand_failures_exactly() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        context.define_bool_local("flag".into());
+
+        assert_eq!(
+            super::bool_binary_operator(
+                int_constant(1),
+                var("flag", type_::bool()),
+                &mut context,
+                BoolExpr::and,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Bool,
+                InvalidExpressionType::Int,
+            )),
+        );
+        assert_eq!(
+            super::bool_binary_operator(
+                var("flag", type_::bool()),
+                int_constant(1),
+                &mut context,
+                BoolExpr::and,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Bool,
+                InvalidExpressionType::Int,
+            )),
+        );
+        assert_eq!(
+            super::int_comparison_operator(
+                string_constant("left"),
+                int_constant(1),
+                &mut context,
+                BoolExpr::gt_int,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Int,
+                InvalidExpressionType::String,
+            )),
+        );
+        assert_eq!(
+            super::int_comparison_operator(
+                int_constant(1),
+                string_constant("right"),
+                &mut context,
+                BoolExpr::gt_int,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Int,
+                InvalidExpressionType::String,
+            )),
+        );
+        assert_eq!(
+            super::float_comparison_operator(
+                int_constant(1),
+                float_constant(),
+                &mut context,
+                BoolExpr::gt_float,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Float,
+                InvalidExpressionType::Int,
+            )),
+        );
+        assert_eq!(
+            super::float_comparison_operator(
+                float_constant(),
+                int_constant(1),
+                &mut context,
+                BoolExpr::gt_float,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Float,
+                InvalidExpressionType::Int,
+            )),
+        );
+        assert_eq!(
+            super::int_binary_operator(
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                },
+                int_constant(1),
+                &mut context,
+                IntExpr::add,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+        assert_eq!(
+            super::int_binary_operator(
+                int_constant(1),
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                },
+                &mut context,
+                IntExpr::add,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+        assert_eq!(
+            super::float_binary_operator(
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::float(),
+                },
+                float_constant(),
+                &mut context,
+                FloatExpr::add,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+        assert_eq!(
+            super::float_binary_operator(
+                float_constant(),
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::float(),
+                },
+                &mut context,
+                FloatExpr::add,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+        assert_eq!(
+            super::string_binary_operator(
+                int_constant(1),
+                string_constant("right"),
+                &mut context,
+                StringExpr::concatenate,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::String,
+                InvalidExpressionType::Int,
+            )),
+        );
+        assert_eq!(
+            super::string_binary_operator(
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::string(),
+                },
+                string_constant("right"),
+                &mut context,
+                StringExpr::concatenate,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+        assert_eq!(
+            super::string_binary_operator(
+                string_constant("left"),
+                int_constant(1),
+                &mut context,
+                StringExpr::concatenate,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::String,
+                InvalidExpressionType::Int,
+            )),
+        );
+    }
+
+    #[test]
+    fn plan_tuple_index_rejects_invalid_typed_ast_shapes() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        context.define_int_local("number".into());
+        context.define_tuple_local("pair".into(), vec![ValueType::String]);
+
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::TupleIndex {
+                    location: dummy_span(),
+                    index: 0,
+                    type_: type_::int(),
+                    tuple: Box::new(var("number", type_::int())),
+                },
+                &mut context,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Tuple,
+                InvalidExpressionType::Int,
+            )),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::TupleIndex {
+                    location: dummy_span(),
+                    index: 0,
+                    type_: type_::bit_array(),
+                    tuple: Box::new(var("pair", type_::tuple(vec![type_::string()]))),
+                },
+                &mut context,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Unsupported,
+                InvalidExpressionType::Tuple,
+            )),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::TupleIndex {
+                    location: dummy_span(),
+                    index: 1,
+                    type_: type_::int(),
+                    tuple: Box::new(var("pair", type_::tuple(vec![type_::string()]))),
+                },
+                &mut context,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Int,
+                InvalidExpressionType::Tuple,
+            )),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::TupleIndex {
+                    location: dummy_span(),
+                    index: 0,
+                    type_: type_::int(),
+                    tuple: Box::new(var("pair", type_::tuple(vec![type_::string()]))),
+                },
+                &mut context,
+            ),
+            Err(expression_type_error(
+                InvalidExpressionType::Int,
+                InvalidExpressionType::String,
+            )),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::TupleIndex {
+                    location: dummy_span(),
+                    index: 0,
+                    type_: type_::int(),
+                    tuple: Box::new(ClauseGuard::Invalid {
+                        location: dummy_span(),
+                        type_: type_::tuple(vec![type_::int()]),
+                    }),
+                },
+                &mut context,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+    }
+
+    #[test]
+    fn plan_local_handles_non_primitive_value_families() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        context.define_nil_local("none".into());
+        context.define_tuple_local("pair".into(), vec![ValueType::Int]);
+        context.define_list_local("values".into(), ValueType::String);
+        context.define_int_function_local(
+            "callback".into(),
+            FunctionType::new(vec![ValueType::Int], ValueType::Int),
+        );
+
+        assert_eq!(
+            super::plan_local("none".into(), &context),
+            Ok(Expr::nil(NilExpr::local_get(NilLocalId(0), "none".into()))),
+        );
+        assert_eq!(
+            super::plan_local("pair".into(), &context),
+            Ok(Expr::tuple(TupleExpr::local_get(
+                TupleLocalId(0),
+                "pair".into(),
+                vec![ValueType::Int],
+            ))),
+        );
+        assert_eq!(
+            super::plan_local("values".into(), &context),
+            Ok(Expr::list(ListExpr::local_get(
+                ListLocalId(0),
+                "values".into(),
+                ValueType::String,
+            ))),
+        );
+        assert_eq!(
+            super::plan_local("callback".into(), &context),
+            Ok(Expr::function(FunctionExpr::int(
+                IntFunctionExpr::local_get(
+                    IntFunctionLocalId(0),
+                    "callback".into(),
+                    FunctionType::new(vec![ValueType::Int], ValueType::Int),
+                ),
+            ))),
+        );
+        assert_eq!(
+            super::plan_local("missing".into(), &context),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::UnknownLocal {
+                    name: "missing".into(),
+                },
+            }),
+        );
+        assert_eq!(
+            super::local_get(LocalId::Int(IntLocalId(0)), "bad".into(), ValueType::String),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+    }
+
+    #[test]
+    fn function_local_get_handles_all_return_families() {
+        let unary_int = FunctionType::new(vec![ValueType::Int], ValueType::Int);
+        let unary_string = FunctionType::new(vec![ValueType::String], ValueType::String);
+        let unary_float = FunctionType::new(vec![ValueType::Float], ValueType::Float);
+        let unary_bool = FunctionType::new(vec![ValueType::Bool], ValueType::Bool);
+        let unary_nil = FunctionType::new(vec![ValueType::Nil], ValueType::Nil);
+        let tuple_type = FunctionType::new(Vec::new(), ValueType::Tuple(vec![ValueType::Int]));
+        let list_type = FunctionType::new(Vec::new(), ValueType::List(Box::new(ValueType::Int)));
+        let function_type = FunctionType::new(
+            Vec::new(),
+            ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+        );
+
+        assert_eq!(
+            function_local_get(
+                FunctionLocalBinding::Int {
+                    local: IntFunctionLocalId(0),
+                    type_: unary_int.clone(),
+                },
+                "f".into(),
+            ),
+            Expr::function(FunctionExpr::int(IntFunctionExpr::local_get(
+                IntFunctionLocalId(0),
+                "f".into(),
+                unary_int,
+            ))),
+        );
+        assert_eq!(
+            function_local_get(
+                FunctionLocalBinding::String {
+                    local: StringFunctionLocalId(0),
+                    type_: unary_string.clone(),
+                },
+                "f".into(),
+            ),
+            Expr::function(FunctionExpr::string(StringFunctionExpr::local_get(
+                StringFunctionLocalId(0),
+                "f".into(),
+                unary_string,
+            ))),
+        );
+        assert_eq!(
+            function_local_get(
+                FunctionLocalBinding::Float {
+                    local: FloatFunctionLocalId(0),
+                    type_: unary_float.clone(),
+                },
+                "f".into(),
+            ),
+            Expr::function(FunctionExpr::float(FloatFunctionExpr::local_get(
+                FloatFunctionLocalId(0),
+                "f".into(),
+                unary_float,
+            ))),
+        );
+        assert_eq!(
+            function_local_get(
+                FunctionLocalBinding::Bool {
+                    local: BoolFunctionLocalId(0),
+                    type_: unary_bool.clone(),
+                },
+                "f".into(),
+            ),
+            Expr::function(FunctionExpr::bool(BoolFunctionExpr::local_get(
+                BoolFunctionLocalId(0),
+                "f".into(),
+                unary_bool,
+            ))),
+        );
+        assert_eq!(
+            function_local_get(
+                FunctionLocalBinding::Nil {
+                    local: NilFunctionLocalId(0),
+                    type_: unary_nil.clone(),
+                },
+                "f".into(),
+            ),
+            Expr::function(FunctionExpr::nil(NilFunctionExpr::local_get(
+                NilFunctionLocalId(0),
+                "f".into(),
+                unary_nil,
+            ))),
+        );
+        assert_eq!(
+            function_local_get(
+                FunctionLocalBinding::Tuple {
+                    local: TupleFunctionLocalId(0),
+                    type_: tuple_type.clone(),
+                },
+                "f".into(),
+            ),
+            Expr::function(FunctionExpr::tuple(TupleFunctionExpr::local_get(
+                TupleFunctionLocalId(0),
+                "f".into(),
+                tuple_type,
+            ))),
+        );
+        assert_eq!(
+            function_local_get(
+                FunctionLocalBinding::List {
+                    local: ListFunctionLocalId(0),
+                    type_: list_type.clone(),
+                },
+                "f".into(),
+            ),
+            Expr::function(FunctionExpr::list(ListFunctionExpr::local_get(
+                ListFunctionLocalId(0),
+                "f".into(),
+                list_type,
+            ))),
+        );
+        assert_eq!(
+            function_local_get(
+                FunctionLocalBinding::Function {
+                    local: FunctionFunctionLocalId(0),
+                    type_: function_type.clone(),
+                },
+                "f".into(),
+            ),
+            Expr::function(FunctionExpr::function(FunctionFunctionExpr::local_get(
+                FunctionFunctionLocalId(0),
+                "f".into(),
+                function_type,
+            ))),
+        );
+    }
+
+    #[test]
+    fn guard_helper_type_classification_is_exact() {
+        assert!(contains_function_value(&ValueType::Function(Box::new(
+            FunctionType::new(Vec::new(), ValueType::Int),
+        ))));
+        assert!(contains_function_value(&ValueType::Tuple(vec![
+            ValueType::Int,
+            ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+        ])));
+        assert!(contains_function_value(&ValueType::List(Box::new(
+            ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+        ))));
+        assert!(!contains_function_value(&ValueType::Tuple(vec![
+            ValueType::Int,
+            ValueType::Float,
+            ValueType::String,
+            ValueType::Bool,
+            ValueType::Nil,
+            ValueType::List(Box::new(ValueType::Int)),
+        ])));
+
+        assert_eq!(
+            [
+                ValueType::Int,
+                ValueType::Float,
+                ValueType::String,
+                ValueType::Bool,
+                ValueType::Nil,
+                ValueType::Tuple(Vec::new()),
+                ValueType::List(Box::new(ValueType::Int)),
+                ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
+            ]
+            .map(invalid_expression_type),
+            [
+                InvalidExpressionType::Int,
+                InvalidExpressionType::Float,
+                InvalidExpressionType::String,
+                InvalidExpressionType::Bool,
+                InvalidExpressionType::Nil,
+                InvalidExpressionType::Tuple,
+                InvalidExpressionType::List,
+                InvalidExpressionType::Function,
+            ],
+        );
+    }
+
+    #[test]
+    fn equality_rejects_function_value_guard() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        context.define_int_function_local(
+            "callback".into(),
+            FunctionType::new(vec![ValueType::Int], ValueType::Int),
+        );
+        let function_type = type_::fn_(vec![type_::int()], type_::int());
+
+        assert_eq!(
+            super::plan_bool(
+                ClauseGuard::BinaryOperator {
+                    location: dummy_span(),
+                    operator: gleam_core::ast::BinOp::Eq,
+                    operator_start: 0,
+                    left: Box::new(var("callback", function_type.clone())),
+                    right: Box::new(var("callback", function_type)),
+                },
+                &mut context,
+            ),
+            Err(PlanError::UnsupportedBinOp {
+                operator: UnsupportedBinOpKind::EqFunction,
+            }),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::BinaryOperator {
+                    location: dummy_span(),
+                    operator: BinOp::NotEq,
+                    operator_start: 0,
+                    left: Box::new(int_constant(1)),
+                    right: Box::new(var(
+                        "callback",
+                        type_::fn_(vec![type_::int()], type_::int())
+                    )),
+                },
+                &mut context,
+            ),
+            Err(PlanError::UnsupportedBinOp {
+                operator: UnsupportedBinOpKind::NotEqFunction,
+            }),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::BinaryOperator {
+                    location: dummy_span(),
+                    operator: BinOp::Eq,
+                    operator_start: 0,
+                    left: Box::new(ClauseGuard::Invalid {
+                        location: dummy_span(),
+                        type_: type_::int(),
+                    }),
+                    right: Box::new(int_constant(1)),
+                },
+                &mut context,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+        assert_eq!(
+            plan_expr(
+                ClauseGuard::BinaryOperator {
+                    location: dummy_span(),
+                    operator: BinOp::Eq,
+                    operator_start: 0,
+                    left: Box::new(int_constant(1)),
+                    right: Box::new(ClauseGuard::Invalid {
+                        location: dummy_span(),
+                        type_: type_::int(),
+                    }),
+                },
+                &mut context,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+    }
+
+    fn int_constant(value: i64) -> ClauseGuard<Arc<Type>> {
+        ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: value.to_string().into(),
+            int_value: value.into(),
+        })
+    }
+
+    fn int_constant_literal(value: i64) -> Constant<Arc<Type>> {
+        Constant::Int {
+            location: dummy_span(),
+            value: value.to_string().into(),
+            int_value: BigInt::from(value),
+        }
+    }
+
+    fn float_constant() -> ClauseGuard<Arc<Type>> {
+        ClauseGuard::Constant(Constant::Float {
+            location: dummy_span(),
+            value: "1.0".into(),
+            float_value: LiteralFloatValue::ONE,
+        })
+    }
+
+    fn string_constant(value: impl Into<EcoString>) -> ClauseGuard<Arc<Type>> {
+        ClauseGuard::Constant(Constant::String {
+            location: dummy_span(),
+            value: value.into(),
+        })
+    }
+
+    fn module_select(
+        module_name: impl Into<EcoString>,
+        literal: Constant<Arc<Type>>,
+    ) -> ClauseGuard<Arc<Type>> {
+        let module_name = module_name.into();
+        ClauseGuard::ModuleSelect {
+            location: dummy_span(),
+            field_start: 0,
+            definition_location: dummy_span(),
+            type_: type_::int(),
+            label: "answer".into(),
+            module_alias: module_name.clone(),
+            module_name,
+            literal,
+        }
+    }
+
+    fn binary(
+        operator: BinOp,
+        left: ClauseGuard<Arc<Type>>,
+        right: ClauseGuard<Arc<Type>>,
+    ) -> ClauseGuard<Arc<Type>> {
+        ClauseGuard::BinaryOperator {
+            location: dummy_span(),
+            operator,
+            operator_start: 0,
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    fn var(name: impl Into<EcoString>, type_: Arc<Type>) -> ClauseGuard<Arc<Type>> {
+        ClauseGuard::Var {
+            location: dummy_span(),
+            type_,
+            name: name.into(),
+            definition_location: dummy_span(),
+            origin: VariableOrigin::generated(),
+        }
+    }
+
+    fn invalid_expression_shape(kind: InvalidExpressionShapeKind) -> PlanError {
+        PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionShape { kind },
+        }
+    }
+
+    fn expression_type_error(
+        expected: InvalidExpressionType,
+        actual: InvalidExpressionType,
+    ) -> PlanError {
+        PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionType { expected, actual },
+        }
+    }
+}

--- a/src/planner/expression/case/int_subject.rs
+++ b/src/planner/expression/case/int_subject.rs
@@ -2,7 +2,7 @@ use super::{
     case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
     validate_clause_shape,
 };
-use crate::plan::{Expr, ExprKind, IntCaseBranches, IntExpr};
+use crate::plan::{BoolExpr, Expr, ExprKind, IntCaseBranches, IntExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use ecow::EcoString;
@@ -21,6 +21,11 @@ pub(super) fn plan(
     let return_type = case_return_type(type_.as_ref())?;
     for clause in &clauses {
         validate_clause_shape(clause)?;
+    }
+    if clauses.iter().any(|clause| clause.guard.is_some()) {
+        let (subject_step, subject) = super::bind_int_case_subject(subject, context);
+        let case = plan_guarded_int_case(type_.as_ref(), return_type, subject, clauses, context)?;
+        return Ok(super::case_subject_block(subject_step, case));
     }
     let needs_subject_binding = clauses.iter().any(clause_has_int_variable_pattern);
     let (subject_step, subject) = if needs_subject_binding {
@@ -67,6 +72,45 @@ pub(super) fn plan(
         Some(step) => super::case_subject_block(step, case),
         None => case,
     })
+}
+
+fn plan_guarded_int_case(
+    case_type: &Type,
+    return_type: ValueType,
+    subject: IntExpr,
+    clauses: Vec<TypedClause>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    for clause in clauses {
+        let pattern = single_case_pattern(clause.pattern)?;
+        let pattern = plan_int_case_pattern(pattern)?;
+        let binding = pattern
+            .bound_name()
+            .cloned()
+            .map(|name| (name, Expr::int(subject.clone())));
+        let is_total = matches!(pattern, IntCasePattern::Any { .. }) && clause.guard.is_none();
+        let match_condition = match pattern {
+            IntCasePattern::Literal(value) => {
+                BoolExpr::equal(Expr::int(subject.clone()), Expr::int(IntExpr::value(value)))
+            }
+            IntCasePattern::Any { .. } => BoolExpr::value(true),
+        };
+        ordered_clauses.push(super::plan_ordered_case_clause(
+            super::OrderedCaseClauseInput {
+                case_type,
+                return_type: &return_type,
+                then: clause.then,
+                variable_binding: binding,
+                guard: clause.guard,
+                match_condition,
+                is_total,
+            },
+            context,
+        )?);
+    }
+
+    super::ordered_case_expr(ordered_clauses)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -185,7 +229,9 @@ fn int_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Int(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -198,7 +244,9 @@ fn string_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::String(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -211,7 +259,9 @@ fn float_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Float(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -224,7 +274,9 @@ fn bool_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Bool(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -237,7 +289,9 @@ fn nil_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Nil(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -250,7 +304,9 @@ fn tuple_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Tuple(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -263,7 +319,9 @@ fn list_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::List(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -318,10 +376,14 @@ fn int_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_int() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -334,10 +396,14 @@ fn string_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_string() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -350,10 +416,14 @@ fn float_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_float() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -366,10 +436,14 @@ fn bool_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_bool() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -382,10 +456,14 @@ fn nil_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_nil() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -398,10 +476,14 @@ fn tuple_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_tuple() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -414,10 +496,14 @@ fn list_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_list() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -430,27 +516,27 @@ fn function_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_function() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
     Ok(typed_clauses)
 }
 
-fn branch_return_type_mismatch() -> PlanError {
-    invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch)
-}
-
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        BoolFunctionId, Expr, FloatExpr, FloatFunctionId, FunctionExpr, FunctionFunctionId,
-        FunctionType, IntCaseBranches, IntFunctionExpr, IntFunctionFunctionId, IntFunctionId,
-        IntLocalId, ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringFunctionId,
-        TupleFunctionId, ValueType,
+        BoolExpr, BoolFunctionId, Expr, FloatExpr, FloatFunctionId, FunctionExpr,
+        FunctionFunctionId, FunctionType, IntCaseBranches, IntFunctionExpr, IntFunctionFunctionId,
+        IntFunctionId, IntLocalId, IntReturn, ListFunctionId, LocalId, NilFunctionId,
+        RuntimeFunctionId, StringFunctionId, TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
         bool_, bool_return_expr, bool_return_int_case, float, function, function_ref, int,
@@ -465,7 +551,7 @@ mod tests {
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
         UnsupportedCaseReason, UnsupportedExpressionKind,
     };
-    use gleam_core::ast::{Pattern, TypedModule};
+    use gleam_core::ast::{ClauseGuard, Constant, Pattern, TypedModule};
     use gleam_core::type_::{self, error::VariableOrigin};
     use num_bigint::BigInt;
 
@@ -667,6 +753,46 @@ pub fn main() {
                             int_return_expr(local_int(1, "other").add_int(int(1))),
                         ),
                     ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_int_case_guard_binds_subject_once_and_falls_through() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 41 {
+    other if other > 40 -> other + 1
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let bind_other = let_int_step(1, "other", local_int(0, "<case:int:0>"));
+        let condition = BoolExpr::block(
+            vec![bind_other.clone()],
+            BoolExpr::and(
+                BoolExpr::value(true),
+                BoolExpr::gt_int(local_int(1, "other").into(), int(40).into()),
+            ),
+        );
+        let guarded_branch = int_return_block(
+            [bind_other],
+            int_return_expr(local_int(1, "other").add_int(int(1))),
+        );
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "<case:int:0>", int(41))],
+                    IntReturn::bool_case(condition, guarded_branch, int_return_expr(int(0))),
                 ),
             ),
             [],
@@ -958,6 +1084,10 @@ pub fn main() {
     fn reject_profile_int_case_patterns() {
         let cases = [
             (
+                r#"pub fn main() { case 1 { 1 | 2 -> 1 _ -> 0 } }"#,
+                UnsupportedCaseReason::AlternativePatterns,
+            ),
+            (
                 r#"pub fn main() { case 1 { 1 as value -> 1 _ -> 0 } }"#,
                 UnsupportedCaseReason::AssignPattern,
             ),
@@ -968,10 +1098,6 @@ pub fn main() {
             (
                 r#"pub fn main() { case 1 { _ as alias -> 1 } }"#,
                 UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"pub fn main() { case 1 { 1 if True -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::Guard,
             ),
         ];
 
@@ -1194,6 +1320,72 @@ fn add_one(value: Int) {
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CaseShape {
                     reason: InvalidCaseShapeReason::MissingFallbackPattern,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_int_case_guard_must_be_bool() {
+        let mut module = compile_int_case_module();
+        let (_, _, clauses) =
+            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Bool,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_guarded_int_case_pattern_shapes() {
+        let mut empty_pattern = compile_int_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut empty_pattern.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+        clauses[0].pattern.clear();
+        assert_eq!(
+            plan_module(empty_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
+                },
+            }),
+        );
+
+        let mut pattern_type_mismatch = compile_int_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut pattern_type_mismatch.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+        clauses[0].pattern[0] = Pattern::String {
+            location: dummy_span(),
+            value: "one".into(),
+        };
+        assert_eq!(
+            plan_module(pattern_type_mismatch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
                 },
             }),
         );

--- a/src/planner/expression/case/string_subject.rs
+++ b/src/planner/expression/case/string_subject.rs
@@ -2,7 +2,7 @@ use super::{
     case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
     validate_clause_shape,
 };
-use crate::plan::{Expr, ExprKind, StringCaseBranches, StringExpr};
+use crate::plan::{BoolExpr, Expr, ExprKind, StringCaseBranches, StringExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use ecow::EcoString;
@@ -20,6 +20,12 @@ pub(super) fn plan(
     let return_type = case_return_type(type_.as_ref())?;
     for clause in &clauses {
         validate_clause_shape(clause)?;
+    }
+    if clauses.iter().any(|clause| clause.guard.is_some()) {
+        let (subject_step, subject) = super::bind_string_case_subject(subject, context);
+        let case =
+            plan_guarded_string_case(type_.as_ref(), return_type, subject, clauses, context)?;
+        return Ok(super::case_subject_block(subject_step, case));
     }
     let needs_subject_binding = clauses.iter().any(clause_has_string_variable_pattern);
     let (subject_step, subject) = if needs_subject_binding {
@@ -66,6 +72,46 @@ pub(super) fn plan(
         Some(step) => super::case_subject_block(step, case),
         None => case,
     })
+}
+
+fn plan_guarded_string_case(
+    case_type: &Type,
+    return_type: ValueType,
+    subject: StringExpr,
+    clauses: Vec<TypedClause>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    for clause in clauses {
+        let pattern = single_case_pattern(clause.pattern)?;
+        let pattern = plan_string_case_pattern(pattern)?;
+        let binding = pattern
+            .bound_name()
+            .cloned()
+            .map(|name| (name, Expr::string(subject.clone())));
+        let is_total = matches!(pattern, StringCasePattern::Any { .. }) && clause.guard.is_none();
+        let match_condition = match pattern {
+            StringCasePattern::Literal(value) => BoolExpr::equal(
+                Expr::string(subject.clone()),
+                Expr::string(StringExpr::value(value)),
+            ),
+            StringCasePattern::Any { .. } => BoolExpr::value(true),
+        };
+        ordered_clauses.push(super::plan_ordered_case_clause(
+            super::OrderedCaseClauseInput {
+                case_type,
+                return_type: &return_type,
+                then: clause.then,
+                variable_binding: binding,
+                guard: clause.guard,
+                match_condition,
+                is_total,
+            },
+            context,
+        )?);
+    }
+
+    super::ordered_case_expr(ordered_clauses)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -186,7 +232,9 @@ fn int_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Int(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -199,7 +247,9 @@ fn string_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::String(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -212,7 +262,9 @@ fn float_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Float(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -225,7 +277,9 @@ fn bool_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Bool(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -238,7 +292,9 @@ fn nil_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Nil(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -251,7 +307,9 @@ fn tuple_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Tuple(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -264,7 +322,9 @@ fn list_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::List(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -319,10 +379,14 @@ fn int_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_int() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -335,10 +399,14 @@ fn string_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_string() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -351,10 +419,14 @@ fn float_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_float() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -367,10 +439,14 @@ fn bool_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_bool() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -383,10 +459,14 @@ fn nil_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_nil() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -399,10 +479,14 @@ fn tuple_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_tuple() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -415,10 +499,14 @@ fn list_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_list() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
@@ -431,27 +519,27 @@ fn function_function_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::Function(clause) = clause.into_kind() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         let Some(clause) = clause.into_function() else {
-            return Err(branch_return_type_mismatch());
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
         };
         typed_clauses.push((value, clause));
     }
     Ok(typed_clauses)
 }
 
-fn branch_return_type_mismatch() -> PlanError {
-    invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch)
-}
-
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        BoolFunctionId, Expr, FloatExpr, FloatFunctionId, FunctionExpr, FunctionFunctionId,
-        FunctionType, IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, IntLocalId,
-        ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringCaseBranches,
-        StringFunctionId, StringLocalId, TupleFunctionId, ValueType,
+        BoolExpr, BoolFunctionId, Expr, FloatExpr, FloatFunctionId, FunctionExpr,
+        FunctionFunctionId, FunctionType, IntFunctionExpr, IntFunctionFunctionId, IntFunctionId,
+        IntLocalId, ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringCaseBranches,
+        StringFunctionId, StringLocalId, StringReturn, TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
         bool_, bool_return_expr, bool_return_string_case, float, function, function_ref, int,
@@ -466,7 +554,7 @@ mod tests {
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
         UnsupportedCaseReason, UnsupportedExpressionKind,
     };
-    use gleam_core::ast::{Pattern, TypedModule};
+    use gleam_core::ast::{ClauseGuard, Constant, Pattern, TypedModule};
     use gleam_core::type_::{self, error::VariableOrigin};
     use num_bigint::BigInt;
 
@@ -610,6 +698,48 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_string_case_guard_binds_subject_once_and_falls_through() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case "geam" {
+    other if other == "geam" -> other
+    _ -> ""
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let bind_other = let_string_step(1, "other", local_string(0, "<case:string:0>"));
+        let condition = BoolExpr::block(
+            vec![bind_other.clone()],
+            BoolExpr::and(
+                BoolExpr::value(true),
+                BoolExpr::equal(local_string(1, "other").into(), string("geam").into()),
+            ),
+        );
+        let guarded_branch =
+            string_return_block([bind_other], string_return_expr(local_string(1, "other")));
+        let expected = module(
+            "main",
+            function(
+                "main",
+                string_return_block(
+                    [let_string_step(0, "<case:string:0>", string("geam"))],
+                    StringReturn::bool_case(
+                        condition,
+                        guarded_branch,
+                        string_return_expr(string("")),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_string_case_wildcard_fallbacks() {
         let actual = plan_module(crate::planner::support::compile(
             r#"
@@ -729,10 +859,6 @@ fn duplicate_literal(value: String) {
                 r#"pub fn main() { case "prefix one" { "prefix " <> rest -> 1 _ -> 0 } }"#,
                 UnsupportedCaseReason::StringPrefixPattern,
             ),
-            (
-                r#"pub fn main() { case "one" { "one" if True -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::Guard,
-            ),
         ];
 
         for (src, reason) in cases {
@@ -765,6 +891,21 @@ pub fn main() {
 
     #[test]
     fn reject_margin_string_case_pattern_shapes() {
+        let mut alternative_pattern = compile_string_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut alternative_pattern.definitions.functions[0].body[0],
+        );
+        clauses[0].alternative_patterns.push(vec![Pattern::String {
+            location: dummy_span(),
+            value: "two".into(),
+        }]);
+        assert_eq!(
+            plan_module(alternative_pattern),
+            Err(PlanError::UnsupportedCase {
+                reason: UnsupportedCaseReason::AlternativePatterns,
+            }),
+        );
+
         let mut variable_type_mismatch = compile_string_case_module();
         let (_, _, clauses) = super::super::expect_case_statement_mut(
             &mut variable_type_mismatch.definitions.functions[0].body[0],
@@ -956,6 +1097,73 @@ fn return_value(value: String) {
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CaseShape {
                     reason: InvalidCaseShapeReason::MissingFallbackPattern,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_guarded_string_case_pattern_shapes() {
+        let mut empty_pattern = compile_string_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut empty_pattern.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+        clauses[0].pattern.clear();
+        assert_eq!(
+            plan_module(empty_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
+                },
+            }),
+        );
+
+        let mut pattern_type_mismatch = compile_string_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut pattern_type_mismatch.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+        clauses[0].pattern[0] = Pattern::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        };
+        assert_eq!(
+            plan_module(pattern_type_mismatch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_string_case_guard_must_be_bool() {
+        let mut module = compile_string_case_module();
+        let (_, _, clauses) =
+            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Bool,
+                    actual: InvalidExpressionType::Int,
                 },
             }),
         );

--- a/src/planner/expression/constant.rs
+++ b/src/planner/expression/constant.rs
@@ -1,4 +1,4 @@
-use super::super::{invalid_expression_type, invalid_expression_type_for_value};
+use super::{invalid_expression_type, invalid_expression_type_for_value};
 use crate::plan::{
     BoolExpr, Expr, FloatExpr, FunctionExpr, IntExpr, ListExpr, NilExpr, StringExpr, TupleExpr,
     ValueType,
@@ -12,7 +12,7 @@ use gleam_core::ast::Constant;
 use gleam_core::type_::{PRELUDE_MODULE_NAME, Type, ValueConstructor, ValueConstructorVariant};
 use std::sync::Arc;
 
-pub(super) fn plan(
+pub(in crate::planner::expression) fn plan(
     literal: Constant<Arc<Type>>,
     context: &PlanContext<'_>,
 ) -> Result<Expr, PlanError> {

--- a/src/planner/expression/function/free_variables.rs
+++ b/src/planner/expression/function/free_variables.rs
@@ -1,7 +1,7 @@
 use ecow::EcoString;
 use gleam_core::ast::{
-    AssignmentKind, Pattern, Statement, TypedArg, TypedExpr, TypedPipelineAssignment,
-    TypedStatement,
+    AssignmentKind, ClauseGuard, Pattern, Statement, TypedArg, TypedClauseGuard, TypedExpr,
+    TypedPipelineAssignment, TypedStatement,
 };
 use gleam_core::type_::{Type, ValueConstructorVariant};
 use std::collections::HashSet;
@@ -147,6 +147,9 @@ fn collect_expr(expression: &TypedExpr, bound: &mut HashSet<EcoString>, free: &m
                 for pattern in &clause.pattern {
                     collect_variable_pattern_bound_name(pattern, &mut branch_bound);
                 }
+                if let Some(guard) = &clause.guard {
+                    collect_clause_guard(guard, &mut branch_bound, free);
+                }
                 collect_expr(&clause.then, &mut branch_bound, free);
             }
         }
@@ -192,6 +195,27 @@ fn collect_pipeline_assignment(
     bound.insert(assignment.name.clone());
 }
 
+fn collect_clause_guard(
+    guard: &TypedClauseGuard,
+    bound: &mut HashSet<EcoString>,
+    free: &mut FreeVariables,
+) {
+    match guard {
+        ClauseGuard::Var { name, .. } => free.record(name, bound),
+        ClauseGuard::Block { value, .. } => collect_clause_guard(value, bound, free),
+        ClauseGuard::BinaryOperator { left, right, .. } => {
+            collect_clause_guard(left, bound, free);
+            collect_clause_guard(right, bound, free);
+        }
+        ClauseGuard::Not { expression, .. } => collect_clause_guard(expression, bound, free),
+        ClauseGuard::TupleIndex { tuple, .. } => collect_clause_guard(tuple, bound, free),
+        ClauseGuard::FieldAccess { container, .. } => collect_clause_guard(container, bound, free),
+        ClauseGuard::Constant(_)
+        | ClauseGuard::ModuleSelect { .. }
+        | ClauseGuard::Invalid { .. } => {}
+    }
+}
+
 fn collect_variable_pattern_bound_name(
     pattern: &Pattern<Arc<Type>>,
     bound: &mut HashSet<EcoString>,
@@ -232,7 +256,7 @@ fn collect_variable_pattern_bound_name(
 #[cfg(test)]
 mod tests {
     use crate::planner::support::{compile, dummy_span};
-    use gleam_core::ast::{Publicity, Statement, TypedExpr};
+    use gleam_core::ast::{ClauseGuard, Constant, Publicity, Statement, TypedExpr};
     use gleam_core::type_::error::VariableOrigin;
     use gleam_core::type_::{self, Deprecation, ValueConstructor, ValueConstructorVariant};
     use vec1::Vec1;
@@ -332,6 +356,102 @@ pub fn main() {
     }
 
     #[test]
+    fn anonymous_free_variables_include_case_guard_only_outer_local() {
+        assert_eq!(
+            anonymous_function_free_variables(
+                r#"
+pub fn main() {
+  let threshold = 40
+  fn() {
+    case 41 {
+      value if value > threshold -> value
+      _ -> 0
+    }
+  }
+  1
+}
+"#,
+            ),
+            vec!["threshold".to_string()],
+        );
+    }
+
+    #[test]
+    fn collect_clause_guard_records_supported_guard_shapes() {
+        let mut bound = std::collections::HashSet::new();
+        bound.insert("bound".into());
+        let mut free = super::FreeVariables::new();
+        let guard = ClauseGuard::Block {
+            location: dummy_span(),
+            value: Box::new(ClauseGuard::BinaryOperator {
+                location: dummy_span(),
+                operator: gleam_core::ast::BinOp::And,
+                operator_start: 0,
+                left: Box::new(ClauseGuard::Not {
+                    location: dummy_span(),
+                    expression: Box::new(guard_var("outer_bool", type_::bool())),
+                }),
+                right: Box::new(ClauseGuard::TupleIndex {
+                    location: dummy_span(),
+                    index: 0,
+                    type_: type_::int(),
+                    tuple: Box::new(guard_var("outer_tuple", type_::tuple(vec![type_::int()]))),
+                }),
+            }),
+        };
+        super::collect_clause_guard(&guard, &mut bound, &mut free);
+        let field_guard = ClauseGuard::FieldAccess {
+            label_location: dummy_span(),
+            index: Some(0),
+            label: "field".into(),
+            type_: type_::int(),
+            container: Box::new(guard_var("outer_record", type_::int())),
+        };
+        super::collect_clause_guard(&field_guard, &mut bound, &mut free);
+        super::collect_clause_guard(&guard_var("bound", type_::int()), &mut bound, &mut free);
+        super::collect_clause_guard(
+            &ClauseGuard::Constant(Constant::Int {
+                location: dummy_span(),
+                value: "1".into(),
+                int_value: 1.into(),
+            }),
+            &mut bound,
+            &mut free,
+        );
+        super::collect_clause_guard(
+            &ClauseGuard::ModuleSelect {
+                location: dummy_span(),
+                field_start: 0,
+                definition_location: dummy_span(),
+                type_: type_::int(),
+                label: "answer".into(),
+                module_name: "main".into(),
+                module_alias: "main".into(),
+                literal: guard_constant_literal(),
+            },
+            &mut bound,
+            &mut free,
+        );
+        super::collect_clause_guard(
+            &ClauseGuard::Invalid {
+                location: dummy_span(),
+                type_: type_::int(),
+            },
+            &mut bound,
+            &mut free,
+        );
+
+        assert_eq!(
+            free.names,
+            vec![
+                "outer_bool".to_string(),
+                "outer_tuple".to_string(),
+                "outer_record".to_string(),
+            ],
+        );
+    }
+
+    #[test]
     fn anonymous_free_variables_treat_tuple_alias_assignment_names_as_bound() {
         assert_eq!(
             anonymous_function_free_variables(
@@ -421,6 +541,27 @@ pub fn main() {
         }
 
         assert_eq!(names, vec!["negate_int_value".to_string()]);
+    }
+
+    fn guard_var(
+        name: impl Into<ecow::EcoString>,
+        type_: std::sync::Arc<gleam_core::type_::Type>,
+    ) -> ClauseGuard<std::sync::Arc<gleam_core::type_::Type>> {
+        ClauseGuard::Var {
+            location: dummy_span(),
+            type_,
+            name: name.into(),
+            definition_location: dummy_span(),
+            origin: VariableOrigin::generated(),
+        }
+    }
+
+    fn guard_constant_literal() -> Constant<std::sync::Arc<gleam_core::type_::Type>> {
+        Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: 1.into(),
+        }
     }
 
     fn anonymous_function_free_variables(src: &str) -> Vec<String> {

--- a/src/planner/expression/var.rs
+++ b/src/planner/expression/var.rs
@@ -1,5 +1,3 @@
-mod constant;
-
 use crate::plan::{
     BoolExpr, BoolFunctionExpr, Expr, FloatExpr, FloatFunctionExpr, FunctionExpr,
     FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr, ListFunctionExpr, LocalId, NilExpr,
@@ -89,7 +87,7 @@ pub(super) fn plan_var(
         }),
         ValueConstructorVariant::ModuleConstant {
             module, literal, ..
-        } if module == *context.module_name => constant::plan(literal, context),
+        } if module == *context.module_name => super::constant::plan(literal, context),
         ValueConstructorVariant::ModuleConstant { .. } => Err(PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::ExpressionShape {
                 kind: InvalidExpressionShapeKind::ModuleSelect,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -134,6 +134,12 @@ mod control_flow {
             tuple_projection_case,
             tuple_case_return_families,
             list_case_return_families,
+            guard,
+            guard_fallthrough,
+            guard_operator_surface,
+            guard_subject_families,
+            guard_closure_capture,
+            literal_guard_ordering,
             variable_pattern,
             variable_pattern_ordering,
             variable_pattern_families,
@@ -404,7 +410,6 @@ mod rejection {
 
     mod case_patterns {
         rejection_cases!("case_patterns";
-            guard,
             alternative_patterns,
             multiple_subjects,
             tuple_pattern,

--- a/tests/fixtures/execution/control_flow/case/guard.gleam
+++ b/tests/fixtures/execution/control_flow/case/guard.gleam
@@ -5,3 +5,5 @@ pub fn main() {
     _ -> 0
   }
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/control_flow/case/guard_closure_capture.gleam
+++ b/tests/fixtures/execution/control_flow/case/guard_closure_capture.gleam
@@ -1,0 +1,11 @@
+pub fn main() {
+  let threshold = 40
+  fn(value) {
+    case value {
+      other if other > threshold -> other + 1
+      _ -> 0
+    }
+  }(41)
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/control_flow/case/guard_fallthrough.gleam
+++ b/tests/fixtures/execution/control_flow/case/guard_fallthrough.gleam
@@ -1,0 +1,9 @@
+pub fn main() {
+  let value = -1
+  case value {
+    other if other > 0 -> 999
+    _ -> 0
+  }
+}
+
+// geam:expect Int(0)

--- a/tests/fixtures/execution/control_flow/case/guard_operator_surface.gleam
+++ b/tests/fixtures/execution/control_flow/case/guard_operator_surface.gleam
@@ -1,0 +1,60 @@
+fn int_ordering(value: Int) {
+  case value {
+    other if other >= 5 && other <= 5 && other < 6 -> True
+    _ -> False
+  }
+}
+
+fn int_arithmetic(value: Int) {
+  case value {
+    other if other + 1 == 6 && other - 1 == 4 && other * 2 == 10 && other / 2 == 2 && other % 2 == 1 -> True
+    _ -> False
+  }
+}
+
+fn float_operators(value: Float) {
+  case value {
+    other if other >=. 1.5 && other <=. 1.5 && other <. 2.0 && other +. 0.5 == 2.0 && other -. 0.5 == 1.0 && other *. 2.0 == 3.0 && other /. 1.5 == 1.0 -> True
+    _ -> False
+  }
+}
+
+fn string_operators(value: String) {
+  case value {
+    other if other <> "am" == "geam" && other != "no" -> True
+    _ -> False
+  }
+}
+
+fn bool_operators(value: Bool) {
+  case value {
+    other if !False && other -> True
+    _ -> False
+  }
+}
+
+fn bool_or_operator(value: Bool) {
+  case value {
+    other if other || False -> True
+    _ -> False
+  }
+}
+
+fn tuple_index_guard(pair: #(Int, String)) {
+  case pair.0 {
+    value if pair.1 == "ok" && value == 1 -> True
+    _ -> False
+  }
+}
+
+pub fn main() {
+  let int_ok = int_ordering(5) && int_arithmetic(5)
+  let float_ok = float_operators(1.5)
+  let string_ok = string_operators("ge")
+  let bool_ok = bool_operators(True) && bool_or_operator(True)
+  let tuple_ok = tuple_index_guard(#(1, "ok"))
+
+  int_ok && float_ok && string_ok && bool_ok && tuple_ok
+}
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/control_flow/case/guard_subject_families.gleam
+++ b/tests/fixtures/execution/control_flow/case/guard_subject_families.gleam
@@ -1,0 +1,40 @@
+pub fn main() {
+  let bool_ok = case True {
+    value if value -> True
+    _ -> False
+  }
+
+  let bool_literal_ok = case False {
+    False if True -> True
+    _ -> False
+  }
+
+  let bool_true_literal_ok = case True {
+    True if True -> True
+    _ -> False
+  }
+
+  let string_ok = case "go" {
+    value if value == "go" -> True
+    _ -> False
+  }
+
+  let string_literal_ok = case "go" {
+    "go" if True -> True
+    _ -> False
+  }
+
+  let float_ok = case 1.5 {
+    value if value >. 1.0 -> True
+    _ -> False
+  }
+
+  let float_literal_ok = case 1.5 {
+    1.5 if True -> True
+    _ -> False
+  }
+
+  bool_ok && bool_literal_ok && bool_true_literal_ok && string_ok && string_literal_ok && float_ok && float_literal_ok
+}
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/control_flow/case/literal_guard_ordering.gleam
+++ b/tests/fixtures/execution/control_flow/case/literal_guard_ordering.gleam
@@ -1,0 +1,9 @@
+pub fn main() {
+  case 1 {
+    1 if False -> 999
+    1 -> 42
+    _ -> 0
+  }
+}
+
+// geam:expect Int(42)


### PR DESCRIPTION
- Lower Bool/Int/Float/String case guards through a dedicated ClauseGuard path.
- Preserve ordered fallthrough and bind guarded subjects once through internal locals.
- Move constant lowering to the expression parent so both vars and guards can reuse it.
- Example: `case value { other if other > 40 -> other + 1 _ -> 0 }`
