### PR TITLE
Support BitArray float-16 segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +921,7 @@ dependencies = [
  "camino",
  "ecow",
  "gleam-core",
+ "half",
  "im",
  "miette",
  "num-bigint",
@@ -1026,6 +1033,17 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
  "serde",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ camino = "1"
 # compile against ecow 0.3.0.
 ecow = "=0.2.6"
 gleam-core = { git = "https://github.com/gleam-lang/gleam", rev = "afc1b7d956b433e638d52dbd06470f53a0b26f6a", package = "gleam-core" }
+half = { version = "2.7.1", default-features = false }
 im = "15"
 miette = "7"
 num-bigint = "0.4.6"

--- a/src/plan/execution/expression/bit_array.rs
+++ b/src/plan/execution/expression/bit_array.rs
@@ -21,6 +21,7 @@ pub(crate) enum StringEncoding {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FloatBitSize {
+    Sixteen,
     ThirtyTwo,
     SixtyFour,
 }

--- a/src/plan/execution/lowering/expression/bit_array.rs
+++ b/src/plan/execution/lowering/expression/bit_array.rs
@@ -110,10 +110,7 @@ fn bit_array_segment(
             endianness,
         } => execution::BitArraySegment::Float {
             value: float_expr(value, context),
-            bit_size: match bit_size {
-                module::FloatBitSize::ThirtyTwo => execution::FloatBitSize::ThirtyTwo,
-                module::FloatBitSize::SixtyFour => execution::FloatBitSize::SixtyFour,
-            },
+            bit_size: lower_float_bit_size(bit_size),
             endianness: lower_endianness(endianness),
         },
         module::BitArraySegment::String { value, encoding } => execution::BitArraySegment::String {
@@ -134,9 +131,38 @@ fn bit_array_segment(
     }
 }
 
+fn lower_float_bit_size(value: module::FloatBitSize) -> execution::FloatBitSize {
+    match value {
+        module::FloatBitSize::Sixteen => execution::FloatBitSize::Sixteen,
+        module::FloatBitSize::ThirtyTwo => execution::FloatBitSize::ThirtyTwo,
+        module::FloatBitSize::SixtyFour => execution::FloatBitSize::SixtyFour,
+    }
+}
+
 fn lower_endianness(value: module::Endianness) -> execution::Endianness {
     match value {
         module::Endianness::Big => execution::Endianness::Big,
         module::Endianness::Little => execution::Endianness::Little,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{execution, lower_float_bit_size, module};
+
+    #[test]
+    fn lowering_preserves_float_bit_sizes() {
+        assert_eq!(
+            [
+                lower_float_bit_size(module::FloatBitSize::Sixteen),
+                lower_float_bit_size(module::FloatBitSize::ThirtyTwo),
+                lower_float_bit_size(module::FloatBitSize::SixtyFour),
+            ],
+            [
+                execution::FloatBitSize::Sixteen,
+                execution::FloatBitSize::ThirtyTwo,
+                execution::FloatBitSize::SixtyFour,
+            ],
+        );
     }
 }

--- a/src/plan/module/expression/bit_array.rs
+++ b/src/plan/module/expression/bit_array.rs
@@ -21,6 +21,7 @@ pub enum StringEncoding {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FloatBitSize {
+    Sixteen,
     ThirtyTwo,
     SixtyFour,
 }

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -62,8 +62,6 @@ pub enum UnsupportedBitArraySegmentReason {
     DynamicSize,
     #[error("sized bits segments are not supported")]
     SizedBits,
-    #[error("16-bit float segments are not supported")]
-    Float16,
     #[error("bit array segment size exceeds the supported host range")]
     SizeOutOfRange,
 }

--- a/src/planner/expression/bit_array.rs
+++ b/src/planner/expression/bit_array.rs
@@ -133,16 +133,11 @@ fn plan_segment<Value>(
             let bit_size = size.unwrap_or(64).checked_mul(unit).ok_or_else(|| {
                 unsupported_error(UnsupportedBitArraySegmentReason::SizeOutOfRange)
             })?;
-            if bit_size == 16 {
-                return unsupported(UnsupportedBitArraySegmentReason::Float16);
-            }
-            if bit_size != 32 && bit_size != 64 {
-                return invalid_segment_option();
-            }
-            let bit_size = if bit_size == 32 {
-                FloatBitSize::ThirtyTwo
-            } else {
-                FloatBitSize::SixtyFour
+            let bit_size = match bit_size {
+                16 => FloatBitSize::Sixteen,
+                32 => FloatBitSize::ThirtyTwo,
+                64 => FloatBitSize::SixtyFour,
+                _ => return invalid_segment_option(),
             };
             Ok(BitArraySegment::Float {
                 value,
@@ -250,6 +245,47 @@ mod tests {
             Ok(BitArraySegment::Int {
                 value: IntExpr::value(0x12.into()),
                 bit_size: 8,
+                endianness: Endianness::Little,
+            }),
+        );
+        assert_eq!(
+            plan_segment(
+                Expr::float(FloatExpr::value(1.5)),
+                vec![
+                    BitArrayOption::Float { location },
+                    BitArrayOption::Size {
+                        location,
+                        value: Box::new(()),
+                        short_form: false,
+                    },
+                    BitArrayOption::Big { location },
+                ],
+                |_: &()| Some(16.into()),
+            ),
+            Ok(BitArraySegment::Float {
+                value: FloatExpr::value(1.5),
+                bit_size: FloatBitSize::Sixteen,
+                endianness: Endianness::Big,
+            }),
+        );
+        assert_eq!(
+            plan_segment(
+                Expr::float(FloatExpr::value(1.5)),
+                vec![
+                    BitArrayOption::Float { location },
+                    BitArrayOption::Size {
+                        location,
+                        value: Box::new(()),
+                        short_form: false,
+                    },
+                    BitArrayOption::Unit { location, value: 2 },
+                    BitArrayOption::Little { location },
+                ],
+                |_: &()| Some(8.into()),
+            ),
+            Ok(BitArraySegment::Float {
+                value: FloatExpr::value(1.5),
+                bit_size: FloatBitSize::Sixteen,
                 endianness: Endianness::Little,
             }),
         );
@@ -433,20 +469,6 @@ mod tests {
         );
         assert_eq!(
             plan_segment(
-                Expr::float(FloatExpr::value(1.0)),
-                vec![BitArrayOption::Size {
-                    location,
-                    value: Box::new(()),
-                    short_form: false,
-                }],
-                |_: &()| Some(16.into()),
-            ),
-            Err(PlanError::UnsupportedBitArraySegment {
-                reason: UnsupportedBitArraySegmentReason::Float16,
-            }),
-        );
-        assert_eq!(
-            plan_segment(
                 Expr::bit_array(BitArrayExpr::value(Vec::new())),
                 vec![
                     BitArrayOption::Bits { location },
@@ -492,10 +514,6 @@ mod tests {
             (
                 "pub fn main() { let bits = <<1>> <<bits:bits-size(8)>> }",
                 UnsupportedBitArraySegmentReason::SizedBits,
-            ),
-            (
-                "pub fn main() { <<1.5:float-size(16)>> }",
-                UnsupportedBitArraySegmentReason::Float16,
             ),
             (
                 "const value = <<1:native>> pub fn main() { value }",

--- a/src/runtime/expression/bit_array.rs
+++ b/src/runtime/expression/bit_array.rs
@@ -194,6 +194,12 @@ fn append_float(
     endianness: Endianness,
 ) {
     let bytes = match (bit_size, endianness) {
+        (FloatBitSize::Sixteen, Endianness::Big) => {
+            half::f16::from_f64(value).to_be_bytes().to_vec()
+        }
+        (FloatBitSize::Sixteen, Endianness::Little) => {
+            half::f16::from_f64(value).to_le_bytes().to_vec()
+        }
         (FloatBitSize::ThirtyTwo, Endianness::Big) => (value as f32).to_be_bytes().to_vec(),
         (FloatBitSize::ThirtyTwo, Endianness::Little) => (value as f32).to_le_bytes().to_vec(),
         (FloatBitSize::SixtyFour, Endianness::Big) => value.to_be_bytes().to_vec(),
@@ -410,6 +416,8 @@ mod tests {
             bit_array(vec![0x34, 0x20], 12),
             bit_array(vec![0xf0], 4),
             bit_array(vec![0x01], 8),
+            bit_array(vec![0x3e, 0x00], 16),
+            bit_array(vec![0x00, 0x3e], 16),
             bit_array(vec![0x3f, 0xc0, 0x00, 0x00], 32),
             bit_array(vec![0x00, 0x00, 0xc0, 0x3f], 32),
             bit_array(vec![0x3f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], 64),

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -63,6 +63,7 @@ mod values {
 mod expressions {
     execution_cases!("expressions";
         bit_array,
+        bit_array_float_16,
         list_bit_array_element,
     );
 }
@@ -515,7 +516,6 @@ mod rejection {
             bit_array_native_endian,
             bit_array_dynamic_size,
             bit_array_sized_bits,
-            bit_array_float_16,
         );
     }
 

--- a/tests/fixtures/execution/expressions/bit_array_float_16.gleam
+++ b/tests/fixtures/execution/expressions/bit_array_float_16.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  #(
+    <<1.5:float-size(16)-big>>,
+    <<1.5:float-size(16)-little>>,
+  )
+}
+
+// geam:expect Tuple([BitArray(bytes=[62, 0], bit_len=16), BitArray(bytes=[0, 62], bit_len=16)])

--- a/tests/fixtures/execution/module_items/constant_bit_array_segments.gleam
+++ b/tests/fixtures/execution/module_items/constant_bit_array_segments.gleam
@@ -5,6 +5,8 @@ const values = #(
   <<0x1234:size(12)-little>>,
   <<-1:size(4)>>,
   <<1:size(2)-unit(4)>>,
+  <<1.5:float-size(16)-big>>,
+  <<1.5:float-size(16)-little>>,
   <<1.5:float-size(32)-big>>,
   <<1.5:float-size(32)-little>>,
   <<1.5:float-size(64)-big>>,
@@ -22,4 +24,4 @@ pub fn main() {
   values
 }
 
-// geam:expect Tuple([BitArray(bytes=[], bit_len=0), BitArray(bytes=[], bit_len=0), BitArray(bytes=[35, 64], bit_len=12), BitArray(bytes=[52, 32], bit_len=12), BitArray(bytes=[240], bit_len=4), BitArray(bytes=[1], bit_len=8), BitArray(bytes=[63, 192, 0, 0], bit_len=32), BitArray(bytes=[0, 0, 192, 63], bit_len=32), BitArray(bytes=[63, 248, 0, 0, 0, 0, 0, 0], bit_len=64), BitArray(bytes=[0, 0, 0, 0, 0, 0, 248, 63], bit_len=64), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[197, 72], bit_len=16), BitArray(bytes=[72, 197], bit_len=16), BitArray(bytes=[0, 0, 0, 65], bit_len=32), BitArray(bytes=[65, 0, 0, 0], bit_len=32), BitArray(bytes=[18], bit_len=8)])
+// geam:expect Tuple([BitArray(bytes=[], bit_len=0), BitArray(bytes=[], bit_len=0), BitArray(bytes=[35, 64], bit_len=12), BitArray(bytes=[52, 32], bit_len=12), BitArray(bytes=[240], bit_len=4), BitArray(bytes=[1], bit_len=8), BitArray(bytes=[62, 0], bit_len=16), BitArray(bytes=[0, 62], bit_len=16), BitArray(bytes=[63, 192, 0, 0], bit_len=32), BitArray(bytes=[0, 0, 192, 63], bit_len=32), BitArray(bytes=[63, 248, 0, 0, 0, 0, 0, 0], bit_len=64), BitArray(bytes=[0, 0, 0, 0, 0, 0, 248, 63], bit_len=64), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[197, 72], bit_len=16), BitArray(bytes=[72, 197], bit_len=16), BitArray(bytes=[0, 0, 0, 65], bit_len=32), BitArray(bytes=[65, 0, 0, 0], bit_len=32), BitArray(bytes=[18], bit_len=8)])

--- a/tests/fixtures/execution/values/bit_array_segments.gleam
+++ b/tests/fixtures/execution/values/bit_array_segments.gleam
@@ -6,6 +6,8 @@ pub fn main() {
     <<0x1234:size(12)-little>>,
     <<-1:size(4)>>,
     <<1:size(2)-unit(4)>>,
+    <<1.5:float-size(16)-big>>,
+    <<1.5:float-size(16)-little>>,
     <<1.5:float-size(32)-big>>,
     <<1.5:float-size(32)-little>>,
     <<1.5:float-size(64)-big>>,
@@ -20,4 +22,4 @@ pub fn main() {
   )
 }
 
-// geam:expect Tuple([BitArray(bytes=[], bit_len=0), BitArray(bytes=[], bit_len=0), BitArray(bytes=[35, 64], bit_len=12), BitArray(bytes=[52, 32], bit_len=12), BitArray(bytes=[240], bit_len=4), BitArray(bytes=[1], bit_len=8), BitArray(bytes=[63, 192, 0, 0], bit_len=32), BitArray(bytes=[0, 0, 192, 63], bit_len=32), BitArray(bytes=[63, 248, 0, 0, 0, 0, 0, 0], bit_len=64), BitArray(bytes=[0, 0, 0, 0, 0, 0, 248, 63], bit_len=64), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[197, 72], bit_len=16), BitArray(bytes=[72, 197], bit_len=16), BitArray(bytes=[0, 0, 0, 65], bit_len=32), BitArray(bytes=[65, 0, 0, 0], bit_len=32), BitArray(bytes=[18], bit_len=8)])
+// geam:expect Tuple([BitArray(bytes=[], bit_len=0), BitArray(bytes=[], bit_len=0), BitArray(bytes=[35, 64], bit_len=12), BitArray(bytes=[52, 32], bit_len=12), BitArray(bytes=[240], bit_len=4), BitArray(bytes=[1], bit_len=8), BitArray(bytes=[62, 0], bit_len=16), BitArray(bytes=[0, 62], bit_len=16), BitArray(bytes=[63, 192, 0, 0], bit_len=32), BitArray(bytes=[0, 0, 192, 63], bit_len=32), BitArray(bytes=[63, 248, 0, 0, 0, 0, 0, 0], bit_len=64), BitArray(bytes=[0, 0, 0, 0, 0, 0, 248, 63], bit_len=64), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[197, 72], bit_len=16), BitArray(bytes=[72, 197], bit_len=16), BitArray(bytes=[0, 0, 0, 65], bit_len=32), BitArray(bytes=[65, 0, 0, 0], bit_len=32), BitArray(bytes=[18], bit_len=8)])

--- a/tests/fixtures/rejection/expressions/bit_array_float_16.gleam
+++ b/tests/fixtures/rejection/expressions/bit_array_float_16.gleam
@@ -1,3 +1,0 @@
-pub fn main() {
-  <<1.5:float-size(16)>>
-}


### PR DESCRIPTION
- Plan 16-bit float segments through module and execution bit-size models.
- Encode big- and little-endian float16 values with half.
- Move float16 fixtures to execution coverage and remove the stale rejection boundary.
