### PR TITLE
Split case subject lowering modules

### DIFF
--- a/src/planner/expression/case.rs
+++ b/src/planner/expression/case.rs
@@ -1,20 +1,12 @@
-mod bool_subject;
-mod float_subject;
 mod guard;
-mod int_subject;
-mod string_subject;
+mod subject;
 
-use crate::plan::{
-    BoolCaseBranches, BoolExpr, BoolLocalId, Expr, ExprKind, FloatExpr, FloatLocalId,
-    FunctionExprKind, IntExpr, IntLocalId, Step, StringExpr, StringLocalId, ValueType,
-};
+use crate::plan::Expr;
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
     InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
 };
-use crate::planner::statement::plan_variable_runtime_step;
-use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedClauseGuard, TypedExpr};
+use gleam_core::ast::{TypedClause, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
@@ -32,30 +24,7 @@ pub(super) fn plan_case(
         return Err(invalid_case_shape(InvalidCaseShapeReason::EmptyClauses));
     }
 
-    if subject.type_().is_bool() {
-        return bool_subject::plan(type_, subject, clauses, context);
-    }
-    if subject.type_().is_int() {
-        return int_subject::plan(type_, subject, clauses, context);
-    }
-    if subject.type_().is_string() {
-        return string_subject::plan(type_, subject, clauses, context);
-    }
-    if subject.type_().is_float() {
-        return float_subject::plan(type_, subject, clauses, context);
-    }
-
-    Err(unsupported_case(
-        UnsupportedCaseReason::UnsupportedSubjectType,
-    ))
-}
-
-pub(super) fn validate_clause_shape(clause: &TypedClause) -> Result<(), PlanError> {
-    if !clause.alternative_patterns.is_empty() {
-        return Err(unsupported_case(UnsupportedCaseReason::AlternativePatterns));
-    }
-
-    Ok(())
+    subject::plan(type_, subject, clauses, context)
 }
 
 fn single_case_subject(subjects: Vec<TypedExpr>) -> Result<TypedExpr, PlanError> {
@@ -70,273 +39,6 @@ fn single_case_subject(subjects: Vec<TypedExpr>) -> Result<TypedExpr, PlanError>
     Ok(subject)
 }
 
-pub(super) fn single_case_pattern(
-    patterns: Vec<Pattern<Arc<Type>>>,
-) -> Result<Pattern<Arc<Type>>, PlanError> {
-    let mut patterns = patterns.into_iter();
-    let pattern = patterns.next().ok_or(invalid_case_shape(
-        InvalidCaseShapeReason::PatternSubjectCountMismatch,
-    ))?;
-    if patterns.next().is_some() {
-        return Err(invalid_case_shape(
-            InvalidCaseShapeReason::PatternSubjectCountMismatch,
-        ));
-    }
-
-    Ok(pattern)
-}
-
-pub(super) fn validate_case_branch_type(case_type: &Type, branch: &Expr) -> Result<(), PlanError> {
-    if ValueType::from_gleam(case_type) == Some(branch.value_type()) {
-        return Ok(());
-    }
-
-    Err(invalid_case_shape(
-        InvalidCaseShapeReason::BranchReturnTypeMismatch,
-    ))
-}
-
-pub(super) fn bool_case_expr(
-    subject: BoolExpr,
-    true_: Expr,
-    false_: Expr,
-) -> Result<Expr, PlanError> {
-    let branches = match (true_.into_kind(), false_.into_kind()) {
-        (ExprKind::Int(true_), ExprKind::Int(false_)) => BoolCaseBranches::Int { true_, false_ },
-        (ExprKind::String(true_), ExprKind::String(false_)) => {
-            BoolCaseBranches::String { true_, false_ }
-        }
-        (ExprKind::Float(true_), ExprKind::Float(false_)) => {
-            BoolCaseBranches::Float { true_, false_ }
-        }
-        (ExprKind::Bool(true_), ExprKind::Bool(false_)) => BoolCaseBranches::Bool { true_, false_ },
-        (ExprKind::Nil(true_), ExprKind::Nil(false_)) => BoolCaseBranches::Nil { true_, false_ },
-        (ExprKind::Tuple(true_), ExprKind::Tuple(false_)) => {
-            BoolCaseBranches::Tuple { true_, false_ }
-        }
-        (ExprKind::List(true_), ExprKind::List(false_)) => BoolCaseBranches::List { true_, false_ },
-        (ExprKind::Function(true_), ExprKind::Function(false_)) => {
-            bool_function_case_branches(true_, false_)?
-        }
-        _ => {
-            return Err(invalid_case_shape(
-                InvalidCaseShapeReason::BranchReturnTypeMismatch,
-            ));
-        }
-    };
-
-    Ok(Expr::bool_case(subject, branches))
-}
-
-fn bool_function_case_branches(
-    true_: crate::plan::FunctionExpr,
-    false_: crate::plan::FunctionExpr,
-) -> Result<BoolCaseBranches, PlanError> {
-    Ok(match (true_.into_kind(), false_.into_kind()) {
-        (FunctionExprKind::Int(true_), FunctionExprKind::Int(false_)) => {
-            BoolCaseBranches::IntFunction { true_, false_ }
-        }
-        (FunctionExprKind::String(true_), FunctionExprKind::String(false_)) => {
-            BoolCaseBranches::StringFunction { true_, false_ }
-        }
-        (FunctionExprKind::Float(true_), FunctionExprKind::Float(false_)) => {
-            BoolCaseBranches::FloatFunction { true_, false_ }
-        }
-        (FunctionExprKind::Bool(true_), FunctionExprKind::Bool(false_)) => {
-            BoolCaseBranches::BoolFunction { true_, false_ }
-        }
-        (FunctionExprKind::Nil(true_), FunctionExprKind::Nil(false_)) => {
-            BoolCaseBranches::NilFunction { true_, false_ }
-        }
-        (FunctionExprKind::Tuple(true_), FunctionExprKind::Tuple(false_)) => {
-            BoolCaseBranches::TupleFunction { true_, false_ }
-        }
-        (FunctionExprKind::List(true_), FunctionExprKind::List(false_)) => {
-            BoolCaseBranches::ListFunction { true_, false_ }
-        }
-        (FunctionExprKind::Function(true_), FunctionExprKind::Function(false_)) => {
-            BoolCaseBranches::FunctionFunction { true_, false_ }
-        }
-        _ => {
-            return Err(invalid_case_shape(
-                InvalidCaseShapeReason::BranchReturnTypeMismatch,
-            ));
-        }
-    })
-}
-
-pub(super) fn case_return_type(case_type: &Type) -> Result<ValueType, PlanError> {
-    ValueType::from_gleam(case_type)
-        .ok_or_else(|| invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch))
-}
-
-pub(super) fn plan_case_branch(
-    case_type: &Type,
-    return_type: &ValueType,
-    then: TypedExpr,
-    variable_binding: Option<(EcoString, Expr)>,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    context.with_local_scope(|context| {
-        let steps = variable_binding
-            .map(|(name, value)| vec![plan_variable_runtime_step(name, value, context)])
-            .unwrap_or_default();
-        let branch =
-            super::plan_expr_with_expected_source_stop_type(then, return_type.clone(), context)?;
-        validate_case_branch_type(case_type, &branch)?;
-
-        if steps.is_empty() {
-            Ok(branch)
-        } else {
-            Ok(super::block::block_expr(steps, branch))
-        }
-    })
-}
-
-#[derive(Clone)]
-pub(super) struct OrderedCaseClause {
-    pub(super) condition: BoolExpr,
-    pub(super) branch: Expr,
-    pub(super) is_total: bool,
-}
-
-pub(super) struct OrderedCaseClauseInput<'a> {
-    pub(super) case_type: &'a Type,
-    pub(super) return_type: &'a ValueType,
-    pub(super) then: TypedExpr,
-    pub(super) variable_binding: Option<(EcoString, Expr)>,
-    pub(super) guard: Option<TypedClauseGuard>,
-    pub(super) match_condition: BoolExpr,
-    pub(super) is_total: bool,
-}
-
-pub(super) fn plan_ordered_case_clause(
-    input: OrderedCaseClauseInput<'_>,
-    context: &mut PlanContext<'_>,
-) -> Result<OrderedCaseClause, PlanError> {
-    let OrderedCaseClauseInput {
-        case_type,
-        return_type,
-        then,
-        variable_binding,
-        guard,
-        match_condition,
-        is_total,
-    } = input;
-
-    context.with_local_scope(|context| {
-        let binding_step =
-            variable_binding.map(|(name, value)| plan_variable_runtime_step(name, value, context));
-        let guard_condition = guard
-            .map(|guard| guard::plan_bool(guard, context))
-            .transpose()?;
-        let condition = match guard_condition {
-            Some(guard_condition) => BoolExpr::and(match_condition, guard_condition),
-            None => match_condition,
-        };
-        let condition = match &binding_step {
-            Some(step) => BoolExpr::block(vec![step.clone()], condition),
-            None => condition,
-        };
-
-        let branch =
-            super::plan_expr_with_expected_source_stop_type(then, return_type.clone(), context)?;
-        validate_case_branch_type(case_type, &branch)?;
-        let branch = if let Some(step) = binding_step {
-            super::block::block_expr(vec![step], branch)
-        } else {
-            branch
-        };
-
-        Ok(OrderedCaseClause {
-            condition,
-            branch,
-            is_total,
-        })
-    })
-}
-
-pub(super) fn ordered_case_expr(clauses: Vec<OrderedCaseClause>) -> Result<Expr, PlanError> {
-    let mut reachable_clauses = Vec::new();
-    for clause in clauses {
-        let is_total = clause.is_total;
-        reachable_clauses.push(clause);
-        if is_total {
-            break;
-        }
-    }
-
-    let Some(last_clause) = reachable_clauses.pop() else {
-        return Err(invalid_case_shape(
-            InvalidCaseShapeReason::MissingFallbackPattern,
-        ));
-    };
-    if !last_clause.is_total {
-        return Err(invalid_case_shape(
-            InvalidCaseShapeReason::MissingFallbackPattern,
-        ));
-    }
-
-    let mut next = last_clause.branch;
-    for clause in reachable_clauses.into_iter().rev() {
-        next = bool_case_expr(clause.condition, clause.branch, next)?;
-    }
-
-    Ok(next)
-}
-
-pub(super) fn bind_int_case_subject(
-    subject: IntExpr,
-    context: &mut PlanContext<'_>,
-) -> (Step, IntExpr) {
-    let local = context.define_internal_int_local();
-    let name = internal_int_case_subject_name(local);
-    (
-        Step::let_int(local, name.clone(), subject),
-        IntExpr::local_get(local, name),
-    )
-}
-
-pub(super) fn bind_string_case_subject(
-    subject: StringExpr,
-    context: &mut PlanContext<'_>,
-) -> (Step, StringExpr) {
-    let local = context.define_internal_string_local();
-    let name = internal_string_case_subject_name(local);
-    (
-        Step::let_string(local, name.clone(), subject),
-        StringExpr::local_get(local, name),
-    )
-}
-
-pub(super) fn bind_float_case_subject(
-    subject: FloatExpr,
-    context: &mut PlanContext<'_>,
-) -> (Step, FloatExpr) {
-    let local = context.define_internal_float_local();
-    let name = internal_float_case_subject_name(local);
-    (
-        Step::let_float(local, name.clone(), subject),
-        FloatExpr::local_get(local, name),
-    )
-}
-
-pub(super) fn bind_bool_case_subject(
-    subject: BoolExpr,
-    context: &mut PlanContext<'_>,
-) -> (Step, BoolExpr) {
-    let local = context.define_internal_bool_local();
-    let name = internal_bool_case_subject_name(local);
-    (
-        Step::let_bool(local, name.clone(), subject),
-        BoolExpr::local_get(local, name),
-    )
-}
-
-pub(super) fn case_subject_block(step: Step, case: Expr) -> Expr {
-    super::block::block_expr(vec![step], case)
-}
-
 pub(super) fn unsupported_case(reason: UnsupportedCaseReason) -> PlanError {
     PlanError::UnsupportedCase { reason }
 }
