### PR TITLE
Support case alternative patterns

### DIFF
--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -64,8 +64,6 @@ pub enum UnsupportedBinOpKind {
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedCaseReason {
-    #[error("alternative patterns are not supported")]
-    AlternativePatterns,
     #[error("multiple subjects are not supported")]
     MultipleSubjects,
     #[error("case subject type is not supported")]

--- a/src/planner/expression/case/subject.rs
+++ b/src/planner/expression/case/subject.rs
@@ -25,6 +25,7 @@ pub(super) fn plan(
     clauses: Vec<TypedClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
+    let clauses = case_clauses(clauses)?;
     match ValueType::from_gleam(subject.type_().as_ref()) {
         Some(ValueType::Bool) => bool_::plan(type_, subject, clauses, context),
         Some(ValueType::Int) => int::plan(type_, subject, clauses, context),
@@ -46,14 +47,44 @@ pub(super) fn plan(
     }
 }
 
-fn validate_clause_shape(clause: &TypedClause) -> Result<(), PlanError> {
-    if !clause.alternative_patterns.is_empty() {
-        return Err(super::unsupported_case(
-            UnsupportedCaseReason::AlternativePatterns,
-        ));
+struct CaseClause {
+    pattern: Pattern<Arc<Type>>,
+    alternative_patterns: Vec<Pattern<Arc<Type>>>,
+    guard: Option<TypedClauseGuard>,
+    then: TypedExpr,
+}
+
+impl CaseClause {
+    fn from_typed(clause: TypedClause) -> Result<Self, PlanError> {
+        let TypedClause {
+            pattern,
+            alternative_patterns,
+            guard,
+            then,
+            ..
+        } = clause;
+        Ok(Self {
+            pattern: single_case_pattern(pattern)?,
+            alternative_patterns: alternative_patterns
+                .into_iter()
+                .map(single_case_pattern)
+                .collect::<Result<_, _>>()?,
+            guard,
+            then,
+        })
     }
 
-    Ok(())
+    fn has_alternative_patterns(&self) -> bool {
+        !self.alternative_patterns.is_empty()
+    }
+
+    fn patterns(&self) -> impl Iterator<Item = Pattern<Arc<Type>>> + '_ {
+        std::iter::once(self.pattern.clone()).chain(self.alternative_patterns.iter().cloned())
+    }
+}
+
+fn case_clauses(clauses: Vec<TypedClause>) -> Result<Vec<CaseClause>, PlanError> {
+    clauses.into_iter().map(CaseClause::from_typed).collect()
 }
 
 fn single_case_pattern(patterns: Vec<Pattern<Arc<Type>>>) -> Result<Pattern<Arc<Type>>, PlanError> {
@@ -355,23 +386,12 @@ mod tests {
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
     use crate::planner::{
-        InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
-        UnsupportedExpressionKind,
+        InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
     };
     use ecow::EcoString;
     use gleam_core::ast::TypedExpr;
     use gleam_core::type_;
     use std::collections::HashMap;
-
-    #[test]
-    fn reject_profile_subject_clause_shapes() {
-        assert_eq!(
-            expect_plan_error(r#"pub fn main() { case True { True | False -> 1 } }"#),
-            PlanError::UnsupportedCase {
-                reason: UnsupportedCaseReason::AlternativePatterns,
-            },
-        );
-    }
 
     #[test]
     fn reject_profile_unreachable_subject_clause_body() {
@@ -448,6 +468,37 @@ pub fn main() {
         clauses[0].pattern.push(pattern);
         assert_eq!(
             plan_module(extra_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
+                },
+            }),
+        );
+
+        let mut empty_alternative_pattern = super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut empty_alternative_pattern.definitions.functions[0].body[0],
+        );
+        clauses[0].alternative_patterns.push(Vec::new());
+        assert_eq!(
+            plan_module(empty_alternative_pattern),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,
+                },
+            }),
+        );
+
+        let mut extra_alternative_pattern = super::super::compile_bool_case_module();
+        let (_, _, clauses) = super::super::expect_case_statement_mut(
+            &mut extra_alternative_pattern.definitions.functions[0].body[0],
+        );
+        let pattern = clauses[0].pattern[0].clone();
+        clauses[0]
+            .alternative_patterns
+            .push(vec![pattern.clone(), pattern]);
+        assert_eq!(
+            plan_module(extra_alternative_pattern),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CaseShape {
                     reason: InvalidCaseShapeReason::PatternSubjectCountMismatch,

--- a/src/planner/expression/case/subject/bool_.rs
+++ b/src/planner/expression/case/subject/bool_.rs
@@ -1,26 +1,26 @@
 use super::super::super::plan_bool_expr;
 use super::super::invalid_case_shape;
-use super::{case_return_type, single_case_pattern, validate_clause_shape};
+use super::{CaseClause, OrderedCaseClause, OrderedCaseClauseInput, case_return_type};
 use crate::plan::{BoolExpr, Expr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, InvalidTypedAstReason, PlanError};
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{Pattern, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
 pub(super) fn plan(
     type_: Arc<Type>,
     subject: TypedExpr,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     let subject = plan_bool_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
-    for clause in &clauses {
-        validate_clause_shape(clause)?;
-    }
-    if clauses.iter().any(|clause| clause.guard.is_some()) {
+    if clauses
+        .iter()
+        .any(|clause| clause.guard.is_some() || clause.has_alternative_patterns())
+    {
         let (subject_step, subject) = super::bind_bool_case_subject(subject, context);
         let case = plan_guarded_bool_case(type_.as_ref(), return_type, subject, clauses, context)?;
         return Ok(super::case_subject_block(subject_step, case));
@@ -35,8 +35,7 @@ pub(super) fn plan(
     let mut true_branch = None;
     let mut false_branch = None;
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_bool_case_pattern(pattern)?;
+        let pattern = plan_bool_case_pattern(clause.pattern)?;
         let bindings = super::branch_bindings(pattern.bound_names(), Expr::bool(subject.clone()));
         let branch =
             super::plan_case_branch(type_.as_ref(), &return_type, clause.then, bindings, context)?;
@@ -72,35 +71,37 @@ fn plan_guarded_bool_case(
     case_type: &Type,
     return_type: ValueType,
     subject: BoolExpr,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let mut true_clauses = Vec::with_capacity(clauses.len());
-    let mut false_clauses = Vec::with_capacity(clauses.len());
+    let mut true_clauses = Vec::new();
+    let mut false_clauses = Vec::new();
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_bool_case_pattern(pattern)?;
-        let bindings = super::branch_bindings(pattern.bound_names(), Expr::bool(subject.clone()));
-        let is_total = clause.guard.is_none();
-        let ordered_clause = super::plan_ordered_case_clause(
-            super::OrderedCaseClauseInput {
-                case_type,
-                return_type: &return_type,
-                then: clause.then,
-                branch_bindings: bindings,
-                guard: clause.guard,
-                match_condition: BoolExpr::value(true),
-                is_total,
-            },
-            context,
-        )?;
+        for pattern in clause.patterns() {
+            let pattern = plan_bool_case_pattern(pattern)?;
+            let bindings =
+                super::branch_bindings(pattern.bound_names(), Expr::bool(subject.clone()));
+            let is_total = clause.guard.is_none();
+            let ordered_clause = super::plan_ordered_case_clause(
+                OrderedCaseClauseInput {
+                    case_type,
+                    return_type: &return_type,
+                    then: clause.then.clone(),
+                    branch_bindings: bindings,
+                    guard: clause.guard.clone(),
+                    match_condition: BoolExpr::value(true),
+                    is_total,
+                },
+                context,
+            )?;
 
-        match pattern {
-            BoolCasePattern::Literal { value: true, .. } => true_clauses.push(ordered_clause),
-            BoolCasePattern::Literal { value: false, .. } => false_clauses.push(ordered_clause),
-            BoolCasePattern::Any { .. } => {
-                true_clauses.push(ordered_clause.clone());
-                false_clauses.push(ordered_clause);
+            match pattern {
+                BoolCasePattern::Literal { value: true, .. } => true_clauses.push(ordered_clause),
+                BoolCasePattern::Literal { value: false, .. } => false_clauses.push(ordered_clause),
+                BoolCasePattern::Any { .. } => {
+                    true_clauses.push(ordered_clause.clone());
+                    false_clauses.push(ordered_clause);
+                }
             }
         }
     }
@@ -113,7 +114,7 @@ fn plan_guarded_bool_case(
 }
 
 fn ordered_bool_case_branch(
-    clauses: Vec<super::OrderedCaseClause>,
+    clauses: Vec<OrderedCaseClause>,
     missing_reason: InvalidCaseShapeReason,
 ) -> Result<Expr, PlanError> {
     super::ordered_case_expr(clauses).map_err(|error| match error {
@@ -209,8 +210,8 @@ fn plan_bool_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<BoolCasePattern
     }
 }
 
-fn clause_has_bool_bound_name(clause: &TypedClause) -> bool {
-    clause.pattern.iter().any(bool_pattern_has_bound_name)
+fn clause_has_bool_bound_name(clause: &CaseClause) -> bool {
+    bool_pattern_has_bound_name(&clause.pattern)
 }
 
 fn bool_pattern_has_bound_name(pattern: &Pattern<Arc<Type>>) -> bool {

--- a/src/planner/expression/case/subject/float.rs
+++ b/src/planner/expression/case/subject/float.rs
@@ -1,26 +1,26 @@
 use super::super::super::plan_float_expr;
 use super::super::invalid_case_shape;
-use super::{case_return_type, single_case_pattern, validate_clause_shape};
+use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
 use crate::plan::{BoolExpr, Expr, ExprKind, FloatCaseBranches, FloatExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError};
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{Pattern, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
 pub(super) fn plan(
     type_: Arc<Type>,
     subject: TypedExpr,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     let subject = plan_float_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
-    for clause in &clauses {
-        validate_clause_shape(clause)?;
-    }
-    if clauses.iter().any(|clause| clause.guard.is_some()) {
+    if clauses
+        .iter()
+        .any(|clause| clause.guard.is_some() || clause.has_alternative_patterns())
+    {
         let (subject_step, subject) = super::bind_float_case_subject(subject, context);
         let case = plan_guarded_float_case(type_.as_ref(), return_type, subject, clauses, context)?;
         return Ok(super::case_subject_block(subject_step, case));
@@ -35,8 +35,7 @@ pub(super) fn plan(
     let mut literal_clauses = Vec::new();
     let mut fallback = None;
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_float_case_pattern(pattern)?;
+        let pattern = plan_float_case_pattern(clause.pattern)?;
         let bindings = super::branch_bindings(pattern.bound_names(), Expr::float(subject.clone()));
         let branch =
             super::plan_case_branch(type_.as_ref(), &return_type, clause.then, bindings, context)?;
@@ -73,34 +72,37 @@ fn plan_guarded_float_case(
     case_type: &Type,
     return_type: ValueType,
     subject: FloatExpr,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    let mut ordered_clauses = Vec::new();
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_float_case_pattern(pattern)?;
-        let bindings = super::branch_bindings(pattern.bound_names(), Expr::float(subject.clone()));
-        let is_total = matches!(pattern, FloatCasePattern::Any { .. }) && clause.guard.is_none();
-        let match_condition = match pattern {
-            FloatCasePattern::Literal { value, .. } => BoolExpr::equal(
-                Expr::float(subject.clone()),
-                Expr::float(FloatExpr::value(value)),
-            ),
-            FloatCasePattern::Any { .. } => BoolExpr::value(true),
-        };
-        ordered_clauses.push(super::plan_ordered_case_clause(
-            super::OrderedCaseClauseInput {
-                case_type,
-                return_type: &return_type,
-                then: clause.then,
-                branch_bindings: bindings,
-                guard: clause.guard,
-                match_condition,
-                is_total,
-            },
-            context,
-        )?);
+        for pattern in clause.patterns() {
+            let pattern = plan_float_case_pattern(pattern)?;
+            let bindings =
+                super::branch_bindings(pattern.bound_names(), Expr::float(subject.clone()));
+            let is_total =
+                matches!(pattern, FloatCasePattern::Any { .. }) && clause.guard.is_none();
+            let match_condition = match pattern {
+                FloatCasePattern::Literal { value, .. } => BoolExpr::equal(
+                    Expr::float(subject.clone()),
+                    Expr::float(FloatExpr::value(value)),
+                ),
+                FloatCasePattern::Any { .. } => BoolExpr::value(true),
+            };
+            ordered_clauses.push(super::plan_ordered_case_clause(
+                OrderedCaseClauseInput {
+                    case_type,
+                    return_type: &return_type,
+                    then: clause.then.clone(),
+                    branch_bindings: bindings,
+                    guard: clause.guard.clone(),
+                    match_condition,
+                    is_total,
+                },
+                context,
+            )?);
+        }
     }
 
     super::ordered_case_expr(ordered_clauses)
@@ -172,8 +174,8 @@ fn plan_float_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<FloatCasePatte
     }
 }
 
-fn clause_has_float_bound_name(clause: &TypedClause) -> bool {
-    clause.pattern.iter().any(float_pattern_has_bound_name)
+fn clause_has_float_bound_name(clause: &CaseClause) -> bool {
+    float_pattern_has_bound_name(&clause.pattern)
 }
 
 fn float_pattern_has_bound_name(pattern: &Pattern<Arc<Type>>) -> bool {
@@ -550,10 +552,9 @@ mod tests {
     use crate::planner::support::{dummy_span, expect_plan_error};
     use crate::planner::{
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
-        UnsupportedCaseReason, UnsupportedExpressionKind,
+        UnsupportedExpressionKind,
     };
     use gleam_core::ast::{ClauseGuard, Constant, Pattern, TypedModule};
-    use gleam_core::parse::LiteralFloatValue;
     use gleam_core::type_::{self, error::VariableOrigin};
     use num_bigint::BigInt;
 
@@ -1145,22 +1146,6 @@ pub fn main() {
 
     #[test]
     fn reject_margin_float_case_pattern_shapes() {
-        let mut alternative_pattern = compile_float_case_module();
-        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
-            &mut alternative_pattern.definitions.functions[0].body[0],
-        );
-        clauses[0].alternative_patterns.push(vec![Pattern::Float {
-            location: dummy_span(),
-            value: "2.0".into(),
-            float_value: LiteralFloatValue::ONE,
-        }]);
-        assert_eq!(
-            plan_module(alternative_pattern),
-            Err(PlanError::UnsupportedCase {
-                reason: UnsupportedCaseReason::AlternativePatterns,
-            }),
-        );
-
         let mut variable_type_mismatch = compile_float_case_module();
         let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut variable_type_mismatch.definitions.functions[0].body[0],

--- a/src/planner/expression/case/subject/function.rs
+++ b/src/planner/expression/case/subject/function.rs
@@ -1,6 +1,6 @@
 use super::super::super::plan_expr_with_expected_source_stop_type;
 use super::super::invalid_case_shape;
-use super::{case_return_type, single_case_pattern, validate_clause_shape};
+use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
 use crate::plan::{
     BoolExpr, Expr, ExprKind, FunctionExpr, FunctionExprKind, FunctionFunctionExpr,
     FunctionFunctionLocalId, FunctionType, IntFunctionExpr, IntFunctionLocalId, Step, ValueType,
@@ -8,7 +8,7 @@ use crate::plan::{
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError};
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{Pattern, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
@@ -16,16 +16,13 @@ pub(super) fn plan(
     type_: Arc<Type>,
     subject: TypedExpr,
     subject_type: FunctionType,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     let subject_value_type = ValueType::Function(Box::new(subject_type));
     let subject =
         plan_expr_with_expected_source_stop_type(subject, subject_value_type.clone(), context)?;
     let return_type = case_return_type(type_.as_ref())?;
-    for clause in &clauses {
-        validate_clause_shape(clause)?;
-    }
 
     let ExprKind::Function(subject) = subject.into_kind() else {
         return Err(invalid_case_shape(
@@ -33,24 +30,25 @@ pub(super) fn plan(
         ));
     };
     let (subject_step, subject) = bind_function_case_subject(subject, context);
-    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    let mut ordered_clauses = Vec::new();
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_function_case_pattern(pattern, &subject_value_type)?;
-        let bindings = super::branch_bindings(pattern.bound_names(), subject.clone());
-        let is_total = clause.guard.is_none();
-        ordered_clauses.push(super::plan_ordered_case_clause(
-            super::OrderedCaseClauseInput {
-                case_type: type_.as_ref(),
-                return_type: &return_type,
-                then: clause.then,
-                branch_bindings: bindings,
-                guard: clause.guard,
-                match_condition: BoolExpr::value(true),
-                is_total,
-            },
-            context,
-        )?);
+        for pattern in clause.patterns() {
+            let pattern = plan_function_case_pattern(pattern, &subject_value_type)?;
+            let bindings = super::branch_bindings(pattern.bound_names(), subject.clone());
+            let is_total = clause.guard.is_none();
+            ordered_clauses.push(super::plan_ordered_case_clause(
+                OrderedCaseClauseInput {
+                    case_type: type_.as_ref(),
+                    return_type: &return_type,
+                    then: clause.then.clone(),
+                    branch_bindings: bindings,
+                    guard: clause.guard.clone(),
+                    match_condition: BoolExpr::value(true),
+                    is_total,
+                },
+                context,
+            )?);
+        }
     }
 
     super::ordered_case_expr(ordered_clauses)
@@ -268,9 +266,7 @@ mod tests {
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
-    use crate::planner::{
-        InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
-    };
+    use crate::planner::{InvalidCaseShapeReason, InvalidTypedAstReason, PlanError};
     use ecow::EcoString;
     use gleam_core::type_::error::VariableOrigin;
     use std::collections::HashMap;
@@ -547,28 +543,6 @@ pub fn main() {
                     function_function_type,
                 ))),
             ),
-        );
-    }
-
-    #[test]
-    fn reject_profile_function_subject_alternative_patterns() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  case add_one {
-    _ | _ -> 1
-  }
-}
-"#,
-            ),
-            PlanError::UnsupportedCase {
-                reason: UnsupportedCaseReason::AlternativePatterns,
-            },
         );
     }
 

--- a/src/planner/expression/case/subject/int.rs
+++ b/src/planner/expression/case/subject/int.rs
@@ -1,11 +1,11 @@
 use super::super::super::plan_int_expr;
 use super::super::invalid_case_shape;
-use super::{case_return_type, single_case_pattern, validate_clause_shape};
+use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
 use crate::plan::{BoolExpr, Expr, ExprKind, IntCaseBranches, IntExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError};
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{Pattern, TypedExpr};
 use gleam_core::type_::Type;
 use num_bigint::BigInt;
 use std::sync::Arc;
@@ -13,15 +13,15 @@ use std::sync::Arc;
 pub(super) fn plan(
     type_: Arc<Type>,
     subject: TypedExpr,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     let subject = plan_int_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
-    for clause in &clauses {
-        validate_clause_shape(clause)?;
-    }
-    if clauses.iter().any(|clause| clause.guard.is_some()) {
+    if clauses
+        .iter()
+        .any(|clause| clause.guard.is_some() || clause.has_alternative_patterns())
+    {
         let (subject_step, subject) = super::bind_int_case_subject(subject, context);
         let case = plan_guarded_int_case(type_.as_ref(), return_type, subject, clauses, context)?;
         return Ok(super::case_subject_block(subject_step, case));
@@ -36,8 +36,7 @@ pub(super) fn plan(
     let mut literal_clauses = Vec::new();
     let mut fallback = None;
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_int_case_pattern(pattern)?;
+        let pattern = plan_int_case_pattern(clause.pattern)?;
         let bindings = super::branch_bindings(pattern.bound_names(), Expr::int(subject.clone()));
         let branch =
             super::plan_case_branch(type_.as_ref(), &return_type, clause.then, bindings, context)?;
@@ -74,33 +73,35 @@ fn plan_guarded_int_case(
     case_type: &Type,
     return_type: ValueType,
     subject: IntExpr,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    let mut ordered_clauses = Vec::new();
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_int_case_pattern(pattern)?;
-        let bindings = super::branch_bindings(pattern.bound_names(), Expr::int(subject.clone()));
-        let is_total = matches!(pattern, IntCasePattern::Any { .. }) && clause.guard.is_none();
-        let match_condition = match pattern {
-            IntCasePattern::Literal { value, .. } => {
-                BoolExpr::equal(Expr::int(subject.clone()), Expr::int(IntExpr::value(value)))
-            }
-            IntCasePattern::Any { .. } => BoolExpr::value(true),
-        };
-        ordered_clauses.push(super::plan_ordered_case_clause(
-            super::OrderedCaseClauseInput {
-                case_type,
-                return_type: &return_type,
-                then: clause.then,
-                branch_bindings: bindings,
-                guard: clause.guard,
-                match_condition,
-                is_total,
-            },
-            context,
-        )?);
+        for pattern in clause.patterns() {
+            let pattern = plan_int_case_pattern(pattern)?;
+            let bindings =
+                super::branch_bindings(pattern.bound_names(), Expr::int(subject.clone()));
+            let is_total = matches!(pattern, IntCasePattern::Any { .. }) && clause.guard.is_none();
+            let match_condition = match pattern {
+                IntCasePattern::Literal { value, .. } => {
+                    BoolExpr::equal(Expr::int(subject.clone()), Expr::int(IntExpr::value(value)))
+                }
+                IntCasePattern::Any { .. } => BoolExpr::value(true),
+            };
+            ordered_clauses.push(super::plan_ordered_case_clause(
+                OrderedCaseClauseInput {
+                    case_type,
+                    return_type: &return_type,
+                    then: clause.then.clone(),
+                    branch_bindings: bindings,
+                    guard: clause.guard.clone(),
+                    match_condition,
+                    is_total,
+                },
+                context,
+            )?);
+        }
     }
 
     super::ordered_case_expr(ordered_clauses)
@@ -172,8 +173,8 @@ fn plan_int_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<IntCasePattern, 
     }
 }
 
-fn clause_has_int_bound_name(clause: &TypedClause) -> bool {
-    clause.pattern.iter().any(int_pattern_has_bound_name)
+fn clause_has_int_bound_name(clause: &CaseClause) -> bool {
+    int_pattern_has_bound_name(&clause.pattern)
 }
 
 fn int_pattern_has_bound_name(pattern: &Pattern<Arc<Type>>) -> bool {
@@ -550,7 +551,7 @@ mod tests {
     use crate::planner::support::{dummy_span, expect_plan_error};
     use crate::planner::{
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
-        UnsupportedCaseReason, UnsupportedExpressionKind,
+        UnsupportedExpressionKind,
     };
     use gleam_core::ast::{ClauseGuard, Constant, Pattern, TypedModule};
     use gleam_core::type_::{self, error::VariableOrigin};
@@ -919,6 +920,44 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_int_case_alternative_patterns_expand_to_ordered_fallthrough() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case 1 {
+    1 | 2 -> 10
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let first_condition = BoolExpr::equal(local_int(0, "<case:int:0>").into(), int(1).into());
+        let second_condition = BoolExpr::equal(local_int(0, "<case:int:0>").into(), int(2).into());
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_int_step(0, "<case:int:0>", int(1))],
+                    IntReturn::bool_case(
+                        first_condition,
+                        int_return_expr(int(10)),
+                        IntReturn::bool_case(
+                            second_condition,
+                            int_return_expr(int(10)),
+                            int_return_expr(int(0)),
+                        ),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn plan_int_case_function_expr_shape() {
         let actual = super::int_case_expr(
             int(1).into(),
@@ -1195,21 +1234,6 @@ pub fn main() {
                     .expect("function-returning function expression"),
             }),
         );
-    }
-
-    #[test]
-    fn reject_profile_int_case_patterns() {
-        let cases = [(
-            r#"pub fn main() { case 1 { 1 | 2 -> 1 _ -> 0 } }"#,
-            UnsupportedCaseReason::AlternativePatterns,
-        )];
-
-        for (src, reason) in cases {
-            assert_eq!(
-                expect_plan_error(src),
-                PlanError::UnsupportedCase { reason },
-            );
-        }
     }
 
     #[test]

--- a/src/planner/expression/case/subject/list.rs
+++ b/src/planner/expression/case/subject/list.rs
@@ -1,11 +1,11 @@
 use super::super::super::plan_expr_with_expected_source_stop_type;
 use super::super::{invalid_case_shape, unsupported_case};
-use super::{case_return_type, single_case_pattern, validate_clause_shape};
+use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
 use crate::plan::{BoolExpr, Expr, ExprKind, ListExpr, ListLocalId, Step, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{Pattern, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
@@ -13,16 +13,13 @@ pub(super) fn plan(
     type_: Arc<Type>,
     subject: TypedExpr,
     element_type: ValueType,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     let subject_value_type = ValueType::List(Box::new(element_type.clone()));
     let subject =
         plan_expr_with_expected_source_stop_type(subject, subject_value_type.clone(), context)?;
     let return_type = case_return_type(type_.as_ref())?;
-    for clause in &clauses {
-        validate_clause_shape(clause)?;
-    }
 
     let ExprKind::List(subject) = subject.into_kind() else {
         return Err(invalid_case_shape(
@@ -30,24 +27,25 @@ pub(super) fn plan(
         ));
     };
     let (subject_step, subject) = bind_list_case_subject(subject, context);
-    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    let mut ordered_clauses = Vec::new();
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_list_case_pattern(pattern, &subject_value_type)?;
-        let bindings = super::branch_bindings(pattern.bound_names(), subject.clone());
-        let is_total = clause.guard.is_none();
-        ordered_clauses.push(super::plan_ordered_case_clause(
-            super::OrderedCaseClauseInput {
-                case_type: type_.as_ref(),
-                return_type: &return_type,
-                then: clause.then,
-                branch_bindings: bindings,
-                guard: clause.guard,
-                match_condition: BoolExpr::value(true),
-                is_total,
-            },
-            context,
-        )?);
+        for pattern in clause.patterns() {
+            let pattern = plan_list_case_pattern(pattern, &subject_value_type)?;
+            let bindings = super::branch_bindings(pattern.bound_names(), subject.clone());
+            let is_total = clause.guard.is_none();
+            ordered_clauses.push(super::plan_ordered_case_clause(
+                OrderedCaseClauseInput {
+                    case_type: type_.as_ref(),
+                    return_type: &return_type,
+                    then: clause.then.clone(),
+                    branch_bindings: bindings,
+                    guard: clause.guard.clone(),
+                    match_condition: BoolExpr::value(true),
+                    is_total,
+                },
+                context,
+            )?);
+        }
     }
 
     super::ordered_case_expr(ordered_clauses)
@@ -276,24 +274,6 @@ pub fn main() {
             ),
             PlanError::UnsupportedCase {
                 reason: UnsupportedCaseReason::ListPattern,
-            },
-        );
-    }
-
-    #[test]
-    fn reject_profile_list_subject_alternative_patterns() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  case [1] {
-    _ | _ -> 1
-  }
-}
-"#,
-            ),
-            PlanError::UnsupportedCase {
-                reason: UnsupportedCaseReason::AlternativePatterns,
             },
         );
     }

--- a/src/planner/expression/case/subject/nil.rs
+++ b/src/planner/expression/case/subject/nil.rs
@@ -1,25 +1,22 @@
 use super::super::super::plan_expr_with_expected_source_stop_type;
 use super::super::invalid_case_shape;
-use super::{case_return_type, single_case_pattern, validate_clause_shape};
+use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
 use crate::plan::{BoolExpr, Expr, ExprKind, NilExpr, NilLocalId, Step, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError};
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{Pattern, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
 pub(super) fn plan(
     type_: Arc<Type>,
     subject: TypedExpr,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     let subject = plan_expr_with_expected_source_stop_type(subject, ValueType::Nil, context)?;
     let return_type = case_return_type(type_.as_ref())?;
-    for clause in &clauses {
-        validate_clause_shape(clause)?;
-    }
 
     let ExprKind::Nil(subject) = subject.into_kind() else {
         return Err(invalid_case_shape(
@@ -27,24 +24,25 @@ pub(super) fn plan(
         ));
     };
     let (subject_step, subject) = bind_nil_case_subject(subject, context);
-    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    let mut ordered_clauses = Vec::new();
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_nil_case_pattern(pattern)?;
-        let bindings = super::branch_bindings(pattern.bound_names(), subject.clone());
-        let is_total = clause.guard.is_none();
-        ordered_clauses.push(super::plan_ordered_case_clause(
-            super::OrderedCaseClauseInput {
-                case_type: type_.as_ref(),
-                return_type: &return_type,
-                then: clause.then,
-                branch_bindings: bindings,
-                guard: clause.guard,
-                match_condition: BoolExpr::value(true),
-                is_total,
-            },
-            context,
-        )?);
+        for pattern in clause.patterns() {
+            let pattern = plan_nil_case_pattern(pattern)?;
+            let bindings = super::branch_bindings(pattern.bound_names(), subject.clone());
+            let is_total = clause.guard.is_none();
+            ordered_clauses.push(super::plan_ordered_case_clause(
+                OrderedCaseClauseInput {
+                    case_type: type_.as_ref(),
+                    return_type: &return_type,
+                    then: clause.then.clone(),
+                    branch_bindings: bindings,
+                    guard: clause.guard.clone(),
+                    match_condition: BoolExpr::value(true),
+                    is_total,
+                },
+                context,
+            )?);
+        }
     }
 
     super::ordered_case_expr(ordered_clauses)
@@ -131,9 +129,7 @@ mod tests {
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
-    use crate::planner::{
-        InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedCaseReason,
-    };
+    use crate::planner::{InvalidCaseShapeReason, InvalidTypedAstReason, PlanError};
     use gleam_core::type_::error::VariableOrigin;
 
     #[test]
@@ -194,24 +190,6 @@ pub fn main() {
         );
 
         assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn reject_profile_nil_subject_alternative_patterns() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  case Nil {
-    _ | _ -> 1
-  }
-}
-"#,
-            ),
-            PlanError::UnsupportedCase {
-                reason: UnsupportedCaseReason::AlternativePatterns,
-            },
-        );
     }
 
     #[test]

--- a/src/planner/expression/case/subject/string.rs
+++ b/src/planner/expression/case/subject/string.rs
@@ -1,29 +1,27 @@
 use super::super::super::plan_string_expr;
 use super::super::invalid_case_shape;
-use super::{case_return_type, single_case_pattern, validate_clause_shape};
+use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
 use crate::plan::{BoolExpr, Expr, ExprKind, StringCaseBranches, StringExpr, ValueType};
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError};
 use ecow::EcoString;
-use gleam_core::ast::{AssignName, Pattern, TypedClause, TypedExpr};
+use gleam_core::ast::{AssignName, Pattern, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
 pub(super) fn plan(
     type_: Arc<Type>,
     subject: TypedExpr,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     let subject = plan_string_expr(subject, context)?;
     let return_type = case_return_type(type_.as_ref())?;
-    for clause in &clauses {
-        validate_clause_shape(clause)?;
-    }
-    if clauses
-        .iter()
-        .any(|clause| clause.guard.is_some() || clause_has_string_prefix_pattern(clause))
-    {
+    if clauses.iter().any(|clause| {
+        clause.guard.is_some()
+            || clause.has_alternative_patterns()
+            || clause_has_string_prefix_pattern(clause)
+    }) {
         let (subject_step, subject) = super::bind_string_case_subject(subject, context);
         let case =
             plan_ordered_string_case(type_.as_ref(), return_type, subject, clauses, context)?;
@@ -39,8 +37,7 @@ pub(super) fn plan(
     let mut literal_clauses = Vec::new();
     let mut fallback = None;
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_literal_string_case_pattern(pattern)?;
+        let pattern = plan_literal_string_case_pattern(clause.pattern)?;
         let bindings = pattern.branch_bindings(&subject);
         let branch =
             super::plan_case_branch(type_.as_ref(), &return_type, clause.then, bindings, context)?;
@@ -77,28 +74,29 @@ fn plan_ordered_string_case(
     case_type: &Type,
     return_type: ValueType,
     subject: StringExpr,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
-    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    let mut ordered_clauses = Vec::new();
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern = plan_string_case_pattern(pattern)?;
-        let bindings = pattern.branch_bindings(&subject);
-        let is_total = pattern.is_total() && clause.guard.is_none();
-        let match_condition = pattern.match_condition(&subject);
-        ordered_clauses.push(super::plan_ordered_case_clause(
-            super::OrderedCaseClauseInput {
-                case_type,
-                return_type: &return_type,
-                then: clause.then,
-                branch_bindings: bindings,
-                guard: clause.guard,
-                match_condition,
-                is_total,
-            },
-            context,
-        )?);
+        for pattern in clause.patterns() {
+            let pattern = plan_string_case_pattern(pattern)?;
+            let bindings = pattern.branch_bindings(&subject);
+            let is_total = pattern.is_total() && clause.guard.is_none();
+            let match_condition = pattern.match_condition(&subject);
+            ordered_clauses.push(super::plan_ordered_case_clause(
+                OrderedCaseClauseInput {
+                    case_type,
+                    return_type: &return_type,
+                    then: clause.then.clone(),
+                    branch_bindings: bindings,
+                    guard: clause.guard.clone(),
+                    match_condition,
+                    is_total,
+                },
+                context,
+            )?);
+        }
     }
 
     super::ordered_case_expr(ordered_clauses)
@@ -334,12 +332,14 @@ fn plan_string_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<StringCasePat
     }
 }
 
-fn clause_has_string_bound_name(clause: &TypedClause) -> bool {
-    clause.pattern.iter().any(string_pattern_has_bound_name)
+fn clause_has_string_bound_name(clause: &CaseClause) -> bool {
+    string_pattern_has_bound_name(&clause.pattern)
 }
 
-fn clause_has_string_prefix_pattern(clause: &TypedClause) -> bool {
-    clause.pattern.iter().any(string_pattern_has_prefix)
+fn clause_has_string_prefix_pattern(clause: &CaseClause) -> bool {
+    std::iter::once(&clause.pattern)
+        .chain(&clause.alternative_patterns)
+        .any(string_pattern_has_prefix)
 }
 
 fn string_pattern_has_bound_name(pattern: &Pattern<Arc<Type>>) -> bool {
@@ -725,7 +725,7 @@ mod tests {
     use crate::planner::support::{dummy_span, expect_plan_error};
     use crate::planner::{
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
-        UnsupportedCaseReason, UnsupportedExpressionKind,
+        UnsupportedExpressionKind,
     };
     use gleam_core::ast::{ClauseGuard, Constant, Pattern, TypedModule};
     use gleam_core::type_::{self, error::VariableOrigin};
@@ -1339,21 +1339,6 @@ pub fn main() {
 
     #[test]
     fn reject_margin_string_case_pattern_shapes() {
-        let mut alternative_pattern = compile_string_case_module();
-        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
-            &mut alternative_pattern.definitions.functions[0].body[0],
-        );
-        clauses[0].alternative_patterns.push(vec![Pattern::String {
-            location: dummy_span(),
-            value: "two".into(),
-        }]);
-        assert_eq!(
-            plan_module(alternative_pattern),
-            Err(PlanError::UnsupportedCase {
-                reason: UnsupportedCaseReason::AlternativePatterns,
-            }),
-        );
-
         let mut variable_type_mismatch = compile_string_case_module();
         let (_, _, clauses) = super::super::super::expect_case_statement_mut(
             &mut variable_type_mismatch.definitions.functions[0].body[0],

--- a/src/planner/expression/case/subject/tuple.rs
+++ b/src/planner/expression/case/subject/tuple.rs
@@ -1,7 +1,7 @@
 use super::super::super::plan_expr_with_expected_source_stop_type;
 use super::super::super::tuple_index_expr;
 use super::super::invalid_case_shape;
-use super::{case_return_type, single_case_pattern, validate_clause_shape};
+use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
 use crate::plan::{
     BoolExpr, Expr, ExprKind, FloatExpr, IntExpr, Step, StringExpr, TupleExpr, TupleLocalId,
     ValueType,
@@ -9,7 +9,7 @@ use crate::plan::{
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use ecow::EcoString;
-use gleam_core::ast::{AssignName, Pattern, SrcSpan, TypedClause, TypedExpr};
+use gleam_core::ast::{AssignName, Pattern, SrcSpan, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
@@ -17,16 +17,13 @@ pub(super) fn plan(
     type_: Arc<Type>,
     subject: TypedExpr,
     subject_type: Vec<ValueType>,
-    clauses: Vec<TypedClause>,
+    clauses: Vec<CaseClause>,
     context: &mut PlanContext<'_>,
 ) -> Result<Expr, PlanError> {
     let subject_value_type = ValueType::Tuple(subject_type.clone());
     let subject =
         plan_expr_with_expected_source_stop_type(subject, subject_value_type.clone(), context)?;
     let return_type = case_return_type(type_.as_ref())?;
-    for clause in &clauses {
-        validate_clause_shape(clause)?;
-    }
 
     let ExprKind::Tuple(subject) = subject.into_kind() else {
         return Err(invalid_case_shape(
@@ -34,25 +31,26 @@ pub(super) fn plan(
         ));
     };
     let (subject_step, subject) = bind_tuple_case_subject(subject, context);
-    let mut ordered_clauses = Vec::with_capacity(clauses.len());
+    let mut ordered_clauses = Vec::new();
     for clause in clauses {
-        let pattern = single_case_pattern(clause.pattern)?;
-        let pattern =
-            plan_tuple_case_pattern(pattern, subject.clone(), subject_value_type.clone())?;
-        let is_total = pattern.is_total() && clause.guard.is_none();
-        let match_condition = pattern.match_condition();
-        ordered_clauses.push(super::plan_ordered_case_clause(
-            super::OrderedCaseClauseInput {
-                case_type: type_.as_ref(),
-                return_type: &return_type,
-                then: clause.then,
-                branch_bindings: pattern.branch_bindings,
-                guard: clause.guard,
-                match_condition,
-                is_total,
-            },
-            context,
-        )?);
+        for pattern in clause.patterns() {
+            let pattern =
+                plan_tuple_case_pattern(pattern, subject.clone(), subject_value_type.clone())?;
+            let is_total = pattern.is_total() && clause.guard.is_none();
+            let match_condition = pattern.match_condition();
+            ordered_clauses.push(super::plan_ordered_case_clause(
+                OrderedCaseClauseInput {
+                    case_type: type_.as_ref(),
+                    return_type: &return_type,
+                    then: clause.then.clone(),
+                    branch_bindings: pattern.branch_bindings,
+                    guard: clause.guard.clone(),
+                    match_condition,
+                    is_total,
+                },
+                context,
+            )?);
+        }
     }
 
     super::ordered_case_expr(ordered_clauses)
@@ -423,6 +421,142 @@ pub fn main() {
                                 ),
                             ),
                             int_return_expr(int(999)),
+                        ),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_tuple_subject_alternatives_bind_each_pattern_scope_independently() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case #(11, 37) {
+    #(value, 0) | #(11, value) -> value
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let tuple_type = vec![ValueType::Int, ValueType::Int];
+        let first_binding = let_int_step(
+            0,
+            "value",
+            local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(0),
+        );
+        let second_binding = let_int_step(
+            1,
+            "value",
+            local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(1),
+        );
+        let first_condition = BoolExpr::equal(
+            Expr::from(local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(1)),
+            Expr::from(int(0)),
+        );
+        let second_condition = BoolExpr::equal(
+            Expr::from(local_tuple(0, "<case:tuple:0>", tuple_type).index_int(0)),
+            Expr::from(int(11)),
+        );
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_tuple_step(
+                        0,
+                        "<case:tuple:0>",
+                        tuple([int(11), int(37)]),
+                    )],
+                    crate::plan::IntReturn::bool_case(
+                        first_condition,
+                        int_return_block([first_binding], int_return_expr(local_int(0, "value"))),
+                        crate::plan::IntReturn::bool_case(
+                            second_condition,
+                            int_return_block(
+                                [second_binding],
+                                int_return_expr(local_int(1, "value")),
+                            ),
+                            int_return_expr(int(0)),
+                        ),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_tuple_subject_alternative_guard_wraps_each_pattern_binding() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case #(11, 37) {
+    #(left, 0) | #(11, left) if left > 20 -> left
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let tuple_type = vec![ValueType::Int, ValueType::Int];
+        let first_binding = let_int_step(
+            0,
+            "left",
+            local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(0),
+        );
+        let second_binding = let_int_step(
+            1,
+            "left",
+            local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(1),
+        );
+        let first_condition = BoolExpr::and(
+            BoolExpr::equal(
+                Expr::from(local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(1)),
+                Expr::from(int(0)),
+            ),
+            BoolExpr::block(
+                vec![first_binding.clone()],
+                BoolExpr::gt_int(local_int(0, "left").into(), int(20).into()),
+            ),
+        );
+        let second_condition = BoolExpr::and(
+            BoolExpr::equal(
+                Expr::from(local_tuple(0, "<case:tuple:0>", tuple_type.clone()).index_int(0)),
+                Expr::from(int(11)),
+            ),
+            BoolExpr::block(
+                vec![second_binding.clone()],
+                BoolExpr::gt_int(local_int(1, "left").into(), int(20).into()),
+            ),
+        );
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_tuple_step(
+                        0,
+                        "<case:tuple:0>",
+                        tuple([int(11), int(37)]),
+                    )],
+                    crate::plan::IntReturn::bool_case(
+                        first_condition,
+                        int_return_block([first_binding], int_return_expr(local_int(0, "left"))),
+                        crate::plan::IntReturn::bool_case(
+                            second_condition,
+                            int_return_block(
+                                [second_binding],
+                                int_return_expr(local_int(1, "left")),
+                            ),
+                            int_return_expr(int(0)),
                         ),
                     ),
                 ),
@@ -844,24 +978,6 @@ pub fn main() {
                     reason: InvalidCaseShapeReason::InvalidPattern,
                 },
             }),
-        );
-    }
-
-    #[test]
-    fn reject_profile_tuple_subject_alternative_patterns() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  case #(1, 2) {
-    _ | _ -> 1
-  }
-}
-"#,
-            ),
-            PlanError::UnsupportedCase {
-                reason: UnsupportedCaseReason::AlternativePatterns,
-            },
         );
     }
 

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -175,6 +175,12 @@ mod control_flow {
             string_prefix_empty,
             tuple_inner_string_prefix_pattern,
             string_prefix_closure_capture,
+            alternative_patterns,
+            alternative_guard_fallthrough,
+            alternative_tuple_binding_positions,
+            alternative_subject_families,
+            alternative_closure_capture,
+            tuple_alternative_patterns,
         );
     }
 }
@@ -440,9 +446,7 @@ mod rejection {
 
     mod case_patterns {
         rejection_cases!("case_patterns";
-            alternative_patterns,
             multiple_subjects,
-            tuple_alternative_patterns,
             tuple_inner_list_pattern,
             list_pattern,
             list_pattern_alias,

--- a/tests/fixtures/execution/control_flow/case/alternative_closure_capture.gleam
+++ b/tests/fixtures/execution/control_flow/case/alternative_closure_capture.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case #(1, 2) {
+    #(1, value) | #(value, 1) -> fn() { value }()
+    _ -> 0
+  }
+}
+
+// geam:expect Int(2)

--- a/tests/fixtures/execution/control_flow/case/alternative_guard_fallthrough.gleam
+++ b/tests/fixtures/execution/control_flow/case/alternative_guard_fallthrough.gleam
@@ -1,0 +1,10 @@
+pub fn main() {
+  let value = 2
+  case value {
+    1 | 2 if False -> 10
+    2 -> 20
+    _ -> 0
+  }
+}
+
+// geam:expect Int(20)

--- a/tests/fixtures/execution/control_flow/case/alternative_patterns.gleam
+++ b/tests/fixtures/execution/control_flow/case/alternative_patterns.gleam
@@ -5,3 +5,5 @@ pub fn main() {
     _ -> 0
   }
 }
+
+// geam:expect Int(10)

--- a/tests/fixtures/execution/control_flow/case/alternative_subject_families.gleam
+++ b/tests/fixtures/execution/control_flow/case/alternative_subject_families.gleam
@@ -1,0 +1,34 @@
+fn apply(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  let bool_value = case True {
+    False | True -> 1
+  }
+  let string_value = case "b" {
+    "a" | "b" -> 2
+    _ -> 0
+  }
+  let float_value = case 2.5 {
+    1.5 | 2.5 -> 3
+    _ -> 0
+  }
+  let nil_value = case Nil {
+    Nil | _ -> 4
+  }
+  let list_value = case [1, 2] {
+    values | _ as values -> values == [1, 2]
+  }
+  let function_value = case apply {
+    f | _ as f -> f(5)
+  }
+
+  bool_value + string_value + float_value + nil_value + function_value
+    + case list_value {
+      True -> 6
+      False -> 0
+    }
+}
+
+// geam:expect Int(22)

--- a/tests/fixtures/execution/control_flow/case/alternative_tuple_binding_positions.gleam
+++ b/tests/fixtures/execution/control_flow/case/alternative_tuple_binding_positions.gleam
@@ -1,0 +1,9 @@
+pub fn main() {
+  let pair = #(11, 37)
+  case pair {
+    #(value, 0) | #(11, value) -> value
+    _ -> 0
+  }
+}
+
+// geam:expect Int(37)

--- a/tests/fixtures/execution/control_flow/case/tuple_alternative_patterns.gleam
+++ b/tests/fixtures/execution/control_flow/case/tuple_alternative_patterns.gleam
@@ -5,3 +5,5 @@ pub fn main() {
     _ -> 0
   }
 }
+
+// geam:expect Int(2)


### PR DESCRIPTION
- Lower `p1 | p2` case clauses as ordered fallthrough candidates.
- Keep each alternative branch binding scope independent, including guards.
- Example: `case 1 { 1 | 2 -> 10 _ -> 0 }`.
- Move accepted alternative case fixtures into execution coverage.
