### PR TITLE
Support case string prefix patterns

### DIFF
--- a/src/plan/expression/bool.rs
+++ b/src/plan/expression/bool.rs
@@ -71,6 +71,10 @@ pub(crate) enum BoolExprKind {
         left: Box<Expr>,
         right: Box<Expr>,
     },
+    StringStartsWith {
+        value: Box<StringExpr>,
+        prefix: EcoString,
+    },
     And {
         left: Box<BoolExpr>,
         right: Box<BoolExpr>,
@@ -244,6 +248,15 @@ impl BoolExpr {
         }
     }
 
+    pub(crate) fn string_starts_with(value: StringExpr, prefix: EcoString) -> Self {
+        Self {
+            kind: BoolExprKind::StringStartsWith {
+                value: Box::new(value),
+                prefix,
+            },
+        }
+    }
+
     pub(crate) fn and(left: BoolExpr, right: BoolExpr) -> Self {
         Self {
             kind: BoolExprKind::And {
@@ -332,8 +345,8 @@ impl BoolExpr {
 mod tests {
     use super::{BoolExpr, BoolExprKind};
     use crate::plan::{
-        BoolFunctionId, BoolFunctionValue, BoolLocalId, Expr, FloatExpr, IntExpr, Step, TupleExpr,
-        ValueType,
+        BoolFunctionId, BoolFunctionValue, BoolLocalId, Expr, FloatExpr, IntExpr, Step, StringExpr,
+        TupleExpr, ValueType,
     };
     use num_bigint::BigInt;
 
@@ -448,6 +461,13 @@ mod tests {
             &BoolExprKind::NotEqual {
                 left: Box::new(Expr::bool(BoolExpr::value(true))),
                 right: Box::new(Expr::bool(BoolExpr::value(false))),
+            },
+        );
+        assert_eq!(
+            BoolExpr::string_starts_with(StringExpr::value("geam".into()), "ge".into()).kind(),
+            &BoolExprKind::StringStartsWith {
+                value: Box::new(StringExpr::value("geam".into())),
+                prefix: "ge".into(),
             },
         );
         assert_eq!(

--- a/src/plan/expression/string.rs
+++ b/src/plan/expression/string.rs
@@ -32,6 +32,10 @@ pub(crate) enum StringExprKind {
         left: Box<StringExpr>,
         right: Box<StringExpr>,
     },
+    DropPrefix {
+        value: Box<StringExpr>,
+        prefix: EcoString,
+    },
     BoolCase {
         subject: Box<BoolExpr>,
         true_: Box<StringExpr>,
@@ -106,6 +110,15 @@ impl StringExpr {
             kind: StringExprKind::Concatenate {
                 left: Box::new(left),
                 right: Box::new(right),
+            },
+        }
+    }
+
+    pub(crate) fn drop_prefix(value: StringExpr, prefix: EcoString) -> Self {
+        Self {
+            kind: StringExprKind::DropPrefix {
+                value: Box::new(value),
+                prefix,
             },
         }
     }
@@ -225,6 +238,13 @@ mod tests {
             &StringExprKind::Concatenate {
                 left: Box::new(StringExpr::value("a".into())),
                 right: Box::new(StringExpr::value("b".into())),
+            },
+        );
+        assert_eq!(
+            StringExpr::drop_prefix(StringExpr::value("hello".into()), "he".into()).kind(),
+            &StringExprKind::DropPrefix {
+                value: Box::new(StringExpr::value("hello".into())),
+                prefix: "he".into(),
             },
         );
         assert_eq!(

--- a/src/plan/frame/expression.rs
+++ b/src/plan/frame/expression.rs
@@ -109,6 +109,7 @@ impl FrameLayout {
                 self.include_string_expr(left);
                 self.include_string_expr(right);
             }
+            StringExprKind::DropPrefix { value, .. } => self.include_string_expr(value),
             StringExprKind::BoolCase {
                 subject,
                 true_,
@@ -180,6 +181,7 @@ impl FrameLayout {
             BoolExprKind::GtEqFloat { left, right } => self.include_float_binary_expr(left, right),
             BoolExprKind::Equal { left, right } => self.include_binary_expr(left, right),
             BoolExprKind::NotEqual { left, right } => self.include_binary_expr(left, right),
+            BoolExprKind::StringStartsWith { value, .. } => self.include_string_expr(value),
             BoolExprKind::And { left, right } => self.include_bool_binary_expr(left, right),
             BoolExprKind::Or { left, right } => self.include_bool_binary_expr(left, right),
             BoolExprKind::BoolCase {
@@ -566,6 +568,25 @@ mod tests {
 
         assert_eq!(layout.ints(), 9);
         assert_eq!(layout.floats(), 4);
+    }
+
+    #[test]
+    fn frame_layout_includes_string_prefix_expression_dependencies() {
+        let steps = vec![
+            Step::evaluate(Expr::bool(BoolExpr::string_starts_with(
+                StringExpr::local_get(StringLocalId(0), "prefix_subject".into()),
+                "pre".into(),
+            ))),
+            Step::evaluate(Expr::string(StringExpr::drop_prefix(
+                StringExpr::local_get(StringLocalId(1), "suffix_subject".into()),
+                "pre".into(),
+            ))),
+        ];
+        let return_ = ReturnExpr::int(IntFunctionId(0), IntExpr::value(0.into()));
+
+        let layout = FrameLayout::from_function_parts(&[], &steps, &return_);
+
+        assert_eq!(layout.strings(), 2);
     }
 
     #[test]

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -72,8 +72,6 @@ pub enum UnsupportedCaseReason {
     UnsupportedSubjectType,
     #[error("list patterns are not supported")]
     ListPattern,
-    #[error("string prefix patterns are not supported")]
-    StringPrefixPattern,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]

--- a/src/planner/expression/case/subject.rs
+++ b/src/planner/expression/case/subject.rs
@@ -211,13 +211,15 @@ fn plan_ordered_case_clause(
             .map(|guard| super::guard::plan_bool(guard, context))
             .transpose()?;
         let condition = match guard_condition {
-            Some(guard_condition) => BoolExpr::and(match_condition, guard_condition),
+            Some(guard_condition) => {
+                let guard_condition = if binding_steps.is_empty() {
+                    guard_condition
+                } else {
+                    BoolExpr::block(binding_steps.clone(), guard_condition)
+                };
+                BoolExpr::and(match_condition, guard_condition)
+            }
             None => match_condition,
-        };
-        let condition = if binding_steps.is_empty() {
-            condition
-        } else {
-            BoolExpr::block(binding_steps.clone(), condition)
         };
 
         let branch = super::super::plan_expr_with_expected_source_stop_type(

--- a/src/planner/expression/case/subject/bool_.rs
+++ b/src/planner/expression/case/subject/bool_.rs
@@ -461,9 +461,9 @@ pub fn main() {
         ))
         .expect("source should plan");
         let bind_other = let_bool_step(1, "other", local_bool(0, "<case:bool:0>"));
-        let condition = BoolExpr::block(
-            vec![bind_other.clone()],
-            BoolExpr::and(BoolExpr::value(true), local_bool(1, "other").into()),
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(vec![bind_other.clone()], local_bool(1, "other").into()),
         );
         let guarded_branch = int_return_block([bind_other], int_return_expr(int(1)));
         let guarded_case = IntReturn::bool_case(condition, guarded_branch, int_return_expr(int(0)));
@@ -501,10 +501,10 @@ pub fn main() {
         .expect("source should plan");
         let bind_value = let_bool_step(1, "value", local_bool(0, "<case:bool:0>"));
         let bind_alias = let_bool_step(2, "alias", local_bool(0, "<case:bool:0>"));
-        let condition = BoolExpr::block(
-            vec![bind_value.clone(), bind_alias.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![bind_value.clone(), bind_alias.clone()],
                 local_bool(1, "value")
                     .and_bool(local_bool(2, "alias"))
                     .into(),

--- a/src/planner/expression/case/subject/float.rs
+++ b/src/planner/expression/case/subject/float.rs
@@ -795,10 +795,10 @@ pub fn main() {
         ))
         .expect("source should plan");
         let bind_other = let_float_step(1, "other", local_float(0, "<case:float:0>"));
-        let condition = BoolExpr::block(
-            vec![bind_other.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![bind_other.clone()],
                 BoolExpr::gt_float(local_float(1, "other").into(), float(1.0).into()),
             ),
         );
@@ -838,10 +838,10 @@ pub fn main() {
         .expect("source should plan");
         let bind_other = let_float_step(1, "other", local_float(0, "<case:float:0>"));
         let bind_alias = let_float_step(2, "alias", local_float(0, "<case:float:0>"));
-        let condition = BoolExpr::block(
-            vec![bind_other.clone(), bind_alias.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![bind_other.clone(), bind_alias.clone()],
                 BoolExpr::gt_float(local_float(2, "alias").into(), float(1.0).into()),
             ),
         );

--- a/src/planner/expression/case/subject/int.rs
+++ b/src/planner/expression/case/subject/int.rs
@@ -851,10 +851,10 @@ pub fn main() {
         ))
         .expect("source should plan");
         let bind_other = let_int_step(1, "other", local_int(0, "<case:int:0>"));
-        let condition = BoolExpr::block(
-            vec![bind_other.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![bind_other.clone()],
                 BoolExpr::gt_int(local_int(1, "other").into(), int(40).into()),
             ),
         );
@@ -892,10 +892,10 @@ pub fn main() {
         .expect("source should plan");
         let bind_other = let_int_step(1, "other", local_int(0, "<case:int:0>"));
         let bind_alias = let_int_step(2, "alias", local_int(0, "<case:int:0>"));
-        let condition = BoolExpr::block(
-            vec![bind_other.clone(), bind_alias.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![bind_other.clone(), bind_alias.clone()],
                 BoolExpr::equal(local_int(2, "alias").into(), int(2).into()),
             ),
         );

--- a/src/planner/expression/case/subject/list.rs
+++ b/src/planner/expression/case/subject/list.rs
@@ -211,20 +211,20 @@ pub fn main() {
             let_list_step(2, "value", local_list(0, "<case:list:0>", ValueType::Int));
         let second_alias_binding =
             let_list_step(3, "alias", local_list(0, "<case:list:0>", ValueType::Int));
-        let first_condition = BoolExpr::block(
-            vec![first_binding.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let first_condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![first_binding.clone()],
                 BoolExpr::equal(
                     Expr::from(local_list(1, "value", ValueType::Int)),
                     Expr::from(list(Vec::<Expr>::new(), ValueType::Int)),
                 ),
             ),
         );
-        let second_condition = BoolExpr::block(
-            vec![second_value_binding.clone(), second_alias_binding.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let second_condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![second_value_binding.clone(), second_alias_binding.clone()],
                 BoolExpr::equal(
                     Expr::from(local_list(3, "alias", ValueType::Int)),
                     Expr::from(list([int(1), int(2)], ValueType::Int)),

--- a/src/planner/expression/case/subject/string.rs
+++ b/src/planner/expression/case/subject/string.rs
@@ -1,11 +1,11 @@
 use super::super::super::plan_string_expr;
-use super::super::{invalid_case_shape, unsupported_case};
+use super::super::invalid_case_shape;
 use super::{case_return_type, single_case_pattern, validate_clause_shape};
 use crate::plan::{BoolExpr, Expr, ExprKind, StringCaseBranches, StringExpr, ValueType};
 use crate::planner::context::PlanContext;
-use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
+use crate::planner::error::{InvalidCaseShapeReason, PlanError};
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{AssignName, Pattern, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
@@ -20,10 +20,13 @@ pub(super) fn plan(
     for clause in &clauses {
         validate_clause_shape(clause)?;
     }
-    if clauses.iter().any(|clause| clause.guard.is_some()) {
+    if clauses
+        .iter()
+        .any(|clause| clause.guard.is_some() || clause_has_string_prefix_pattern(clause))
+    {
         let (subject_step, subject) = super::bind_string_case_subject(subject, context);
         let case =
-            plan_guarded_string_case(type_.as_ref(), return_type, subject, clauses, context)?;
+            plan_ordered_string_case(type_.as_ref(), return_type, subject, clauses, context)?;
         return Ok(super::case_subject_block(subject_step, case));
     }
     let needs_subject_binding = clauses.iter().any(clause_has_string_bound_name);
@@ -37,13 +40,13 @@ pub(super) fn plan(
     let mut fallback = None;
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_string_case_pattern(pattern)?;
-        let bindings = super::branch_bindings(pattern.bound_names(), Expr::string(subject.clone()));
+        let pattern = plan_literal_string_case_pattern(pattern)?;
+        let bindings = pattern.branch_bindings(&subject);
         let branch =
             super::plan_case_branch(type_.as_ref(), &return_type, clause.then, bindings, context)?;
 
         match pattern {
-            StringCasePattern::Literal { value, .. } => {
+            LiteralStringCasePattern::Literal { value, .. } => {
                 if fallback.is_none()
                     && literal_clauses
                         .iter()
@@ -52,7 +55,7 @@ pub(super) fn plan(
                     literal_clauses.push((value, branch));
                 }
             }
-            StringCasePattern::Any { .. } => {
+            LiteralStringCasePattern::Any { .. } => {
                 if fallback.is_none() {
                     fallback = Some(branch);
                 }
@@ -70,7 +73,7 @@ pub(super) fn plan(
     })
 }
 
-fn plan_guarded_string_case(
+fn plan_ordered_string_case(
     case_type: &Type,
     return_type: ValueType,
     subject: StringExpr,
@@ -81,15 +84,9 @@ fn plan_guarded_string_case(
     for clause in clauses {
         let pattern = single_case_pattern(clause.pattern)?;
         let pattern = plan_string_case_pattern(pattern)?;
-        let bindings = super::branch_bindings(pattern.bound_names(), Expr::string(subject.clone()));
-        let is_total = matches!(pattern, StringCasePattern::Any { .. }) && clause.guard.is_none();
-        let match_condition = match pattern {
-            StringCasePattern::Literal { value, .. } => BoolExpr::equal(
-                Expr::string(subject.clone()),
-                Expr::string(StringExpr::value(value)),
-            ),
-            StringCasePattern::Any { .. } => BoolExpr::value(true),
-        };
+        let bindings = pattern.branch_bindings(&subject);
+        let is_total = pattern.is_total() && clause.guard.is_none();
+        let match_condition = pattern.match_condition(&subject);
         ordered_clauses.push(super::plan_ordered_case_clause(
             super::OrderedCaseClauseInput {
                 case_type,
@@ -111,57 +108,219 @@ fn plan_guarded_string_case(
 enum StringCasePattern {
     Literal {
         value: EcoString,
-        bound_names: Vec<EcoString>,
+        subject_bindings: Vec<EcoString>,
+    },
+    Prefix {
+        prefix: EcoString,
+        prefix_bindings: Vec<StringPrefixBinding>,
+        subject_bindings: Vec<EcoString>,
     },
     Any {
-        bound_names: Vec<EcoString>,
+        subject_bindings: Vec<EcoString>,
     },
 }
 
-impl StringCasePattern {
-    fn bound_names(&self) -> &[EcoString] {
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StringPrefixBinding {
+    PrefixLiteral(EcoString),
+    Suffix(EcoString),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LiteralStringCasePattern {
+    Literal {
+        value: EcoString,
+        subject_bindings: Vec<EcoString>,
+    },
+    Any {
+        subject_bindings: Vec<EcoString>,
+    },
+}
+
+impl LiteralStringCasePattern {
+    fn branch_bindings(&self, subject: &StringExpr) -> Vec<(EcoString, Expr)> {
         match self {
-            StringCasePattern::Literal { bound_names, .. }
-            | StringCasePattern::Any { bound_names } => bound_names,
+            LiteralStringCasePattern::Literal {
+                subject_bindings, ..
+            }
+            | LiteralStringCasePattern::Any { subject_bindings } => subject_bindings
+                .iter()
+                .map(|name| (name.clone(), Expr::string(subject.clone())))
+                .collect(),
         }
     }
 
-    fn add_bound_name(&mut self, name: EcoString) {
+    fn add_subject_binding(&mut self, name: EcoString) {
         match self {
-            StringCasePattern::Literal { bound_names, .. }
-            | StringCasePattern::Any { bound_names } => {
-                bound_names.push(name);
+            LiteralStringCasePattern::Literal {
+                subject_bindings, ..
+            }
+            | LiteralStringCasePattern::Any { subject_bindings } => {
+                subject_bindings.push(name);
             }
         }
     }
+}
+
+impl StringCasePattern {
+    fn branch_bindings(&self, subject: &StringExpr) -> Vec<(EcoString, Expr)> {
+        match self {
+            StringCasePattern::Literal {
+                subject_bindings, ..
+            }
+            | StringCasePattern::Any { subject_bindings } => subject_bindings
+                .iter()
+                .map(|name| (name.clone(), Expr::string(subject.clone())))
+                .collect(),
+            StringCasePattern::Prefix {
+                prefix,
+                prefix_bindings,
+                subject_bindings,
+            } => {
+                let mut bindings: Vec<_> = prefix_bindings
+                    .iter()
+                    .map(|binding| match binding {
+                        StringPrefixBinding::PrefixLiteral(name) => (
+                            name.clone(),
+                            Expr::string(StringExpr::value(prefix.clone())),
+                        ),
+                        StringPrefixBinding::Suffix(name) => (
+                            name.clone(),
+                            Expr::string(StringExpr::drop_prefix(subject.clone(), prefix.clone())),
+                        ),
+                    })
+                    .collect();
+                bindings.extend(
+                    subject_bindings
+                        .iter()
+                        .map(|name| (name.clone(), Expr::string(subject.clone()))),
+                );
+                bindings
+            }
+        }
+    }
+
+    fn match_condition(&self, subject: &StringExpr) -> BoolExpr {
+        match self {
+            StringCasePattern::Literal { value, .. } => BoolExpr::equal(
+                Expr::string(subject.clone()),
+                Expr::string(StringExpr::value(value.clone())),
+            ),
+            StringCasePattern::Prefix { prefix, .. } => {
+                BoolExpr::string_starts_with(subject.clone(), prefix.clone())
+            }
+            StringCasePattern::Any { .. } => BoolExpr::value(true),
+        }
+    }
+
+    fn is_total(&self) -> bool {
+        matches!(self, StringCasePattern::Any { .. })
+    }
+
+    fn add_subject_binding(&mut self, name: EcoString) {
+        match self {
+            StringCasePattern::Literal {
+                subject_bindings, ..
+            }
+            | StringCasePattern::Prefix {
+                subject_bindings, ..
+            }
+            | StringCasePattern::Any { subject_bindings } => {
+                subject_bindings.push(name);
+            }
+        }
+    }
+}
+
+fn plan_literal_string_case_pattern(
+    pattern: Pattern<Arc<Type>>,
+) -> Result<LiteralStringCasePattern, PlanError> {
+    match pattern {
+        Pattern::String { value, .. } => Ok(LiteralStringCasePattern::Literal {
+            value,
+            subject_bindings: Vec::new(),
+        }),
+        Pattern::Variable { name, type_, .. } if type_.is_string() => {
+            Ok(LiteralStringCasePattern::Any {
+                subject_bindings: vec![name],
+            })
+        }
+        Pattern::Variable { .. } => Err(invalid_case_shape(
+            InvalidCaseShapeReason::PatternTypeMismatch,
+        )),
+        Pattern::Discard { type_, .. } if type_.is_string() => Ok(LiteralStringCasePattern::Any {
+            subject_bindings: Vec::new(),
+        }),
+        Pattern::Discard { .. } => Err(invalid_case_shape(
+            InvalidCaseShapeReason::PatternTypeMismatch,
+        )),
+        Pattern::Assign { name, pattern, .. } => {
+            let mut pattern = plan_literal_string_case_pattern(*pattern)?;
+            pattern.add_subject_binding(name);
+            Ok(pattern)
+        }
+        Pattern::Invalid { .. } => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
+        Pattern::Int { .. }
+        | Pattern::Float { .. }
+        | Pattern::BitArraySize(_)
+        | Pattern::List { .. }
+        | Pattern::Constructor { .. }
+        | Pattern::Tuple { .. }
+        | Pattern::BitArray { .. }
+        | Pattern::StringPrefix { .. } => Err(invalid_case_shape(
+            InvalidCaseShapeReason::PatternTypeMismatch,
+        )),
+    }
+}
+
+fn prefix_bindings(
+    left_side_assignment: Option<(EcoString, gleam_core::ast::SrcSpan)>,
+    right_side_assignment: AssignName,
+) -> Vec<StringPrefixBinding> {
+    let mut bindings = Vec::new();
+    if let Some((name, _)) = left_side_assignment {
+        bindings.push(StringPrefixBinding::PrefixLiteral(name));
+    }
+    if let AssignName::Variable(name) = right_side_assignment {
+        bindings.push(StringPrefixBinding::Suffix(name));
+    }
+
+    bindings
 }
 
 fn plan_string_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<StringCasePattern, PlanError> {
     match pattern {
         Pattern::String { value, .. } => Ok(StringCasePattern::Literal {
             value,
-            bound_names: Vec::new(),
+            subject_bindings: Vec::new(),
         }),
         Pattern::Variable { name, type_, .. } if type_.is_string() => Ok(StringCasePattern::Any {
-            bound_names: vec![name],
+            subject_bindings: vec![name],
         }),
         Pattern::Variable { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
         Pattern::Discard { type_, .. } if type_.is_string() => Ok(StringCasePattern::Any {
-            bound_names: Vec::new(),
+            subject_bindings: Vec::new(),
         }),
         Pattern::Discard { .. } => Err(invalid_case_shape(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
         Pattern::Assign { name, pattern, .. } => {
             let mut pattern = plan_string_case_pattern(*pattern)?;
-            pattern.add_bound_name(name);
+            pattern.add_subject_binding(name);
             Ok(pattern)
         }
-        Pattern::StringPrefix { .. } => {
-            Err(unsupported_case(UnsupportedCaseReason::StringPrefixPattern))
-        }
+        Pattern::StringPrefix {
+            left_side_string,
+            left_side_assignment,
+            right_side_assignment,
+            ..
+        } => Ok(StringCasePattern::Prefix {
+            prefix: left_side_string,
+            prefix_bindings: prefix_bindings(left_side_assignment, right_side_assignment),
+            subject_bindings: Vec::new(),
+        }),
         Pattern::Invalid { .. } => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
         Pattern::Int { .. }
         | Pattern::Float { .. }
@@ -179,10 +338,22 @@ fn clause_has_string_bound_name(clause: &TypedClause) -> bool {
     clause.pattern.iter().any(string_pattern_has_bound_name)
 }
 
+fn clause_has_string_prefix_pattern(clause: &TypedClause) -> bool {
+    clause.pattern.iter().any(string_pattern_has_prefix)
+}
+
 fn string_pattern_has_bound_name(pattern: &Pattern<Arc<Type>>) -> bool {
     match pattern {
         Pattern::Variable { type_, .. } if type_.is_string() => true,
         Pattern::Assign { .. } => true,
+        _ => false,
+    }
+}
+
+fn string_pattern_has_prefix(pattern: &Pattern<Arc<Type>>) -> bool {
+    match pattern {
+        Pattern::StringPrefix { .. } => true,
+        Pattern::Assign { pattern, .. } => string_pattern_has_prefix(pattern),
         _ => false,
     }
 }
@@ -539,8 +710,9 @@ mod tests {
     use crate::plan::{
         BoolExpr, BoolFunctionId, Expr, FloatExpr, FloatFunctionId, FunctionExpr,
         FunctionFunctionId, FunctionType, IntFunctionExpr, IntFunctionFunctionId, IntFunctionId,
-        IntLocalId, ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, StringCaseBranches,
-        StringFunctionId, StringLocalId, StringReturn, TupleFunctionId, ValueType,
+        IntLocalId, ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, Step,
+        StringCaseBranches, StringExpr, StringFunctionId, StringLocalId, StringReturn,
+        TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
         bool_, bool_return_expr, bool_return_string_case, float, function, function_ref, int,
@@ -793,10 +965,10 @@ pub fn main() {
         ))
         .expect("source should plan");
         let bind_other = let_string_step(1, "other", local_string(0, "<case:string:0>"));
-        let condition = BoolExpr::block(
-            vec![bind_other.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![bind_other.clone()],
                 BoolExpr::equal(local_string(1, "other").into(), string("geam").into()),
             ),
         );
@@ -836,10 +1008,10 @@ pub fn main() {
         .expect("source should plan");
         let bind_other = let_string_step(1, "other", local_string(0, "<case:string:0>"));
         let bind_alias = let_string_step(2, "alias", local_string(0, "<case:string:0>"));
-        let condition = BoolExpr::block(
-            vec![bind_other.clone(), bind_alias.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![bind_other.clone(), bind_alias.clone()],
                 BoolExpr::equal(local_string(2, "alias").into(), string("geam").into()),
             ),
         );
@@ -857,6 +1029,184 @@ pub fn main() {
                         condition,
                         guarded_branch,
                         string_return_expr(string("")),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_string_case_prefix_binds_suffix_after_match() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case "Hello, Geam" {
+    "Hello, " <> name -> name
+    _ -> "Unknown"
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let subject = local_string(0, "<case:string:0>");
+        let suffix = StringExpr::drop_prefix(subject.into(), "Hello, ".into());
+        let expected = module(
+            "main",
+            function(
+                "main",
+                string_return_block(
+                    [let_string_step(0, "<case:string:0>", string("Hello, Geam"))],
+                    StringReturn::bool_case(
+                        BoolExpr::string_starts_with(
+                            local_string(0, "<case:string:0>").into(),
+                            "Hello, ".into(),
+                        ),
+                        string_return_block(
+                            [Step::let_string(StringLocalId(1), "name".into(), suffix)],
+                            string_return_expr(local_string(1, "name")),
+                        ),
+                        string_return_expr(string("Unknown")),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_string_case_prefix_whole_alias_binds_suffix_then_subject_alias() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case "Hello, Geam" {
+    "Hello, " <> name as whole -> name <> whole
+    _ -> "Unknown"
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let subject = local_string(0, "<case:string:0>");
+        let bind_name = Step::let_string(
+            StringLocalId(1),
+            "name".into(),
+            StringExpr::drop_prefix(subject.into(), "Hello, ".into()),
+        );
+        let bind_whole = let_string_step(2, "whole", local_string(0, "<case:string:0>"));
+        let expected = module(
+            "main",
+            function(
+                "main",
+                string_return_block(
+                    [let_string_step(0, "<case:string:0>", string("Hello, Geam"))],
+                    StringReturn::bool_case(
+                        BoolExpr::string_starts_with(
+                            local_string(0, "<case:string:0>").into(),
+                            "Hello, ".into(),
+                        ),
+                        string_return_block(
+                            [bind_name, bind_whole],
+                            string_return_expr(
+                                local_string(1, "name").concatenate(local_string(2, "whole")),
+                            ),
+                        ),
+                        string_return_expr(string("Unknown")),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn string_case_pattern_assigns_literal_subject_alias() {
+        assert_eq!(
+            super::plan_string_case_pattern(Pattern::Assign {
+                name: "alias".into(),
+                location: dummy_span(),
+                pattern: Box::new(Pattern::String {
+                    location: dummy_span(),
+                    value: "geam".into(),
+                }),
+            }),
+            Ok(super::StringCasePattern::Literal {
+                value: "geam".into(),
+                subject_bindings: vec!["alias".into()],
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_string_case_pattern_assign_invalid_inner_pattern() {
+        assert_eq!(
+            super::plan_string_case_pattern(Pattern::Assign {
+                name: "alias".into(),
+                location: dummy_span(),
+                pattern: Box::new(Pattern::Invalid {
+                    location: dummy_span(),
+                    type_: type_::string(),
+                }),
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::InvalidPattern,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn plan_string_case_prefix_guard_wraps_suffix_binding_after_match() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case "Hello, Geam" {
+    "Hello, " as prefix <> name if name == "Geam" -> prefix <> name
+    _ -> "Unknown"
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let subject = local_string(0, "<case:string:0>");
+        let bind_prefix = let_string_step(1, "prefix", string("Hello, "));
+        let bind_name = Step::let_string(
+            StringLocalId(2),
+            "name".into(),
+            StringExpr::drop_prefix(subject.into(), "Hello, ".into()),
+        );
+        let condition = BoolExpr::and(
+            BoolExpr::string_starts_with(
+                local_string(0, "<case:string:0>").into(),
+                "Hello, ".into(),
+            ),
+            BoolExpr::block(
+                vec![bind_prefix.clone(), bind_name.clone()],
+                BoolExpr::equal(local_string(2, "name").into(), string("Geam").into()),
+            ),
+        );
+        let expected = module(
+            "main",
+            function(
+                "main",
+                string_return_block(
+                    [let_string_step(0, "<case:string:0>", string("Hello, Geam"))],
+                    StringReturn::bool_case(
+                        condition,
+                        string_return_block(
+                            [bind_prefix, bind_name],
+                            string_return_expr(
+                                local_string(1, "prefix").concatenate(local_string(2, "name")),
+                            ),
+                        ),
+                        string_return_expr(string("Unknown")),
                     ),
                 ),
             ),
@@ -965,21 +1315,6 @@ fn duplicate_literal(value: String) {
         )));
 
         assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn reject_profile_string_case_patterns() {
-        let cases = [(
-            r#"pub fn main() { case "prefix one" { "prefix " <> rest -> 1 _ -> 0 } }"#,
-            UnsupportedCaseReason::StringPrefixPattern,
-        )];
-
-        for (src, reason) in cases {
-            assert_eq!(
-                expect_plan_error(src),
-                PlanError::UnsupportedCase { reason },
-            );
-        }
     }
 
     #[test]
@@ -1211,6 +1546,75 @@ fn return_value(value: String) {
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CaseShape {
                     reason: InvalidCaseShapeReason::MissingFallbackPattern,
+                },
+            }),
+        );
+
+        let mut variable_type_mismatch = compile_string_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut variable_type_mismatch.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+        clauses[0].pattern[0] = Pattern::Variable {
+            location: dummy_span(),
+            name: "value".into(),
+            type_: type_::bool(),
+            origin: VariableOrigin::generated(),
+        };
+        assert_eq!(
+            plan_module(variable_type_mismatch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
+
+        let mut discard_type_mismatch = compile_string_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut discard_type_mismatch.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+        clauses[0].pattern[0] = Pattern::Discard {
+            name: "_".into(),
+            location: dummy_span(),
+            type_: type_::bool(),
+        };
+        assert_eq!(
+            plan_module(discard_type_mismatch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
+
+        let mut invalid_pattern = compile_string_case_module();
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut invalid_pattern.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Constant(Constant::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: BigInt::from(1),
+        }));
+        clauses[0].pattern[0] = Pattern::Invalid {
+            location: dummy_span(),
+            type_: type_::string(),
+        };
+        assert_eq!(
+            plan_module(invalid_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::InvalidPattern,
                 },
             }),
         );

--- a/src/planner/expression/case/subject/tuple.rs
+++ b/src/planner/expression/case/subject/tuple.rs
@@ -9,7 +9,7 @@ use crate::plan::{
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{AssignName, Pattern, SrcSpan, TypedClause, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
@@ -81,6 +81,36 @@ impl TupleCasePattern {
             branch_bindings: Vec::new(),
             is_total: false,
         }
+    }
+
+    fn string_prefix(
+        value: Expr,
+        prefix: EcoString,
+        left_side_assignment: Option<(EcoString, SrcSpan)>,
+        right_side_assignment: AssignName,
+    ) -> Result<Self, PlanError> {
+        let Some(value) = value.into_string() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::PatternTypeMismatch,
+            ));
+        };
+        let mut pattern = Self {
+            match_condition: Some(BoolExpr::string_starts_with(value.clone(), prefix.clone())),
+            branch_bindings: Vec::new(),
+            is_total: false,
+        };
+        if let Some((name, _)) = left_side_assignment {
+            pattern
+                .branch_bindings
+                .push((name, Expr::string(StringExpr::value(prefix.clone()))));
+        }
+        if let AssignName::Variable(name) = right_side_assignment {
+            pattern
+                .branch_bindings
+                .push((name, Expr::string(StringExpr::drop_prefix(value, prefix))));
+        }
+
+        Ok(pattern)
     }
 
     fn with_binding(mut self, name: EcoString, value: Expr) -> Self {
@@ -173,8 +203,16 @@ fn plan_tuple_case_pattern(
         Pattern::List { .. } if matches!(subject_type, ValueType::List(_)) => Err(
             super::super::unsupported_case(UnsupportedCaseReason::ListPattern),
         ),
-        Pattern::StringPrefix { .. } if subject_type == ValueType::String => Err(
-            super::super::unsupported_case(UnsupportedCaseReason::StringPrefixPattern),
+        Pattern::StringPrefix {
+            left_side_string,
+            left_side_assignment,
+            right_side_assignment,
+            ..
+        } if subject_type == ValueType::String => TupleCasePattern::string_prefix(
+            value,
+            left_side_string,
+            left_side_assignment,
+            right_side_assignment,
         ),
         Pattern::Int { .. }
         | Pattern::Float { .. }
@@ -254,10 +292,11 @@ fn internal_tuple_case_subject_name(local: TupleLocalId) -> EcoString {
 
 #[cfg(test)]
 mod tests {
-    use crate::plan::{BoolExpr, Expr, ValueType};
+    use crate::plan::{BoolExpr, Expr, Step, StringExpr, StringLocalId, ValueType};
     use crate::planner::dsl::{
         bool_, float, function, int, int_return_block, int_return_expr, let_int_step,
-        let_tuple_step, local_int, local_tuple, module, nil, string, tuple,
+        let_tuple_step, local_int, local_string, local_tuple, module, nil, string,
+        string_return_block, string_return_expr, tuple,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -344,10 +383,10 @@ pub fn main() {
             "alias",
             local_tuple(0, "<case:tuple:0>", tuple_type.clone()),
         );
-        let first_condition = BoolExpr::block(
-            vec![first_binding.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let first_condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![first_binding.clone()],
                 BoolExpr::gt_int(
                     local_tuple(1, "value", tuple_type.clone())
                         .index_int(0)
@@ -356,10 +395,10 @@ pub fn main() {
                 ),
             ),
         );
-        let second_condition = BoolExpr::block(
-            vec![second_value_binding.clone(), second_alias_binding.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let second_condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![second_value_binding.clone(), second_alias_binding.clone()],
                 BoolExpr::equal(
                     Expr::from(local_tuple(3, "alias", tuple_type.clone()).index_int(1)),
                     Expr::from(int(2)),
@@ -461,19 +500,13 @@ pub fn main() {
             "value",
             local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(1),
         );
-        let first_condition = BoolExpr::block(
-            vec![first_binding.clone()],
-            BoolExpr::equal(
-                Expr::from(local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(0)),
-                Expr::from(int(1)),
-            ),
+        let first_condition = BoolExpr::equal(
+            Expr::from(local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(0)),
+            Expr::from(int(1)),
         );
-        let second_condition = BoolExpr::block(
-            vec![second_binding.clone()],
-            BoolExpr::equal(
-                Expr::from(local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(0)),
-                Expr::from(int(2)),
-            ),
+        let second_condition = BoolExpr::equal(
+            Expr::from(local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(0)),
+            Expr::from(int(2)),
         );
         let expected = module(
             "main",
@@ -525,10 +558,10 @@ pub fn main() {
             "right",
             local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(1),
         );
-        let condition = BoolExpr::block(
-            vec![left_binding.clone(), right_binding.clone()],
-            BoolExpr::and(
-                BoolExpr::value(true),
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![left_binding.clone(), right_binding.clone()],
                 BoolExpr::gt_int(local_int(0, "left").into(), int(0).into()),
             ),
         );
@@ -681,22 +714,87 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_tuple_subject_inner_string_prefix_pattern() {
+    fn tuple_case_pattern_binds_string_prefix_left_alias() {
+        let actual = super::plan_tuple_case_pattern(
+            Pattern::StringPrefix {
+                location: dummy_span(),
+                left_location: dummy_span(),
+                left_side_assignment: Some(("prefix".into(), dummy_span())),
+                right_location: dummy_span(),
+                left_side_string: "Hello, ".into(),
+                right_side_assignment: AssignName::Discard("_rest".into()),
+            },
+            Expr::from(string("Hello, Geam")),
+            ValueType::String,
+        );
+
         assert_eq!(
-            expect_plan_error(
-                r#"
+            actual,
+            Ok(super::TupleCasePattern {
+                match_condition: Some(BoolExpr::string_starts_with(
+                    string("Hello, Geam").into(),
+                    "Hello, ".into(),
+                )),
+                branch_bindings: vec![("prefix".into(), Expr::from(string("Hello, ")))],
+                is_total: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn plan_tuple_subject_inner_string_prefix_pattern_uses_tuple_projection() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
 pub fn main() {
-  case #("Hello, Geam", 1) {
-    #("Hello, " <> name, value) -> value
-    _ -> 0
+  case #("Hello, Geam", "!") {
+    #("Hello, " <> name, suffix) -> name <> suffix
+    _ -> "none"
   }
 }
 "#,
-            ),
-            PlanError::UnsupportedCase {
-                reason: UnsupportedCaseReason::StringPrefixPattern,
-            },
+        ))
+        .expect("source should plan");
+        let tuple_type = vec![ValueType::String, ValueType::String];
+        let first_element = local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_string(0);
+        let second_element = local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_string(1);
+        let bind_name = Step::let_string(
+            StringLocalId(0),
+            "name".into(),
+            StringExpr::drop_prefix(first_element.into(), "Hello, ".into()),
         );
+        let bind_suffix =
+            Step::let_string(StringLocalId(1), "suffix".into(), second_element.into());
+        let expected = module(
+            "main",
+            function(
+                "main",
+                string_return_block(
+                    [let_tuple_step(
+                        0,
+                        "<case:tuple:0>",
+                        tuple([string("Hello, Geam"), string("!")]),
+                    )],
+                    crate::plan::StringReturn::bool_case(
+                        BoolExpr::string_starts_with(
+                            local_tuple(0, "<case:tuple:0>", tuple_type)
+                                .index_string(0)
+                                .into(),
+                            "Hello, ".into(),
+                        ),
+                        string_return_block(
+                            [bind_name, bind_suffix],
+                            string_return_expr(
+                                local_string(0, "name").concatenate(local_string(1, "suffix")),
+                            ),
+                        ),
+                        string_return_expr(string("none")),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
     }
 
     #[test]
@@ -986,6 +1084,25 @@ pub fn main() {
                 },
                 Expr::from(int(1)),
                 ValueType::Int,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
+        assert_eq!(
+            super::plan_tuple_case_pattern(
+                gleam_core::ast::Pattern::StringPrefix {
+                    location: dummy_span(),
+                    left_location: dummy_span(),
+                    left_side_assignment: None,
+                    right_location: dummy_span(),
+                    left_side_string: "prefix".into(),
+                    right_side_assignment: AssignName::Variable("rest".into()),
+                },
+                Expr::from(int(1)),
+                ValueType::String,
             ),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CaseShape {

--- a/src/planner/expression/function/free_variables.rs
+++ b/src/planner/expression/function/free_variables.rs
@@ -241,12 +241,23 @@ fn collect_variable_pattern_bound_name(
                 collect_variable_pattern_bound_name(&tail.pattern, bound);
             }
         }
+        Pattern::StringPrefix {
+            left_side_assignment,
+            right_side_assignment,
+            ..
+        } => {
+            if let Some((name, _)) = left_side_assignment {
+                bound.insert(name.clone());
+            }
+            if let gleam_core::ast::AssignName::Variable(name) = right_side_assignment {
+                bound.insert(name.clone());
+            }
+        }
         Pattern::Int { .. }
         | Pattern::Float { .. }
         | Pattern::String { .. }
         | Pattern::Constructor { .. }
         | Pattern::BitArray { .. }
-        | Pattern::StringPrefix { .. }
         | Pattern::BitArraySize(_)
         | Pattern::Discard { .. }
         | Pattern::Invalid { .. } => {}
@@ -256,7 +267,7 @@ fn collect_variable_pattern_bound_name(
 #[cfg(test)]
 mod tests {
     use crate::planner::support::{compile, dummy_span};
-    use gleam_core::ast::{ClauseGuard, Constant, Publicity, Statement, TypedExpr};
+    use gleam_core::ast::{AssignName, ClauseGuard, Constant, Publicity, Statement, TypedExpr};
     use gleam_core::type_::error::VariableOrigin;
     use gleam_core::type_::{self, Deprecation, ValueConstructor, ValueConstructorVariant};
     use vec1::Vec1;
@@ -353,6 +364,67 @@ pub fn main() {
                 "plain_assert_condition".to_string(),
             ],
         );
+    }
+
+    #[test]
+    fn anonymous_free_variables_treat_string_prefix_pattern_names_as_bound() {
+        assert_eq!(
+            anonymous_function_free_variables(
+                r#"
+pub fn main() {
+  fn() {
+    case "Hello, Geam" {
+      "Hello, " as prefix <> name -> prefix <> name
+      _ -> ""
+    }
+  }
+  1
+}
+"#,
+            ),
+            Vec::<String>::new(),
+        );
+    }
+
+    #[test]
+    fn collect_variable_pattern_bound_name_records_string_prefix_alias_and_suffix_names() {
+        let mut bound = std::collections::HashSet::new();
+
+        super::collect_variable_pattern_bound_name(
+            &gleam_core::ast::Pattern::StringPrefix {
+                location: dummy_span(),
+                left_location: dummy_span(),
+                left_side_assignment: Some(("prefix".into(), dummy_span())),
+                right_location: dummy_span(),
+                left_side_string: "Hello, ".into(),
+                right_side_assignment: AssignName::Variable("name".into()),
+            },
+            &mut bound,
+        );
+
+        assert_eq!(
+            bound,
+            std::collections::HashSet::from(["prefix".into(), "name".into()]),
+        );
+    }
+
+    #[test]
+    fn collect_variable_pattern_bound_name_ignores_discard_string_prefix_names() {
+        let mut bound = std::collections::HashSet::new();
+
+        super::collect_variable_pattern_bound_name(
+            &gleam_core::ast::Pattern::StringPrefix {
+                location: dummy_span(),
+                left_location: dummy_span(),
+                left_side_assignment: None,
+                right_location: dummy_span(),
+                left_side_string: "Hello, ".into(),
+                right_side_assignment: AssignName::Discard("_rest".into()),
+            },
+            &mut bound,
+        );
+
+        assert_eq!(bound, std::collections::HashSet::new());
     }
 
     #[test]

--- a/src/runtime/expression/bool.rs
+++ b/src/runtime/expression/bool.rs
@@ -62,6 +62,9 @@ pub(in crate::runtime) fn eval_bool_expr(
         BoolExprKind::NotEqual { left, right } => {
             Ok(eval_expr(plan, frame, left)? != eval_expr(plan, frame, right)?)
         }
+        BoolExprKind::StringStartsWith { value, prefix } => {
+            Ok(eval_string_expr(plan, frame, value)?.starts_with(prefix.as_str()))
+        }
         BoolExprKind::And { left, right } => {
             let left = eval_bool_expr(plan, frame, left)?;
             eval_and(left, || eval_bool_expr(plan, frame, right))
@@ -251,6 +254,72 @@ pub fn main() {
 "#,
             ),
             Value::Bool(false),
+        );
+    }
+
+    #[test]
+    fn eval_string_starts_with() {
+        let plan = crate::runtime::plan_src("pub fn main() { True }");
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_bool_expr(
+                &plan,
+                &mut frame,
+                &BoolExpr::string_starts_with(
+                    StringExpr::value("Hello, Geam".into()),
+                    "Hello, ".into()
+                ),
+            ),
+            Ok(true),
+        );
+        assert_eq!(
+            eval_bool_expr(
+                &plan,
+                &mut frame,
+                &BoolExpr::string_starts_with(
+                    StringExpr::value("안녕, 글림".into()),
+                    "안녕, ".into()
+                ),
+            ),
+            Ok(true),
+        );
+        assert_eq!(
+            eval_bool_expr(
+                &plan,
+                &mut frame,
+                &BoolExpr::string_starts_with(
+                    StringExpr::value("Hello, Geam".into()),
+                    "Goodbye".into()
+                ),
+            ),
+            Ok(false),
+        );
+        assert_eq!(
+            eval_bool_expr(
+                &plan,
+                &mut frame,
+                &BoolExpr::string_starts_with(StringExpr::value("abc".into()), "".into()),
+            ),
+            Ok(true),
+        );
+    }
+
+    #[test]
+    fn eval_string_starts_with_propagates_value_error() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_bool_expr(
+                &plan,
+                &mut frame,
+                &BoolExpr::string_starts_with(error_string_expr(), "prefix".into()),
+            ),
+            Err(function_return_family_error_value(
+                FunctionReturnFamily::String,
+                FunctionReturnFamily::Int,
+            )),
         );
     }
 

--- a/src/runtime/expression/string.rs
+++ b/src/runtime/expression/string.rs
@@ -35,6 +35,10 @@ pub(in crate::runtime) fn eval_string_expr(
             eval_string_expr(plan, frame, right)?,
         )
         .into()),
+        StringExprKind::DropPrefix { value, prefix } => Ok(eval_string_expr(plan, frame, value)?
+            .strip_prefix(prefix.as_str())
+            .unwrap_or("")
+            .into()),
         StringExprKind::BoolCase {
             subject,
             true_,
@@ -144,6 +148,63 @@ pub fn main() {
 "#,
             ),
             Value::String("hello, geam".into()),
+        );
+    }
+
+    #[test]
+    fn eval_string_drop_prefix() {
+        let plan = crate::runtime::plan_src(r#"pub fn main() { "value" }"#);
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_string_expr(
+                &plan,
+                &mut frame,
+                &StringExpr::drop_prefix(StringExpr::value("Hello, Geam".into()), "Hello, ".into()),
+            ),
+            Ok("Geam".into()),
+        );
+        assert_eq!(
+            eval_string_expr(
+                &plan,
+                &mut frame,
+                &StringExpr::drop_prefix(StringExpr::value("안녕, 글림".into()), "안녕, ".into()),
+            ),
+            Ok("글림".into()),
+        );
+        assert_eq!(
+            eval_string_expr(
+                &plan,
+                &mut frame,
+                &StringExpr::drop_prefix(StringExpr::value("abc".into()), "".into()),
+            ),
+            Ok("abc".into()),
+        );
+        assert_eq!(
+            eval_string_expr(
+                &plan,
+                &mut frame,
+                &StringExpr::drop_prefix(StringExpr::value("Hello, Geam".into()), "Goodbye".into()),
+            ),
+            Ok("".into()),
+        );
+    }
+
+    #[test]
+    fn eval_string_drop_prefix_propagates_value_error() {
+        let plan = plan();
+        let mut frame = Frame::default();
+
+        assert_eq!(
+            eval_string_expr(
+                &plan,
+                &mut frame,
+                &StringExpr::drop_prefix(error_string_expr(), "prefix".into()),
+            ),
+            Err(function_return_family_error_value(
+                FunctionReturnFamily::String,
+                FunctionReturnFamily::Bool,
+            )),
         );
     }
 

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -165,6 +165,16 @@ mod control_flow {
             pattern_alias_guard,
             pattern_alias_scope,
             pattern_alias_closure_capture,
+            string_prefix_pattern,
+            string_prefix_whole_alias,
+            string_prefix_fallthrough,
+            string_prefix_left_alias,
+            string_prefix_discard_suffix,
+            string_prefix_guard,
+            string_prefix_unicode,
+            string_prefix_empty,
+            tuple_inner_string_prefix_pattern,
+            string_prefix_closure_capture,
         );
     }
 }
@@ -434,9 +444,6 @@ mod rejection {
             multiple_subjects,
             tuple_alternative_patterns,
             tuple_inner_list_pattern,
-            tuple_inner_string_prefix_pattern,
-            string_prefix_pattern,
-            string_prefix_pattern_alias,
             list_pattern,
             list_pattern_alias,
             unsupported_subject_type,

--- a/tests/fixtures/execution/control_flow/case/string_prefix_closure_capture.gleam
+++ b/tests/fixtures/execution/control_flow/case/string_prefix_closure_capture.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case "Hello, Geam" {
+    "Hello, " <> name -> fn() { name }()
+    _ -> "Unknown"
+  }
+}
+
+// geam:expect String("Geam")

--- a/tests/fixtures/execution/control_flow/case/string_prefix_discard_suffix.gleam
+++ b/tests/fixtures/execution/control_flow/case/string_prefix_discard_suffix.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case "Hello, Geam" {
+    "Hello, " <> _rest -> "matched"
+    _ -> "Unknown"
+  }
+}
+
+// geam:expect String("matched")

--- a/tests/fixtures/execution/control_flow/case/string_prefix_empty.gleam
+++ b/tests/fixtures/execution/control_flow/case/string_prefix_empty.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case "Geam" {
+    "" <> rest -> rest
+    _ -> "Unknown"
+  }
+}
+
+// geam:expect String("Geam")

--- a/tests/fixtures/execution/control_flow/case/string_prefix_fallthrough.gleam
+++ b/tests/fixtures/execution/control_flow/case/string_prefix_fallthrough.gleam
@@ -1,7 +1,8 @@
 pub fn main() {
-  let value = "Hello, Geam"
-  case value {
+  case "Goodbye, Geam" {
     "Hello, " <> name -> name
     _ -> "Unknown"
   }
 }
+
+// geam:expect String("Unknown")

--- a/tests/fixtures/execution/control_flow/case/string_prefix_guard.gleam
+++ b/tests/fixtures/execution/control_flow/case/string_prefix_guard.gleam
@@ -1,0 +1,9 @@
+pub fn main() {
+  case "Hello, Geam" {
+    "Hello, " <> name if name == "Nobody" -> "wrong"
+    "Hello, " <> name if name == "Geam" -> name
+    _ -> "Unknown"
+  }
+}
+
+// geam:expect String("Geam")

--- a/tests/fixtures/execution/control_flow/case/string_prefix_left_alias.gleam
+++ b/tests/fixtures/execution/control_flow/case/string_prefix_left_alias.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case "Hello, Geam" {
+    "Hello, " as prefix <> name -> prefix <> name
+    _ -> "Unknown"
+  }
+}
+
+// geam:expect String("Hello, Geam")

--- a/tests/fixtures/execution/control_flow/case/string_prefix_pattern.gleam
+++ b/tests/fixtures/execution/control_flow/case/string_prefix_pattern.gleam
@@ -1,7 +1,9 @@
 pub fn main() {
   let value = "Hello, Geam"
   case value {
-    "Hello, " <> name as greeting -> greeting <> name
+    "Hello, " <> name -> name
     _ -> "Unknown"
   }
 }
+
+// geam:expect String("Geam")

--- a/tests/fixtures/execution/control_flow/case/string_prefix_unicode.gleam
+++ b/tests/fixtures/execution/control_flow/case/string_prefix_unicode.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case "안녕, 글림" {
+    "안녕, " <> name -> name
+    _ -> "Unknown"
+  }
+}
+
+// geam:expect String("글림")

--- a/tests/fixtures/execution/control_flow/case/string_prefix_whole_alias.gleam
+++ b/tests/fixtures/execution/control_flow/case/string_prefix_whole_alias.gleam
@@ -1,0 +1,9 @@
+pub fn main() {
+  let value = "Hello, Geam"
+  case value {
+    "Hello, " <> name as greeting -> greeting <> name
+    _ -> "Unknown"
+  }
+}
+
+// geam:expect String("Hello, GeamGeam")

--- a/tests/fixtures/execution/control_flow/case/tuple_inner_string_prefix_pattern.gleam
+++ b/tests/fixtures/execution/control_flow/case/tuple_inner_string_prefix_pattern.gleam
@@ -5,3 +5,5 @@ pub fn main() {
     _ -> 0
   }
 }
+
+// geam:expect Int(1)


### PR DESCRIPTION
- Add string prefix match/suffix projection plan nodes and runtime evaluation.
- Lower `"prefix" <> rest` case patterns for string subjects and tuple elements.
- Preserve ordered guard fallthrough while binding prefix/suffix names only after a match.
- Example: `case "Hello, Geam" { "Hello, " <> name -> name }` returns `"Geam"`.
- Cover prefix aliases, discard suffixes, Unicode prefixes, empty prefixes, guards, and closure capture.