@@ -345,22 +47,6 @@ pub(super) fn invalid_case_shape(reason: InvalidCaseShapeReason) -> PlanError {
     PlanError::InvalidTypedAst {
         reason: InvalidTypedAstReason::CaseShape { reason },
     }
-}
-
-fn internal_int_case_subject_name(local: IntLocalId) -> EcoString {
-    format!("<case:int:{}>", local.0).into()
-}
-
-fn internal_string_case_subject_name(local: StringLocalId) -> EcoString {
-    format!("<case:string:{}>", local.0).into()
-}
-
-fn internal_float_case_subject_name(local: FloatLocalId) -> EcoString {
-    format!("<case:float:{}>", local.0).into()
-}
-
-fn internal_bool_case_subject_name(local: BoolLocalId) -> EcoString {
-    format!("<case:bool:{}>", local.0).into()
 }
 
 #[cfg(test)]
@@ -430,18 +116,11 @@ pub(super) fn expect_expression_statement(statement: &TypedStatement) -> &TypedE
 
 #[cfg(test)]
 mod tests {
-    use crate::plan::{BoolExpr, Expr, IntExpr};
-    use crate::planner::context::{AnonymousFunctions, PlanContext};
     use crate::planner::plan_module;
-    use crate::planner::support::{compile_minimal_module, dummy_span, expect_plan_error};
+    use crate::planner::support::{compile_minimal_module, expect_plan_error};
     use crate::planner::{
         InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
-        UnsupportedExpressionKind,
     };
-    use ecow::EcoString;
-    use gleam_core::ast::TypedExpr;
-    use gleam_core::type_;
-    use std::collections::HashMap;
 
     #[test]
     fn reject_profile_case_expressions() {
@@ -456,10 +135,6 @@ pub fn main() {
 }
 "#,
                 UnsupportedCaseReason::MultipleSubjects,
-            ),
-            (
-                r#"pub fn main() { case True { True | False -> 1 } }"#,
-                UnsupportedCaseReason::AlternativePatterns,
             ),
             (
                 r#"pub fn main() { case #(1, 2) { _ -> 1 } }"#,
@@ -477,57 +152,6 @@ pub fn main() {
                 PlanError::UnsupportedCase { reason },
             );
         }
-    }
-
-    #[test]
-    fn reject_profile_unreachable_case_clause_body() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  case True {
-    _ -> 1
-    True -> echo 2
-  }
-}
-"#,
-            ),
-            PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::Echo,
-            },
-        );
-
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  case 1 {
-    _ -> 1
-    1 -> echo 2
-  }
-}
-"#,
-            ),
-            PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::Echo,
-            },
-        );
-
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  case 1 {
-    value if value > 0 -> echo value
-    _ -> 0
-  }
-}
-"#,
-            ),
-            PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::Echo,
-            },
-        );
     }
 
     #[test]
