### PR TITLE
Restore complete BitArray coverage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/src/plan/execution/id.rs
+++ b/src/plan/execution/id.rs
@@ -584,8 +584,8 @@ mod tests {
     use super::{
         BitArrayFunctionFunctionId, BitArrayListLocalId, BoolListLocalId, FloatListLocalId,
         FunctionFunctionId, FunctionListLocalId, FunctionReturnFamily, IntFunctionFunctionId,
-        IntListLocalId, ListListLocalId, ListLocal, NilListLocalId, StringListLocalId,
-        TupleListLocalId,
+        IntListLocalId, ListFunctionFunctionId, ListListLocalId, ListLocal, NilListLocalId,
+        RuntimeFunctionId, StringListLocalId, TupleListLocalId,
     };
     use crate::plan::ValueType;
 
@@ -742,6 +742,37 @@ pub fn main() { Nil }
         assert_eq!(
             FunctionFunctionId::Int(IntFunctionFunctionId(0)).bit_array(),
             None,
+        );
+    }
+
+    #[test]
+    fn bit_array_list_function_function_id_preserves_exact_return_type() {
+        let plan = execution_plan("pub fn main() -> fn() -> List(BitArray) { fn() { [] } }");
+        let list_type = plan.bit_array_list_function_id(0).type_id();
+        let return_type = crate::plan::execution::FunctionType::new(
+            Vec::new(),
+            crate::plan::execution::ValueType::List(list_type.list_type()),
+        );
+        let id = ListFunctionFunctionId::BitArray {
+            id: super::BitArrayListFunctionFunctionId(0),
+            type_: return_type.clone(),
+            list_type,
+        };
+
+        assert_eq!(
+            plan.main_runtime(),
+            RuntimeFunctionId::Function {
+                id: FunctionFunctionId::List(id.clone()),
+                return_type: return_type.clone(),
+            },
+        );
+
+        assert_eq!(
+            plan.function_type(id.type_()),
+            crate::plan::FunctionType::new(
+                Vec::new(),
+                crate::plan::ValueType::List(Box::new(crate::plan::ValueType::BitArray)),
+            ),
         );
     }
 

--- a/src/plan/module/frame/return_/function.rs
+++ b/src/plan/module/frame/return_/function.rs
@@ -509,14 +509,15 @@ impl FrameLayout {
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        BitArrayFunctionFunctionId, BoolExpr, BoolFunctionExpr, BoolFunctionFunctionId,
-        BoolFunctionLocalId, BoolLocalId, CallArg, Expr, FloatExpr, FloatFunctionExpr,
-        FloatFunctionFunctionId, FloatFunctionLocalId, FloatLocalId, FrameLayout,
-        FunctionFunctionExpr, FunctionFunctionFunctionId, FunctionFunctionLocalId, FunctionType,
-        IntExpr, IntFunctionFunctionId, IntFunctionLocalId, IntLocalId, ListFunctionExpr,
-        ListFunctionFunctionId, ListFunctionLocal, NilFunctionExpr, NilFunctionFunctionId,
-        NilFunctionLocalId, ReturnBody, ReturnExpr, Step, StringExpr, StringFunctionExpr,
-        StringFunctionFunctionId, StringFunctionLocalId, StringLocalId, ValueType,
+        BitArrayFunctionExpr, BitArrayFunctionFunctionId, BitArrayFunctionLocalId, BoolExpr,
+        BoolFunctionExpr, BoolFunctionFunctionId, BoolFunctionLocalId, BoolLocalId, CallArg, Expr,
+        FloatExpr, FloatFunctionExpr, FloatFunctionFunctionId, FloatFunctionLocalId, FloatLocalId,
+        FrameLayout, FunctionFunctionExpr, FunctionFunctionFunctionId, FunctionFunctionLocalId,
+        FunctionType, IntExpr, IntFunctionFunctionId, IntFunctionLocalId, IntLocalId,
+        ListFunctionExpr, ListFunctionFunctionId, ListFunctionLocal, NilFunctionExpr,
+        NilFunctionFunctionId, NilFunctionLocalId, ReturnBody, ReturnExpr, Step, StringExpr,
+        StringFunctionExpr, StringFunctionFunctionId, StringFunctionLocalId, StringLocalId,
+        ValueType,
     };
 
     #[test]
@@ -784,6 +785,50 @@ mod tests {
         let layout = FrameLayout::from_function_parts(&[], &[], &return_);
 
         assert_eq!(layout.ints(), 4);
+    }
+
+    #[test]
+    fn frame_layout_includes_every_bit_array_function_return_case_dependency() {
+        let type_ = FunctionType::new(Vec::new(), ValueType::BitArray);
+        let local = |index: usize, name: &str| {
+            BitArrayFunctionExpr::local_get(
+                BitArrayFunctionLocalId(index),
+                name.into(),
+                type_.clone(),
+            )
+        };
+        let return_ = ReturnExpr::bit_array_function_body(
+            BitArrayFunctionFunctionId(0),
+            type_.clone(),
+            ReturnBody::bool_case(
+                BoolExpr::local_get(BoolLocalId(0), "bool_subject".into()),
+                ReturnBody::int_case(
+                    IntExpr::local_get(IntLocalId(1), "int_subject".into()),
+                    vec![(
+                        1.into(),
+                        ReturnBody::string_case(
+                            StringExpr::local_get(StringLocalId(2), "string_subject".into()),
+                            vec![("one".into(), ReturnBody::expr(local(4, "string_branch")))],
+                            ReturnBody::expr(local(5, "string_fallback")),
+                        ),
+                    )],
+                    ReturnBody::float_case(
+                        FloatExpr::local_get(FloatLocalId(3), "float_subject".into()),
+                        vec![(1.0, ReturnBody::expr(local(6, "float_branch")))],
+                        ReturnBody::expr(local(7, "float_fallback")),
+                    ),
+                ),
+                ReturnBody::expr(local(8, "bool_fallback")),
+            ),
+        );
+
+        let layout = FrameLayout::from_function_parts(&[], &[], &return_);
+
+        assert_eq!(layout.bools(), 1);
+        assert_eq!(layout.ints(), 2);
+        assert_eq!(layout.strings(), 3);
+        assert_eq!(layout.floats(), 4);
+        assert_eq!(layout.bit_array_functions, 9);
     }
 
     #[test]

