### PR TITLE
Add case pattern alias support

### DIFF
--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -66,8 +66,6 @@ pub enum UnsupportedBinOpKind {
 pub enum UnsupportedCaseReason {
     #[error("alternative patterns are not supported")]
     AlternativePatterns,
-    #[error("assign patterns are not supported")]
-    AssignPattern,
     #[error("multiple subjects are not supported")]
     MultipleSubjects,
     #[error("case subject type is not supported")]

--- a/src/planner/expression/case/subject.rs
+++ b/src/planner/expression/case/subject.rs
@@ -147,13 +147,11 @@ fn plan_case_branch(
     case_type: &Type,
     return_type: &ValueType,
     then: TypedExpr,
-    variable_binding: Option<(EcoString, Expr)>,
+    branch_bindings: Vec<(EcoString, Expr)>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     context.with_local_scope(|context| {
-        let steps = variable_binding
-            .map(|(name, value)| vec![plan_variable_runtime_step(name, value, context)])
-            .unwrap_or_default();
+        let steps = plan_branch_binding_steps(branch_bindings, context);
         let branch = super::super::plan_expr_with_expected_source_stop_type(
             then,
             return_type.clone(),
@@ -180,7 +178,7 @@ struct OrderedCaseClauseInput<'a> {
     case_type: &'a Type,
     return_type: &'a ValueType,
     then: TypedExpr,
-    variable_binding: Option<(EcoString, Expr)>,
+    branch_bindings: Vec<(EcoString, Expr)>,
     guard: Option<TypedClauseGuard>,
     match_condition: BoolExpr,
     is_total: bool,
@@ -194,15 +192,14 @@ fn plan_ordered_case_clause(
         case_type,
         return_type,
         then,
-        variable_binding,
+        branch_bindings,
         guard,
         match_condition,
         is_total,
     } = input;
 
     context.with_local_scope(|context| {
-        let binding_step =
-            variable_binding.map(|(name, value)| plan_variable_runtime_step(name, value, context));
+        let binding_steps = plan_branch_binding_steps(branch_bindings, context);
         let guard_condition = guard
             .map(|guard| super::guard::plan_bool(guard, context))
             .transpose()?;
@@ -210,9 +207,10 @@ fn plan_ordered_case_clause(
             Some(guard_condition) => BoolExpr::and(match_condition, guard_condition),
             None => match_condition,
         };
-        let condition = match &binding_step {
-            Some(step) => BoolExpr::block(vec![step.clone()], condition),
-            None => condition,
+        let condition = if binding_steps.is_empty() {
+            condition
+        } else {
+            BoolExpr::block(binding_steps.clone(), condition)
         };
 
         let branch = super::super::plan_expr_with_expected_source_stop_type(
@@ -221,10 +219,10 @@ fn plan_ordered_case_clause(
             context,
         )?;
         validate_case_branch_type(case_type, &branch)?;
-        let branch = if let Some(step) = binding_step {
-            super::super::block::block_expr(vec![step], branch)
-        } else {
+        let branch = if binding_steps.is_empty() {
             branch
+        } else {
+            super::super::block::block_expr(binding_steps, branch)
         };
 
         Ok(OrderedCaseClause {
@@ -233,6 +231,24 @@ fn plan_ordered_case_clause(
             is_total,
         })
     })
+}
+
+fn branch_bindings(names: &[EcoString], value: Expr) -> Vec<(EcoString, Expr)> {
+    names
+        .iter()
+        .cloned()
+        .map(|name| (name, value.clone()))
+        .collect()
+}
+
+fn plan_branch_binding_steps(
+    bindings: Vec<(EcoString, Expr)>,
+    context: &mut PlanContext<'_>,
+) -> Vec<Step> {
+    bindings
+        .into_iter()
+        .map(|(name, value)| plan_variable_runtime_step(name, value, context))
+        .collect()
 }
 
 fn ordered_case_expr(clauses: Vec<OrderedCaseClause>) -> Result<Expr, PlanError> {
@@ -547,7 +563,7 @@ pub fn main() {
                 case_type: case_type.as_ref(),
                 return_type: &crate::plan::ValueType::String,
                 then: super::super::super::typed_int_expr(1),
-                variable_binding: None,
+                branch_bindings: Vec::new(),
                 guard: None,
                 match_condition: BoolExpr::value(true),
                 is_total: true,

--- a/src/planner/expression/case/subject/bool_.rs
+++ b/src/planner/expression/case/subject/bool_.rs
@@ -1,11 +1,9 @@
 use super::super::super::plan_bool_expr;
-use super::super::{invalid_case_shape, unsupported_case};
+use super::super::invalid_case_shape;
 use super::{case_return_type, single_case_pattern, validate_clause_shape};
 use crate::plan::{BoolExpr, Expr, ValueType};
 use crate::planner::context::PlanContext;
-use crate::planner::error::{
-    InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
-};
+use crate::planner::error::{InvalidCaseShapeReason, InvalidTypedAstReason, PlanError};
 use ecow::EcoString;
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
@@ -27,7 +25,7 @@ pub(super) fn plan(
         let case = plan_guarded_bool_case(type_.as_ref(), return_type, subject, clauses, context)?;
         return Ok(super::case_subject_block(subject_step, case));
     }
-    let needs_subject_binding = clauses.iter().any(clause_has_bool_variable_pattern);
+    let needs_subject_binding = clauses.iter().any(clause_has_bool_bound_name);
     let (subject_step, subject) = if needs_subject_binding {
         let (step, subject) = super::bind_bool_case_subject(subject, context);
         (Some(step), subject)
@@ -39,16 +37,17 @@ pub(super) fn plan(
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_bool_case_pattern(pattern)?;
-        let binding = pattern
-            .bound_name()
-            .cloned()
-            .map(|name| (name, Expr::bool(subject.clone())));
+        let bindings = super::branch_bindings(pattern.bound_names(), Expr::bool(subject.clone()));
         let branch =
-            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, binding, context)?;
+            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, bindings, context)?;
 
         match pattern {
-            BoolCasePattern::True => set_case_branch(&mut true_branch, branch),
-            BoolCasePattern::False => set_case_branch(&mut false_branch, branch),
+            BoolCasePattern::Literal { value: true, .. } => {
+                set_case_branch(&mut true_branch, branch)
+            }
+            BoolCasePattern::Literal { value: false, .. } => {
+                set_case_branch(&mut false_branch, branch)
+            }
             BoolCasePattern::Any { .. } => {
                 set_case_branch(&mut true_branch, branch.clone());
                 set_case_branch(&mut false_branch, branch);
@@ -81,17 +80,14 @@ fn plan_guarded_bool_case(
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_bool_case_pattern(pattern)?;
-        let binding = pattern
-            .bound_name()
-            .cloned()
-            .map(|name| (name, Expr::bool(subject.clone())));
+        let bindings = super::branch_bindings(pattern.bound_names(), Expr::bool(subject.clone()));
         let is_total = clause.guard.is_none();
         let ordered_clause = super::plan_ordered_case_clause(
             super::OrderedCaseClauseInput {
                 case_type,
                 return_type: &return_type,
                 then: clause.then,
-                variable_binding: binding,
+                branch_bindings: bindings,
                 guard: clause.guard,
                 match_condition: BoolExpr::value(true),
                 is_total,
@@ -100,8 +96,8 @@ fn plan_guarded_bool_case(
         )?;
 
         match pattern {
-            BoolCasePattern::True => true_clauses.push(ordered_clause),
-            BoolCasePattern::False => false_clauses.push(ordered_clause),
+            BoolCasePattern::Literal { value: true, .. } => true_clauses.push(ordered_clause),
+            BoolCasePattern::Literal { value: false, .. } => false_clauses.push(ordered_clause),
             BoolCasePattern::Any { .. } => {
                 true_clauses.push(ordered_clause.clone());
                 false_clauses.push(ordered_clause);
@@ -133,16 +129,29 @@ fn ordered_bool_case_branch(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum BoolCasePattern {
-    True,
-    False,
-    Any { bound_name: Option<EcoString> },
+    Literal {
+        value: bool,
+        bound_names: Vec<EcoString>,
+    },
+    Any {
+        bound_names: Vec<EcoString>,
+    },
 }
 
 impl BoolCasePattern {
-    fn bound_name(&self) -> Option<&EcoString> {
+    fn bound_names(&self) -> &[EcoString] {
         match self {
-            BoolCasePattern::Any { bound_name } => bound_name.as_ref(),
-            BoolCasePattern::True | BoolCasePattern::False => None,
+            BoolCasePattern::Literal { bound_names, .. } | BoolCasePattern::Any { bound_names } => {
+                bound_names
+            }
+        }
+    }
+
+    fn add_bound_name(&mut self, name: EcoString) {
+        match self {
+            BoolCasePattern::Literal { bound_names, .. } | BoolCasePattern::Any { bound_names } => {
+                bound_names.push(name);
+            }
         }
     }
 }
@@ -156,28 +165,35 @@ fn plan_bool_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<BoolCasePattern
             type_,
             ..
         } if arguments.is_empty() && spread.is_none() && type_.is_bool() => match name.as_str() {
-            "True" => Ok(BoolCasePattern::True),
-            "False" => Ok(BoolCasePattern::False),
+            "True" => Ok(BoolCasePattern::Literal {
+                value: true,
+                bound_names: Vec::new(),
+            }),
+            "False" => Ok(BoolCasePattern::Literal {
+                value: false,
+                bound_names: Vec::new(),
+            }),
             _ => Err(invalid_case_shape(
                 InvalidCaseShapeReason::PatternTypeMismatch,
             )),
         },
         Pattern::Variable { name, type_, .. } if type_.is_bool() => Ok(BoolCasePattern::Any {
-            bound_name: Some(name),
+            bound_names: vec![name],
         }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Discard { type_, .. } if type_.is_bool() => {
-            Ok(BoolCasePattern::Any { bound_name: None })
-        }
+        Pattern::Discard { type_, .. } if type_.is_bool() => Ok(BoolCasePattern::Any {
+            bound_names: Vec::new(),
+        }),
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Assign { pattern, .. } => match validate_bool_case_assign_pattern(&pattern) {
-            Ok(()) => Err(unsupported_case(UnsupportedCaseReason::AssignPattern)),
-            Err(reason) => Err(invalid_case_shape(reason)),
-        },
+        Pattern::Assign { name, pattern, .. } => {
+            let mut pattern = plan_bool_case_pattern(*pattern)?;
+            pattern.add_bound_name(name);
+            Ok(pattern)
+        }
         Pattern::Invalid { .. } => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
         Pattern::Int { .. }
         | Pattern::Float { .. }
@@ -193,37 +209,15 @@ fn plan_bool_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<BoolCasePattern
     }
 }
 
-fn clause_has_bool_variable_pattern(clause: &TypedClause) -> bool {
-    clause.pattern.iter().any(|pattern| {
-        matches!(
-            pattern,
-            Pattern::Variable { type_, .. } if type_.is_bool()
-        )
-    })
+fn clause_has_bool_bound_name(clause: &TypedClause) -> bool {
+    clause.pattern.iter().any(bool_pattern_has_bound_name)
 }
 
-fn validate_bool_case_assign_pattern(
-    pattern: &Pattern<Arc<Type>>,
-) -> Result<(), InvalidCaseShapeReason> {
+fn bool_pattern_has_bound_name(pattern: &Pattern<Arc<Type>>) -> bool {
     match pattern {
-        Pattern::Constructor {
-            name,
-            arguments,
-            spread,
-            type_,
-            ..
-        } if arguments.is_empty() && spread.is_none() && type_.is_bool() => {
-            if matches!(name.as_str(), "True" | "False") {
-                Ok(())
-            } else {
-                Err(InvalidCaseShapeReason::PatternTypeMismatch)
-            }
-        }
-        Pattern::Variable { type_, .. } | Pattern::Discard { type_, .. } if type_.is_bool() => {
-            Ok(())
-        }
-        Pattern::Invalid { .. } => Err(InvalidCaseShapeReason::InvalidPattern),
-        _ => Err(InvalidCaseShapeReason::PatternTypeMismatch),
+        Pattern::Variable { type_, .. } if type_.is_bool() => true,
+        Pattern::Assign { .. } => true,
+        _ => false,
     }
 }
 
@@ -252,7 +246,7 @@ mod tests {
     use crate::planner::support::{dummy_span, expect_plan_error};
     use crate::planner::{
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
-        UnsupportedCaseReason, UnsupportedExpressionKind,
+        UnsupportedExpressionKind,
     };
     use gleam_core::ast::{BinOp, ClauseGuard, Constant, Pattern};
     use gleam_core::type_::{self, error::VariableOrigin};
@@ -385,6 +379,75 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_bool_case_variable_alias_binds_inner_then_alias_in_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case True {
+    value as alias -> value && alias
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let branch = bool_return_block(
+            [
+                let_bool_step(1, "value", local_bool(0, "<case:bool:0>")),
+                let_bool_step(2, "alias", local_bool(0, "<case:bool:0>")),
+            ],
+            bool_return_expr(local_bool(1, "value").and_bool(local_bool(2, "alias"))),
+        );
+        let expected = module(
+            "main",
+            function(
+                "main",
+                bool_return_block(
+                    [let_bool_step(0, "<case:bool:0>", bool_(true))],
+                    bool_return_bool_case(local_bool(0, "<case:bool:0>"), branch.clone(), branch),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_bool_case_literal_alias_binds_subject_once_for_alias_value() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case True {
+    True as alias -> alias
+    False -> False
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                bool_return_block(
+                    [let_bool_step(0, "<case:bool:0>", bool_(true))],
+                    bool_return_bool_case(
+                        local_bool(0, "<case:bool:0>"),
+                        bool_return_block(
+                            [let_bool_step(1, "alias", local_bool(0, "<case:bool:0>"))],
+                            bool_return_expr(local_bool(1, "alias")),
+                        ),
+                        bool_return_expr(bool_(false)),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_bool_case_guard_binds_subject_once_and_falls_through() {
         let actual = plan_module(crate::planner::support::compile(
             r#"
@@ -411,6 +474,58 @@ pub fn main() {
                 int_return_block(
                     [let_bool_step(0, "<case:bool:0>", bool_(true))],
                     int_return_bool_case(
+                        local_bool(0, "<case:bool:0>"),
+                        guarded_case.clone(),
+                        guarded_case,
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_bool_case_guarded_alias_binds_guard_and_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case True {
+    value as alias if value && alias -> alias
+    _ -> False
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let bind_value = let_bool_step(1, "value", local_bool(0, "<case:bool:0>"));
+        let bind_alias = let_bool_step(2, "alias", local_bool(0, "<case:bool:0>"));
+        let condition = BoolExpr::block(
+            vec![bind_value.clone(), bind_alias.clone()],
+            BoolExpr::and(
+                BoolExpr::value(true),
+                local_bool(1, "value")
+                    .and_bool(local_bool(2, "alias"))
+                    .into(),
+            ),
+        );
+        let guarded_branch = bool_return_block(
+            [bind_value, bind_alias],
+            bool_return_expr(local_bool(2, "alias")),
+        );
+        let guarded_case = crate::plan::BoolReturn::bool_case(
+            condition,
+            guarded_branch,
+            bool_return_expr(bool_(false)),
+        );
+        let expected = module(
+            "main",
+            function(
+                "main",
+                bool_return_block(
+                    [let_bool_step(0, "<case:bool:0>", bool_(true))],
+                    bool_return_bool_case(
                         local_bool(0, "<case:bool:0>"),
                         guarded_case.clone(),
                         guarded_case,
@@ -751,50 +866,6 @@ fn duplicate_true(value: Bool) {
             ))),
         );
     }
-    #[test]
-    fn reject_profile_bool_case_patterns() {
-        let cases = [
-            (
-                r#"
-pub fn main() {
-  case True {
-    True as value -> 1
-    False -> 0
-  }
-}
-"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"
-pub fn main() {
-  case True {
-    value as alias -> 1
-  }
-}
-"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"
-pub fn main() {
-  case True {
-    _ as alias -> 1
-  }
-}
-"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-        ];
-
-        for (src, reason) in cases {
-            assert_eq!(
-                expect_plan_error(src),
-                PlanError::UnsupportedCase { reason },
-            );
-        }
-    }
-
     #[test]
     fn reject_profile_bool_case_subject_expression() {
         assert_eq!(

--- a/src/planner/expression/case/subject/float.rs
+++ b/src/planner/expression/case/subject/float.rs
@@ -1,9 +1,9 @@
 use super::super::super::plan_float_expr;
-use super::super::{invalid_case_shape, unsupported_case};
+use super::super::invalid_case_shape;
 use super::{case_return_type, single_case_pattern, validate_clause_shape};
 use crate::plan::{BoolExpr, Expr, ExprKind, FloatCaseBranches, FloatExpr, ValueType};
 use crate::planner::context::PlanContext;
-use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
+use crate::planner::error::{InvalidCaseShapeReason, PlanError};
 use ecow::EcoString;
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
@@ -25,7 +25,7 @@ pub(super) fn plan(
         let case = plan_guarded_float_case(type_.as_ref(), return_type, subject, clauses, context)?;
         return Ok(super::case_subject_block(subject_step, case));
     }
-    let needs_subject_binding = clauses.iter().any(clause_has_float_variable_pattern);
+    let needs_subject_binding = clauses.iter().any(clause_has_float_bound_name);
     let (subject_step, subject) = if needs_subject_binding {
         let (step, subject) = super::bind_float_case_subject(subject, context);
         (Some(step), subject)
@@ -37,15 +37,12 @@ pub(super) fn plan(
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_float_case_pattern(pattern)?;
-        let binding = pattern
-            .bound_name()
-            .cloned()
-            .map(|name| (name, Expr::float(subject.clone())));
+        let bindings = super::branch_bindings(pattern.bound_names(), Expr::float(subject.clone()));
         let branch =
-            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, binding, context)?;
+            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, bindings, context)?;
 
         match pattern {
-            FloatCasePattern::Literal(value) => {
+            FloatCasePattern::Literal { value, .. } => {
                 if fallback.is_none()
                     && literal_clauses
                         .iter()
@@ -83,13 +80,10 @@ fn plan_guarded_float_case(
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_float_case_pattern(pattern)?;
-        let binding = pattern
-            .bound_name()
-            .cloned()
-            .map(|name| (name, Expr::float(subject.clone())));
+        let bindings = super::branch_bindings(pattern.bound_names(), Expr::float(subject.clone()));
         let is_total = matches!(pattern, FloatCasePattern::Any { .. }) && clause.guard.is_none();
         let match_condition = match pattern {
-            FloatCasePattern::Literal(value) => BoolExpr::equal(
+            FloatCasePattern::Literal { value, .. } => BoolExpr::equal(
                 Expr::float(subject.clone()),
                 Expr::float(FloatExpr::value(value)),
             ),
@@ -100,7 +94,7 @@ fn plan_guarded_float_case(
                 case_type,
                 return_type: &return_type,
                 then: clause.then,
-                variable_binding: binding,
+                branch_bindings: bindings,
                 guard: clause.guard,
                 match_condition,
                 is_total,
@@ -114,38 +108,56 @@ fn plan_guarded_float_case(
 
 #[derive(Debug, Clone, PartialEq)]
 enum FloatCasePattern {
-    Literal(f64),
-    Any { bound_name: Option<EcoString> },
+    Literal {
+        value: f64,
+        bound_names: Vec<EcoString>,
+    },
+    Any {
+        bound_names: Vec<EcoString>,
+    },
 }
 
 impl FloatCasePattern {
-    fn bound_name(&self) -> Option<&EcoString> {
+    fn bound_names(&self) -> &[EcoString] {
         match self {
-            FloatCasePattern::Any { bound_name } => bound_name.as_ref(),
-            FloatCasePattern::Literal(_) => None,
+            FloatCasePattern::Literal { bound_names, .. }
+            | FloatCasePattern::Any { bound_names } => bound_names,
+        }
+    }
+
+    fn add_bound_name(&mut self, name: EcoString) {
+        match self {
+            FloatCasePattern::Literal { bound_names, .. }
+            | FloatCasePattern::Any { bound_names } => {
+                bound_names.push(name);
+            }
         }
     }
 }
 
 fn plan_float_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<FloatCasePattern, PlanError> {
     match pattern {
-        Pattern::Float { float_value, .. } => Ok(FloatCasePattern::Literal(float_value.value())),
+        Pattern::Float { float_value, .. } => Ok(FloatCasePattern::Literal {
+            value: float_value.value(),
+            bound_names: Vec::new(),
+        }),
         Pattern::Variable { name, type_, .. } if type_.is_float() => Ok(FloatCasePattern::Any {
-            bound_name: Some(name),
+            bound_names: vec![name],
         }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Discard { type_, .. } if type_.is_float() => {
-            Ok(FloatCasePattern::Any { bound_name: None })
-        }
+        Pattern::Discard { type_, .. } if type_.is_float() => Ok(FloatCasePattern::Any {
+            bound_names: Vec::new(),
+        }),
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Assign { pattern, .. } => match validate_float_case_assign_pattern(&pattern) {
-            Ok(()) => Err(unsupported_case(UnsupportedCaseReason::AssignPattern)),
-            Err(reason) => Err(invalid_case_shape(reason)),
-        },
+        Pattern::Assign { name, pattern, .. } => {
+            let mut pattern = plan_float_case_pattern(*pattern)?;
+            pattern.add_bound_name(name);
+            Ok(pattern)
+        }
         Pattern::Invalid { .. } => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
         Pattern::Int { .. }
         | Pattern::String { .. }
@@ -160,25 +172,15 @@ fn plan_float_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<FloatCasePatte
     }
 }
 
-fn clause_has_float_variable_pattern(clause: &TypedClause) -> bool {
-    clause.pattern.iter().any(|pattern| {
-        matches!(
-            pattern,
-            Pattern::Variable { type_, .. } if type_.is_float()
-        )
-    })
+fn clause_has_float_bound_name(clause: &TypedClause) -> bool {
+    clause.pattern.iter().any(float_pattern_has_bound_name)
 }
 
-fn validate_float_case_assign_pattern(
-    pattern: &Pattern<Arc<Type>>,
-) -> Result<(), InvalidCaseShapeReason> {
+fn float_pattern_has_bound_name(pattern: &Pattern<Arc<Type>>) -> bool {
     match pattern {
-        Pattern::Float { .. } => Ok(()),
-        Pattern::Variable { type_, .. } | Pattern::Discard { type_, .. } if type_.is_float() => {
-            Ok(())
-        }
-        Pattern::Invalid { .. } => Err(InvalidCaseShapeReason::InvalidPattern),
-        _ => Err(InvalidCaseShapeReason::PatternTypeMismatch),
+        Pattern::Variable { type_, .. } if type_.is_float() => true,
+        Pattern::Assign { .. } => true,
+        _ => false,
     }
 }
 
@@ -703,6 +705,83 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_float_case_variable_alias_binds_inner_then_alias_in_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 1.5 {
+    other as alias -> other +. alias
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                float_return_block(
+                    [let_float_step(0, "<case:float:0>", float(1.5))],
+                    float_return_float_case(
+                        local_float(0, "<case:float:0>"),
+                        [],
+                        float_return_block(
+                            [
+                                let_float_step(1, "other", local_float(0, "<case:float:0>")),
+                                let_float_step(2, "alias", local_float(0, "<case:float:0>")),
+                            ],
+                            float_return_expr(
+                                local_float(1, "other").add_float(local_float(2, "alias")),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_float_case_literal_alias_binds_subject_once_for_alias_value() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 1.5 {
+    1.5 as alias -> alias
+    _ -> 0.0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                float_return_block(
+                    [let_float_step(0, "<case:float:0>", float(1.5))],
+                    float_return_float_case(
+                        local_float(0, "<case:float:0>"),
+                        [(
+                            1.5,
+                            float_return_block(
+                                [let_float_step(1, "alias", local_float(0, "<case:float:0>"))],
+                                float_return_expr(local_float(1, "alias")),
+                            ),
+                        )],
+                        float_return_expr(float(0.0)),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_float_case_guard_binds_subject_once_and_falls_through() {
         let actual = plan_module(crate::planner::support::compile(
             r#"
@@ -725,6 +804,51 @@ pub fn main() {
         );
         let guarded_branch =
             float_return_block([bind_other], float_return_expr(local_float(1, "other")));
+        let expected = module(
+            "main",
+            function(
+                "main",
+                float_return_block(
+                    [let_float_step(0, "<case:float:0>", float(1.5))],
+                    FloatReturn::bool_case(
+                        condition,
+                        guarded_branch,
+                        float_return_expr(float(0.0)),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_float_case_guarded_alias_binds_guard_and_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 1.5 {
+    other as alias if alias >. 1.0 -> other +. alias
+    _ -> 0.0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let bind_other = let_float_step(1, "other", local_float(0, "<case:float:0>"));
+        let bind_alias = let_float_step(2, "alias", local_float(0, "<case:float:0>"));
+        let condition = BoolExpr::block(
+            vec![bind_other.clone(), bind_alias.clone()],
+            BoolExpr::and(
+                BoolExpr::value(true),
+                BoolExpr::gt_float(local_float(2, "alias").into(), float(1.0).into()),
+            ),
+        );
+        let guarded_branch = float_return_block(
+            [bind_other, bind_alias],
+            float_return_expr(local_float(1, "other").add_float(local_float(2, "alias"))),
+        );
         let expected = module(
             "main",
             function(
@@ -997,31 +1121,6 @@ fn duplicate_literal(value: Float) {
                     .expect("function-returning function expression"),
             }),
         );
-    }
-
-    #[test]
-    fn reject_profile_float_case_patterns() {
-        let cases = [
-            (
-                r#"pub fn main() { case 1.0 { 1.0 as value -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"pub fn main() { case 1.0 { value as alias -> 1 } }"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"pub fn main() { case 1.0 { _ as alias -> 1 } }"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-        ];
-
-        for (src, reason) in cases {
-            assert_eq!(
-                expect_plan_error(src),
-                PlanError::UnsupportedCase { reason },
-            );
-        }
     }
 
     #[test]
@@ -1611,28 +1710,5 @@ pub fn main() {
 }
 "#,
         )
-    }
-
-    #[test]
-    fn reject_margin_float_case_assign_literal_pattern_still_profile_boundary() {
-        let mut module = compile_float_case_module();
-        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
-            &mut module.definitions.functions[0].body[0],
-        );
-        clauses[0].pattern[0] = Pattern::Assign {
-            name: "value".into(),
-            location: dummy_span(),
-            pattern: Box::new(Pattern::Float {
-                location: dummy_span(),
-                value: "1.0".into(),
-                float_value: LiteralFloatValue::ONE,
-            }),
-        };
-        assert_eq!(
-            plan_module(module),
-            Err(PlanError::UnsupportedCase {
-                reason: UnsupportedCaseReason::AssignPattern,
-            }),
-        );
     }
 }

--- a/src/planner/expression/case/subject/int.rs
+++ b/src/planner/expression/case/subject/int.rs
@@ -1,9 +1,9 @@
 use super::super::super::plan_int_expr;
-use super::super::{invalid_case_shape, unsupported_case};
+use super::super::invalid_case_shape;
 use super::{case_return_type, single_case_pattern, validate_clause_shape};
 use crate::plan::{BoolExpr, Expr, ExprKind, IntCaseBranches, IntExpr, ValueType};
 use crate::planner::context::PlanContext;
-use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
+use crate::planner::error::{InvalidCaseShapeReason, PlanError};
 use ecow::EcoString;
 use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
@@ -26,7 +26,7 @@ pub(super) fn plan(
         let case = plan_guarded_int_case(type_.as_ref(), return_type, subject, clauses, context)?;
         return Ok(super::case_subject_block(subject_step, case));
     }
-    let needs_subject_binding = clauses.iter().any(clause_has_int_variable_pattern);
+    let needs_subject_binding = clauses.iter().any(clause_has_int_bound_name);
     let (subject_step, subject) = if needs_subject_binding {
         let (step, subject) = super::bind_int_case_subject(subject, context);
         (Some(step), subject)
@@ -38,15 +38,12 @@ pub(super) fn plan(
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_int_case_pattern(pattern)?;
-        let binding = pattern
-            .bound_name()
-            .cloned()
-            .map(|name| (name, Expr::int(subject.clone())));
+        let bindings = super::branch_bindings(pattern.bound_names(), Expr::int(subject.clone()));
         let branch =
-            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, binding, context)?;
+            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, bindings, context)?;
 
         match pattern {
-            IntCasePattern::Literal(value) => {
+            IntCasePattern::Literal { value, .. } => {
                 if fallback.is_none()
                     && literal_clauses
                         .iter()
@@ -84,13 +81,10 @@ fn plan_guarded_int_case(
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_int_case_pattern(pattern)?;
-        let binding = pattern
-            .bound_name()
-            .cloned()
-            .map(|name| (name, Expr::int(subject.clone())));
+        let bindings = super::branch_bindings(pattern.bound_names(), Expr::int(subject.clone()));
         let is_total = matches!(pattern, IntCasePattern::Any { .. }) && clause.guard.is_none();
         let match_condition = match pattern {
-            IntCasePattern::Literal(value) => {
+            IntCasePattern::Literal { value, .. } => {
                 BoolExpr::equal(Expr::int(subject.clone()), Expr::int(IntExpr::value(value)))
             }
             IntCasePattern::Any { .. } => BoolExpr::value(true),
@@ -100,7 +94,7 @@ fn plan_guarded_int_case(
                 case_type,
                 return_type: &return_type,
                 then: clause.then,
-                variable_binding: binding,
+                branch_bindings: bindings,
                 guard: clause.guard,
                 match_condition,
                 is_total,
@@ -114,38 +108,56 @@ fn plan_guarded_int_case(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum IntCasePattern {
-    Literal(BigInt),
-    Any { bound_name: Option<EcoString> },
+    Literal {
+        value: BigInt,
+        bound_names: Vec<EcoString>,
+    },
+    Any {
+        bound_names: Vec<EcoString>,
+    },
 }
 
 impl IntCasePattern {
-    fn bound_name(&self) -> Option<&EcoString> {
+    fn bound_names(&self) -> &[EcoString] {
         match self {
-            IntCasePattern::Any { bound_name } => bound_name.as_ref(),
-            IntCasePattern::Literal(_) => None,
+            IntCasePattern::Literal { bound_names, .. } | IntCasePattern::Any { bound_names } => {
+                bound_names
+            }
+        }
+    }
+
+    fn add_bound_name(&mut self, name: EcoString) {
+        match self {
+            IntCasePattern::Literal { bound_names, .. } | IntCasePattern::Any { bound_names } => {
+                bound_names.push(name);
+            }
         }
     }
 }
 
 fn plan_int_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<IntCasePattern, PlanError> {
     match pattern {
-        Pattern::Int { int_value, .. } => Ok(IntCasePattern::Literal(int_value)),
+        Pattern::Int { int_value, .. } => Ok(IntCasePattern::Literal {
+            value: int_value,
+            bound_names: Vec::new(),
+        }),
         Pattern::Variable { name, type_, .. } if type_.is_int() => Ok(IntCasePattern::Any {
-            bound_name: Some(name),
+            bound_names: vec![name],
         }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Discard { type_, .. } if type_.is_int() => {
-            Ok(IntCasePattern::Any { bound_name: None })
-        }
+        Pattern::Discard { type_, .. } if type_.is_int() => Ok(IntCasePattern::Any {
+            bound_names: Vec::new(),
+        }),
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Assign { pattern, .. } => match validate_int_case_assign_pattern(&pattern) {
-            Ok(()) => Err(unsupported_case(UnsupportedCaseReason::AssignPattern)),
-            Err(reason) => Err(invalid_case_shape(reason)),
-        },
+        Pattern::Assign { name, pattern, .. } => {
+            let mut pattern = plan_int_case_pattern(*pattern)?;
+            pattern.add_bound_name(name);
+            Ok(pattern)
+        }
         Pattern::Invalid { .. } => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
         Pattern::Float { .. }
         | Pattern::String { .. }
@@ -160,25 +172,15 @@ fn plan_int_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<IntCasePattern, 
     }
 }
 
-fn clause_has_int_variable_pattern(clause: &TypedClause) -> bool {
-    clause.pattern.iter().any(|pattern| {
-        matches!(
-            pattern,
-            Pattern::Variable { type_, .. } if type_.is_int()
-        )
-    })
+fn clause_has_int_bound_name(clause: &TypedClause) -> bool {
+    clause.pattern.iter().any(int_pattern_has_bound_name)
 }
 
-fn validate_int_case_assign_pattern(
-    pattern: &Pattern<Arc<Type>>,
-) -> Result<(), InvalidCaseShapeReason> {
+fn int_pattern_has_bound_name(pattern: &Pattern<Arc<Type>>) -> bool {
     match pattern {
-        Pattern::Int { .. } => Ok(()),
-        Pattern::Variable { type_, .. } | Pattern::Discard { type_, .. } if type_.is_int() => {
-            Ok(())
-        }
-        Pattern::Invalid { .. } => Err(InvalidCaseShapeReason::InvalidPattern),
-        _ => Err(InvalidCaseShapeReason::PatternTypeMismatch),
+        Pattern::Variable { type_, .. } if type_.is_int() => true,
+        Pattern::Assign { .. } => true,
+        _ => false,
     }
 }
 
@@ -761,6 +763,81 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_int_case_variable_alias_binds_inner_then_alias_in_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 41 {
+    other as alias -> other + alias
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "<case:int:0>", int(41))],
+                    int_return_int_case(
+                        local_int(0, "<case:int:0>"),
+                        [],
+                        int_return_block(
+                            [
+                                let_int_step(1, "other", local_int(0, "<case:int:0>")),
+                                let_int_step(2, "alias", local_int(0, "<case:int:0>")),
+                            ],
+                            int_return_expr(local_int(1, "other").add_int(local_int(2, "alias"))),
+                        ),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_int_case_literal_alias_binds_subject_once_for_alias_value() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 1 {
+    1 as alias -> alias
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "<case:int:0>", int(1))],
+                    int_return_int_case(
+                        local_int(0, "<case:int:0>"),
+                        [(
+                            1,
+                            int_return_block(
+                                [let_int_step(1, "alias", local_int(0, "<case:int:0>"))],
+                                int_return_expr(local_int(1, "alias")),
+                            ),
+                        )],
+                        int_return_expr(int(0)),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_int_case_guard_binds_subject_once_and_falls_through() {
         let actual = plan_module(crate::planner::support::compile(
             r#"
@@ -791,6 +868,47 @@ pub fn main() {
                 "main",
                 int_return_block(
                     [let_int_step(0, "<case:int:0>", int(41))],
+                    IntReturn::bool_case(condition, guarded_branch, int_return_expr(int(0))),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_int_case_guarded_alias_binds_guard_and_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 2 {
+    other as alias if alias == 2 -> other + alias
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let bind_other = let_int_step(1, "other", local_int(0, "<case:int:0>"));
+        let bind_alias = let_int_step(2, "alias", local_int(0, "<case:int:0>"));
+        let condition = BoolExpr::block(
+            vec![bind_other.clone(), bind_alias.clone()],
+            BoolExpr::and(
+                BoolExpr::value(true),
+                BoolExpr::equal(local_int(2, "alias").into(), int(2).into()),
+            ),
+        );
+        let guarded_branch = int_return_block(
+            [bind_other, bind_alias],
+            int_return_expr(local_int(1, "other").add_int(local_int(2, "alias"))),
+        );
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "<case:int:0>", int(2))],
                     IntReturn::bool_case(condition, guarded_branch, int_return_expr(int(0))),
                 ),
             ),
@@ -1081,24 +1199,10 @@ pub fn main() {
 
     #[test]
     fn reject_profile_int_case_patterns() {
-        let cases = [
-            (
-                r#"pub fn main() { case 1 { 1 | 2 -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::AlternativePatterns,
-            ),
-            (
-                r#"pub fn main() { case 1 { 1 as value -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"pub fn main() { case 1 { value as alias -> 1 } }"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"pub fn main() { case 1 { _ as alias -> 1 } }"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-        ];
+        let cases = [(
+            r#"pub fn main() { case 1 { 1 | 2 -> 1 _ -> 0 } }"#,
+            UnsupportedCaseReason::AlternativePatterns,
+        )];
 
         for (src, reason) in cases {
             assert_eq!(

--- a/src/planner/expression/case/subject/string.rs
+++ b/src/planner/expression/case/subject/string.rs
@@ -26,7 +26,7 @@ pub(super) fn plan(
             plan_guarded_string_case(type_.as_ref(), return_type, subject, clauses, context)?;
         return Ok(super::case_subject_block(subject_step, case));
     }
-    let needs_subject_binding = clauses.iter().any(clause_has_string_variable_pattern);
+    let needs_subject_binding = clauses.iter().any(clause_has_string_bound_name);
     let (subject_step, subject) = if needs_subject_binding {
         let (step, subject) = super::bind_string_case_subject(subject, context);
         (Some(step), subject)
@@ -38,15 +38,12 @@ pub(super) fn plan(
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_string_case_pattern(pattern)?;
-        let binding = pattern
-            .bound_name()
-            .cloned()
-            .map(|name| (name, Expr::string(subject.clone())));
+        let bindings = super::branch_bindings(pattern.bound_names(), Expr::string(subject.clone()));
         let branch =
-            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, binding, context)?;
+            super::plan_case_branch(type_.as_ref(), &return_type, clause.then, bindings, context)?;
 
         match pattern {
-            StringCasePattern::Literal(value) => {
+            StringCasePattern::Literal { value, .. } => {
                 if fallback.is_none()
                     && literal_clauses
                         .iter()
@@ -84,13 +81,10 @@ fn plan_guarded_string_case(
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_string_case_pattern(pattern)?;
-        let binding = pattern
-            .bound_name()
-            .cloned()
-            .map(|name| (name, Expr::string(subject.clone())));
+        let bindings = super::branch_bindings(pattern.bound_names(), Expr::string(subject.clone()));
         let is_total = matches!(pattern, StringCasePattern::Any { .. }) && clause.guard.is_none();
         let match_condition = match pattern {
-            StringCasePattern::Literal(value) => BoolExpr::equal(
+            StringCasePattern::Literal { value, .. } => BoolExpr::equal(
                 Expr::string(subject.clone()),
                 Expr::string(StringExpr::value(value)),
             ),
@@ -101,7 +95,7 @@ fn plan_guarded_string_case(
                 case_type,
                 return_type: &return_type,
                 then: clause.then,
-                variable_binding: binding,
+                branch_bindings: bindings,
                 guard: clause.guard,
                 match_condition,
                 is_total,
@@ -115,38 +109,56 @@ fn plan_guarded_string_case(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum StringCasePattern {
-    Literal(EcoString),
-    Any { bound_name: Option<EcoString> },
+    Literal {
+        value: EcoString,
+        bound_names: Vec<EcoString>,
+    },
+    Any {
+        bound_names: Vec<EcoString>,
+    },
 }
 
 impl StringCasePattern {
-    fn bound_name(&self) -> Option<&EcoString> {
+    fn bound_names(&self) -> &[EcoString] {
         match self {
-            StringCasePattern::Any { bound_name } => bound_name.as_ref(),
-            StringCasePattern::Literal(_) => None,
+            StringCasePattern::Literal { bound_names, .. }
+            | StringCasePattern::Any { bound_names } => bound_names,
+        }
+    }
+
+    fn add_bound_name(&mut self, name: EcoString) {
+        match self {
+            StringCasePattern::Literal { bound_names, .. }
+            | StringCasePattern::Any { bound_names } => {
+                bound_names.push(name);
+            }
         }
     }
 }
 
 fn plan_string_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<StringCasePattern, PlanError> {
     match pattern {
-        Pattern::String { value, .. } => Ok(StringCasePattern::Literal(value)),
+        Pattern::String { value, .. } => Ok(StringCasePattern::Literal {
+            value,
+            bound_names: Vec::new(),
+        }),
         Pattern::Variable { name, type_, .. } if type_.is_string() => Ok(StringCasePattern::Any {
-            bound_name: Some(name),
+            bound_names: vec![name],
         }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Discard { type_, .. } if type_.is_string() => {
-            Ok(StringCasePattern::Any { bound_name: None })
-        }
+        Pattern::Discard { type_, .. } if type_.is_string() => Ok(StringCasePattern::Any {
+            bound_names: Vec::new(),
+        }),
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
-        Pattern::Assign { pattern, .. } => match validate_string_case_assign_pattern(&pattern) {
-            Ok(()) => Err(unsupported_case(UnsupportedCaseReason::AssignPattern)),
-            Err(reason) => Err(invalid_case_shape(reason)),
-        },
+        Pattern::Assign { name, pattern, .. } => {
+            let mut pattern = plan_string_case_pattern(*pattern)?;
+            pattern.add_bound_name(name);
+            Ok(pattern)
+        }
         Pattern::StringPrefix { .. } => {
             Err(unsupported_case(UnsupportedCaseReason::StringPrefixPattern))
         }
@@ -163,25 +175,15 @@ fn plan_string_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<StringCasePat
     }
 }
 
-fn clause_has_string_variable_pattern(clause: &TypedClause) -> bool {
-    clause.pattern.iter().any(|pattern| {
-        matches!(
-            pattern,
-            Pattern::Variable { type_, .. } if type_.is_string()
-        )
-    })
+fn clause_has_string_bound_name(clause: &TypedClause) -> bool {
+    clause.pattern.iter().any(string_pattern_has_bound_name)
 }
 
-fn validate_string_case_assign_pattern(
-    pattern: &Pattern<Arc<Type>>,
-) -> Result<(), InvalidCaseShapeReason> {
+fn string_pattern_has_bound_name(pattern: &Pattern<Arc<Type>>) -> bool {
     match pattern {
-        Pattern::String { .. } => Ok(()),
-        Pattern::Variable { type_, .. } | Pattern::Discard { type_, .. } if type_.is_string() => {
-            Ok(())
-        }
-        Pattern::Invalid { .. } => Err(InvalidCaseShapeReason::InvalidPattern),
-        _ => Err(InvalidCaseShapeReason::PatternTypeMismatch),
+        Pattern::Variable { type_, .. } if type_.is_string() => true,
+        Pattern::Assign { .. } => true,
+        _ => false,
     }
 }
 
@@ -697,6 +699,87 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_string_case_variable_alias_binds_inner_then_alias_in_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case "geam" {
+    other as alias -> other <> alias
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                string_return_block(
+                    [let_string_step(0, "<case:string:0>", string("geam"))],
+                    string_return_string_case(
+                        local_string(0, "<case:string:0>"),
+                        [],
+                        string_return_block(
+                            [
+                                let_string_step(1, "other", local_string(0, "<case:string:0>")),
+                                let_string_step(2, "alias", local_string(0, "<case:string:0>")),
+                            ],
+                            string_return_expr(
+                                local_string(1, "other").concatenate(local_string(2, "alias")),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_string_case_literal_alias_binds_subject_once_for_alias_value() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case "geam" {
+    "geam" as alias -> alias
+    _ -> ""
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function(
+                "main",
+                string_return_block(
+                    [let_string_step(0, "<case:string:0>", string("geam"))],
+                    string_return_string_case(
+                        local_string(0, "<case:string:0>"),
+                        [(
+                            "geam",
+                            string_return_block(
+                                [let_string_step(
+                                    1,
+                                    "alias",
+                                    local_string(0, "<case:string:0>"),
+                                )],
+                                string_return_expr(local_string(1, "alias")),
+                            ),
+                        )],
+                        string_return_expr(string("")),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_string_case_guard_binds_subject_once_and_falls_through() {
         let actual = plan_module(crate::planner::support::compile(
             r#"
@@ -719,6 +802,51 @@ pub fn main() {
         );
         let guarded_branch =
             string_return_block([bind_other], string_return_expr(local_string(1, "other")));
+        let expected = module(
+            "main",
+            function(
+                "main",
+                string_return_block(
+                    [let_string_step(0, "<case:string:0>", string("geam"))],
+                    StringReturn::bool_case(
+                        condition,
+                        guarded_branch,
+                        string_return_expr(string("")),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_string_case_guarded_alias_binds_guard_and_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case "geam" {
+    other as alias if alias == "geam" -> other <> alias
+    _ -> ""
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let bind_other = let_string_step(1, "other", local_string(0, "<case:string:0>"));
+        let bind_alias = let_string_step(2, "alias", local_string(0, "<case:string:0>"));
+        let condition = BoolExpr::block(
+            vec![bind_other.clone(), bind_alias.clone()],
+            BoolExpr::and(
+                BoolExpr::value(true),
+                BoolExpr::equal(local_string(2, "alias").into(), string("geam").into()),
+            ),
+        );
+        let guarded_branch = string_return_block(
+            [bind_other, bind_alias],
+            string_return_expr(local_string(1, "other").concatenate(local_string(2, "alias"))),
+        );
         let expected = module(
             "main",
             function(
@@ -841,24 +969,10 @@ fn duplicate_literal(value: String) {
 
     #[test]
     fn reject_profile_string_case_patterns() {
-        let cases = [
-            (
-                r#"pub fn main() { case "one" { "one" as value -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"pub fn main() { case "one" { value as alias -> 1 } }"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"pub fn main() { case "one" { _ as alias -> 1 } }"#,
-                UnsupportedCaseReason::AssignPattern,
-            ),
-            (
-                r#"pub fn main() { case "prefix one" { "prefix " <> rest -> 1 _ -> 0 } }"#,
-                UnsupportedCaseReason::StringPrefixPattern,
-            ),
-        ];
+        let cases = [(
+            r#"pub fn main() { case "prefix one" { "prefix " <> rest -> 1 _ -> 0 } }"#,
+            UnsupportedCaseReason::StringPrefixPattern,
+        )];
 
         for (src, reason) in cases {
             assert_eq!(

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -145,6 +145,12 @@ mod control_flow {
             variable_pattern_families,
             variable_pattern_closure_capture,
             variable_pattern_scope,
+            pattern_alias,
+            pattern_alias_literal_and_discard,
+            pattern_alias_families,
+            pattern_alias_guard,
+            pattern_alias_scope,
+            pattern_alias_closure_capture,
         );
     }
 }
@@ -413,10 +419,12 @@ mod rejection {
             alternative_patterns,
             multiple_subjects,
             tuple_pattern,
+            tuple_pattern_alias,
             tuple_subject,
             string_prefix_pattern,
+            string_prefix_pattern_alias,
             list_pattern,
-            pattern_alias,
+            list_pattern_alias,
             unsupported_subject_type,
         );
     }

--- a/tests/fixtures/execution/control_flow/case/pattern_alias.gleam
+++ b/tests/fixtures/execution/control_flow/case/pattern_alias.gleam
@@ -1,7 +1,9 @@
 pub fn main() {
   let value = 1
   case value {
-    other as alias -> alias
+    other as alias -> other + alias
     _ -> 0
   }
 }
+
+// geam:expect Int(2)

--- a/tests/fixtures/execution/control_flow/case/pattern_alias_closure_capture.gleam
+++ b/tests/fixtures/execution/control_flow/case/pattern_alias_closure_capture.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case 21 {
+    value as alias -> fn() { value + alias }()
+    _ -> 0
+  }
+}
+
+// geam:expect Int(42)

--- a/tests/fixtures/execution/control_flow/case/pattern_alias_families.gleam
+++ b/tests/fixtures/execution/control_flow/case/pattern_alias_families.gleam
@@ -1,0 +1,37 @@
+pub fn main() {
+  let bool_literal = case True {
+    True as alias -> alias
+    False -> False
+  }
+
+  let bool_variable = case True {
+    value as alias -> value && alias
+  }
+
+  let string_variable = case "one" {
+    value as alias -> value <> alias
+  }
+
+  let string_literal = case "one" {
+    "one" as alias -> alias
+    _ -> ""
+  }
+
+  let float_literal = case 1.5 {
+    1.5 as alias -> alias +. 0.5
+    _ -> 0.0
+  }
+
+  let float_variable = case 1.5 {
+    value as alias -> value +. alias
+  }
+
+  bool_literal
+  && bool_variable
+  && string_variable == "oneone"
+  && string_literal == "one"
+  && float_literal == 2.0
+  && float_variable == 3.0
+}
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/control_flow/case/pattern_alias_guard.gleam
+++ b/tests/fixtures/execution/control_flow/case/pattern_alias_guard.gleam
@@ -1,0 +1,26 @@
+pub fn main() {
+  let value = 2
+  let int_guard = case value {
+    other as alias if other + alias == 4 -> alias
+    _ -> 0
+  }
+
+  let bool_guard = case True {
+    value as alias if value && alias -> alias
+    _ -> False
+  }
+
+  let string_guard = case "one" {
+    value as alias if value == alias -> alias
+    _ -> ""
+  }
+
+  let float_guard = case 1.5 {
+    value as alias if value == alias -> value +. alias
+    _ -> 0.0
+  }
+
+  int_guard == 2 && bool_guard && string_guard == "one" && float_guard == 3.0
+}
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/control_flow/case/pattern_alias_literal_and_discard.gleam
+++ b/tests/fixtures/execution/control_flow/case/pattern_alias_literal_and_discard.gleam
@@ -1,0 +1,15 @@
+pub fn main() {
+  let literal = case 1 {
+    1 as alias -> alias == 1
+    _ -> False
+  }
+
+  let discard = case 2 {
+    1 -> False
+    _ as alias -> alias == 2
+  }
+
+  literal && discard
+}
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/control_flow/case/pattern_alias_scope.gleam
+++ b/tests/fixtures/execution/control_flow/case/pattern_alias_scope.gleam
@@ -1,0 +1,12 @@
+pub fn main() {
+  let other = 10
+  let alias = 20
+  let result = case 1 {
+    other as alias -> other + alias
+    _ -> 0
+  }
+
+  result + other + alias
+}
+
+// geam:expect Int(32)

--- a/tests/fixtures/rejection/case_patterns/list_pattern_alias.gleam
+++ b/tests/fixtures/rejection/case_patterns/list_pattern_alias.gleam
@@ -1,0 +1,7 @@
+pub fn main() {
+  let values = [1, 2]
+  case values {
+    [first, ..] as whole -> first
+    _ -> 0
+  }
+}

--- a/tests/fixtures/rejection/case_patterns/string_prefix_pattern_alias.gleam
+++ b/tests/fixtures/rejection/case_patterns/string_prefix_pattern_alias.gleam
@@ -1,0 +1,7 @@
+pub fn main() {
+  let value = "Hello, Geam"
+  case value {
+    "Hello, " <> name as greeting -> greeting <> name
+    _ -> "Unknown"
+  }
+}

--- a/tests/fixtures/rejection/case_patterns/tuple_pattern_alias.gleam
+++ b/tests/fixtures/rejection/case_patterns/tuple_pattern_alias.gleam
@@ -1,0 +1,6 @@
+pub fn main() {
+  let pair = #(1, 2)
+  case pair {
+    #(left, right) as whole -> left + right + whole.0
+  }
+}


### PR DESCRIPTION
- Support `literal as alias`, `variable as alias`, and `_ as alias` for Bool/Int/Float/String case subjects.
- Bind inner variable names before alias names, and keep alias bindings visible to guards and branch bodies.
- Example: `case value { other as alias -> other + alias _ -> 0 }`
- Keep tuple, list, and string-prefix pattern aliases rejected through their existing unsupported pattern boundaries.