@@ -556,169 +180,6 @@ pub fn main() {
                     reason: InvalidCaseShapeReason::EmptyClauses,
                 },
             }),
-        );
-
-        let mut empty_pattern = super::compile_bool_case_module();
-        let (_, _, clauses) =
-            super::expect_case_statement_mut(&mut empty_pattern.definitions.functions[0].body[0]);
-        clauses[0].pattern.clear();
-        assert_eq!(
-            plan_module(empty_pattern),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CaseShape {
-                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
-                },
-            }),
-        );
-
-        let mut extra_pattern = super::compile_bool_case_module();
-        let (_, _, clauses) =
-            super::expect_case_statement_mut(&mut extra_pattern.definitions.functions[0].body[0]);
-        let pattern = clauses[0].pattern[0].clone();
-        clauses[0].pattern.push(pattern);
-        assert_eq!(
-            plan_module(extra_pattern),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CaseShape {
-                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
-                },
-            }),
-        );
-
-        let mut case_type_mismatch = super::compile_bool_case_module();
-        let (case_type, _, _) = super::expect_case_statement_mut(
-            &mut case_type_mismatch.definitions.functions[0].body[0],
-        );
-        *case_type = type_::bool();
-        assert_eq!(
-            plan_module(case_type_mismatch),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CaseShape {
-                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
-                },
-            }),
-        );
-
-        let mut branch_type_mismatch = super::compile_bool_case_module();
-        let (case_type, _, clauses) = super::expect_case_statement_mut(
-            &mut branch_type_mismatch.definitions.functions[0].body[0],
-        );
-        *case_type = type_::string();
-        clauses[0].then = TypedExpr::String {
-            location: dummy_span(),
-            type_: type_::string(),
-            value: "bad".into(),
-        };
-        assert_eq!(
-            plan_module(branch_type_mismatch),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CaseShape {
-                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
-                },
-            }),
-        );
-    }
-
-    #[test]
-    fn reject_margin_ordered_case_expr_requires_total_fallback() {
-        assert_eq!(
-            super::ordered_case_expr(Vec::new()),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CaseShape {
-                    reason: InvalidCaseShapeReason::MissingFallbackPattern,
-                },
-            }),
-        );
-        assert_eq!(
-            super::ordered_case_expr(vec![super::OrderedCaseClause {
-                condition: BoolExpr::value(false),
-                branch: Expr::int(IntExpr::value(1.into())),
-                is_total: false,
-            }]),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CaseShape {
-                    reason: InvalidCaseShapeReason::MissingFallbackPattern,
-                },
-            }),
-        );
-    }
-
-    #[test]
-    fn ordered_case_expr_preserves_source_ordered_fallthrough_shape() {
-        assert_eq!(
-            super::ordered_case_expr(vec![super::OrderedCaseClause {
-                condition: BoolExpr::value(true),
-                branch: Expr::int(IntExpr::value(1.into())),
-                is_total: true,
-            }]),
-            Ok(Expr::int(IntExpr::value(1.into()))),
-        );
-        assert_eq!(
-            super::ordered_case_expr(vec![
-                super::OrderedCaseClause {
-                    condition: BoolExpr::value(false),
-                    branch: Expr::int(IntExpr::value(1.into())),
-                    is_total: false,
-                },
-                super::OrderedCaseClause {
-                    condition: BoolExpr::value(true),
-                    branch: Expr::int(IntExpr::value(0.into())),
-                    is_total: true,
-                }
-            ]),
-            Ok(Expr::int(IntExpr::bool_case(
-                BoolExpr::value(false),
-                IntExpr::value(1.into()),
-                IntExpr::value(0.into()),
-            ))),
-        );
-        assert_eq!(
-            super::ordered_case_expr(vec![
-                super::OrderedCaseClause {
-                    condition: BoolExpr::value(true),
-                    branch: Expr::int(IntExpr::value(10.into())),
-                    is_total: true,
-                },
-                super::OrderedCaseClause {
-                    condition: BoolExpr::value(true),
-                    branch: Expr::int(IntExpr::value(999.into())),
-                    is_total: false,
-                },
-            ]),
-            Ok(Expr::int(IntExpr::value(10.into()))),
-        );
-    }
-
-    #[test]
-    fn reject_margin_ordered_case_clause_branch_type_mismatch() {
-        let module = EcoString::from("main");
-        let functions = HashMap::new();
-        let mut anonymous = AnonymousFunctions::default();
-        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
-        let case_type = type_::string();
-
-        let actual = super::plan_ordered_case_clause(
-            super::OrderedCaseClauseInput {
-                case_type: case_type.as_ref(),
-                return_type: &crate::plan::ValueType::String,
-                then: super::super::typed_int_expr(1),
-                variable_binding: None,
-                guard: None,
-                match_condition: BoolExpr::value(true),
-                is_total: true,
-            },
-            &mut context,
-        );
-        let error = actual
-            .map(|_| ())
-            .expect_err("branch type mismatch should reject ordered case clause");
-        assert_eq!(
-            error,
-            PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CaseShape {
-                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
-                },
-            },
         );
     }
 