--- a/src/planner/dsl.rs
+++ b/src/planner/dsl.rs
@@ -3,17 +3,18 @@ mod function;
 mod module;
 
 pub(crate) use expression::{
-    block_function, block_int, block_int_function, bool_, bool_arg, bool_case_int_function,
-    bool_function_ref, call_bool, call_float, call_int, call_int_function,
-    call_int_returning_function, call_list, capture_int, capture_tuple, equal, evaluate_step,
-    float, float_arg, float_function_ref, function_function_closure, function_function_ref,
-    function_ref, int, int_arg, int_case_int_function, int_function_arg, int_function_call_arg,
-    int_function_closure, int_function_ref, let_bool_function_step, let_bool_step, let_float_step,
-    let_int_function_step, let_int_step, let_list_step, let_nil_function_step, let_nil_step,
-    let_string_function_step, let_string_step, let_tuple_step, list, list_function_ref,
-    list_spread, local_bool, local_float, local_int, local_int_function, local_list, local_nil,
-    local_string, local_tuple, nil, nil_arg, nil_function_ref, not_equal, string, string_arg,
-    string_function_ref, tuple, tuple_arg, tuple_function_closure, tuple_function_ref,
+    bit_array, bit_array_function_ref, block_function, block_int, block_int_function, bool_,
+    bool_arg, bool_case_int_function, bool_function_ref, call_bool, call_float, call_int,
+    call_int_function, call_int_returning_function, call_list, capture_int, capture_tuple, equal,
+    evaluate_step, float, float_arg, float_function_ref, function_function_closure,
+    function_function_ref, function_ref, int, int_arg, int_case_int_function, int_function_arg,
+    int_function_call_arg, int_function_closure, int_function_ref, let_bool_function_step,
+    let_bool_step, let_float_step, let_int_function_step, let_int_step, let_list_step,
+    let_nil_function_step, let_nil_step, let_string_function_step, let_string_step, let_tuple_step,
+    list, list_function_ref, list_spread, local_bool, local_float, local_int, local_int_function,
+    local_list, local_nil, local_string, local_tuple, nil, nil_arg, nil_function_ref, not_equal,
+    string, string_arg, string_function_ref, tuple, tuple_arg, tuple_function_closure,
+    tuple_function_ref,
 };
 pub(crate) use function::{
     bool_function_return_block, bool_function_return_bool_case, bool_function_return_expr,

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -1386,6 +1386,19 @@ pub fn main() {
     }
 
     #[test]
+    fn plan_list_index_expr_preserves_bit_array_item_family() {
+        let list = ListExpr::value(Vec::new(), ValueType::BitArray);
+
+        assert_eq!(
+            super::list_index_expr(list.clone(), 2, ValueType::BitArray),
+            Ok(Expr::bit_array(BitArrayExpr::list_index(
+                list.into_bit_array().expect("bit array list"),
+                2,
+            ))),
+        );
+    }
+
+    #[test]
     fn plan_tuple_index_result_families() {
         assert_tuple_index_plan(
             r#"

--- a/src/planner/expression/bit_array.rs
+++ b/src/planner/expression/bit_array.rs
@@ -51,7 +51,7 @@ enum SegmentKind {
 fn plan_segment<Value>(
     value: Expr,
     options: Vec<BitArrayOption<Value>>,
-    int_literal: impl Fn(&Value) -> Option<BigInt>,
+    int_literal: fn(&Value) -> Option<BigInt>,
 ) -> Result<BitArraySegment, PlanError> {
     let value_type = value.value_type();
     let mut kind = None;
@@ -275,6 +275,18 @@ mod tests {
         );
         assert_eq!(
             plan_segment(
+                Expr::float(FloatExpr::value(1.5)),
+                vec![BitArrayOption::Float { location }],
+                |_: &()| None,
+            ),
+            Ok(BitArraySegment::Float {
+                value: FloatExpr::value(1.5),
+                bit_size: FloatBitSize::SixtyFour,
+                endianness: Endianness::Big,
+            }),
+        );
+        assert_eq!(
+            plan_segment(
                 Expr::bit_array(BitArrayExpr::value(Vec::new())),
                 vec![BitArrayOption::Bits { location }],
                 |_: &()| None,
@@ -319,7 +331,19 @@ mod tests {
         for options in [
             vec![
                 BitArrayOption::Int { location },
+                BitArrayOption::Int { location },
+            ],
+            vec![
+                BitArrayOption::Int { location },
                 BitArrayOption::Float { location },
+            ],
+            vec![
+                BitArrayOption::Bits { location },
+                BitArrayOption::Bits { location },
+            ],
+            vec![
+                BitArrayOption::Utf8 { location },
+                BitArrayOption::Utf8 { location },
             ],
             vec![
                 BitArrayOption::Int { location },
@@ -409,6 +433,37 @@ mod tests {
         );
         assert_eq!(
             plan_segment(
+                Expr::float(FloatExpr::value(1.0)),
+                vec![BitArrayOption::Size {
+                    location,
+                    value: Box::new(()),
+                    short_form: false,
+                }],
+                |_: &()| Some(16.into()),
+            ),
+            Err(PlanError::UnsupportedBitArraySegment {
+                reason: UnsupportedBitArraySegmentReason::Float16,
+            }),
+        );
+        assert_eq!(
+            plan_segment(
+                Expr::bit_array(BitArrayExpr::value(Vec::new())),
+                vec![
+                    BitArrayOption::Bits { location },
+                    BitArrayOption::Size {
+                        location,
+                        value: Box::new(()),
+                        short_form: false,
+                    },
+                ],
+                |_: &()| Some(8.into()),
+            ),
+            Err(PlanError::UnsupportedBitArraySegment {
+                reason: UnsupportedBitArraySegmentReason::SizedBits,
+            }),
+        );
+        assert_eq!(
+            plan_segment(
                 Expr::int(IntExpr::value(1.into())),
                 vec![BitArrayOption::Size {
                     location,
@@ -442,6 +497,10 @@ mod tests {
                 "pub fn main() { <<1.5:float-size(16)>> }",
                 UnsupportedBitArraySegmentReason::Float16,
             ),
+            (
+                "const value = <<1:native>> pub fn main() { value }",
+                UnsupportedBitArraySegmentReason::NativeEndianness,
+            ),
         ];
 
         for (source, reason) in cases {
@@ -450,6 +509,16 @@ mod tests {
                 PlanError::UnsupportedBitArraySegment { reason },
             );
         }
+    }
+
+    #[test]
+    fn reject_profile_bit_array_segment_expression_error() {
+        assert_eq!(
+            crate::planner::support::expect_plan_error("pub fn main() { <<echo 1>> }"),
+            PlanError::UnsupportedExpression {
+                kind: crate::planner::error::UnsupportedExpressionKind::Echo,
+            },
+        );
     }
 
     #[test]

--- a/src/planner/expression/case/guard.rs
+++ b/src/planner/expression/case/guard.rs
@@ -385,13 +385,13 @@ fn invalid_expression_shape(kind: InvalidExpressionShapeKind) -> Result<Expr, Pl
 mod tests {
     use super::{contains_function_value, function_local_get, invalid_expression_type, plan_expr};
     use crate::plan::{
-        BitArrayFunctionExpr, BitArrayFunctionLocalId, BoolExpr, BoolFunctionExpr,
-        BoolFunctionLocalId, BoolLocalId, Expr, FloatExpr, FloatFunctionExpr, FloatFunctionLocalId,
-        FunctionExpr, FunctionFunctionExpr, FunctionFunctionLocalId, FunctionType, IntExpr,
-        IntFunctionExpr, IntFunctionLocalId, IntLocalId, ListExpr, ListFunctionExpr, ListLocal,
-        LocalId, NilExpr, NilFunctionExpr, NilFunctionLocalId, NilLocalId, StringExpr,
-        StringFunctionExpr, StringFunctionLocalId, StringListLocalId, TupleExpr, TupleFunctionExpr,
-        TupleFunctionLocalId, TupleLocalId, ValueType,
+        BitArrayExpr, BitArrayFunctionExpr, BitArrayFunctionLocalId, BitArrayLocalId, BoolExpr,
+        BoolFunctionExpr, BoolFunctionLocalId, BoolLocalId, Expr, FloatExpr, FloatFunctionExpr,
+        FloatFunctionLocalId, FunctionExpr, FunctionFunctionExpr, FunctionFunctionLocalId,
+        FunctionType, IntExpr, IntFunctionExpr, IntFunctionLocalId, IntLocalId, ListExpr,
+        ListFunctionExpr, ListLocal, LocalId, NilExpr, NilFunctionExpr, NilFunctionLocalId,
+        NilLocalId, StringExpr, StringFunctionExpr, StringFunctionLocalId, StringListLocalId,
+        TupleExpr, TupleFunctionExpr, TupleFunctionLocalId, TupleLocalId, ValueType,
     };
     use crate::planner::context::{AnonymousFunctions, FunctionLocalBinding, PlanContext};
     use crate::planner::support::dummy_span;
@@ -1040,6 +1040,7 @@ mod tests {
         let functions = HashMap::new();
         let mut anonymous = AnonymousFunctions::default();
         let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        context.define_bit_array_local("bits".into());
         context.define_nil_local("none".into());
         context.define_tuple_local("pair".into(), vec![ValueType::Int]);
         context.define_list_local("values".into(), ValueType::String);
@@ -1048,6 +1049,13 @@ mod tests {
             FunctionType::new(vec![ValueType::Int], ValueType::Int),
         );
 
+        assert_eq!(
+            super::plan_local("bits".into(), &context),
+            Ok(Expr::bit_array(BitArrayExpr::local_get(
+                BitArrayLocalId(0),
+                "bits".into(),
+            ))),
+        );
         assert_eq!(
             super::plan_local("none".into(), &context),
             Ok(Expr::nil(NilExpr::local_get(NilLocalId(0), "none".into()))),

--- a/src/planner/expression/case/subject.rs
+++ b/src/planner/expression/case/subject.rs
@@ -348,6 +348,17 @@ fn case_return_type(case_type: &Type) -> Result<ValueType, PlanError> {
         .ok_or_else(|| super::invalid_case_shape(InvalidCaseShapeReason::BranchReturnTypeMismatch))
 }
 
+#[cfg(test)]
+fn unsupported_case_return_type() -> Arc<Type> {
+    gleam_core::type_::named(
+        "package",
+        "main",
+        "Unsupported",
+        gleam_core::ast::Publicity::Public,
+        Vec::new(),
+    )
+}
+
 fn plan_case_branch(
     case_type: &Type,
     return_type: &ValueType,
@@ -598,6 +609,20 @@ mod tests {
                 BoolExpr::value(true),
                 BoolListCaseBranches::String { true_, false_ },
             ))),
+        );
+
+        let true_ = ListExpr::value(Vec::new(), ValueType::BitArray)
+            .into_bit_array()
+            .expect("bit array list should build BitArrayListExpr");
+        let false_ = ListExpr::value(Vec::new(), ValueType::BitArray)
+            .into_bit_array()
+            .expect("bit array list should build BitArrayListExpr");
+        assert_eq!(
+            super::bool_list_case_branches(
+                ListExpr::BitArray(true_.clone()),
+                ListExpr::BitArray(false_.clone()),
+            ),
+            Ok(BoolListCaseBranches::BitArray { true_, false_ }),
         );
 
         let true_ = ListExpr::value(Vec::new(), ValueType::Float)
@@ -919,6 +944,22 @@ pub fn main() {
 pub fn main() {
   case Ok(1), 2 {
     _, _ -> 0
+  }
+}
+"#,
+            ),
+            super::super::unsupported_case(UnsupportedCaseReason::UnsupportedSubjectType),
+        );
+    }
+
+    #[test]
+    fn reject_profile_single_subject_with_unsupported_value_family() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case Ok(1) {
+    _ -> 0
   }
 }
 "#,

--- a/src/planner/expression/case/subject/bit_array.rs
+++ b/src/planner/expression/case/subject/bit_array.rs
@@ -104,6 +104,7 @@ mod tests {
     use crate::planner::support::{dummy_span, expect_plan_error};
     use crate::planner::{
         InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
+        UnsupportedPatternKind,
     };
     use gleam_core::ast::Pattern;
 
@@ -160,6 +161,28 @@ pub fn main() {
 
     #[test]
     fn reject_margin_bit_array_subject_invalid_and_mismatched_patterns() {
+        let mut unsupported_case_type = crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case <<1>> {
+    _ -> 1
+  }
+}
+"#,
+        );
+        let (case_type, _, _) = super::super::super::expect_case_statement_mut(
+            &mut unsupported_case_type.definitions.functions[0].body[0],
+        );
+        *case_type = super::super::unsupported_case_return_type();
+        assert_eq!(
+            plan_module(unsupported_case_type),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            }),
+        );
+
         let mut invalid = crate::planner::support::compile(
             r#"
 pub fn main() {
@@ -211,6 +234,35 @@ pub fn main() {
             }),
         );
 
+        let mut invalid_alias = crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case <<1>> {
+    value as alias -> 1
+  }
+}
+"#,
+        );
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut invalid_alias.definitions.functions[0].body[0],
+        );
+        clauses[0].pattern[0] = Pattern::Assign {
+            name: "alias".into(),
+            location: dummy_span(),
+            pattern: Box::new(Pattern::Invalid {
+                location: dummy_span(),
+                type_: gleam_core::type_::bit_array(),
+            }),
+        };
+        assert_eq!(
+            plan_module(invalid_alias),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::InvalidPattern,
+                },
+            }),
+        );
+
         let mut subject_mismatch = crate::planner::support::compile(
             r#"
 pub fn main() {
@@ -236,6 +288,43 @@ pub fn main() {
                     reason: InvalidCaseShapeReason::PatternTypeMismatch,
                 },
             }),
+        );
+    }
+
+    #[test]
+    fn reject_profile_structural_bit_array_pattern() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case <<1>> {
+    <<1>> -> 1
+    _ -> 0
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedPattern {
+                kind: UnsupportedPatternKind::BitArray,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_profile_bit_array_subject_expression_error() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case echo <<1>> {
+    _ -> 1
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedExpression {
+                kind: crate::planner::UnsupportedExpressionKind::Echo,
+            },
         );
     }
 

--- a/src/planner/expression/case/subject/bool_.rs
+++ b/src/planner/expression/case/subject/bool_.rs
@@ -1238,7 +1238,7 @@ pub fn main() {
         let (type_, _, _) = super::super::super::expect_case_statement_mut(
             &mut module.definitions.functions[0].body[0],
         );
-        *type_ = type_::bit_array();
+        *type_ = super::super::unsupported_case_return_type();
 
         assert_eq!(
             plan_module(module),

--- a/src/planner/expression/case/subject/float.rs
+++ b/src/planner/expression/case/subject/float.rs
@@ -592,11 +592,11 @@ mod tests {
         RuntimeFunctionId, StringFunctionId, TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        bool_, bool_return_expr, bool_return_float_case, float, float_return_block,
-        float_return_expr, float_return_float_case, function, function_ref, int, int_return_expr,
-        int_return_float_case, let_float_step, list, list_return_expr, list_return_float_case,
-        local_float, module, nil, nil_return_expr, nil_return_float_case, return_list, string,
-        string_return_expr, string_return_float_case, tuple,
+        bit_array, bit_array_function_ref, bool_, bool_return_expr, bool_return_float_case, float,
+        float_return_block, float_return_expr, float_return_float_case, function, function_ref,
+        int, int_return_expr, int_return_float_case, let_float_step, list, list_return_expr,
+        list_return_float_case, local_float, module, nil, nil_return_expr, nil_return_float_case,
+        return_list, string, string_return_expr, string_return_float_case, tuple,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -1484,8 +1484,25 @@ fn add_one(value: Float) {
         let (type_, _, _) = super::super::super::expect_case_statement_mut(
             &mut module.definitions.functions[0].body[0],
         );
-        *type_ = type_::bit_array();
+        *type_ = super::super::unsupported_case_return_type();
         assert_eq!(plan_module(module), Err(case_branch_return_type_mismatch()));
+
+        assert_eq!(
+            super::float_case_expr(
+                float(1.0).into(),
+                vec![(1.0, int(1).into())],
+                bit_array([]).into(),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::float_case_expr(
+                float(1.0).into(),
+                vec![(1.0, int_function_ref_expr(0))],
+                bit_array_function_ref(0, Vec::<LocalId>::new()).into(),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
 
         assert_eq!(
             super::float_case_expr(

--- a/src/planner/expression/case/subject/function.rs
+++ b/src/planner/expression/case/subject/function.rs
@@ -272,14 +272,15 @@ fn internal_function_function_case_subject_name(local: FunctionFunctionLocalId) 
 mod tests {
     use super::bind_function_case_subject;
     use crate::plan::{
-        Expr, FunctionExpr, FunctionFunctionExpr, FunctionFunctionFunctionId, FunctionFunctionId,
-        FunctionFunctionLocalId, FunctionType, IntLocalId, LocalId, Step, ValueType,
+        BitArrayFunctionExpr, BitArrayFunctionLocalId, Expr, FunctionExpr, FunctionFunctionExpr,
+        FunctionFunctionFunctionId, FunctionFunctionId, FunctionFunctionLocalId, FunctionType,
+        IntLocalId, LocalId, Step, ValueType,
     };
     use crate::planner::context::{AnonymousFunctions, FunctionInfo, PlanContext};
     use crate::planner::dsl::{
-        bool_function_ref, call_int_function, float_function_ref, function, function_function_ref,
-        int, int_function_call_arg, int_function_ref, int_return_block, int_return_expr,
-        let_bool_function_step, let_int_function_step, let_nil_function_step,
+        bit_array_function_ref, bool_function_ref, call_int_function, float_function_ref, function,
+        function_function_ref, int, int_function_call_arg, int_function_ref, int_return_block,
+        int_return_expr, let_bool_function_step, let_int_function_step, let_nil_function_step,
         let_string_function_step, list_function_ref, local_int, local_int_function, module,
         nil_function_ref, string_function_ref, tuple_function_ref,
     };
@@ -427,6 +428,24 @@ pub fn main() {
                         FunctionType::new(Vec::new(), ValueType::String),
                     ),
                 )),
+            ),
+        );
+        assert_eq!(
+            bind_function_case_subject(
+                bit_array_function_ref(0, Vec::<LocalId>::new()).into(),
+                &mut context,
+            ),
+            (
+                Step::let_bit_array_function(
+                    BitArrayFunctionLocalId(0),
+                    "<case:bit_array_function:0>".into(),
+                    bit_array_function_ref(0, Vec::<LocalId>::new()).into(),
+                ),
+                Expr::function(FunctionExpr::bit_array(BitArrayFunctionExpr::local_get(
+                    BitArrayFunctionLocalId(0),
+                    "<case:bit_array_function:0>".into(),
+                    FunctionType::new(Vec::new(), ValueType::BitArray),
+                ))),
             ),
         );
         assert_eq!(
@@ -640,7 +659,7 @@ pub fn main() {
         let (case_type, _, _) = super::super::super::expect_case_statement_mut(
             &mut unsupported_case_type.definitions.functions[1].body[0],
         );
-        *case_type = gleam_core::type_::bit_array();
+        *case_type = super::super::unsupported_case_return_type();
         assert_eq!(
             plan_module(unsupported_case_type),
             Err(PlanError::InvalidTypedAst {

--- a/src/planner/expression/case/subject/int.rs
+++ b/src/planner/expression/case/subject/int.rs
@@ -591,11 +591,11 @@ mod tests {
         RuntimeFunctionId, StringFunctionId, TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        bool_, bool_return_expr, bool_return_int_case, float, function, function_ref, int,
-        int_return_block, int_return_expr, int_return_int_case, let_int_step, list,
-        list_return_expr, list_return_int_case, local_int, module, nil, nil_return_expr,
-        nil_return_int_case, return_list, string, string_return_expr, string_return_int_case,
-        tuple,
+        bit_array, bit_array_function_ref, bool_, bool_return_expr, bool_return_int_case, float,
+        function, function_ref, int, int_return_block, int_return_expr, int_return_int_case,
+        let_int_step, list, list_return_expr, list_return_int_case, local_int, module, nil,
+        nil_return_expr, nil_return_int_case, return_list, string, string_return_expr,
+        string_return_int_case, tuple,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -1611,8 +1611,25 @@ fn add_one(value: Int) {
         let (type_, _, _) = super::super::super::expect_case_statement_mut(
             &mut module.definitions.functions[0].body[0],
         );
-        *type_ = type_::bit_array();
+        *type_ = super::super::unsupported_case_return_type();
         assert_eq!(plan_module(module), Err(case_branch_return_type_mismatch()));
+
+        assert_eq!(
+            super::int_case_expr(
+                int(1).into(),
+                vec![(BigInt::from(1), int(1).into())],
+                bit_array([]).into(),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::int_case_expr(
+                int(1).into(),
+                vec![(BigInt::from(1), int_function_ref_expr(0))],
+                bit_array_function_ref(0, Vec::<LocalId>::new()).into(),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
 
         assert_eq!(
             super::int_case_expr(

--- a/src/planner/expression/case/subject/list.rs
+++ b/src/planner/expression/case/subject/list.rs
@@ -413,6 +413,7 @@ mod tests {
     use crate::planner::support::{dummy_span, expect_plan_error};
     use crate::planner::{
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
+        UnsupportedPatternKind,
     };
     use gleam_core::type_::error::VariableOrigin;
 
@@ -700,7 +701,7 @@ pub fn main() {
         let (case_type, _, _) = super::super::super::expect_case_statement_mut(
             &mut unsupported_case_type.definitions.functions[0].body[0],
         );
-        *case_type = gleam_core::type_::bit_array();
+        *case_type = super::super::unsupported_case_return_type();
         assert_eq!(
             plan_module(unsupported_case_type),
             Err(PlanError::InvalidTypedAst {
@@ -1570,6 +1571,25 @@ pub fn main() {
                     reason: InvalidCaseShapeReason::PatternTypeMismatch,
                 },
             }),
+        );
+    }
+
+    #[test]
+    fn reject_profile_list_nested_bit_array_pattern() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case [<<1>>] {
+    [<<1>>] -> 1
+    _ -> 0
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedPattern {
+                kind: UnsupportedPatternKind::BitArray,
+            },
         );
     }
 }

--- a/src/planner/expression/case/subject/nil.rs
+++ b/src/planner/expression/case/subject/nil.rs
@@ -242,7 +242,7 @@ pub fn main() {
         let (case_type, _, _) = super::super::super::expect_case_statement_mut(
             &mut unsupported_case_type.definitions.functions[0].body[0],
         );
-        *case_type = gleam_core::type_::bit_array();
+        *case_type = super::super::unsupported_case_return_type();
         assert_eq!(
             plan_module(unsupported_case_type),
             Err(PlanError::InvalidTypedAst {

--- a/src/planner/expression/case/subject/string.rs
+++ b/src/planner/expression/case/subject/string.rs
@@ -767,11 +767,11 @@ mod tests {
         TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        bool_, bool_return_expr, bool_return_string_case, float, function, function_ref, int,
-        int_return_expr, int_return_string_case, let_string_step, list, list_return_expr,
-        list_return_string_case, local_string, module, nil, nil_return_expr,
-        nil_return_string_case, return_list, string, string_return_block, string_return_expr,
-        string_return_string_case, tuple,
+        bit_array, bit_array_function_ref, bool_, bool_return_expr, bool_return_string_case, float,
+        function, function_ref, int, int_return_expr, int_return_string_case, let_string_step,
+        list, list_return_expr, list_return_string_case, local_string, module, nil,
+        nil_return_expr, nil_return_string_case, return_list, string, string_return_block,
+        string_return_expr, string_return_string_case, tuple,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -1752,8 +1752,25 @@ fn return_value(value: String) {
         let (type_, _, _) = super::super::super::expect_case_statement_mut(
             &mut module.definitions.functions[0].body[0],
         );
-        *type_ = type_::bit_array();
+        *type_ = super::super::unsupported_case_return_type();
         assert_eq!(plan_module(module), Err(case_branch_return_type_mismatch()));
+
+        assert_eq!(
+            super::string_case_expr(
+                string("one").into(),
+                vec![("one".into(), int(1).into())],
+                bit_array([]).into(),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::string_case_expr(
+                string("one").into(),
+                vec![("one".into(), int_function_ref_expr(0))],
+                bit_array_function_ref(0, Vec::<LocalId>::new()).into(),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
 
         assert_eq!(
             super::string_case_expr(

--- a/src/planner/expression/case/subject/tuple.rs
+++ b/src/planner/expression/case/subject/tuple.rs
@@ -313,7 +313,9 @@ mod tests {
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
-    use crate::planner::{InvalidCaseShapeReason, InvalidTypedAstReason, PlanError};
+    use crate::planner::{
+        InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedPatternKind,
+    };
     use gleam_core::ast::{AssignName, Pattern};
     use gleam_core::parse::LiteralFloatValue;
     use gleam_core::type_::error::VariableOrigin;
@@ -1132,7 +1134,7 @@ pub fn main() {
         let (case_type, _, _) = super::super::super::expect_case_statement_mut(
             &mut unsupported_case_type.definitions.functions[0].body[0],
         );
-        *case_type = gleam_core::type_::bit_array();
+        *case_type = super::super::unsupported_case_return_type();
         assert_eq!(
             plan_module(unsupported_case_type),
             Err(PlanError::InvalidTypedAst {
@@ -1436,6 +1438,25 @@ pub fn main() {
                     reason: InvalidCaseShapeReason::PatternTypeMismatch,
                 },
             }),
+        );
+    }
+
+    #[test]
+    fn reject_profile_tuple_nested_bit_array_pattern() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case #(<<1>>) {
+    #(<<1>>) -> 1
+    _ -> 0
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedPattern {
+                kind: UnsupportedPatternKind::BitArray,
+            },
         );
     }
 }

--- a/src/planner/expression/constant.rs
+++ b/src/planner/expression/constant.rs
@@ -299,7 +299,9 @@ mod tests {
     use crate::planner::plan_module;
     use crate::planner::support::{compile, dummy_span, expect_plan_error};
     use gleam_core::analyse::Inferred;
-    use gleam_core::ast::{Constant, Publicity, RecordBeingUpdated, Statement, TypedExpr};
+    use gleam_core::ast::{
+        BitArraySegment, Constant, Publicity, RecordBeingUpdated, Statement, TypedExpr,
+    };
     use gleam_core::type_::error::VariableOrigin;
     use gleam_core::type_::{self, Deprecation, ValueConstructor, ValueConstructorVariant};
     use std::collections::HashMap;
@@ -423,6 +425,67 @@ pub fn main() {
 
     #[test]
     fn reject_margin_invalid_constant_shapes() {
+        let invalid = || Constant::Invalid {
+            location: dummy_span(),
+            type_: type_::int(),
+            extra_information: None,
+        };
+        let invalid_error = Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionShape {
+                kind: InvalidExpressionShapeKind::Invalid,
+            },
+        });
+
+        assert_eq!(
+            plan_constant_literal(Constant::StringConcatenation {
+                location: dummy_span(),
+                left: Box::new(invalid()),
+                right: Box::new(Constant::String {
+                    location: dummy_span(),
+                    value: "right".into(),
+                }),
+            }),
+            invalid_error,
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::Tuple {
+                location: dummy_span(),
+                elements: vec![invalid()],
+                type_: type_::tuple(vec![type_::int()]),
+            }),
+            invalid_error,
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: vec![invalid()],
+                type_: type_::list(type_::int()),
+                tail: None,
+            }),
+            invalid_error,
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::List {
+                location: dummy_span(),
+                elements: Vec::new(),
+                type_: type_::list(type_::int()),
+                tail: Some(Box::new(invalid())),
+            }),
+            invalid_error,
+        );
+        assert_eq!(
+            plan_constant_literal(Constant::BitArray {
+                location: dummy_span(),
+                segments: vec![BitArraySegment {
+                    location: dummy_span(),
+                    value: Box::new(invalid()),
+                    options: Vec::new(),
+                    type_: type_::int(),
+                }],
+            }),
+            invalid_error,
+        );
+
         assert_eq!(
             plan_constant_literal(Constant::Tuple {
                 location: dummy_span(),

--- a/src/planner/expression/function/free_variables.rs
+++ b/src/planner/expression/function/free_variables.rs
@@ -465,7 +465,7 @@ pub fn main() {
 pub fn main() {
   let value = 1
   let size = 8
-  fn() { <<value:size(size)>> }
+  fn() { <<value:int, value:size(size)>> }
   1
 }
 "#,

--- a/src/planner/function/return_body/function_value.rs
+++ b/src/planner/function/return_body/function_value.rs
@@ -1055,7 +1055,55 @@ mod tests {
                 vec![step.clone()],
                 value.clone(),
             )),
-            ReturnBody::block(vec![step], ReturnBody::expr(value)),
+            ReturnBody::block(vec![step], ReturnBody::expr(value.clone())),
+        );
+        assert_eq!(
+            bit_array_function_return(BitArrayFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                value.clone(),
+                value.clone(),
+            )),
+            ReturnBody::bool_case(
+                BoolExpr::value(true),
+                ReturnBody::expr(value.clone()),
+                ReturnBody::expr(value.clone()),
+            ),
+        );
+        assert_eq!(
+            bit_array_function_return(BitArrayFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(BigInt::from(1), value.clone())],
+                value.clone(),
+            )),
+            ReturnBody::int_case(
+                IntExpr::value(1.into()),
+                vec![(BigInt::from(1), ReturnBody::expr(value.clone()))],
+                ReturnBody::expr(value.clone()),
+            ),
+        );
+        assert_eq!(
+            bit_array_function_return(BitArrayFunctionExpr::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), value.clone())],
+                value.clone(),
+            )),
+            ReturnBody::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), ReturnBody::expr(value.clone()))],
+                ReturnBody::expr(value.clone()),
+            ),
+        );
+        assert_eq!(
+            bit_array_function_return(BitArrayFunctionExpr::float_case(
+                FloatExpr::value(1.0),
+                vec![(1.0, value.clone())],
+                value.clone(),
+            )),
+            ReturnBody::float_case(
+                FloatExpr::value(1.0),
+                vec![(1.0, ReturnBody::expr(value.clone()))],
+                ReturnBody::expr(value),
+            ),
         );
     }
 

--- a/src/runtime/expression/bit_array.rs
+++ b/src/runtime/expression/bit_array.rs
@@ -231,18 +231,36 @@ use bitvec::view::BitView;
 
 #[cfg(test)]
 mod tests {
+    use bitvec::order::Msb0;
+    use bitvec::vec::BitVec;
+
     use crate::plan::{
-        BitArrayExpr, BitArrayFunctionId, BoolExpr, Expr, FloatExpr, FunctionId, FunctionPlan,
-        IntExpr, ListExpr, ModulePlan, PanicExpr, PanicSite, ReturnExpr, Step, StringExpr,
-        TupleExpr, ValueType,
+        BitArrayExpr, BitArrayFunctionId, BitArraySegment, BoolExpr, Endianness, Expr,
+        FloatBitSize, FloatExpr, FunctionId, FunctionPlan, IntExpr, ListExpr, ModulePlan,
+        PanicExpr, PanicSite, ReturnExpr, Step, StringEncoding, StringExpr, TupleExpr, ValueType,
     };
-    use crate::runtime::{ExecutionError, run_main};
+    use crate::runtime::{BitArrayValue, ExecutionError, ListValue, Value, run_main};
 
     #[test]
     fn module_expression_errors_propagate_through_bit_array_wrappers() {
         let panic = || PanicExpr::panic_at(None, PanicSite::unknown());
         let fallback = || BitArrayExpr::value(Vec::new());
         let expressions = [
+            BitArrayExpr::value(vec![BitArraySegment::Int {
+                value: IntExpr::panic(panic()),
+                bit_size: 8,
+                endianness: Endianness::Big,
+            }]),
+            BitArrayExpr::value(vec![BitArraySegment::Float {
+                value: FloatExpr::panic(panic()),
+                bit_size: FloatBitSize::SixtyFour,
+                endianness: Endianness::Big,
+            }]),
+            BitArrayExpr::value(vec![BitArraySegment::String {
+                value: StringExpr::panic(panic()),
+                encoding: StringEncoding::Utf8,
+            }]),
+            BitArrayExpr::value(vec![BitArraySegment::Bits(BitArrayExpr::panic(panic()))]),
             BitArrayExpr::tuple_index(TupleExpr::panic(panic(), vec![ValueType::BitArray]), 0),
             BitArrayExpr::list_index(
                 ListExpr::panic(panic(), ValueType::BitArray)
@@ -285,6 +303,125 @@ mod tests {
                 actual: ValueType::Int,
             },
         );
+    }
+
+    #[test]
+    fn source_aligned_little_endian_integer_preserves_byte_order() {
+        assert_eq!(
+            crate::runtime::run_src("pub fn main() { <<0x1234:little-size(16)>> }"),
+            Value::BitArray(BitArrayValue::from_bytes(vec![0x34, 0x12])),
+        );
+    }
+
+    #[test]
+    fn source_expression_paths_preserve_bit_array_values() {
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../tests/fixtures/execution/values/bit_array_expression_paths.gleam"
+            )),
+            Value::Tuple(
+                [
+                    1, 2, 3, 11, 12, 3, 4, 5, 6, 7, 8, 9, 10, 14, 15, 16, 17, 18, 19, 20, 21, 13
+                ]
+                .into_iter()
+                .map(|byte| Value::BitArray(BitArrayValue::from_bytes(vec![byte])))
+                .collect(),
+            ),
+        );
+    }
+
+    #[test]
+    fn source_expression_segments_preserve_bit_array_encodings() {
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../tests/fixtures/execution/values/bit_array_segments.gleam"
+            )),
+            expected_segment_values(),
+        );
+    }
+
+    #[test]
+    fn source_constant_segments_preserve_bit_array_encodings() {
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../tests/fixtures/execution/module_items/constant_bit_array_segments.gleam"
+            )),
+            expected_segment_values(),
+        );
+    }
+
+    #[test]
+    fn source_list_function_paths_preserve_bit_array_values() {
+        let bit_array = |byte| Value::BitArray(BitArrayValue::from_bytes(vec![byte]));
+
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../tests/fixtures/execution/values/bit_array_list_function_paths.gleam"
+            )),
+            Value::Tuple(vec![
+                bit_array(1),
+                bit_array(1),
+                bit_array(1),
+                bit_array(1),
+                bit_array(1),
+            ]),
+        );
+    }
+
+    #[test]
+    fn source_let_assert_tail_preserves_bit_array_values() {
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../tests/fixtures/execution/bindings/let_assert_bit_array_list.gleam"
+            )),
+            Value::Tuple(vec![
+                Value::BitArray(BitArrayValue::from_bytes(vec![1])),
+                Value::List(ListValue::bit_array(vec![BitArrayValue::from_bytes(vec![
+                    2
+                ])])),
+            ]),
+        );
+    }
+
+    #[test]
+    fn source_tail_calls_preserve_bit_array_return_families() {
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../tests/fixtures/execution/functions/tail_call/bit_array_return_families.gleam"
+            )),
+            Value::Tuple(vec![
+                Value::BitArray(BitArrayValue::from_bytes(vec![1])),
+                Value::BitArray(BitArrayValue::from_bytes(vec![2])),
+            ]),
+        );
+    }
+
+    fn expected_segment_values() -> Value {
+        let bit_array = |bytes, bit_len| {
+            let mut bits = BitVec::<u8, Msb0>::from_vec(bytes);
+            bits.truncate(bit_len);
+            Value::BitArray(BitArrayValue::from_evaluated(&bits))
+        };
+
+        Value::Tuple(vec![
+            bit_array(vec![], 0),
+            bit_array(vec![], 0),
+            bit_array(vec![0x23, 0x40], 12),
+            bit_array(vec![0x34, 0x20], 12),
+            bit_array(vec![0xf0], 4),
+            bit_array(vec![0x01], 8),
+            bit_array(vec![0x3f, 0xc0, 0x00, 0x00], 32),
+            bit_array(vec![0x00, 0x00, 0xc0, 0x3f], 32),
+            bit_array(vec![0x3f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], 64),
+            bit_array(vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf8, 0x3f], 64),
+            bit_array(vec![0xec, 0x95, 0x88], 24),
+            bit_array(vec![0xec, 0x95, 0x88], 24),
+            bit_array(vec![0xc5, 0x48], 16),
+            bit_array(vec![0x48, 0xc5], 16),
+            bit_array(vec![0x00, 0x00, 0x00, 0x41], 32),
+            bit_array(vec![0x41, 0x00, 0x00, 0x00], 32),
+            bit_array(vec![0x12], 8),
+        ])
     }
 
     fn run_module_bit_array_expression(expression: BitArrayExpr) -> ExecutionError {

--- a/src/runtime/expression/function/bit_array.rs
+++ b/src/runtime/expression/function/bit_array.rs
@@ -151,7 +151,7 @@ mod tests {
         Expr, FloatExpr, FunctionId, FunctionPlan, FunctionType, IntExpr, IntLocalId, ListExpr,
         ModulePlan, PanicExpr, PanicSite, ReturnExpr, Step, StringExpr, TupleExpr, ValueType,
     };
-    use crate::runtime::{ExecutionError, run_main};
+    use crate::runtime::{BitArrayValue, ExecutionError, Value, run_main};
 
     #[test]
     fn module_expression_errors_propagate_through_bit_array_function_wrappers() {
@@ -296,6 +296,24 @@ mod tests {
                 ))),
                 actual: ValueType::Int,
             },