--- a/src/planner/expression/case/subject.rs
+++ b/src/planner/expression/case/subject.rs
@@ -1,0 +1,569 @@
+mod bool_;
+mod float;
+mod int;
+mod string;
+
+use crate::plan::{
+    BoolCaseBranches, BoolExpr, BoolLocalId, Expr, ExprKind, FloatExpr, FloatLocalId,
+    FunctionExprKind, IntExpr, IntLocalId, Step, StringExpr, StringLocalId, ValueType,
+};
+use crate::planner::context::PlanContext;
+use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
+use crate::planner::statement::plan_variable_runtime_step;
+use ecow::EcoString;
+use gleam_core::ast::{Pattern, TypedClause, TypedClauseGuard, TypedExpr};
+use gleam_core::type_::Type;
+use std::sync::Arc;
+
+pub(super) fn plan(
+    type_: Arc<Type>,
+    subject: TypedExpr,
+    clauses: Vec<TypedClause>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    if subject.type_().is_bool() {
+        return bool_::plan(type_, subject, clauses, context);
+    }
+    if subject.type_().is_int() {
+        return int::plan(type_, subject, clauses, context);
+    }
+    if subject.type_().is_string() {
+        return string::plan(type_, subject, clauses, context);
+    }
+    if subject.type_().is_float() {
+        return float::plan(type_, subject, clauses, context);
+    }
+
+    Err(super::unsupported_case(
+        UnsupportedCaseReason::UnsupportedSubjectType,
+    ))
+}
+
+fn validate_clause_shape(clause: &TypedClause) -> Result<(), PlanError> {
+    if !clause.alternative_patterns.is_empty() {
+        return Err(super::unsupported_case(
+            UnsupportedCaseReason::AlternativePatterns,
+        ));
+    }
+
+    Ok(())
+}
+
+fn single_case_pattern(patterns: Vec<Pattern<Arc<Type>>>) -> Result<Pattern<Arc<Type>>, PlanError> {
+    let mut patterns = patterns.into_iter();
+    let pattern = patterns.next().ok_or(super::invalid_case_shape(
+        InvalidCaseShapeReason::PatternSubjectCountMismatch,
+    ))?;
+    if patterns.next().is_some() {
+        return Err(super::invalid_case_shape(
+            InvalidCaseShapeReason::PatternSubjectCountMismatch,
+        ));
+    }
+
+    Ok(pattern)
+}
+
+fn validate_case_branch_type(case_type: &Type, branch: &Expr) -> Result<(), PlanError> {
+    if ValueType::from_gleam(case_type) == Some(branch.value_type()) {
+        return Ok(());
+    }
+
+    Err(super::invalid_case_shape(
+        InvalidCaseShapeReason::BranchReturnTypeMismatch,
+    ))
+}
+
+fn bool_case_expr(subject: BoolExpr, true_: Expr, false_: Expr) -> Result<Expr, PlanError> {
+    let branches = match (true_.into_kind(), false_.into_kind()) {
+        (ExprKind::Int(true_), ExprKind::Int(false_)) => BoolCaseBranches::Int { true_, false_ },
+        (ExprKind::String(true_), ExprKind::String(false_)) => {
+            BoolCaseBranches::String { true_, false_ }
+        }
+        (ExprKind::Float(true_), ExprKind::Float(false_)) => {
+            BoolCaseBranches::Float { true_, false_ }
+        }
+        (ExprKind::Bool(true_), ExprKind::Bool(false_)) => BoolCaseBranches::Bool { true_, false_ },
+        (ExprKind::Nil(true_), ExprKind::Nil(false_)) => BoolCaseBranches::Nil { true_, false_ },
+        (ExprKind::Tuple(true_), ExprKind::Tuple(false_)) => {
+            BoolCaseBranches::Tuple { true_, false_ }
+        }
+        (ExprKind::List(true_), ExprKind::List(false_)) => BoolCaseBranches::List { true_, false_ },
+        (ExprKind::Function(true_), ExprKind::Function(false_)) => {
+            bool_function_case_branches(true_, false_)?
+        }
+        _ => {
+            return Err(super::invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        }
+    };
+
+    Ok(Expr::bool_case(subject, branches))
+}
+
+fn bool_function_case_branches(
+    true_: crate::plan::FunctionExpr,
+    false_: crate::plan::FunctionExpr,
+) -> Result<BoolCaseBranches, PlanError> {
+    Ok(match (true_.into_kind(), false_.into_kind()) {
+        (FunctionExprKind::Int(true_), FunctionExprKind::Int(false_)) => {
+            BoolCaseBranches::IntFunction { true_, false_ }
+        }
+        (FunctionExprKind::String(true_), FunctionExprKind::String(false_)) => {
+            BoolCaseBranches::StringFunction { true_, false_ }
+        }
+        (FunctionExprKind::Float(true_), FunctionExprKind::Float(false_)) => {
+            BoolCaseBranches::FloatFunction { true_, false_ }
+        }
+        (FunctionExprKind::Bool(true_), FunctionExprKind::Bool(false_)) => {
+            BoolCaseBranches::BoolFunction { true_, false_ }
+        }
+        (FunctionExprKind::Nil(true_), FunctionExprKind::Nil(false_)) => {
+            BoolCaseBranches::NilFunction { true_, false_ }
+        }
+        (FunctionExprKind::Tuple(true_), FunctionExprKind::Tuple(false_)) => {
+            BoolCaseBranches::TupleFunction { true_, false_ }
+        }
+        (FunctionExprKind::List(true_), FunctionExprKind::List(false_)) => {
+            BoolCaseBranches::ListFunction { true_, false_ }
+        }
+        (FunctionExprKind::Function(true_), FunctionExprKind::Function(false_)) => {
+            BoolCaseBranches::FunctionFunction { true_, false_ }
+        }
+        _ => {
+            return Err(super::invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        }
+    })
+}
+
+fn case_return_type(case_type: &Type) -> Result<ValueType, PlanError> {
+    ValueType::from_gleam(case_type)
+        .ok_or_else(|| super::invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch))
+}
+
+fn plan_case_branch(
+    case_type: &Type,
+    return_type: &ValueType,
+    then: TypedExpr,
+    variable_binding: Option<(EcoString, Expr)>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    context.with_local_scope(|context| {
+        let steps = variable_binding
+            .map(|(name, value)| vec![plan_variable_runtime_step(name, value, context)])
+            .unwrap_or_default();
+        let branch = super::super::plan_expr_with_expected_source_stop_type(
+            then,
+            return_type.clone(),
+            context,
+        )?;
+        validate_case_branch_type(case_type, &branch)?;
+
+        if steps.is_empty() {
+            Ok(branch)
+        } else {
+            Ok(super::super::block::block_expr(steps, branch))
+        }
+    })
+}
+
+#[derive(Clone)]
+struct OrderedCaseClause {
+    condition: BoolExpr,
+    branch: Expr,
+    is_total: bool,
+}
+
+struct OrderedCaseClauseInput<'a> {
+    case_type: &'a Type,
+    return_type: &'a ValueType,
+    then: TypedExpr,
+    variable_binding: Option<(EcoString, Expr)>,
+    guard: Option<TypedClauseGuard>,
+    match_condition: BoolExpr,
+    is_total: bool,
+}
+
+fn plan_ordered_case_clause(
+    input: OrderedCaseClauseInput<'_>,
+    context: &mut PlanContext<'_>,
+) -> Result<OrderedCaseClause, PlanError> {
+    let OrderedCaseClauseInput {
+        case_type,
+        return_type,
+        then,
+        variable_binding,
+        guard,
+        match_condition,
+        is_total,
+    } = input;
+
+    context.with_local_scope(|context| {
+        let binding_step =
+            variable_binding.map(|(name, value)| plan_variable_runtime_step(name, value, context));
+        let guard_condition = guard
+            .map(|guard| super::guard::plan_bool(guard, context))
+            .transpose()?;
+        let condition = match guard_condition {
+            Some(guard_condition) => BoolExpr::and(match_condition, guard_condition),
+            None => match_condition,
+        };
+        let condition = match &binding_step {
+            Some(step) => BoolExpr::block(vec![step.clone()], condition),
+            None => condition,
+        };
+
+        let branch = super::super::plan_expr_with_expected_source_stop_type(
+            then,
+            return_type.clone(),
+            context,
+        )?;
+        validate_case_branch_type(case_type, &branch)?;
+        let branch = if let Some(step) = binding_step {
+            super::super::block::block_expr(vec![step], branch)
+        } else {
+            branch
+        };
+
+        Ok(OrderedCaseClause {
+            condition,
+            branch,
+            is_total,
+        })
+    })
+}
+
+fn ordered_case_expr(clauses: Vec<OrderedCaseClause>) -> Result<Expr, PlanError> {
+    let mut reachable_clauses = Vec::new();
+    for clause in clauses {
+        let is_total = clause.is_total;
+        reachable_clauses.push(clause);
+        if is_total {
+            break;
+        }
+    }
+
+    let Some(last_clause) = reachable_clauses.pop() else {
+        return Err(super::invalid_case_shape(
+            InvalidCaseShapeReason::MissingFallbackPattern,
+        ));
+    };
+    if !last_clause.is_total {
+        return Err(super::invalid_case_shape(
+            InvalidCaseShapeReason::MissingFallbackPattern,
+        ));
+    }
+
+    let mut next = last_clause.branch;
+    for clause in reachable_clauses.into_iter().rev() {
+        next = bool_case_expr(clause.condition, clause.branch, next)?;
+    }
+
+    Ok(next)
+}
+
+fn bind_int_case_subject(subject: IntExpr, context: &mut PlanContext<'_>) -> (Step, IntExpr) {
+    let local = context.define_internal_int_local();
+    let name = internal_int_case_subject_name(local);
+    (
+        Step::let_int(local, name.clone(), subject),
+        IntExpr::local_get(local, name),
+    )
+}
+
+fn bind_string_case_subject(
+    subject: StringExpr,
+    context: &mut PlanContext<'_>,
+) -> (Step, StringExpr) {
+    let local = context.define_internal_string_local();
+    let name = internal_string_case_subject_name(local);
+    (
+        Step::let_string(local, name.clone(), subject),
+        StringExpr::local_get(local, name),
+    )
+}
+
+fn bind_float_case_subject(subject: FloatExpr, context: &mut PlanContext<'_>) -> (Step, FloatExpr) {
+    let local = context.define_internal_float_local();
+    let name = internal_float_case_subject_name(local);
+    (
+        Step::let_float(local, name.clone(), subject),
+        FloatExpr::local_get(local, name),
+    )
+}
+
+fn bind_bool_case_subject(subject: BoolExpr, context: &mut PlanContext<'_>) -> (Step, BoolExpr) {
+    let local = context.define_internal_bool_local();
+    let name = internal_bool_case_subject_name(local);
+    (
+        Step::let_bool(local, name.clone(), subject),
+        BoolExpr::local_get(local, name),
+    )
+}
+
+fn case_subject_block(step: Step, case: Expr) -> Expr {
+    super::super::block::block_expr(vec![step], case)
+}
+
+fn internal_int_case_subject_name(local: IntLocalId) -> EcoString {
+    format!("<case:int:{}>", local.0).into()
+}
+
+fn internal_string_case_subject_name(local: StringLocalId) -> EcoString {
+    format!("<case:string:{}>", local.0).into()
+}
+
+fn internal_float_case_subject_name(local: FloatLocalId) -> EcoString {
+    format!("<case:float:{}>", local.0).into()
+}
+
+fn internal_bool_case_subject_name(local: BoolLocalId) -> EcoString {
+    format!("<case:bool:{}>", local.0).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::plan::{BoolExpr, Expr, IntExpr};
+    use crate::planner::context::{AnonymousFunctions, PlanContext};
+    use crate::planner::plan_module;
+    use crate::planner::support::{dummy_span, expect_plan_error};
+    use crate::planner::{
+        InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
+        UnsupportedExpressionKind,
+    };
+    use ecow::EcoString;
+    use gleam_core::ast::TypedExpr;
+    use gleam_core::type_;
+    use std::collections::HashMap;
+
+    #[test]
+    fn reject_profile_subject_clause_shapes() {
+        assert_eq!(
+            expect_plan_error(r#"pub fn main() { case True { True | False -> 1 } }"#),
+            PlanError::UnsupportedCase {
+                reason: UnsupportedCaseReason::AlternativePatterns,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_profile_unreachable_subject_clause_body() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case True {
+    _ -> 1
+    True -> echo 2
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Echo,
+            },
+        );
+
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case 1 {
+    _ -> 1
+    1 -> echo 2
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Echo,
+            },
+        );
+
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case 1 {
+    value if value > 0 -> echo value
+    _ -> 0
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: UnsupportedExpressionKind::Echo,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_margin_subject_clause_shapes() {
+        let mut empty_pattern = super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut empty_pattern.definitions.functions[0].body[0],
+        );
+        clauses[0].pattern.clear();
+        assert_eq!(
+            plan_module(empty_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
+                },
+            }),
+        );
+
+        let mut extra_pattern = super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut extra_pattern.definitions.functions[0].body[0],
+        );
+        let pattern = clauses[0].pattern[0].clone();
+        clauses[0].pattern.push(pattern);
+        assert_eq!(
+            plan_module(extra_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
+                },
+            }),
+        );
+
+        let mut case_type_mismatch = super::super::compile_bool_case_module();
+        let (case_type, _, _) = super::super::expect_case_statement_mut(
+            &mut case_type_mismatch.definitions.functions[0].body[0],
+        );
+        *case_type = type_::bool();
+        assert_eq!(
+            plan_module(case_type_mismatch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            }),
+        );
+
+        let mut branch_type_mismatch = super::super::compile_bool_case_module();
+        let (case_type, _, clauses) = super::super::expect_case_statement_mut(
+            &mut branch_type_mismatch.definitions.functions[0].body[0],
+        );
+        *case_type = type_::string();
+        clauses[0].then = TypedExpr::String {
+            location: dummy_span(),
+            type_: type_::string(),
+            value: "bad".into(),
+        };
+        assert_eq!(
+            plan_module(branch_type_mismatch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_ordered_case_expr_requires_total_fallback() {
+        assert_eq!(
+            super::ordered_case_expr(Vec::new()),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::MissingFallbackPattern,
+                },
+            }),
+        );
+        assert_eq!(
+            super::ordered_case_expr(vec![super::OrderedCaseClause {
+                condition: BoolExpr::value(false),
+                branch: Expr::int(IntExpr::value(1.into())),
+                is_total: false,
+            }]),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::MissingFallbackPattern,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn ordered_case_expr_preserves_source_ordered_fallthrough_shape() {
+        assert_eq!(
+            super::ordered_case_expr(vec![super::OrderedCaseClause {
+                condition: BoolExpr::value(true),
+                branch: Expr::int(IntExpr::value(1.into())),
+                is_total: true,
+            }]),
+            Ok(Expr::int(IntExpr::value(1.into()))),
+        );
+        assert_eq!(
+            super::ordered_case_expr(vec![
+                super::OrderedCaseClause {
+                    condition: BoolExpr::value(false),
+                    branch: Expr::int(IntExpr::value(1.into())),
+                    is_total: false,
+                },
+                super::OrderedCaseClause {
+                    condition: BoolExpr::value(true),
+                    branch: Expr::int(IntExpr::value(0.into())),
+                    is_total: true,
+                }
+            ]),
+            Ok(Expr::int(IntExpr::bool_case(
+                BoolExpr::value(false),
+                IntExpr::value(1.into()),
+                IntExpr::value(0.into()),
+            ))),
+        );
+        assert_eq!(
+            super::ordered_case_expr(vec![
+                super::OrderedCaseClause {
+                    condition: BoolExpr::value(true),
+                    branch: Expr::int(IntExpr::value(10.into())),
+                    is_total: true,
+                },
+                super::OrderedCaseClause {
+                    condition: BoolExpr::value(true),
+                    branch: Expr::int(IntExpr::value(999.into())),
+                    is_total: false,
+                },
+            ]),
+            Ok(Expr::int(IntExpr::value(10.into()))),
+        );
+    }
+
+    #[test]
+    fn reject_margin_ordered_case_clause_branch_type_mismatch() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        let case_type = type_::string();
+
+        let actual = super::plan_ordered_case_clause(
+            super::OrderedCaseClauseInput {
+                case_type: case_type.as_ref(),
+                return_type: &crate::plan::ValueType::String,
+                then: super::super::super::typed_int_expr(1),
+                variable_binding: None,
+                guard: None,
+                match_condition: BoolExpr::value(true),
+                is_total: true,
+            },
+            &mut context,
+        );
+        let error = actual
+            .map(|_| ())
+            .expect_err("branch type mismatch should reject ordered case clause");
+        assert_eq!(
+            error,
+            PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            },
+        );
+    }
+}

--- a/src/planner/expression/case/subject/bool_.rs
+++ b/src/planner/expression/case/subject/bool_.rs
@@ -1,7 +1,6 @@
-use super::{
-    case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
-    validate_clause_shape,
-};
+use super::super::super::plan_bool_expr;
+use super::super::{invalid_case_shape, unsupported_case};
+use super::{case_return_type, single_case_pattern, validate_clause_shape};
 use crate::plan::{BoolExpr, Expr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
@@ -18,7 +17,7 @@ pub(super) fn plan(
     clauses: Vec<TypedClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let subject = super::super::plan_bool_expr(subject, context)?;
+    let subject = plan_bool_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
     for clause in &clauses {
         validate_clause_shape(clause)?;
@@ -841,8 +840,8 @@ pub fn main() {
 
     #[test]
     fn reject_margin_bool_case_pattern_shapes() {
-        let mut invalid_pattern = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut invalid_pattern = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut invalid_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Invalid {
@@ -858,8 +857,8 @@ pub fn main() {
             }),
         );
 
-        let mut pattern_type_mismatch = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut pattern_type_mismatch = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut pattern_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Int {
@@ -876,8 +875,8 @@ pub fn main() {
             }),
         );
 
-        let mut variable_type_mismatch = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut variable_type_mismatch = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut variable_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Variable {
@@ -895,8 +894,8 @@ pub fn main() {
             }),
         );
 
-        let mut discard_type_mismatch = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut discard_type_mismatch = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut discard_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Discard {
@@ -913,8 +912,8 @@ pub fn main() {
             }),
         );
 
-        let mut assign_type_mismatch = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut assign_type_mismatch = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut assign_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Assign {
@@ -935,8 +934,8 @@ pub fn main() {
             }),
         );
 