+        );
+    }
+
+    #[test]
+    fn source_function_value_paths_preserve_bit_array_calls() {
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../../tests/fixtures/execution/values/bit_array_function_value_paths.gleam"
+            )),
+            Value::Tuple(
+                [
+                    1, 2, 3, 4, 24, 5, 6, 23, 7, 99, 9, 99, 11, 99, 13, 99, 16, 99, 17, 99, 18, 99,
+                    19, 99, 15, 20, 21, 22
+                ]
+                .into_iter()
+                .map(|byte| Value::BitArray(BitArrayValue::from_bytes(vec![byte])))
+                .collect(),
+            ),
         );
     }
 

--- a/src/runtime/state.rs
+++ b/src/runtime/state.rs
@@ -584,6 +584,13 @@ pub fn main() { 0 }
         let second = state.bit_array(type_id, Vec::new());
         assert_eq!(second.core.slot(), slot);
         assert_eq!(state.bit_array_values(&second), &[]);
+
+        let value = ListValueId::BitArray(second.clone());
+        assert_eq!(state.list_len(&value), 0);
+        let rebuilt = ListValueId::from_core(&plan, type_id.list_type(), value.into_core());
+        assert_eq!(rebuilt, ListValueId::BitArray(second.clone()));
+        let dropped = state.drop_first(&ListValueId::BitArray(second), 0);
+        assert_eq!(state.list_len(&dropped), 0);
     }
 
     #[test]