-        let mut assign_constructor_name_mismatch = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut assign_constructor_name_mismatch = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut assign_constructor_name_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Assign {
@@ -962,8 +961,8 @@ pub fn main() {
             }),
         );
 
-        let mut assign_invalid_pattern = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut assign_invalid_pattern = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut assign_invalid_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Assign {
@@ -983,8 +982,8 @@ pub fn main() {
             }),
         );
 
-        let mut bool_constructor_name_mismatch = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut bool_constructor_name_mismatch = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut bool_constructor_name_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Constructor {
@@ -1006,8 +1005,8 @@ pub fn main() {
             }),
         );
 
-        let mut missing_true_pattern = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut missing_true_pattern = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut missing_true_pattern.definitions.functions[0].body[0],
         );
         clauses.remove(0);
@@ -1020,8 +1019,8 @@ pub fn main() {
             }),
         );
 
-        let mut missing_false_pattern = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut missing_false_pattern = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut missing_false_pattern.definitions.functions[0].body[0],
         );
         clauses.pop();
@@ -1037,8 +1036,8 @@ pub fn main() {
 
     #[test]
     fn reject_margin_guarded_bool_case_pattern_shapes() {
-        let mut empty_pattern = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut empty_pattern = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut empty_pattern.definitions.functions[0].body[0],
         );
         clauses[0].guard = Some(bool_true_guard());
@@ -1052,8 +1051,8 @@ pub fn main() {
             }),
         );
 
-        let mut pattern_type_mismatch = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut pattern_type_mismatch = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut pattern_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].guard = Some(bool_true_guard());
@@ -1074,8 +1073,8 @@ pub fn main() {
 
     #[test]
     fn reject_margin_guarded_bool_case_missing_patterns() {
-        let mut missing_true_pattern = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut missing_true_pattern = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut missing_true_pattern.definitions.functions[0].body[0],
         );
         clauses.remove(0);
@@ -1089,8 +1088,8 @@ pub fn main() {
             }),
         );
 
-        let mut missing_false_pattern = super::super::compile_bool_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let mut missing_false_pattern = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut missing_false_pattern.definitions.functions[0].body[0],
         );
         clauses.pop();