--- a/src/runtime/value/bit_array.rs
+++ b/src/runtime/value/bit_array.rs
@@ -84,6 +84,18 @@ mod tests {
     }
 
     #[test]
+    fn checked_parts_preserve_empty_and_aligned_values() {
+        assert_eq!(
+            BitArrayValue::try_from_parts(Vec::new(), 0),
+            Ok(BitArrayValue::from_bytes(Vec::new())),
+        );
+        assert_eq!(
+            BitArrayValue::try_from_parts(vec![0xa5], 8),
+            Ok(BitArrayValue::from_bytes(vec![0xa5])),
+        );
+    }
+
+    #[test]
     fn checked_parts_reject_bit_length_beyond_supplied_bytes() {
         assert_eq!(
             BitArrayValue::try_from_parts(vec![0], 9),

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -42,6 +42,7 @@ mod values {
         bit_array_composition,
         bit_array_expression_paths,
         bit_array_function_value_paths,
+        bit_array_list_case_result,
         bit_array_list_function_paths,
         bit_array_returned_closure_capture,
         tuple_value,
@@ -70,6 +71,7 @@ mod module_items {
     execution_cases!("module_items";
         constant,
         constant_bit_array,
+        constant_bit_array_segments,
         constant_list_bit_array,
         constant_value_families,
         constant_function_value,
@@ -98,6 +100,7 @@ mod bindings {
         nested_tuple_destructuring,
         nested_pattern_alias_assignment,
         list_tail_assignment,
+        let_assert_bit_array_list,
         let_assert_list_destructuring,
         let_assert_fixed_list,
         let_assert_empty_list,
@@ -337,6 +340,7 @@ mod functions {
             list_tail_recursion_replaces_allocations,
             list_tail_recursion_item_families,
             block_case_tail_call,
+            bit_array_return_families,
             function_returning_tail_call,
             function_returning_tail_call_families,
         );

--- a/tests/fixtures/execution/bindings/let_assert_bit_array_list.gleam
+++ b/tests/fixtures/execution/bindings/let_assert_bit_array_list.gleam
@@ -1,0 +1,6 @@
+pub fn main() {
+  let assert [first, ..rest] = [<<1>>, <<2>>]
+  #(first, rest)
+}
+
+// geam:expect Tuple([BitArray(bytes=[1], bit_len=8), List(BitArray)([BitArray(bytes=[2], bit_len=8)])])

--- a/tests/fixtures/execution/functions/tail_call/bit_array_return_families.gleam
+++ b/tests/fixtures/execution/functions/tail_call/bit_array_return_families.gleam
@@ -1,0 +1,24 @@
+fn list_tail(count: Int) -> List(BitArray) {
+  case count {
+    0 -> [<<1>>]
+    _ -> list_tail(count - 1)
+  }
+}
+
+fn identity(value: BitArray) -> BitArray {
+  value
+}
+
+fn function_tail(count: Int) -> fn(BitArray) -> BitArray {
+  case count {
+    0 -> identity
+    _ -> function_tail(count - 1)
+  }
+}
+
+pub fn main() {
+  let assert [value] = list_tail(2)
+  #(value, function_tail(2)(<<2>>))
+}
+
+// geam:expect Tuple([BitArray(bytes=[1], bit_len=8), BitArray(bytes=[2], bit_len=8)])

--- a/tests/fixtures/execution/module_items/constant_bit_array_segments.gleam
+++ b/tests/fixtures/execution/module_items/constant_bit_array_segments.gleam
@@ -1,0 +1,25 @@
+const values = #(
+  <<>>,
+  <<1:size(0)>>,
+  <<0x1234:size(12)-big>>,
+  <<0x1234:size(12)-little>>,
+  <<-1:size(4)>>,
+  <<1:size(2)-unit(4)>>,
+  <<1.5:float-size(32)-big>>,
+  <<1.5:float-size(32)-little>>,
+  <<1.5:float-size(64)-big>>,
+  <<1.5:float-size(64)-little>>,
+  <<"안">>,
+  <<"안":utf8>>,
+  <<"안":utf16-big>>,
+  <<"안":utf16-little>>,
+  <<"A":utf32-big>>,
+  <<"A":utf32-little>>,
+  <<1:size(4), <<2:size(4)>>:bits>>,
+)
+
+pub fn main() {
+  values
+}
+
+// geam:expect Tuple([BitArray(bytes=[], bit_len=0), BitArray(bytes=[], bit_len=0), BitArray(bytes=[35, 64], bit_len=12), BitArray(bytes=[52, 32], bit_len=12), BitArray(bytes=[240], bit_len=4), BitArray(bytes=[1], bit_len=8), BitArray(bytes=[63, 192, 0, 0], bit_len=32), BitArray(bytes=[0, 0, 192, 63], bit_len=32), BitArray(bytes=[63, 248, 0, 0, 0, 0, 0, 0], bit_len=64), BitArray(bytes=[0, 0, 0, 0, 0, 0, 248, 63], bit_len=64), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[197, 72], bit_len=16), BitArray(bytes=[72, 197], bit_len=16), BitArray(bytes=[0, 0, 0, 65], bit_len=32), BitArray(bytes=[65, 0, 0, 0], bit_len=32), BitArray(bytes=[18], bit_len=8)])

--- a/tests/fixtures/execution/values/bit_array_list_case_result.gleam
+++ b/tests/fixtures/execution/values/bit_array_list_case_result.gleam
@@ -1,0 +1,12 @@
+fn choose(value: Bool) -> List(BitArray) {
+  case value {
+    True -> [<<1>>]
+    False -> [<<2>>]
+  }
+}
+
+pub fn main() {
+  #(choose(True), choose(False))
+}
+
+// geam:expect Tuple([List(BitArray)([BitArray(bytes=[1], bit_len=8)]), List(BitArray)([BitArray(bytes=[2], bit_len=8)])])


### PR DESCRIPTION
## Summary

- Restore 100% line and region coverage after adding the BitArray core value family.
- Run the checks workflow for pull requests targeting `main`.

## Changes

- Add execution fixtures for BitArray constants, list case results, let-assert tails, and tail calls.
- Cover missing planner, lowering, frame, function, and runtime paths with exact owner-level assertions.
- Refine test names and helpers, removing duplicate and coverage-only assertions.
- Add the `pull_request` trigger to the existing checks workflow.