@@ -1143,9 +1142,10 @@ pub fn main() {
 
     #[test]
     fn reject_margin_bool_case_subject_type_mismatch() {
-        let mut module = super::super::compile_bool_case_module();
-        let (_, subjects, _) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let mut module = super::super::super::compile_bool_case_module();
+        let (_, subjects, _) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         subjects[0] = gleam_core::ast::TypedExpr::String {
             location: dummy_span(),
             type_: type_::bool(),
@@ -1165,9 +1165,10 @@ pub fn main() {
 
     #[test]
     fn reject_margin_bool_case_return_type_unsupported() {
-        let mut module = super::super::compile_bool_case_module();
-        let (type_, _, _) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let mut module = super::super::super::compile_bool_case_module();
+        let (type_, _, _) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         *type_ = type_::bit_array();
 
         assert_eq!(
@@ -1182,9 +1183,10 @@ pub fn main() {
 
     #[test]
     fn reject_margin_bool_case_guard_must_be_bool() {
-        let mut module = super::super::compile_bool_case_module();
-        let (_, _, clauses) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let mut module = super::super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
             location: dummy_span(),
             value: "1".into(),
@@ -1270,8 +1272,9 @@ fn stringify(value: Int) {
             })
             .map(|function| &mut function.body)
             .expect("expected main function");
-        let replacement = super::super::expect_expression_statement(&body[1]).clone();
-        let (_, _, clauses) = super::super::expect_assignment_case_statement_mut(&mut body[0]);
+        let replacement = super::super::super::expect_expression_statement(&body[1]).clone();
+        let (_, _, clauses) =
+            super::super::super::expect_assignment_case_statement_mut(&mut body[0]);
         clauses[1].then = replacement;
 
         assert_eq!(

--- a/src/planner/expression/case/subject/float.rs
+++ b/src/planner/expression/case/subject/float.rs
@@ -1,7 +1,6 @@
-use super::{
-    case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
-    validate_clause_shape,
-};
+use super::super::super::plan_float_expr;
+use super::super::{invalid_case_shape, unsupported_case};
+use super::{case_return_type, single_case_pattern, validate_clause_shape};
 use crate::plan::{BoolExpr, Expr, ExprKind, FloatCaseBranches, FloatExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
@@ -16,7 +15,7 @@ pub(super) fn plan(
     clauses: Vec<TypedClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let subject = super::super::plan_float_expr(subject, context)?;
+    let subject = plan_float_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
     for clause in &clauses {
         validate_clause_shape(clause)?;
@@ -1048,7 +1047,7 @@ pub fn main() {
     #[test]
     fn reject_margin_float_case_pattern_shapes() {
         let mut alternative_pattern = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut alternative_pattern.definitions.functions[0].body[0],
         );
         clauses[0].alternative_patterns.push(vec![Pattern::Float {
@@ -1064,7 +1063,7 @@ pub fn main() {
         );
 
         let mut variable_type_mismatch = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut variable_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Variable {
@@ -1083,7 +1082,7 @@ pub fn main() {
         );
 
         let mut discard_type_mismatch = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut discard_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[1].pattern[0] = Pattern::Discard {
@@ -1101,7 +1100,7 @@ pub fn main() {
         );
 
         let mut invalid_pattern = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut invalid_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Invalid {
@@ -1118,7 +1117,7 @@ pub fn main() {
         );
 
         let mut pattern_type_mismatch = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut pattern_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::String {
@@ -1135,7 +1134,7 @@ pub fn main() {
         );
 
         let mut assign_invalid_pattern = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut assign_invalid_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Assign {
@@ -1156,7 +1155,7 @@ pub fn main() {
         );
 
         let mut assign_type_mismatch = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut assign_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Assign {
@@ -1177,7 +1176,7 @@ pub fn main() {
         );
 
         let mut empty_pattern = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut empty_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern.clear();
@@ -1191,7 +1190,7 @@ pub fn main() {
         );
 
         let mut case_type_mismatch = compile_float_case_module();
-        let (case_type, _, _) = super::super::expect_case_statement_mut(
+        let (case_type, _, _) = super::super::super::expect_case_statement_mut(
             &mut case_type_mismatch.definitions.functions[0].body[0],
         );
         *case_type = type_::bool();
@@ -1205,7 +1204,7 @@ pub fn main() {
         );
 
         let mut missing_fallback_pattern = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut missing_fallback_pattern.definitions.functions[0].body[0],
         );
         clauses.pop();
@@ -1245,7 +1244,8 @@ fn add_one(value: Float) {
             })
             .map(|function| &mut function.body)
             .expect("expected main function");
-        let (_, _, clauses) = super::super::expect_assignment_case_statement_mut(&mut body[0]);
+        let (_, _, clauses) =
+            super::super::super::expect_assignment_case_statement_mut(&mut body[0]);
         clauses.pop();
         assert_eq!(
             plan_module(missing_function_fallback_pattern),
@@ -1260,7 +1260,7 @@ fn add_one(value: Float) {
     #[test]
     fn reject_margin_guarded_float_case_pattern_shapes() {
         let mut empty_pattern = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut empty_pattern.definitions.functions[0].body[0],
         );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
@@ -1279,7 +1279,7 @@ fn add_one(value: Float) {
         );
 
         let mut pattern_type_mismatch = compile_float_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut pattern_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
@@ -1304,8 +1304,9 @@ fn add_one(value: Float) {
     #[test]
     fn reject_margin_float_case_guard_must_be_bool() {
         let mut module = compile_float_case_module();
-        let (_, _, clauses) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
             location: dummy_span(),
             value: "1".into(),
@@ -1326,8 +1327,9 @@ fn add_one(value: Float) {
     #[test]
     fn reject_margin_float_case_subject_type_mismatch() {
         let mut module = compile_float_case_module();
-        let (_, subjects, _) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (_, subjects, _) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         subjects[0] = gleam_core::ast::TypedExpr::String {
             location: dummy_span(),
             type_: type_::float(),
@@ -1348,8 +1350,9 @@ fn add_one(value: Float) {
     #[test]
     fn reject_margin_float_case_expr_type_mismatch() {
         let mut module = compile_float_case_module();
-        let (type_, _, _) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (type_, _, _) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         *type_ = type_::bit_array();
         assert_eq!(plan_module(module), Err(case_branch_return_type_mismatch()));
 
@@ -1613,8 +1616,9 @@ pub fn main() {
     #[test]
     fn reject_margin_float_case_assign_literal_pattern_still_profile_boundary() {
         let mut module = compile_float_case_module();
-        let (_, _, clauses) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         clauses[0].pattern[0] = Pattern::Assign {
             name: "value".into(),
             location: dummy_span(),

--- a/src/planner/expression/case/subject/int.rs
+++ b/src/planner/expression/case/subject/int.rs
@@ -1,7 +1,6 @@
-use super::{
-    case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
-    validate_clause_shape,
-};
+use super::super::super::plan_int_expr;
+use super::super::{invalid_case_shape, unsupported_case};
+use super::{case_return_type, single_case_pattern, validate_clause_shape};
 use crate::plan::{BoolExpr, Expr, ExprKind, IntCaseBranches, IntExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
@@ -17,7 +16,7 @@ pub(super) fn plan(
     clauses: Vec<TypedClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let subject = super::super::plan_int_expr(subject, context)?;
+    let subject = plan_int_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
     for clause in &clauses {
         validate_clause_shape(clause)?;
@@ -1132,7 +1131,7 @@ pub fn main() {
     #[test]
     fn reject_margin_int_case_pattern_shapes() {
         let mut variable_type_mismatch = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut variable_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Variable {
@@ -1151,7 +1150,7 @@ pub fn main() {
         );
 
         let mut discard_type_mismatch = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut discard_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[1].pattern[0] = Pattern::Discard {
@@ -1169,7 +1168,7 @@ pub fn main() {
         );
 
         let mut invalid_pattern = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut invalid_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Invalid {
@@ -1186,7 +1185,7 @@ pub fn main() {
         );
 
         let mut pattern_type_mismatch = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut pattern_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::String {
@@ -1203,7 +1202,7 @@ pub fn main() {
         );
 
         let mut assign_invalid_pattern = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut assign_invalid_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Assign {
@@ -1224,7 +1223,7 @@ pub fn main() {
         );
 
         let mut assign_type_mismatch = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut assign_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Assign {
@@ -1245,7 +1244,7 @@ pub fn main() {
         );
 
         let mut empty_pattern = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut empty_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern.clear();
@@ -1259,7 +1258,7 @@ pub fn main() {
         );
 
         let mut case_type_mismatch = compile_int_case_module();
-        let (case_type, _, _) = super::super::expect_case_statement_mut(
+        let (case_type, _, _) = super::super::super::expect_case_statement_mut(
             &mut case_type_mismatch.definitions.functions[0].body[0],
         );
         *case_type = type_::bool();
@@ -1273,7 +1272,7 @@ pub fn main() {
         );
 
         let mut missing_fallback_pattern = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut missing_fallback_pattern.definitions.functions[0].body[0],
         );
         clauses.pop();
@@ -1313,7 +1312,8 @@ fn add_one(value: Int) {
             })
             .map(|function| &mut function.body)
             .expect("expected main function");
-        let (_, _, clauses) = super::super::expect_assignment_case_statement_mut(&mut body[0]);
+        let (_, _, clauses) =
+            super::super::super::expect_assignment_case_statement_mut(&mut body[0]);
         clauses.pop();
         assert_eq!(
             plan_module(missing_function_fallback_pattern),
@@ -1328,8 +1328,9 @@ fn add_one(value: Int) {
     #[test]
     fn reject_margin_int_case_guard_must_be_bool() {
         let mut module = compile_int_case_module();
-        let (_, _, clauses) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
             location: dummy_span(),
             value: "1".into(),
@@ -1350,7 +1351,7 @@ fn add_one(value: Int) {
     #[test]
     fn reject_margin_guarded_int_case_pattern_shapes() {
         let mut empty_pattern = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut empty_pattern.definitions.functions[0].body[0],
         );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
@@ -1369,7 +1370,7 @@ fn add_one(value: Int) {
         );
 
         let mut pattern_type_mismatch = compile_int_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut pattern_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
@@ -1394,8 +1395,9 @@ fn add_one(value: Int) {
     #[test]
     fn reject_margin_int_case_subject_type_mismatch() {
         let mut module = compile_int_case_module();
-        let (_, subjects, _) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (_, subjects, _) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         subjects[0] = gleam_core::ast::TypedExpr::String {
             location: dummy_span(),
             type_: type_::int(),
@@ -1416,8 +1418,9 @@ fn add_one(value: Int) {
     #[test]
     fn reject_margin_int_case_expr_type_mismatch() {
         let mut module = compile_int_case_module();
-        let (type_, _, _) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (type_, _, _) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         *type_ = type_::bit_array();
         assert_eq!(plan_module(module), Err(case_branch_return_type_mismatch()));
 
@@ -1633,8 +1636,9 @@ fn stringify(value: Int) {
             })
             .map(|function| &mut function.body)
             .expect("expected main function");
-        let replacement = super::super::expect_expression_statement(&body[1]).clone();
-        let (_, _, clauses) = super::super::expect_assignment_case_statement_mut(&mut body[0]);
+        let replacement = super::super::super::expect_expression_statement(&body[1]).clone();
+        let (_, _, clauses) =
+            super::super::super::expect_assignment_case_statement_mut(&mut body[0]);
         clauses[1].then = replacement;
 
         assert_eq!(

--- a/src/planner/expression/case/subject/string.rs
+++ b/src/planner/expression/case/subject/string.rs
@@ -1,7 +1,6 @@
-use super::{
-    case_return_type, invalid_case_shape, single_case_pattern, unsupported_case,
-    validate_clause_shape,
-};
+use super::super::super::plan_string_expr;
+use super::super::{invalid_case_shape, unsupported_case};
+use super::{case_return_type, single_case_pattern, validate_clause_shape};
 use crate::plan::{BoolExpr, Expr, ExprKind, StringCaseBranches, StringExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
@@ -16,7 +15,7 @@ pub(super) fn plan(
     clauses: Vec<TypedClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let subject = super::super::plan_string_expr(subject, context)?;
+    let subject = plan_string_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
     for clause in &clauses {
         validate_clause_shape(clause)?;
@@ -892,7 +891,7 @@ pub fn main() {
     #[test]
     fn reject_margin_string_case_pattern_shapes() {
         let mut alternative_pattern = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut alternative_pattern.definitions.functions[0].body[0],
         );
         clauses[0].alternative_patterns.push(vec![Pattern::String {
@@ -907,7 +906,7 @@ pub fn main() {
         );
 
         let mut variable_type_mismatch = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut variable_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Variable {
@@ -926,7 +925,7 @@ pub fn main() {
         );
 
         let mut discard_type_mismatch = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut discard_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[1].pattern[0] = Pattern::Discard {
@@ -944,7 +943,7 @@ pub fn main() {
         );
 
         let mut invalid_pattern = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut invalid_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Invalid {
@@ -961,7 +960,7 @@ pub fn main() {
         );
 
         let mut pattern_type_mismatch = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut pattern_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Int {
@@ -979,7 +978,7 @@ pub fn main() {
         );
 
         let mut assign_invalid_pattern = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut assign_invalid_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Assign {
@@ -1000,7 +999,7 @@ pub fn main() {
         );
 
         let mut assign_type_mismatch = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut assign_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].pattern[0] = Pattern::Assign {
@@ -1022,7 +1021,7 @@ pub fn main() {
         );
 
         let mut empty_pattern = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut empty_pattern.definitions.functions[0].body[0],
         );
         clauses[0].pattern.clear();
@@ -1036,7 +1035,7 @@ pub fn main() {
         );
 
         let mut case_type_mismatch = compile_string_case_module();
-        let (case_type, _, _) = super::super::expect_case_statement_mut(
+        let (case_type, _, _) = super::super::super::expect_case_statement_mut(
             &mut case_type_mismatch.definitions.functions[0].body[0],
         );
         *case_type = type_::bool();
@@ -1050,7 +1049,7 @@ pub fn main() {
         );
 
         let mut missing_fallback_pattern = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut missing_fallback_pattern.definitions.functions[0].body[0],
         );
         clauses.pop();
@@ -1090,7 +1089,8 @@ fn return_value(value: String) {
             })
             .map(|function| &mut function.body)
             .expect("expected main function");
-        let (_, _, clauses) = super::super::expect_assignment_case_statement_mut(&mut body[0]);
+        let (_, _, clauses) =
+            super::super::super::expect_assignment_case_statement_mut(&mut body[0]);
         clauses.pop();
         assert_eq!(
             plan_module(missing_function_fallback_pattern),
@@ -1105,7 +1105,7 @@ fn return_value(value: String) {
     #[test]
     fn reject_margin_guarded_string_case_pattern_shapes() {
         let mut empty_pattern = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut empty_pattern.definitions.functions[0].body[0],
         );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
@@ -1124,7 +1124,7 @@ fn return_value(value: String) {
         );
 
         let mut pattern_type_mismatch = compile_string_case_module();
-        let (_, _, clauses) = super::super::expect_case_statement_mut(
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut pattern_type_mismatch.definitions.functions[0].body[0],
         );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
@@ -1150,8 +1150,9 @@ fn return_value(value: String) {
     #[test]
     fn reject_margin_string_case_guard_must_be_bool() {
         let mut module = compile_string_case_module();
-        let (_, _, clauses) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
             location: dummy_span(),
             value: "1".into(),
@@ -1172,8 +1173,9 @@ fn return_value(value: String) {
     #[test]
     fn reject_margin_string_case_subject_type_mismatch() {
         let mut module = compile_string_case_module();
-        let (_, subjects, _) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (_, subjects, _) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         subjects[0] = gleam_core::ast::TypedExpr::Int {
             location: dummy_span(),
             type_: type_::string(),
@@ -1195,8 +1197,9 @@ fn return_value(value: String) {
     #[test]
     fn reject_margin_string_case_expr_type_mismatch() {
         let mut module = compile_string_case_module();
-        let (type_, _, _) =
-            super::super::expect_case_statement_mut(&mut module.definitions.functions[0].body[0]);
+        let (type_, _, _) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
         *type_ = type_::bit_array();
         assert_eq!(plan_module(module), Err(case_branch_return_type_mismatch()));
 


### PR DESCRIPTION
- Move Bool/Int/Float/String case subject lowering under `case/subject`.
- Keep `case.rs` as the case facade for subject validation and shared error constructors.
- Rehome subject-owned tests beside the new subject module without changing case behavior.
