### PR TITLE
Support BitArray structural patterns

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -6,9 +6,11 @@ mod value_type;
 #[cfg(test)]
 pub(crate) use module::ListReturn;
 pub(crate) use module::{
-    AssertBinding, AssertPattern, BitArrayExprKind, BitArrayFunctionExprKind,
-    BitArrayFunctionReference, BitArrayFunctionReturn, BitArrayListExpr, BitArrayListItem,
-    BitArrayReturn, BitArraySegment, BoolCaseBranches, BoolExprKind, BoolFunctionExprKind,
+    AssertBinding, AssertPattern, BitArrayBindingPattern, BitArrayExprKind,
+    BitArrayFunctionExprKind, BitArrayFunctionReference, BitArrayFunctionReturn, BitArrayListExpr,
+    BitArrayListItem, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
+    BitArrayPatternSizeExpr, BitArrayPatternValue, BitArrayReturn, BitArraySegment,
+    BitArrayStringPattern, BoolCaseBranches, BoolExprKind, BoolFunctionExprKind,
     BoolFunctionReference, BoolFunctionReturn, BoolListCaseBranches, BoolListExpr, BoolListItem,
     BoolReturn, CallArgKind, CaptureArg, CaptureArgKind, Endianness, ExprKind, FloatBitSize,
     FloatCaseBranches, FloatExprKind, FloatFunctionExprKind, FloatFunctionReference,
@@ -20,8 +22,8 @@ pub(crate) use module::{
     ListExpr, ListFunctionExprKind, ListFunctionReference, ListFunctionReturn, ListItem,
     ListListExpr, ListListItem, ListLocalExpr, ListSpreadElements, NilExprKind,
     NilFunctionExprKind, NilFunctionReference, NilFunctionReturn, NilListExpr, NilListItem,
-    NilReturn, PanicExpr, ParamLocal, ReturnBody, ReturnBodyKind, ReturnExprKind,
-    RuntimeFunctionId, StepKind, StringCaseBranches, StringEncoding, StringExprKind,
+    NilReturn, PanicExpr, ParamLocal, PatternBinding, ReturnBody, ReturnBodyKind, ReturnExprKind,
+    RuntimeFunctionId, Signedness, StepKind, StringCaseBranches, StringEncoding, StringExprKind,
     StringFunctionExprKind, StringFunctionReference, StringFunctionReturn, StringListExpr,
     StringListItem, StringReturn, TupleExprKind, TupleFunctionExprKind, TupleFunctionReference,
     TupleFunctionReturn, TupleListExpr, TupleListItem, TupleReturn, TypedListExpr,

--- a/src/plan/execution.rs
+++ b/src/plan/execution.rs
@@ -4,6 +4,7 @@ mod function;
 mod id;
 mod lowering;
 mod param;
+mod pattern;
 mod reference;
 mod return_;
 mod step;
@@ -48,6 +49,11 @@ pub(crate) use id::{
     TupleListFunctionLocalId, TupleListLocalId, TupleLocalId,
 };
 pub(crate) use param::ParamLocal;
+pub(crate) use pattern::{
+    BitArrayBindingPattern, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
+    BitArrayPatternSizeExpr, BitArrayPatternValue, BitArrayStringPattern, PatternBinding,
+    Signedness,
+};
 pub(crate) use reference::{ClosureTemplate, FunctionReference};
 pub(crate) use return_::{
     BitArrayFunctionReturn, BitArrayListReturn, BitArrayReturn, BoolFunctionReturn, BoolListReturn,

--- a/src/plan/execution/expression/bool.rs
+++ b/src/plan/execution/expression/bool.rs
@@ -2,7 +2,7 @@ use super::{
     BoolFunctionExpr, BoolListExpr, CallArg, Expr, FloatExpr, IntExpr, ListExpr, PanicExpr,
     StringExpr, TupleExpr,
 };
-use crate::plan::execution::{BoolFunctionId, BoolLocalId, Step};
+use crate::plan::execution::{BitArrayExpr, BitArrayPattern, BoolFunctionId, BoolLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
 
@@ -84,6 +84,10 @@ pub(crate) enum BoolExprKind {
     ListLengthAtLeast {
         value: Box<ListExpr>,
         length: usize,
+    },
+    BitArrayMatches {
+        value: Box<BitArrayExpr>,
+        pattern: BitArrayPattern,
     },
     And {
         left: Box<BoolExpr>,

--- a/src/plan/execution/lowering.rs
+++ b/src/plan/execution/lowering.rs
@@ -2,6 +2,7 @@ mod expression;
 mod frame;
 mod id;
 mod param;
+mod pattern;
 mod return_;
 mod step;
 mod table;

--- a/src/plan/execution/lowering/expression/bool.rs
+++ b/src/plan/execution/lowering/expression/bool.rs
@@ -86,6 +86,10 @@ pub(in crate::plan::execution::lowering) fn bool_expr(
             value: Box::new(list_expr(*value, context)),
             length,
         },
+        M::BitArrayMatches { value, pattern } => E::BitArrayMatches {
+            value: Box::new(super::bit_array_expr(*value, context)),
+            pattern: super::super::pattern::bit_array_pattern(pattern),
+        },
         M::And { left, right } => E::And {
             left: Box::new(bool_expr(*left, context)),
             right: Box::new(bool_expr(*right, context)),

--- a/src/plan/execution/lowering/pattern.rs
+++ b/src/plan/execution/lowering/pattern.rs
@@ -1,0 +1,167 @@
+use crate::plan::{execution, module};
+
+pub(super) fn bit_array_pattern(pattern: module::BitArrayPattern) -> execution::BitArrayPattern {
+    execution::BitArrayPattern::new(
+        pattern
+            .into_segments()
+            .into_iter()
+            .map(bit_array_segment)
+            .collect(),
+    )
+}
+
+fn bit_array_segment(segment: module::BitArrayPatternSegment) -> execution::BitArrayPatternSegment {
+    use execution::BitArrayPatternSegment as E;
+    use module::BitArrayPatternSegment as M;
+
+    match segment {
+        M::Int {
+            pattern,
+            size,
+            endianness,
+            signedness,
+        } => E::Int {
+            pattern: pattern_value(pattern, |local| execution::IntLocalId(local.0)),
+            size: pattern_size(size),
+            endianness: endianness.into(),
+            signedness: signedness.into(),
+        },
+        M::Float {
+            pattern,
+            size,
+            endianness,
+        } => E::Float {
+            pattern: pattern_value(pattern, |local| execution::FloatLocalId(local.0)),
+            size: pattern_size(size),
+            endianness: endianness.into(),
+        },
+        M::Bits {
+            pattern,
+            size,
+            unit,
+        } => E::Bits {
+            pattern: binding_pattern(pattern, |local| execution::BitArrayLocalId(local.0)),
+            size: size.map(pattern_size),
+            unit,
+        },
+        M::String { pattern, encoding } => E::String {
+            pattern: match pattern {
+                module::BitArrayStringPattern::Literal(value) => {
+                    execution::BitArrayStringPattern::Literal(value)
+                }
+                module::BitArrayStringPattern::Discard => execution::BitArrayStringPattern::Discard,
+            },
+            encoding: encoding.into(),
+        },
+    }
+}
+
+fn pattern_size(size: module::BitArrayPatternSize) -> execution::BitArrayPatternSize {
+    let (value, unit) = size.into_parts();
+    execution::BitArrayPatternSize::new(pattern_size_expr(value), unit)
+}
+
+fn pattern_size_expr(value: module::BitArrayPatternSizeExpr) -> execution::BitArrayPatternSizeExpr {
+    use execution::BitArrayPatternSizeExpr as E;
+    use module::BitArrayPatternSizeExpr as M;
+
+    match value {
+        M::Value(value) => E::Value(value),
+        M::LocalGet { local, .. } => E::LocalGet(execution::IntLocalId(local.0)),
+        M::Add { left, right } => E::Add {
+            left: Box::new(pattern_size_expr(*left)),
+            right: Box::new(pattern_size_expr(*right)),
+        },
+        M::Subtract { left, right } => E::Subtract {
+            left: Box::new(pattern_size_expr(*left)),
+            right: Box::new(pattern_size_expr(*right)),
+        },
+        M::Multiply { left, right } => E::Multiply {
+            left: Box::new(pattern_size_expr(*left)),
+            right: Box::new(pattern_size_expr(*right)),
+        },
+        M::Divide { left, right } => E::Divide {
+            left: Box::new(pattern_size_expr(*left)),
+            right: Box::new(pattern_size_expr(*right)),
+        },
+        M::Remainder { left, right } => E::Remainder {
+            left: Box::new(pattern_size_expr(*left)),
+            right: Box::new(pattern_size_expr(*right)),
+        },
+    }
+}
+
+fn pattern_value<Value, ModuleLocal, ExecutionLocal>(
+    pattern: module::BitArrayPatternValue<Value, ModuleLocal>,
+    local: impl Copy + Fn(ModuleLocal) -> ExecutionLocal,
+) -> execution::BitArrayPatternValue<Value, ExecutionLocal> {
+    match pattern {
+        module::BitArrayPatternValue::Literal(value) => {
+            execution::BitArrayPatternValue::Literal(value)
+        }
+        module::BitArrayPatternValue::Bind(binding) => {
+            execution::BitArrayPatternValue::Bind(pattern_binding(binding, local))
+        }
+        module::BitArrayPatternValue::Discard => execution::BitArrayPatternValue::Discard,
+        module::BitArrayPatternValue::Alias { pattern, binding } => {
+            execution::BitArrayPatternValue::Alias {
+                pattern: Box::new(pattern_value(*pattern, local)),
+                binding: pattern_binding(binding, local),
+            }
+        }
+    }
+}
+
+fn binding_pattern<ModuleLocal, ExecutionLocal>(
+    pattern: module::BitArrayBindingPattern<ModuleLocal>,
+    local: impl Copy + Fn(ModuleLocal) -> ExecutionLocal,
+) -> execution::BitArrayBindingPattern<ExecutionLocal> {
+    match pattern {
+        module::BitArrayBindingPattern::Bind(binding) => {
+            execution::BitArrayBindingPattern::Bind(pattern_binding(binding, local))
+        }
+        module::BitArrayBindingPattern::Discard => execution::BitArrayBindingPattern::Discard,
+        module::BitArrayBindingPattern::Alias { pattern, binding } => {
+            execution::BitArrayBindingPattern::Alias {
+                pattern: Box::new(binding_pattern(*pattern, local)),
+                binding: pattern_binding(binding, local),
+            }
+        }
+    }
+}
+
+fn pattern_binding<ModuleLocal, ExecutionLocal>(
+    binding: module::PatternBinding<ModuleLocal>,
+    local: impl FnOnce(ModuleLocal) -> ExecutionLocal,
+) -> execution::PatternBinding<ExecutionLocal> {
+    let (binding, _) = binding.into_parts();
+    execution::PatternBinding::new(local(binding))
+}
+
+impl From<module::Signedness> for execution::Signedness {
+    fn from(value: module::Signedness) -> Self {
+        match value {
+            module::Signedness::Signed => Self::Signed,
+            module::Signedness::Unsigned => Self::Unsigned,
+        }
+    }
+}
+
+impl From<module::Endianness> for execution::Endianness {
+    fn from(value: module::Endianness) -> Self {
+        match value {
+            module::Endianness::Big => Self::Big,
+            module::Endianness::Little => Self::Little,
+        }
+    }
+}
+
+impl From<module::StringEncoding> for execution::StringEncoding {
+    fn from(value: module::StringEncoding) -> Self {
+        match value {
+            module::StringEncoding::Utf8 => Self::Utf8,
+            module::StringEncoding::Utf16(endianness) => Self::Utf16(endianness.into()),
+            module::StringEncoding::Utf32(endianness) => Self::Utf32(endianness.into()),
+        }
+    }
+}

--- a/src/plan/execution/lowering/step.rs
+++ b/src/plan/execution/lowering/step.rs
@@ -166,6 +166,19 @@ fn lower_step(step: module::Step, context: &mut super::LoweringContext) -> execu
             site,
             pattern_span,
         },
+        M::AssertBitArray {
+            local,
+            pattern,
+            message,
+            site,
+            pattern_span,
+        } => E::AssertBitArray {
+            local: execution::BitArrayLocalId(local.0),
+            pattern: assert_pattern(pattern, context),
+            message: message.map(|message| string_expr(message, context)),
+            site,
+            pattern_span,
+        },
         M::AssertBool {
             condition,
             message,
@@ -204,6 +217,9 @@ fn assert_pattern(
                 tail.map(|tail| assert_tail(tail, context)),
             ))
         }
+        module::AssertPattern::BitArray(pattern) => {
+            execution::AssertPattern::BitArray(super::pattern::bit_array_pattern(pattern))
+        }
         module::AssertPattern::Alias { pattern, binding } => execution::AssertPattern::Alias {
             pattern: Box::new(assert_pattern(*pattern, context)),
             binding: assert_binding(binding, context),
@@ -235,10 +251,47 @@ fn assert_tail(
 #[cfg(test)]
 mod tests {
     use crate::plan::execution::{
-        AssertBinding, AssertPattern, ExecutionPlan, IntListLocalId, ListAssertPattern,
-        ListAssertTail, ListFunctionId, ListListFunctionId, ListListTypeId, ListLocal,
-        ListLocalExpr, ParamLocal, RuntimeFunctionId, Step, StepKind,
+        AssertBinding, AssertPattern, BitArrayBindingPattern, BitArrayLocalId,
+        BitArrayPatternSegment, BitArrayPatternSizeExpr, BitArrayPatternValue, ExecutionPlan,
+        IntFunctionId, IntListLocalId, IntLocalId, ListAssertPattern, ListAssertTail,
+        ListFunctionId, ListListFunctionId, ListListTypeId, ListLocal, ListLocalExpr, ParamLocal,
+        RuntimeFunctionId, Step, StepKind,
     };
+
+    #[test]
+    fn lowering_removes_bit_array_pattern_names_and_preserves_typed_bindings() {
+        let source = r#"
+pub fn main() {
+  let assert <<1 as alias, rest:bits>> = <<1, 2>>
+  alias
+}
+"#;
+        let typed = crate::compile_typed_module("main", "main.gleam", source)
+            .expect("source should compile");
+        let module_plan = crate::plan_module(typed).expect("source should plan");
+        let plan = ExecutionPlan::from_module_plan(module_plan);
+        let function = plan.int_function(IntFunctionId(0));
+        assert_eq!(function.steps().len(), 2);
+        assert_eq!(
+            expect_bit_array_assert_shape(&function.steps()[1]),
+            (
+                BitArrayLocalId(0),
+                1.into(),
+                IntLocalId(0),
+                1,
+                8.into(),
+                BitArrayLocalId(1),
+                1,
+            ),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "expected a lowered BitArray assert shape")]
+    fn bit_array_assert_fixture_guard_rejects_int_binding() {
+        let plan = execution_plan("pub fn main() { let value = 1 value }");
+        let _ = expect_bit_array_assert_shape(&plan.int_function(IntFunctionId(0)).steps()[0]);
+    }
 
     #[test]
     fn lowering_preserves_parent_and_child_list_types_through_assert_bindings() {
@@ -369,6 +422,50 @@ pub fn main() {
             RuntimeFunctionId::List(ListFunctionId::List(main)) => main,
             _ => panic!("expected a List(List) main function"),
         }
+    }
+
+    fn expect_bit_array_assert_shape(
+        step: &Step,
+    ) -> (
+        BitArrayLocalId,
+        num_bigint::BigInt,
+        IntLocalId,
+        u8,
+        num_bigint::BigInt,
+        BitArrayLocalId,
+        u8,
+    ) {
+        if let StepKind::AssertBitArray {
+            local,
+            pattern: AssertPattern::BitArray(pattern),
+            ..
+        } = step.kind()
+            && let [
+                BitArrayPatternSegment::Int {
+                    pattern: BitArrayPatternValue::Alias { pattern, binding },
+                    size,
+                    ..
+                },
+                BitArrayPatternSegment::Bits {
+                    pattern: BitArrayBindingPattern::Bind(rest),
+                    size: None,
+                    unit,
+                },
+            ] = pattern.segments()
+            && let BitArrayPatternValue::Literal(value) = pattern.as_ref()
+            && let BitArrayPatternSizeExpr::Value(size_value) = size.value()
+        {
+            return (
+                *local,
+                value.clone(),
+                *binding.local(),
+                size.unit(),
+                size_value.clone(),
+                *rest.local(),
+                *unit,
+            );
+        }
+        panic!("expected a lowered BitArray assert shape");
     }
 
     fn expect_nested_list_binding(step: &Step) -> &crate::plan::execution::ListListExpr {

--- a/src/plan/execution/pattern.rs
+++ b/src/plan/execution/pattern.rs
@@ -1,0 +1,7 @@
+mod bit_array;
+
+pub(crate) use bit_array::{
+    BitArrayBindingPattern, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
+    BitArrayPatternSizeExpr, BitArrayPatternValue, BitArrayStringPattern, PatternBinding,
+    Signedness,
+};

--- a/src/plan/execution/pattern/bit_array.rs
+++ b/src/plan/execution/pattern/bit_array.rs
@@ -1,0 +1,115 @@
+use crate::plan::execution::{
+    BitArrayLocalId, Endianness, FloatLocalId, IntLocalId, StringEncoding,
+};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+pub(crate) struct BitArrayPattern {
+    segments: Vec<BitArrayPatternSegment>,
+}
+
+pub(crate) enum BitArrayPatternSegment {
+    Int {
+        pattern: BitArrayPatternValue<BigInt, IntLocalId>,
+        size: BitArrayPatternSize,
+        endianness: Endianness,
+        signedness: Signedness,
+    },
+    Float {
+        pattern: BitArrayPatternValue<f64, FloatLocalId>,
+        size: BitArrayPatternSize,
+        endianness: Endianness,
+    },
+    Bits {
+        pattern: BitArrayBindingPattern<BitArrayLocalId>,
+        size: Option<BitArrayPatternSize>,
+        unit: u8,
+    },
+    String {
+        pattern: BitArrayStringPattern,
+        encoding: StringEncoding,
+    },
+}
+
+pub(crate) struct BitArrayPatternSize {
+    value: BitArrayPatternSizeExpr,
+    unit: u8,
+}
+
+pub(crate) enum BitArrayPatternSizeExpr {
+    Value(BigInt),
+    LocalGet(IntLocalId),
+    Add { left: Box<Self>, right: Box<Self> },
+    Subtract { left: Box<Self>, right: Box<Self> },
+    Multiply { left: Box<Self>, right: Box<Self> },
+    Divide { left: Box<Self>, right: Box<Self> },
+    Remainder { left: Box<Self>, right: Box<Self> },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Signedness {
+    Signed,
+    Unsigned,
+}
+
+pub(crate) enum BitArrayPatternValue<Value, Local> {
+    Literal(Value),
+    Bind(PatternBinding<Local>),
+    Discard,
+    Alias {
+        pattern: Box<Self>,
+        binding: PatternBinding<Local>,
+    },
+}
+
+pub(crate) enum BitArrayStringPattern {
+    Literal(EcoString),
+    Discard,
+}
+
+pub(crate) enum BitArrayBindingPattern<Local> {
+    Bind(PatternBinding<Local>),
+    Discard,
+    Alias {
+        pattern: Box<Self>,
+        binding: PatternBinding<Local>,
+    },
+}
+
+pub(crate) struct PatternBinding<Local> {
+    local: Local,
+}
+
+impl BitArrayPattern {
+    pub(in crate::plan::execution) fn new(segments: Vec<BitArrayPatternSegment>) -> Self {
+        Self { segments }
+    }
+
+    pub(crate) fn segments(&self) -> &[BitArrayPatternSegment] {
+        &self.segments
+    }
+}
+
+impl BitArrayPatternSize {
+    pub(in crate::plan::execution) fn new(value: BitArrayPatternSizeExpr, unit: u8) -> Self {
+        Self { value, unit }
+    }
+
+    pub(crate) fn value(&self) -> &BitArrayPatternSizeExpr {
+        &self.value
+    }
+
+    pub(crate) fn unit(&self) -> u8 {
+        self.unit
+    }
+}
+
+impl<Local> PatternBinding<Local> {
+    pub(in crate::plan::execution) fn new(local: Local) -> Self {
+        Self { local }
+    }
+
+    pub(crate) fn local(&self) -> &Local {
+        &self.local
+    }
+}

--- a/src/plan/execution/step.rs
+++ b/src/plan/execution/step.rs
@@ -11,6 +11,7 @@ use super::id::{
     ListFunctionLocal, ListLocal, NilFunctionLocalId, NilLocalId, StringFunctionLocalId,
     StringLocalId, TupleFunctionLocalId, TupleLocalId,
 };
+use crate::plan::execution::BitArrayPattern;
 use crate::plan::{PanicSite, SourceSpan};
 
 pub struct Step {
@@ -26,6 +27,7 @@ pub(crate) enum AssertPattern {
     Discard,
     Tuple(Vec<AssertPattern>),
     List(ListAssertPattern),
+    BitArray(BitArrayPattern),
     Alias {
         pattern: Box<AssertPattern>,
         binding: AssertBinding,
@@ -116,6 +118,13 @@ pub(crate) enum StepKind {
     },
     AssertList {
         local: ListLocal,
+        pattern: AssertPattern,
+        message: Option<StringExpr>,
+        site: PanicSite,
+        pattern_span: SourceSpan,
+    },
+    AssertBitArray {
+        local: BitArrayLocalId,
         pattern: AssertPattern,
         message: Option<StringExpr>,
         site: PanicSite,

--- a/src/plan/module.rs
+++ b/src/plan/module.rs
@@ -2,6 +2,7 @@ mod expression;
 mod frame;
 mod function;
 mod id;
+mod pattern;
 mod reference;
 mod step;
 
@@ -64,6 +65,11 @@ pub use id::{
     TupleListFunctionLocalId, TupleListLocalId, TupleLocalId,
 };
 pub(crate) use id::{FunctionFunctionId, RuntimeFunctionId};
+pub(crate) use pattern::{
+    BitArrayBindingPattern, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
+    BitArrayPatternSizeExpr, BitArrayPatternValue, BitArrayStringPattern, PatternBinding,
+    Signedness,
+};
 pub(crate) use reference::{
     BitArrayFunctionReference, BoolFunctionReference, FloatFunctionReference,
     FunctionFunctionReference, FunctionReference, IntFunctionReference, ListFunctionReference,

--- a/src/plan/module/expression/bool.rs
+++ b/src/plan/module/expression/bool.rs
@@ -2,6 +2,7 @@ use super::{
     BoolFunctionExpr, BoolListExpr, CallArg, Expr, FloatExpr, IntExpr, ListExpr, PanicExpr,
     StringExpr, TupleExpr,
 };
+use crate::plan::{BitArrayExpr, BitArrayPattern};
 use crate::plan::{BoolFunctionId, BoolLocalId, Step};
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -87,6 +88,10 @@ pub(crate) enum BoolExprKind {
     ListLengthAtLeast {
         value: Box<ListExpr>,
         length: usize,
+    },
+    BitArrayMatches {
+        value: Box<BitArrayExpr>,
+        pattern: BitArrayPattern,
     },
     And {
         left: Box<BoolExpr>,
@@ -293,6 +298,15 @@ impl BoolExpr {
             kind: BoolExprKind::ListLengthAtLeast {
                 value: Box::new(value),
                 length,
+            },
+        }
+    }
+
+    pub(crate) fn bit_array_matches(value: BitArrayExpr, pattern: BitArrayPattern) -> Self {
+        Self {
+            kind: BoolExprKind::BitArrayMatches {
+                value: Box::new(value),
+                pattern,
             },
         }
     }

--- a/src/plan/module/frame/expression.rs
+++ b/src/plan/module/frame/expression.rs
@@ -262,6 +262,10 @@ impl FrameLayout {
             BoolExprKind::StringStartsWith { value, .. } => self.include_string_expr(value),
             BoolExprKind::ListLengthEquals { value, .. }
             | BoolExprKind::ListLengthAtLeast { value, .. } => self.include_list_expr(value),
+            BoolExprKind::BitArrayMatches { value, pattern } => {
+                self.include_bit_array_expr(value);
+                self.include_bit_array_pattern(pattern);
+            }
             BoolExprKind::And { left, right } => self.include_bool_binary_expr(left, right),
             BoolExprKind::Or { left, right } => self.include_bool_binary_expr(left, right),
             BoolExprKind::BoolCase {
@@ -309,6 +313,88 @@ impl FrameLayout {
             BoolExprKind::Block { steps, return_ } => {
                 self.include_steps(steps);
                 self.include_bool_expr(return_);
+            }
+        }
+    }
+
+    pub(in crate::plan::module::frame) fn include_bit_array_pattern(
+        &mut self,
+        pattern: &crate::plan::BitArrayPattern,
+    ) {
+        for segment in pattern.segments() {
+            match segment {
+                crate::plan::BitArrayPatternSegment::Int { pattern, size, .. } => {
+                    self.include_bit_array_pattern_size_expr(size.value());
+                    self.include_bit_array_pattern_value(pattern, |layout, local| {
+                        layout.include_int(*local)
+                    });
+                }
+                crate::plan::BitArrayPatternSegment::Float { pattern, size, .. } => {
+                    self.include_bit_array_pattern_size_expr(size.value());
+                    self.include_bit_array_pattern_value(pattern, |layout, local| {
+                        layout.include_float(*local)
+                    });
+                }
+                crate::plan::BitArrayPatternSegment::Bits { pattern, size, .. } => {
+                    if let Some(size) = size {
+                        self.include_bit_array_pattern_size_expr(size.value());
+                    }
+                    self.include_bit_array_binding_pattern(pattern, |layout, local| {
+                        layout.include_bit_array(*local)
+                    });
+                }
+                crate::plan::BitArrayPatternSegment::String { .. } => {}
+            }
+        }
+    }
+
+    fn include_bit_array_pattern_size_expr(
+        &mut self,
+        expression: &crate::plan::BitArrayPatternSizeExpr,
+    ) {
+        use crate::plan::BitArrayPatternSizeExpr;
+
+        match expression {
+            BitArrayPatternSizeExpr::Value(_) => {}
+            BitArrayPatternSizeExpr::LocalGet { local, .. } => self.include_int(*local),
+            BitArrayPatternSizeExpr::Add { left, right }
+            | BitArrayPatternSizeExpr::Subtract { left, right }
+            | BitArrayPatternSizeExpr::Multiply { left, right }
+            | BitArrayPatternSizeExpr::Divide { left, right }
+            | BitArrayPatternSizeExpr::Remainder { left, right } => {
+                self.include_bit_array_pattern_size_expr(left);
+                self.include_bit_array_pattern_size_expr(right);
+            }
+        }
+    }
+
+    fn include_bit_array_pattern_value<Value, Local>(
+        &mut self,
+        pattern: &crate::plan::BitArrayPatternValue<Value, Local>,
+        include: impl Copy + Fn(&mut Self, &Local),
+    ) {
+        match pattern {
+            crate::plan::BitArrayPatternValue::Literal(_)
+            | crate::plan::BitArrayPatternValue::Discard => {}
+            crate::plan::BitArrayPatternValue::Bind(binding) => include(self, binding.local()),
+            crate::plan::BitArrayPatternValue::Alias { pattern, binding } => {
+                self.include_bit_array_pattern_value(pattern, include);
+                include(self, binding.local());
+            }
+        }
+    }
+
+    fn include_bit_array_binding_pattern<Local>(
+        &mut self,
+        pattern: &crate::plan::BitArrayBindingPattern<Local>,
+        include: impl Copy + Fn(&mut Self, &Local),
+    ) {
+        match pattern {
+            crate::plan::BitArrayBindingPattern::Discard => {}
+            crate::plan::BitArrayBindingPattern::Bind(binding) => include(self, binding.local()),
+            crate::plan::BitArrayBindingPattern::Alias { pattern, binding } => {
+                self.include_bit_array_binding_pattern(pattern, include);
+                include(self, binding.local());
             }
         }
     }

--- a/src/plan/module/frame/step.rs
+++ b/src/plan/module/frame/step.rs
@@ -87,6 +87,18 @@ impl FrameLayout {
                     self.include_string_expr(message);
                 }
             }
+            StepKind::AssertBitArray {
+                local,
+                pattern,
+                message,
+                ..
+            } => {
+                self.include_bit_array(*local);
+                self.include_assert_pattern(pattern);
+                if let Some(message) = message {
+                    self.include_string_expr(message);
+                }
+            }
             StepKind::AssertBool {
                 condition, message, ..
             } => {
@@ -118,6 +130,7 @@ impl FrameLayout {
                 }
             }
             AssertPattern::List(pattern) => self.include_list_assert_pattern(pattern),
+            AssertPattern::BitArray(pattern) => self.include_bit_array_pattern(pattern),
             AssertPattern::Alias { pattern, binding } => {
                 self.include_assert_pattern(pattern);
                 self.include_local(binding.local());

--- a/src/plan/module/pattern.rs
+++ b/src/plan/module/pattern.rs
@@ -1,0 +1,7 @@
+mod bit_array;
+
+pub(crate) use bit_array::{
+    BitArrayBindingPattern, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
+    BitArrayPatternSizeExpr, BitArrayPatternValue, BitArrayStringPattern, PatternBinding,
+    Signedness,
+};

--- a/src/plan/module/pattern/bit_array.rs
+++ b/src/plan/module/pattern/bit_array.rs
@@ -1,0 +1,175 @@
+use crate::plan::{BitArrayLocalId, Endianness, FloatLocalId, IntLocalId, StringEncoding};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BitArrayPattern {
+    segments: Vec<BitArrayPatternSegment>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum BitArrayPatternSegment {
+    Int {
+        pattern: BitArrayPatternValue<BigInt, IntLocalId>,
+        size: BitArrayPatternSize,
+        endianness: Endianness,
+        signedness: Signedness,
+    },
+    Float {
+        pattern: BitArrayPatternValue<f64, FloatLocalId>,
+        size: BitArrayPatternSize,
+        endianness: Endianness,
+    },
+    Bits {
+        pattern: BitArrayBindingPattern<BitArrayLocalId>,
+        size: Option<BitArrayPatternSize>,
+        unit: u8,
+    },
+    String {
+        pattern: BitArrayStringPattern,
+        encoding: StringEncoding,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BitArrayPatternSize {
+    value: BitArrayPatternSizeExpr,
+    unit: u8,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum BitArrayPatternSizeExpr {
+    Value(BigInt),
+    LocalGet { local: IntLocalId, name: EcoString },
+    Add { left: Box<Self>, right: Box<Self> },
+    Subtract { left: Box<Self>, right: Box<Self> },
+    Multiply { left: Box<Self>, right: Box<Self> },
+    Divide { left: Box<Self>, right: Box<Self> },
+    Remainder { left: Box<Self>, right: Box<Self> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Signedness {
+    Signed,
+    Unsigned,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum BitArrayPatternValue<Value, Local> {
+    Literal(Value),
+    Bind(PatternBinding<Local>),
+    Discard,
+    Alias {
+        pattern: Box<Self>,
+        binding: PatternBinding<Local>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BitArrayStringPattern {
+    Literal(EcoString),
+    Discard,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BitArrayBindingPattern<Local> {
+    Bind(PatternBinding<Local>),
+    Discard,
+    Alias {
+        pattern: Box<Self>,
+        binding: PatternBinding<Local>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PatternBinding<Local> {
+    local: Local,
+    name: EcoString,
+}
+
+impl BitArrayPattern {
+    pub(crate) fn new(segments: Vec<BitArrayPatternSegment>) -> Self {
+        Self { segments }
+    }
+
+    pub(crate) fn segments(&self) -> &[BitArrayPatternSegment] {
+        &self.segments
+    }
+
+    pub(crate) fn into_segments(self) -> Vec<BitArrayPatternSegment> {
+        self.segments
+    }
+}
+
+impl BitArrayPatternSize {
+    pub(crate) fn new(value: BitArrayPatternSizeExpr, unit: u8) -> Self {
+        Self { value, unit }
+    }
+
+    pub(crate) fn value(&self) -> &BitArrayPatternSizeExpr {
+        &self.value
+    }
+
+    pub(crate) fn into_parts(self) -> (BitArrayPatternSizeExpr, u8) {
+        (self.value, self.unit)
+    }
+}
+
+impl BitArrayPatternSizeExpr {
+    pub(crate) fn value(value: BigInt) -> Self {
+        Self::Value(value)
+    }
+
+    pub(crate) fn local_get(local: IntLocalId, name: EcoString) -> Self {
+        Self::LocalGet { local, name }
+    }
+
+    pub(crate) fn add(left: Self, right: Self) -> Self {
+        Self::Add {
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    pub(crate) fn subtract(left: Self, right: Self) -> Self {
+        Self::Subtract {
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    pub(crate) fn multiply(left: Self, right: Self) -> Self {
+        Self::Multiply {
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    pub(crate) fn divide(left: Self, right: Self) -> Self {
+        Self::Divide {
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    pub(crate) fn remainder(left: Self, right: Self) -> Self {
+        Self::Remainder {
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+}
+
+impl<Local> PatternBinding<Local> {
+    pub(crate) fn new(local: Local, name: EcoString) -> Self {
+        Self { local, name }
+    }
+
+    pub(crate) fn local(&self) -> &Local {
+        &self.local
+    }
+
+    pub(crate) fn into_parts(self) -> (Local, EcoString) {
+        (self.local, self.name)
+    }
+}

--- a/src/plan/module/step.rs
+++ b/src/plan/module/step.rs
@@ -11,6 +11,7 @@ use super::id::{
     ListFunctionLocal, ListLocal, NilFunctionLocalId, NilLocalId, StringFunctionLocalId,
     StringLocalId, TupleFunctionLocalId, TupleLocalId,
 };
+use crate::plan::BitArrayPattern;
 use crate::plan::{PanicSite, SourceSpan, ValueType};
 use ecow::EcoString;
 
@@ -25,19 +26,20 @@ pub(crate) struct AssertBinding {
     name: EcoString,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum AssertPattern {
     Bind(AssertBinding),
     Discard,
     Tuple(Vec<AssertPattern>),
     List(ListAssertPattern),
+    BitArray(BitArrayPattern),
     Alias {
         pattern: Box<AssertPattern>,
         binding: AssertBinding,
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ListAssertPattern {
     element_type: ValueType,
     elements: Vec<AssertPattern>,
@@ -149,6 +151,13 @@ pub(crate) enum StepKind {
         site: PanicSite,
         pattern_span: SourceSpan,
     },
+    AssertBitArray {
+        local: BitArrayLocalId,
+        pattern: AssertPattern,
+        message: Option<StringExpr>,
+        site: PanicSite,
+        pattern_span: SourceSpan,
+    },
     AssertBool {
         condition: BoolExpr,
         message: Option<StringExpr>,
@@ -181,6 +190,10 @@ impl AssertPattern {
             pattern: Box::new(pattern),
             binding,
         }
+    }
+
+    pub(crate) fn bit_array(pattern: BitArrayPattern) -> Self {
+        Self::BitArray(pattern)
     }
 }
 
@@ -400,6 +413,24 @@ impl Step {
     ) -> Self {
         Self {
             kind: StepKind::AssertList {
+                local,
+                pattern,
+                message,
+                site,
+                pattern_span,
+            },
+        }
+    }
+
+    pub(crate) fn assert_bit_array_at(
+        local: BitArrayLocalId,
+        pattern: AssertPattern,
+        message: Option<StringExpr>,
+        site: PanicSite,
+        pattern_span: SourceSpan,
+    ) -> Self {
+        Self {
+            kind: StepKind::AssertBitArray {
                 local,
                 pattern,
                 message,

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -5,6 +5,7 @@ mod error;
 mod expression;
 mod function;
 mod module;
+mod pattern;
 mod statement;
 
 pub use error::{

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -32,8 +32,6 @@ pub enum UnsupportedPatternKind {
     List,
     #[error("literal")]
     Literal,
-    #[error("bit array")]
-    BitArray,
     #[error("constructor")]
     Constructor,
     #[error("string prefix")]

--- a/src/planner/expression/case/subject.rs
+++ b/src/planner/expression/case/subject.rs
@@ -14,9 +14,7 @@ use crate::plan::{
     ValueType,
 };
 use crate::planner::context::PlanContext;
-use crate::planner::error::{
-    InvalidCaseShapeReason, PlanError, UnsupportedCaseReason, UnsupportedPatternKind,
-};
+use crate::planner::error::{InvalidCaseShapeReason, PlanError, UnsupportedCaseReason};
 use crate::planner::statement::plan_variable_runtime_step;
 use ecow::EcoString;
 use gleam_core::ast::{Pattern, SrcSpan, TypedClause, TypedClauseGuard, TypedExpr};
@@ -222,12 +220,6 @@ fn validate_case_branch_type(case_type: &Type, branch: &Expr) -> Result<(), Plan
     ))
 }
 
-fn unsupported_bit_array_pattern<T>() -> Result<T, PlanError> {
-    Err(PlanError::UnsupportedPattern {
-        kind: UnsupportedPatternKind::BitArray,
-    })
-}
-
 fn bool_case_expr(subject: BoolExpr, true_: Expr, false_: Expr) -> Result<Expr, PlanError> {
     let branches = match (true_.into_kind(), false_.into_kind()) {
         (ExprKind::Int(true_), ExprKind::Int(false_)) => BoolCaseBranches::Int { true_, false_ },
@@ -400,6 +392,19 @@ struct OrderedCaseClauseInput<'a> {
     is_total: bool,
 }
 
+struct OrderedCasePattern {
+    match_condition: BoolExpr,
+    branch_bindings: Vec<(EcoString, Expr)>,
+    is_total: bool,
+}
+
+struct OrderedCaseCandidateInput<'a> {
+    case_type: &'a Type,
+    return_type: &'a ValueType,
+    then: TypedExpr,
+    guard: Option<TypedClauseGuard>,
+}
+
 fn plan_ordered_case_clause(
     input: OrderedCaseClauseInput<'_>,
     context: &mut PlanContext<'_>,
@@ -414,7 +419,43 @@ fn plan_ordered_case_clause(
         is_total,
     } = input;
 
+    plan_ordered_case_candidate(
+        OrderedCaseCandidateInput {
+            case_type,
+            return_type,
+            then,
+            guard,
+        },
+        context,
+        |_| {
+            Ok(OrderedCasePattern {
+                match_condition,
+                branch_bindings,
+                is_total,
+            })
+        },
+    )
+}
+
+fn plan_ordered_case_candidate(
+    input: OrderedCaseCandidateInput<'_>,
+    context: &mut PlanContext<'_>,
+    plan_pattern: impl FnOnce(&mut PlanContext<'_>) -> Result<OrderedCasePattern, PlanError>,
+) -> Result<OrderedCaseClause, PlanError> {
+    let OrderedCaseCandidateInput {
+        case_type,
+        return_type,
+        then,
+        guard,
+    } = input;
+
     context.with_local_scope(|context| {
+        let OrderedCasePattern {
+            match_condition,
+            branch_bindings,
+            is_total,
+        } = plan_pattern(context)?;
+        let is_guarded = guard.is_some();
         let binding_steps = plan_branch_binding_steps(branch_bindings, context);
         let guard_condition = guard
             .map(|guard| super::guard::plan_bool(guard, context))
@@ -446,7 +487,7 @@ fn plan_ordered_case_clause(
         Ok(OrderedCaseClause {
             condition,
             branch,
-            is_total,
+            is_total: is_total && !is_guarded,
         })
     })
 }

--- a/src/planner/expression/case/subject/bit_array.rs
+++ b/src/planner/expression/case/subject/bit_array.rs
@@ -1,11 +1,12 @@
 use super::super::super::plan_expr_with_expected_source_stop_type;
 use super::super::invalid_case_shape;
-use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
+use super::{CaseClause, OrderedCaseCandidateInput, OrderedCasePattern, case_return_type};
 use crate::plan::{BitArrayExpr, BitArrayLocalId, BoolExpr, Expr, ExprKind, Step, ValueType};
 use crate::planner::context::PlanContext;
-use crate::planner::error::{InvalidCaseShapeReason, PlanError};
+use crate::planner::error::{InvalidCaseShapeReason, InvalidTypedAstReason, PlanError};
+use crate::planner::pattern::plan_bit_array_pattern;
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, TypedExpr};
+use gleam_core::ast::{BitArrayOption, BitArraySegment, Pattern, TypedExpr};
 use gleam_core::type_::Type;
 use std::sync::Arc;
 
@@ -26,20 +27,22 @@ pub(super) fn plan(
     let mut ordered_clauses = Vec::new();
     for clause in clauses {
         for pattern in clause.patterns() {
-            let pattern = plan_pattern(pattern)?;
-            let bindings = super::branch_bindings(&pattern.bound_names, subject.clone());
-            let is_total = clause.guard.is_none();
-            ordered_clauses.push(super::plan_ordered_case_clause(
-                OrderedCaseClauseInput {
+            ordered_clauses.push(super::plan_ordered_case_candidate(
+                OrderedCaseCandidateInput {
                     case_type: type_.as_ref(),
                     return_type: &return_type,
                     then: clause.then.clone(),
-                    branch_bindings: bindings,
                     guard: clause.guard.clone(),
-                    match_condition: BoolExpr::value(true),
-                    is_total,
                 },
                 context,
+                |context| {
+                    let pattern = plan_pattern(pattern, subject.clone(), context)?;
+                    Ok(OrderedCasePattern {
+                        match_condition: pattern.match_condition,
+                        branch_bindings: pattern.branch_bindings,
+                        is_total: pattern.is_total,
+                    })
+                },
             )?);
         }
     }
@@ -48,27 +51,44 @@ pub(super) fn plan(
         .map(|case| super::case_subject_block(subject_step, case))
 }
 
-struct BitArrayCasePattern {
-    bound_names: Vec<EcoString>,
+pub(super) struct BitArrayCasePattern {
+    match_condition: BoolExpr,
+    branch_bindings: Vec<(EcoString, Expr)>,
+    is_total: bool,
 }
 
-fn plan_pattern(pattern: Pattern<Arc<Type>>) -> Result<BitArrayCasePattern, PlanError> {
+impl BitArrayCasePattern {
+    pub(super) fn into_parts(self) -> (BoolExpr, Vec<(EcoString, Expr)>, bool) {
+        (self.match_condition, self.branch_bindings, self.is_total)
+    }
+}
+
+fn plan_pattern(
+    pattern: Pattern<Arc<Type>>,
+    subject: BitArrayExpr,
+    context: &mut PlanContext<'_>,
+) -> Result<BitArrayCasePattern, PlanError> {
     match pattern {
         Pattern::Variable { name, type_, .. } if type_.is_bit_array() => Ok(BitArrayCasePattern {
-            bound_names: vec![name],
+            match_condition: BoolExpr::value(true),
+            branch_bindings: vec![(name, Expr::bit_array(subject))],
+            is_total: true,
         }),
         Pattern::Discard { type_, .. } if type_.is_bit_array() => Ok(BitArrayCasePattern {
-            bound_names: Vec::new(),
+            match_condition: BoolExpr::value(true),
+            branch_bindings: Vec::new(),
+            is_total: true,
         }),
         Pattern::Assign { name, pattern, .. } => {
-            let mut pattern = plan_pattern(*pattern)?;
-            pattern.bound_names.push(name);
+            let mut pattern = plan_pattern(*pattern, subject.clone(), context)?;
+            pattern
+                .branch_bindings
+                .push((name, Expr::bit_array(subject)));
             Ok(pattern)
         }
+        Pattern::BitArray { segments, .. } => plan_structural_pattern(segments, subject, context),
         Pattern::Invalid { .. } => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
-        Pattern::BitArraySize(_) | Pattern::BitArray { .. } => {
-            super::unsupported_bit_array_pattern()
-        }
+        Pattern::BitArraySize(_) => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
         Pattern::Variable { .. }
         | Pattern::Discard { .. }
         | Pattern::Int { .. }
@@ -83,12 +103,77 @@ fn plan_pattern(pattern: Pattern<Arc<Type>>) -> Result<BitArrayCasePattern, Plan
     }
 }
 
-fn bind_subject(subject: BitArrayExpr, context: &mut PlanContext<'_>) -> (Step, Expr) {
+pub(super) fn plan_structural_pattern(
+    segments: Vec<BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>>,
+    subject: BitArrayExpr,
+    context: &mut PlanContext<'_>,
+) -> Result<BitArrayCasePattern, PlanError> {
+    if let Some(branch_bindings) = plan_total_bits_pattern(&segments, subject.clone())? {
+        return Ok(BitArrayCasePattern {
+            match_condition: BoolExpr::value(true),
+            branch_bindings,
+            is_total: true,
+        });
+    }
+    let (pattern, is_total) = plan_bit_array_pattern(segments, context)?;
+    Ok(BitArrayCasePattern {
+        match_condition: BoolExpr::bit_array_matches(subject, pattern),
+        branch_bindings: Vec::new(),
+        is_total,
+    })
+}
+
+fn plan_total_bits_pattern(
+    segments: &[BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>],
+    subject: BitArrayExpr,
+) -> Result<Option<Vec<(EcoString, Expr)>>, PlanError> {
+    let [segment] = segments else {
+        return Ok(None);
+    };
+    if segment.size().is_some()
+        || !matches!(segment.options.as_slice(), [BitArrayOption::Bits { .. }])
+    {
+        return Ok(None);
+    }
+
+    let mut names = Vec::new();
+    collect_total_bits_bindings(segment.value.as_ref(), &mut names)?;
+    let subject = Expr::bit_array(subject);
+    Ok(Some(
+        names
+            .into_iter()
+            .map(|name| (name, subject.clone()))
+            .collect(),
+    ))
+}
+
+fn collect_total_bits_bindings(
+    pattern: &Pattern<Arc<Type>>,
+    names: &mut Vec<EcoString>,
+) -> Result<(), PlanError> {
+    match pattern {
+        Pattern::Variable { name, type_, .. } if type_.is_bit_array() => {
+            names.push(name.clone());
+            Ok(())
+        }
+        Pattern::Discard { type_, .. } if type_.is_bit_array() => Ok(()),
+        Pattern::Assign { name, pattern, .. } => {
+            collect_total_bits_bindings(pattern, names)?;
+            names.push(name.clone());
+            Ok(())
+        }
+        _ => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::InvalidPattern,
+        }),
+    }
+}
+
+fn bind_subject(subject: BitArrayExpr, context: &mut PlanContext<'_>) -> (Step, BitArrayExpr) {
     let local = context.define_internal_bit_array_local();
     let name = internal_subject_name(local);
     (
         Step::let_bit_array(local, name.clone(), subject),
-        Expr::bit_array(BitArrayExpr::local_get(local, name)),
+        BitArrayExpr::local_get(local, name),
     )
 }
 
@@ -98,15 +183,26 @@ fn internal_subject_name(local: BitArrayLocalId) -> EcoString {
 
 #[cfg(test)]
 mod tests {
-    use crate::plan::{BitArrayExpr, BitArrayLocalId, BitArraySegment, Endianness, IntExpr, Step};
-    use crate::planner::dsl::{function, int, int_return_block, int_return_expr, module};
+    use crate::plan::{
+        BitArrayExpr, BitArrayLocalId, BitArrayPattern, BitArrayPatternSegment,
+        BitArrayPatternSize, BitArrayPatternSizeExpr, BitArrayPatternValue, BitArrayReturn,
+        BitArraySegment, BoolExpr, Endianness, Expr, IntExpr, IntLocalId, PatternBinding,
+        Signedness, Step,
+    };
+    use crate::planner::dsl::{
+        function, int, int_return_block, int_return_expr, local_int, module,
+    };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
     use crate::planner::{
-        InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
-        UnsupportedPatternKind,
+        InvalidCaseShapeReason, InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError,
+        UnsupportedExpressionKind,
     };
-    use gleam_core::ast::Pattern;
+    use gleam_core::ast::{
+        BitArrayOption, BitArraySegment as PatternBitArraySegment, BitArraySize, ClauseGuard,
+        Pattern, TypedExpr,
+    };
+    use gleam_core::type_;
 
     #[test]
     fn plan_bit_array_subject_alias_binds_inner_then_alias_after_single_subject_eval() {
@@ -289,25 +385,434 @@ pub fn main() {
                 },
             }),
         );
-    }
 
-    #[test]
-    fn reject_profile_structural_bit_array_pattern() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+        let mut invalid_size = crate::planner::support::compile(
+            r#"
 pub fn main() {
   case <<1>> {
-    <<1>> -> 1
+    _ -> 1
+  }
+}
+"#,
+        );
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut invalid_size.definitions.functions[0].body[0],
+        );
+        clauses[0].pattern[0] = Pattern::BitArraySize(BitArraySize::Int {
+            location: dummy_span(),
+            value: "8".into(),
+            int_value: 8.into(),
+        });
+        assert_eq!(
+            plan_module(invalid_size),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::InvalidPattern,
+                },
+            }),
+        );
+
+        let mut invalid_guard = crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case <<1>> {
+    _ if True -> 1
     _ -> 0
   }
 }
 "#,
-            ),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::BitArray,
-            },
         );
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut invalid_guard.definitions.functions[0].body[0],
+        );
+        clauses[0].guard = Some(ClauseGuard::Invalid {
+            location: dummy_span(),
+            type_: type_::bool(),
+        });
+        assert_eq!(
+            plan_module(invalid_guard),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+
+        let mut invalid_branch = crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case <<1>> {
+    _ -> 1
+  }
+}
+"#,
+        );
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut invalid_branch.definitions.functions[0].body[0],
+        );
+        clauses[0].then = TypedExpr::Invalid {
+            location: dummy_span(),
+            type_: type_::int(),
+            extra_information: None,
+        };
+        assert_eq!(
+            plan_module(invalid_branch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+
+        let mut branch_type_mismatch = crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case <<1>> {
+    _ -> 1
+  }
+}
+"#,
+        );
+        let (case_type, _, _) = super::super::super::expect_case_statement_mut(
+            &mut branch_type_mismatch.definitions.functions[0].body[0],
+        );
+        *case_type = type_::bool();
+        assert_eq!(
+            plan_module(branch_type_mismatch),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_invalid_total_bit_array_pattern_binding() {
+        for invalid_binding in [
+            Pattern::Discard {
+                location: dummy_span(),
+                name: "_".into(),
+                type_: type_::int(),
+            },
+            Pattern::Assign {
+                name: "alias".into(),
+                location: dummy_span(),
+                pattern: Box::new(Pattern::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }),
+            },
+        ] {
+            let segments = vec![PatternBitArraySegment {
+                location: dummy_span(),
+                value: Box::new(invalid_binding),
+                options: vec![BitArrayOption::Bits {
+                    location: dummy_span(),
+                }],
+                type_: type_::bit_array(),
+            }];
+            let mut invalid = crate::planner::support::compile(
+                r#"
+pub fn main() {
+  case <<1>> {
+    <<_:bits>> -> 1
+  }
+}
+"#,
+            );
+            let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+                &mut invalid.definitions.functions[0].body[0],
+            );
+            clauses[0].pattern[0] = Pattern::BitArray {
+                location: dummy_span(),
+                segments,
+            };
+
+            assert_eq!(
+                plan_module(invalid),
+                Err(PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::InvalidPattern,
+                }),
+            );
+        }
+    }
+
+    #[test]
+    fn plan_structural_bit_array_pattern_evaluates_subject_once() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case <<1, 2>> {
+    <<1, 2>> -> 1
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let subject_name = "<case:bit_array:0>";
+        let subject = BitArrayExpr::value(vec![
+            BitArraySegment::Int {
+                value: IntExpr::value(1.into()),
+                bit_size: 8,
+                endianness: Endianness::Big,
+            },
+            BitArraySegment::Int {
+                value: IntExpr::value(2.into()),
+                bit_size: 8,
+                endianness: Endianness::Big,
+            },
+        ]);
+        let pattern = BitArrayPattern::new(vec![
+            BitArrayPatternSegment::Int {
+                pattern: BitArrayPatternValue::Literal(1.into()),
+                size: BitArrayPatternSize::new(BitArrayPatternSizeExpr::value(8.into()), 1),
+                endianness: Endianness::Big,
+                signedness: Signedness::Unsigned,
+            },
+            BitArrayPatternSegment::Int {
+                pattern: BitArrayPatternValue::Literal(2.into()),
+                size: BitArrayPatternSize::new(BitArrayPatternSizeExpr::value(8.into()), 1),
+                endianness: Endianness::Big,
+                signedness: Signedness::Unsigned,
+            },
+        ]);
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [Step::let_bit_array(
+                        BitArrayLocalId(0),
+                        subject_name.into(),
+                        subject,
+                    )],
+                    crate::plan::IntReturn::bool_case(
+                        BoolExpr::bit_array_matches(
+                            BitArrayExpr::local_get(BitArrayLocalId(0), subject_name.into()),
+                            pattern,
+                        ),
+                        int_return_expr(int(1)),
+                        int_return_expr(int(0)),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_total_bits_pattern_binds_subject_without_runtime_match_condition() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case <<1>> {
+    <<_ as inner:bits>> as whole -> inner
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let subject_name = "<case:bit_array:0>";
+        let subject = BitArrayExpr::value(vec![BitArraySegment::Int {
+            value: IntExpr::value(1.into()),
+            bit_size: 8,
+            endianness: Endianness::Big,
+        }]);
+        let expected = module(
+            "main",
+            function(
+                "main",
+                BitArrayReturn::block(
+                    vec![Step::let_bit_array(
+                        BitArrayLocalId(0),
+                        subject_name.into(),
+                        subject,
+                    )],
+                    BitArrayReturn::block(
+                        vec![
+                            Step::let_bit_array(
+                                BitArrayLocalId(1),
+                                "inner".into(),
+                                BitArrayExpr::local_get(BitArrayLocalId(0), subject_name.into()),
+                            ),
+                            Step::let_bit_array(
+                                BitArrayLocalId(2),
+                                "whole".into(),
+                                BitArrayExpr::local_get(BitArrayLocalId(0), subject_name.into()),
+                            ),
+                        ],
+                        BitArrayReturn::expr(BitArrayExpr::local_get(
+                            BitArrayLocalId(1),
+                            "inner".into(),
+                        )),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_bit_array_pattern_binding_is_visible_to_guard_and_branch() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case <<1>> {
+    <<value>> if value > 0 -> value
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let subject_name = "<case:bit_array:0>";
+        let subject = BitArrayExpr::value(vec![BitArraySegment::Int {
+            value: IntExpr::value(1.into()),
+            bit_size: 8,
+            endianness: Endianness::Big,
+        }]);
+        let pattern = BitArrayPattern::new(vec![BitArrayPatternSegment::Int {
+            pattern: BitArrayPatternValue::Bind(PatternBinding::new(IntLocalId(0), "value".into())),
+            size: BitArrayPatternSize::new(BitArrayPatternSizeExpr::value(8.into()), 1),
+            endianness: Endianness::Big,
+            signedness: Signedness::Unsigned,
+        }]);
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [Step::let_bit_array(
+                        BitArrayLocalId(0),
+                        subject_name.into(),
+                        subject,
+                    )],
+                    crate::plan::IntReturn::bool_case(
+                        BoolExpr::and(
+                            BoolExpr::bit_array_matches(
+                                BitArrayExpr::local_get(BitArrayLocalId(0), subject_name.into()),
+                                pattern,
+                            ),
+                            BoolExpr::gt_int(local_int(0, "value").into(), int(0).into()),
+                        ),
+                        int_return_expr(local_int(0, "value")),
+                        int_return_expr(int(0)),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_guarded_bit_array_alias_binds_guard_and_branch_scope() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case <<1>> {
+    value as alias if value == alias -> 1
+    _ -> 0
+  }
+}
+"#,
+        ))
+        .expect("source should plan");
+        let subject_name = "<case:bit_array:0>";
+        let subject = BitArrayExpr::value(vec![BitArraySegment::Int {
+            value: IntExpr::value(1.into()),
+            bit_size: 8,
+            endianness: Endianness::Big,
+        }]);
+        let bind_value = Step::let_bit_array(
+            BitArrayLocalId(1),
+            "value".into(),
+            BitArrayExpr::local_get(BitArrayLocalId(0), subject_name.into()),
+        );
+        let bind_alias = Step::let_bit_array(
+            BitArrayLocalId(2),
+            "alias".into(),
+            BitArrayExpr::local_get(BitArrayLocalId(0), subject_name.into()),
+        );
+        let condition = BoolExpr::and(
+            BoolExpr::value(true),
+            BoolExpr::block(
+                vec![bind_value.clone(), bind_alias.clone()],
+                BoolExpr::equal(
+                    Expr::bit_array(BitArrayExpr::local_get(BitArrayLocalId(1), "value".into())),
+                    Expr::bit_array(BitArrayExpr::local_get(BitArrayLocalId(2), "alias".into())),
+                ),
+            ),
+        );
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [Step::let_bit_array(
+                        BitArrayLocalId(0),
+                        subject_name.into(),
+                        subject,
+                    )],
+                    crate::plan::IntReturn::bool_case(
+                        condition,
+                        int_return_block([bind_value, bind_alias], int_return_expr(int(1))),
+                        int_return_expr(int(0)),
+                    ),
+                ),
+            ),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_total_bits_binding_collection_preserves_inner_to_outer_order() {
+        let variable = Pattern::Variable {
+            location: dummy_span(),
+            name: "value".into(),
+            type_: type_::bit_array(),
+            origin: gleam_core::type_::error::VariableOrigin::generated(),
+        };
+        let nested_alias = Pattern::Assign {
+            location: dummy_span(),
+            name: "outer".into(),
+            pattern: Box::new(Pattern::Assign {
+                location: dummy_span(),
+                name: "inner".into(),
+                pattern: Box::new(variable),
+            }),
+        };
+        let mut names = Vec::new();
+
+        assert_eq!(
+            super::collect_total_bits_bindings(&nested_alias, &mut names),
+            Ok(()),
+        );
+        assert_eq!(names, ["value", "inner", "outer"]);
+
+        let mut discard_names = Vec::new();
+        assert_eq!(
+            super::collect_total_bits_bindings(
+                &Pattern::Discard {
+                    location: dummy_span(),
+                    name: "_".into(),
+                    type_: type_::bit_array(),
+                },
+                &mut discard_names,
+            ),
+            Ok(()),
+        );
+        assert_eq!(discard_names, Vec::<ecow::EcoString>::new());
     }
 
     #[test]

--- a/src/planner/expression/case/subject/list.rs
+++ b/src/planner/expression/case/subject/list.rs
@@ -1,7 +1,7 @@
 use super::super::super::plan_expr_with_expected_source_stop_type;
 use super::super::super::{list_index_expr, tuple_index_expr};
 use super::super::invalid_case_shape;
-use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
+use super::{CaseClause, OrderedCaseCandidateInput, OrderedCasePattern, case_return_type};
 use crate::plan::{
     BoolExpr, Expr, ExprKind, FloatExpr, IntExpr, ListExpr, ListLocal, Step, StringExpr, ValueType,
 };
@@ -33,21 +33,28 @@ pub(super) fn plan(
     let mut ordered_clauses = Vec::new();
     for clause in clauses {
         for pattern in clause.patterns() {
-            let pattern =
-                plan_list_case_pattern(pattern, subject.clone(), subject_value_type.clone())?;
-            let is_total = pattern.is_total() && clause.guard.is_none();
-            let match_condition = pattern.match_condition();
-            ordered_clauses.push(super::plan_ordered_case_clause(
-                OrderedCaseClauseInput {
+            ordered_clauses.push(super::plan_ordered_case_candidate(
+                OrderedCaseCandidateInput {
                     case_type: type_.as_ref(),
                     return_type: &return_type,
                     then: clause.then.clone(),
-                    branch_bindings: pattern.branch_bindings,
                     guard: clause.guard.clone(),
-                    match_condition,
-                    is_total,
                 },
                 context,
+                |context| {
+                    let pattern = plan_list_case_pattern_with_context(
+                        pattern,
+                        subject.clone(),
+                        subject_value_type.clone(),
+                        context,
+                    )?;
+                    let is_total = pattern.is_total();
+                    Ok(OrderedCasePattern {
+                        match_condition: pattern.match_condition(),
+                        branch_bindings: pattern.branch_bindings,
+                        is_total,
+                    })
+                },
             )?);
         }
     }
@@ -128,12 +135,35 @@ impl ListCasePattern {
     pub(super) fn into_parts(self) -> (Option<BoolExpr>, Vec<(EcoString, Expr)>, bool) {
         (self.match_condition, self.branch_bindings, self.is_total)
     }
+
+    fn from_bit_array_pattern(pattern: super::bit_array::BitArrayCasePattern) -> Self {
+        let (match_condition, branch_bindings, is_total) = pattern.into_parts();
+        Self {
+            match_condition: Some(match_condition),
+            branch_bindings,
+            is_total,
+        }
+    }
 }
 
+#[cfg(test)]
 pub(super) fn plan_list_case_pattern(
     pattern: Pattern<Arc<Type>>,
     value: Expr,
     subject_type: ValueType,
+) -> Result<ListCasePattern, PlanError> {
+    let module_name = EcoString::from("main");
+    let functions = std::collections::HashMap::new();
+    let mut anonymous = crate::planner::context::AnonymousFunctions::default();
+    let mut context = PlanContext::new(&module_name, &functions, &mut anonymous);
+    plan_list_case_pattern_with_context(pattern, value, subject_type, &mut context)
+}
+
+pub(super) fn plan_list_case_pattern_with_context(
+    pattern: Pattern<Arc<Type>>,
+    value: Expr,
+    subject_type: ValueType,
+    context: &mut PlanContext<'_>,
 ) -> Result<ListCasePattern, PlanError> {
     match pattern {
         Pattern::Variable { name, type_, .. } if matches_type(type_.as_ref(), &subject_type) => {
@@ -149,7 +179,12 @@ pub(super) fn plan_list_case_pattern(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
         Pattern::Assign { name, pattern, .. } => {
-            let pattern = plan_list_case_pattern(*pattern, value.clone(), subject_type)?;
+            let pattern = plan_list_case_pattern_with_context(
+                *pattern,
+                value.clone(),
+                subject_type,
+                context,
+            )?;
             Ok(pattern.with_binding(name, value))
         }
         Pattern::List {
@@ -163,8 +198,11 @@ pub(super) fn plan_list_case_pattern(
             type_,
             value,
             subject_type,
+            context,
         ),
-        Pattern::Tuple { elements, .. } => plan_tuple_case_pattern(elements, value, subject_type),
+        Pattern::Tuple { elements, .. } => {
+            plan_tuple_case_pattern(elements, value, subject_type, context)
+        }
         Pattern::Int { int_value, .. } if subject_type == ValueType::Int => Ok(
             ListCasePattern::literal(value, Expr::int(IntExpr::value(int_value))),
         ),
@@ -222,9 +260,18 @@ pub(super) fn plan_list_case_pattern(
             right_side_assignment,
         ),
         Pattern::Invalid { .. } => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
-        Pattern::BitArraySize(_) | Pattern::BitArray { .. } => {
-            super::unsupported_bit_array_pattern()
+        Pattern::BitArray { segments, .. } if subject_type == ValueType::BitArray => {
+            let Some(value) = value.into_bit_array() else {
+                return Err(invalid_case_shape(
+                    InvalidCaseShapeReason::PatternTypeMismatch,
+                ));
+            };
+            super::bit_array::plan_structural_pattern(segments, value, context)
+                .map(ListCasePattern::from_bit_array_pattern)
         }
+        Pattern::BitArraySize(_) | Pattern::BitArray { .. } => Err(invalid_case_shape(
+            InvalidCaseShapeReason::PatternTypeMismatch,
+        )),
         Pattern::Int { .. }
         | Pattern::Float { .. }
         | Pattern::String { .. }
@@ -241,6 +288,7 @@ fn plan_list_structural_case_pattern(
     type_: Arc<Type>,
     value: Expr,
     subject_type: ValueType,
+    context: &mut PlanContext<'_>,
 ) -> Result<ListCasePattern, PlanError> {
     let pattern_type =
         ValueType::from_gleam(type_.as_ref()).ok_or(PlanError::UnsupportedExpression {
@@ -267,10 +315,11 @@ fn plan_list_structural_case_pattern(
     let mut patterns = Vec::with_capacity(elements.len());
     for (index, pattern) in elements.into_iter().enumerate() {
         let value = list_index_expr(list.clone(), index, element_type.clone())?;
-        patterns.push(plan_list_case_pattern(
+        patterns.push(plan_list_case_pattern_with_context(
             pattern,
             value,
             element_type.clone(),
+            context,
         )?);
     }
 
@@ -293,6 +342,7 @@ fn plan_tuple_case_pattern(
     elements: Vec<Pattern<Arc<Type>>>,
     value: Expr,
     subject_type: ValueType,
+    context: &mut PlanContext<'_>,
 ) -> Result<ListCasePattern, PlanError> {
     let ValueType::Tuple(element_types) = subject_type else {
         return Err(invalid_case_shape(
@@ -313,7 +363,9 @@ fn plan_tuple_case_pattern(
     let mut patterns = Vec::with_capacity(elements.len());
     for (index, (pattern, type_)) in elements.into_iter().zip(element_types).enumerate() {
         let value = tuple_index_expr(tuple.clone(), index, type_.clone());
-        patterns.push(plan_list_case_pattern(pattern, value, type_)?);
+        patterns.push(plan_list_case_pattern_with_context(
+            pattern, value, type_, context,
+        )?);
     }
 
     Ok(combine_list_case_patterns(patterns))
@@ -402,7 +454,9 @@ fn internal_list_case_subject_name(local: &ListLocal) -> EcoString {
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        BoolExpr, Expr, IntListLocalId, IntLocalId, ListExpr, ListLocal, Step, StringExpr,
+        BitArrayExpr, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
+        BitArrayPatternSizeExpr, BitArrayPatternValue, BitArraySegment, BoolExpr, Endianness, Expr,
+        IntExpr, IntListLocalId, IntLocalId, ListExpr, ListLocal, Signedness, Step, StringExpr,
         ValueType,
     };
     use crate::planner::dsl::{
@@ -413,7 +467,6 @@ mod tests {
     use crate::planner::support::{dummy_span, expect_plan_error};
     use crate::planner::{
         InvalidCaseShapeReason, InvalidExpressionType, InvalidTypedAstReason, PlanError,
-        UnsupportedPatternKind,
     };
     use gleam_core::type_::error::VariableOrigin;
 
@@ -1572,13 +1625,42 @@ pub fn main() {
                 },
             }),
         );
+        assert_eq!(
+            super::plan_list_case_pattern(
+                gleam_core::ast::Pattern::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                },
+                Expr::int(IntExpr::value(1.into())),
+                ValueType::BitArray,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
+        assert_eq!(
+            super::plan_list_case_pattern(
+                gleam_core::ast::Pattern::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                },
+                Expr::bit_array(BitArrayExpr::value(Vec::new())),
+                ValueType::Int,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
     }
 
     #[test]
-    fn reject_profile_list_nested_bit_array_pattern() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+    fn plan_list_nested_bit_array_pattern_checks_length_before_projection() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
 pub fn main() {
   case [<<1>>] {
     [<<1>>] -> 1
@@ -1586,10 +1668,52 @@ pub fn main() {
   }
 }
 "#,
+        ))
+        .expect("source should plan");
+        let subject_name = "<case:list:bit array:0>";
+        let subject = BitArrayExpr::value(vec![BitArraySegment::Int {
+            value: IntExpr::value(1.into()),
+            bit_size: 8,
+            endianness: Endianness::Big,
+        }]);
+        let pattern = BitArrayPattern::new(vec![BitArrayPatternSegment::Int {
+            pattern: BitArrayPatternValue::Literal(1.into()),
+            size: BitArrayPatternSize::new(BitArrayPatternSizeExpr::value(8.into()), 1),
+            endianness: Endianness::Big,
+            signedness: Signedness::Unsigned,
+        }]);
+        let local: ListExpr = local_list(0, subject_name, ValueType::BitArray).into();
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [let_list_step(
+                        0,
+                        subject_name,
+                        list([Expr::bit_array(subject)], ValueType::BitArray),
+                    )],
+                    crate::plan::IntReturn::bool_case(
+                        BoolExpr::and(
+                            BoolExpr::list_length_equals(local.clone(), 1),
+                            BoolExpr::bit_array_matches(
+                                BitArrayExpr::list_index(
+                                    local
+                                        .into_bit_array()
+                                        .expect("local must be List(BitArray)"),
+                                    0,
+                                ),
+                                pattern,
+                            ),
+                        ),
+                        int_return_expr(int(1)),
+                        int_return_expr(int(0)),
+                    ),
+                ),
             ),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::BitArray,
-            },
+            [],
         );
+
+        assert_eq!(actual, expected);
     }
 }

--- a/src/planner/expression/case/subject/tuple.rs
+++ b/src/planner/expression/case/subject/tuple.rs
@@ -1,7 +1,7 @@
 use super::super::super::plan_expr_with_expected_source_stop_type;
 use super::super::super::tuple_index_expr;
 use super::super::invalid_case_shape;
-use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
+use super::{CaseClause, OrderedCaseCandidateInput, OrderedCasePattern, case_return_type};
 use crate::plan::{
     BoolExpr, Expr, ExprKind, FloatExpr, IntExpr, Step, StringExpr, TupleExpr, TupleLocalId,
     ValueType,
@@ -34,21 +34,28 @@ pub(super) fn plan(
     let mut ordered_clauses = Vec::new();
     for clause in clauses {
         for pattern in clause.patterns() {
-            let pattern =
-                plan_tuple_case_pattern(pattern, subject.clone(), subject_value_type.clone())?;
-            let is_total = pattern.is_total() && clause.guard.is_none();
-            let match_condition = pattern.match_condition();
-            ordered_clauses.push(super::plan_ordered_case_clause(
-                OrderedCaseClauseInput {
+            ordered_clauses.push(super::plan_ordered_case_candidate(
+                OrderedCaseCandidateInput {
                     case_type: type_.as_ref(),
                     return_type: &return_type,
                     then: clause.then.clone(),
-                    branch_bindings: pattern.branch_bindings,
                     guard: clause.guard.clone(),
-                    match_condition,
-                    is_total,
                 },
                 context,
+                |context| {
+                    let pattern = plan_tuple_case_pattern_with_context(
+                        pattern,
+                        subject.clone(),
+                        subject_value_type.clone(),
+                        context,
+                    )?;
+                    let is_total = pattern.is_total();
+                    Ok(OrderedCasePattern {
+                        match_condition: pattern.match_condition(),
+                        branch_bindings: pattern.branch_bindings,
+                        is_total,
+                    })
+                },
             )?);
         }
     }
@@ -127,10 +134,11 @@ impl TupleCasePattern {
     }
 }
 
-fn plan_tuple_case_pattern(
+fn plan_tuple_case_pattern_with_context(
     pattern: Pattern<Arc<Type>>,
     value: Expr,
     subject_type: ValueType,
+    context: &mut PlanContext<'_>,
 ) -> Result<TupleCasePattern, PlanError> {
     match pattern {
         Pattern::Variable { name, type_, .. } if matches_type(type_.as_ref(), &subject_type) => {
@@ -146,11 +154,16 @@ fn plan_tuple_case_pattern(
             InvalidCaseShapeReason::PatternTypeMismatch,
         )),
         Pattern::Assign { name, pattern, .. } => {
-            let pattern = plan_tuple_case_pattern(*pattern, value.clone(), subject_type)?;
+            let pattern = plan_tuple_case_pattern_with_context(
+                *pattern,
+                value.clone(),
+                subject_type,
+                context,
+            )?;
             Ok(pattern.with_binding(name, value))
         }
         Pattern::Tuple { elements, .. } => {
-            plan_tuple_structural_case_pattern(elements, value, subject_type)
+            plan_tuple_structural_case_pattern(elements, value, subject_type, context)
         }
         Pattern::Int { int_value, .. } if subject_type == ValueType::Int => Ok(
             TupleCasePattern::literal(value, Expr::int(IntExpr::value(int_value))),
@@ -199,7 +212,12 @@ fn plan_tuple_case_pattern(
         }
         Pattern::Invalid { .. } => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
         Pattern::List { .. } if matches!(subject_type, ValueType::List(_)) => {
-            let pattern = super::list::plan_list_case_pattern(pattern, value, subject_type)?;
+            let pattern = super::list::plan_list_case_pattern_with_context(
+                pattern,
+                value,
+                subject_type,
+                context,
+            )?;
             Ok(TupleCasePattern::from_list_pattern(pattern))
         }
         Pattern::StringPrefix {
@@ -213,9 +231,18 @@ fn plan_tuple_case_pattern(
             left_side_assignment,
             right_side_assignment,
         ),
-        Pattern::BitArraySize(_) | Pattern::BitArray { .. } => {
-            super::unsupported_bit_array_pattern()
+        Pattern::BitArray { segments, .. } if subject_type == ValueType::BitArray => {
+            let Some(value) = value.into_bit_array() else {
+                return Err(invalid_case_shape(
+                    InvalidCaseShapeReason::PatternTypeMismatch,
+                ));
+            };
+            super::bit_array::plan_structural_pattern(segments, value, context)
+                .map(TupleCasePattern::from_bit_array_pattern)
         }
+        Pattern::BitArraySize(_) | Pattern::BitArray { .. } => Err(invalid_case_shape(
+            InvalidCaseShapeReason::PatternTypeMismatch,
+        )),
         Pattern::Int { .. }
         | Pattern::Float { .. }
         | Pattern::String { .. }
@@ -231,6 +258,7 @@ fn plan_tuple_structural_case_pattern(
     elements: Vec<Pattern<Arc<Type>>>,
     value: Expr,
     subject_type: ValueType,
+    context: &mut PlanContext<'_>,
 ) -> Result<TupleCasePattern, PlanError> {
     let ValueType::Tuple(element_types) = subject_type else {
         return Err(invalid_case_shape(
@@ -251,10 +279,25 @@ fn plan_tuple_structural_case_pattern(
     let mut patterns = Vec::with_capacity(elements.len());
     for (index, (pattern, type_)) in elements.into_iter().zip(element_types).enumerate() {
         let value = tuple_index_expr(tuple.clone(), index, type_.clone());
-        patterns.push(plan_tuple_case_pattern(pattern, value, type_)?);
+        patterns.push(plan_tuple_case_pattern_with_context(
+            pattern, value, type_, context,
+        )?);
     }
 
     Ok(combine_tuple_case_patterns(patterns))
+}
+
+#[cfg(test)]
+fn plan_tuple_case_pattern(
+    pattern: Pattern<Arc<Type>>,
+    value: Expr,
+    subject_type: ValueType,
+) -> Result<TupleCasePattern, PlanError> {
+    let module_name = EcoString::from("main");
+    let functions = std::collections::HashMap::new();
+    let mut anonymous = crate::planner::context::AnonymousFunctions::default();
+    let mut context = PlanContext::new(&module_name, &functions, &mut anonymous);
+    plan_tuple_case_pattern_with_context(pattern, value, subject_type, &mut context)
 }
 
 fn combine_tuple_case_patterns(patterns: Vec<TupleCasePattern>) -> TupleCasePattern {
@@ -277,6 +320,15 @@ impl TupleCasePattern {
         let (match_condition, branch_bindings, is_total) = pattern.into_parts();
         Self {
             match_condition,
+            branch_bindings,
+            is_total,
+        }
+    }
+
+    fn from_bit_array_pattern(pattern: super::bit_array::BitArrayCasePattern) -> Self {
+        let (match_condition, branch_bindings, is_total) = pattern.into_parts();
+        Self {
+            match_condition: Some(match_condition),
             branch_bindings,
             is_total,
         }
@@ -304,7 +356,10 @@ fn internal_tuple_case_subject_name(local: TupleLocalId) -> EcoString {
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        BoolExpr, Expr, IntLocalId, ListExpr, Step, StringExpr, StringLocalId, ValueType,
+        BitArrayExpr, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
+        BitArrayPatternSizeExpr, BitArrayPatternValue, BitArraySegment, BoolExpr, Endianness, Expr,
+        IntExpr, IntLocalId, ListExpr, Signedness, Step, StringExpr, StringLocalId, TupleExpr,
+        TupleLocalId, ValueType,
     };
     use crate::planner::dsl::{
         bool_, float, function, int, int_return_block, int_return_expr, let_int_step,
@@ -313,9 +368,7 @@ mod tests {
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
-    use crate::planner::{
-        InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedPatternKind,
-    };
+    use crate::planner::{InvalidCaseShapeReason, InvalidTypedAstReason, PlanError};
     use gleam_core::ast::{AssignName, Pattern};
     use gleam_core::parse::LiteralFloatValue;
     use gleam_core::type_::error::VariableOrigin;
@@ -1007,28 +1060,57 @@ pub fn main() {
 
     #[test]
     fn reject_margin_tuple_inner_list_pattern_errors_are_propagated() {
+        let mut module = crate::planner::support::compile(
+            r#"
+pub fn main() {
+  case #([1]) {
+    #([value]) -> value
+    _ -> 0
+  }
+}
+"#,
+        );
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
+        let elements = expect_single_tuple_list_elements(&mut clauses[0].pattern[0]);
+        elements[0] = Pattern::List {
+            location: dummy_span(),
+            elements: Vec::new(),
+            tail: None,
+            type_: gleam_core::type_::int(),
+        };
+
         assert_eq!(
-            super::plan_tuple_case_pattern(
-                Pattern::List {
-                    location: dummy_span(),
-                    elements: vec![Pattern::List {
-                        location: dummy_span(),
-                        elements: Vec::new(),
-                        tail: None,
-                        type_: gleam_core::type_::int(),
-                    }],
-                    tail: None,
-                    type_: gleam_core::type_::list(gleam_core::type_::int()),
-                },
-                list([int(1)], ValueType::Int).into(),
-                ValueType::List(Box::new(ValueType::Int)),
-            ),
+            plan_module(module),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CaseShape {
                     reason: InvalidCaseShapeReason::PatternTypeMismatch,
                 },
             }),
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "expected a single tuple-inner list pattern")]
+    fn tuple_inner_list_fixture_guard_rejects_int_pattern() {
+        let mut pattern = Pattern::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: 1.into(),
+        };
+        let _ = expect_single_tuple_list_elements(&mut pattern);
+    }
+
+    fn expect_single_tuple_list_elements(
+        pattern: &mut Pattern<std::sync::Arc<gleam_core::type_::Type>>,
+    ) -> &mut Vec<Pattern<std::sync::Arc<gleam_core::type_::Type>>> {
+        if let Pattern::Tuple { elements, .. } = pattern
+            && let [Pattern::List { elements, .. }] = elements.as_mut_slice()
+        {
+            return elements;
+        }
+        panic!("expected a single tuple-inner list pattern");
     }
 
     #[test]
@@ -1210,6 +1292,36 @@ pub fn main() {
                 },
                 Expr::from(tuple([int(1)])),
                 tuple_type.clone(),
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
+        assert_eq!(
+            super::plan_tuple_case_pattern(
+                Pattern::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                },
+                Expr::int(IntExpr::value(1.into())),
+                ValueType::BitArray,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::PatternTypeMismatch,
+                },
+            }),
+        );
+        assert_eq!(
+            super::plan_tuple_case_pattern(
+                Pattern::BitArray {
+                    location: dummy_span(),
+                    segments: Vec::new(),
+                },
+                Expr::bit_array(BitArrayExpr::value(Vec::new())),
+                ValueType::Int,
             ),
             Err(PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::CaseShape {
@@ -1442,10 +1554,9 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_tuple_nested_bit_array_pattern() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+    fn plan_tuple_nested_bit_array_pattern_projects_before_matching() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
 pub fn main() {
   case #(<<1>>) {
     #(<<1>>) -> 1
@@ -1453,10 +1564,51 @@ pub fn main() {
   }
 }
 "#,
+        ))
+        .expect("source should plan");
+        let tuple_type = vec![ValueType::BitArray];
+        let subject_name = "<case:tuple:0>";
+        let subject = BitArrayExpr::value(vec![BitArraySegment::Int {
+            value: IntExpr::value(1.into()),
+            bit_size: 8,
+            endianness: Endianness::Big,
+        }]);
+        let pattern = BitArrayPattern::new(vec![BitArrayPatternSegment::Int {
+            pattern: BitArrayPatternValue::Literal(1.into()),
+            size: BitArrayPatternSize::new(BitArrayPatternSizeExpr::value(8.into()), 1),
+            endianness: Endianness::Big,
+            signedness: Signedness::Unsigned,
+        }]);
+        let expected = module(
+            "main",
+            function(
+                "main",
+                int_return_block(
+                    [Step::let_tuple(
+                        TupleLocalId(0),
+                        subject_name.into(),
+                        TupleExpr::value(vec![Expr::bit_array(subject)], tuple_type.clone()),
+                    )],
+                    crate::plan::IntReturn::bool_case(
+                        BoolExpr::bit_array_matches(
+                            BitArrayExpr::tuple_index(
+                                TupleExpr::local_get(
+                                    TupleLocalId(0),
+                                    subject_name.into(),
+                                    tuple_type,
+                                ),
+                                0,
+                            ),
+                            pattern,
+                        ),
+                        int_return_expr(int(1)),
+                        int_return_expr(int(0)),
+                    ),
+                ),
             ),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::BitArray,
-            },
+            [],
         );
+
+        assert_eq!(actual, expected);
     }
 }

--- a/src/planner/expression/function/free_variables.rs
+++ b/src/planner/expression/function/free_variables.rs
@@ -1,7 +1,7 @@
 use ecow::EcoString;
 use gleam_core::ast::{
-    AssignmentKind, ClauseGuard, Pattern, Statement, TypedArg, TypedClauseGuard, TypedExpr,
-    TypedPipelineAssignment, TypedStatement,
+    AssignmentKind, BitArraySize, ClauseGuard, Pattern, Statement, TypedArg, TypedClauseGuard,
+    TypedExpr, TypedPipelineAssignment, TypedStatement,
 };
 use gleam_core::type_::{Type, ValueConstructorVariant};
 use std::collections::HashSet;
@@ -72,7 +72,7 @@ fn collect_statement(
             {
                 collect_expr(message, bound, free);
             }
-            collect_variable_pattern_bound_name(&assignment.pattern, bound);
+            collect_pattern(&assignment.pattern, bound, free);
         }
         Statement::Use(use_) => {
             collect_expr(&use_.call, bound, free);
@@ -145,7 +145,13 @@ fn collect_expr(expression: &TypedExpr, bound: &mut HashSet<EcoString>, free: &m
             for clause in clauses {
                 let mut branch_bound = bound.clone();
                 for pattern in &clause.pattern {
-                    collect_variable_pattern_bound_name(pattern, &mut branch_bound);
+                    collect_pattern(pattern, &mut branch_bound, free);
+                }
+                for alternative in &clause.alternative_patterns {
+                    let mut alternative_bound = bound.clone();
+                    for pattern in alternative {
+                        collect_pattern(pattern, &mut alternative_bound, free);
+                    }
                 }
                 if let Some(guard) = &clause.guard {
                     collect_clause_guard(guard, &mut branch_bound, free);
@@ -225,31 +231,41 @@ fn collect_clause_guard(
     }
 }
 
-fn collect_variable_pattern_bound_name(
+fn collect_pattern(
     pattern: &Pattern<Arc<Type>>,
     bound: &mut HashSet<EcoString>,
+    free: &mut FreeVariables,
 ) {
     match pattern {
         Pattern::Variable { name, .. } => {
             bound.insert(name.clone());
         }
         Pattern::Assign { name, pattern, .. } => {
-            collect_variable_pattern_bound_name(pattern, bound);
+            collect_pattern(pattern, bound, free);
             bound.insert(name.clone());
         }
         Pattern::Tuple { elements, .. } => {
             for element in elements {
-                collect_variable_pattern_bound_name(element, bound);
+                collect_pattern(element, bound, free);
             }
         }
         Pattern::List { elements, tail, .. } => {
             for element in elements {
-                collect_variable_pattern_bound_name(element, bound);
+                collect_pattern(element, bound, free);
             }
             if let Some(tail) = tail {
-                collect_variable_pattern_bound_name(&tail.pattern, bound);
+                collect_pattern(&tail.pattern, bound, free);
             }
         }
+        Pattern::BitArray { segments, .. } => {
+            for segment in segments {
+                if let Some(Pattern::BitArraySize(size)) = segment.size() {
+                    collect_bit_array_size(size, bound, free);
+                }
+                collect_pattern(segment.value.as_ref(), bound, free);
+            }
+        }
+        Pattern::BitArraySize(size) => collect_bit_array_size(size, bound, free),
         Pattern::StringPrefix {
             left_side_assignment,
             right_side_assignment,
@@ -266,17 +282,33 @@ fn collect_variable_pattern_bound_name(
         | Pattern::Float { .. }
         | Pattern::String { .. }
         | Pattern::Constructor { .. }
-        | Pattern::BitArray { .. }
-        | Pattern::BitArraySize(_)
         | Pattern::Discard { .. }
         | Pattern::Invalid { .. } => {}
+    }
+}
+
+fn collect_bit_array_size(
+    size: &BitArraySize<Arc<Type>>,
+    bound: &HashSet<EcoString>,
+    free: &mut FreeVariables,
+) {
+    match size {
+        BitArraySize::Variable { name, .. } => free.record(name, bound),
+        BitArraySize::BinaryOperator { left, right, .. } => {
+            collect_bit_array_size(left, bound, free);
+            collect_bit_array_size(right, bound, free);
+        }
+        BitArraySize::Block { inner, .. } => collect_bit_array_size(inner, bound, free),
+        BitArraySize::Int { .. } => {}
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::planner::support::{compile, dummy_span};
-    use gleam_core::ast::{AssignName, ClauseGuard, Constant, Publicity, Statement, TypedExpr};
+    use gleam_core::ast::{
+        AssignName, BitArraySize, ClauseGuard, Constant, Pattern, Publicity, Statement, TypedExpr,
+    };
     use gleam_core::type_::error::VariableOrigin;
     use gleam_core::type_::{self, Deprecation, ValueConstructor, ValueConstructorVariant};
     use vec1::Vec1;
@@ -396,10 +428,11 @@ pub fn main() {
     }
 
     #[test]
-    fn collect_variable_pattern_bound_name_records_string_prefix_alias_and_suffix_names() {
+    fn collect_pattern_records_string_prefix_alias_and_suffix_names() {
         let mut bound = std::collections::HashSet::new();
+        let mut free = super::FreeVariables::new();
 
-        super::collect_variable_pattern_bound_name(
+        super::collect_pattern(
             &gleam_core::ast::Pattern::StringPrefix {
                 location: dummy_span(),
                 left_location: dummy_span(),
@@ -409,19 +442,22 @@ pub fn main() {
                 right_side_assignment: AssignName::Variable("name".into()),
             },
             &mut bound,
+            &mut free,
         );
 
         assert_eq!(
             bound,
             std::collections::HashSet::from(["prefix".into(), "name".into()]),
         );
+        assert_eq!(free.names, Vec::<String>::new());
     }
 
     #[test]
-    fn collect_variable_pattern_bound_name_ignores_discard_string_prefix_names() {
+    fn collect_pattern_ignores_discard_string_prefix_names() {
         let mut bound = std::collections::HashSet::new();
+        let mut free = super::FreeVariables::new();
 
-        super::collect_variable_pattern_bound_name(
+        super::collect_pattern(
             &gleam_core::ast::Pattern::StringPrefix {
                 location: dummy_span(),
                 left_location: dummy_span(),
@@ -431,9 +467,11 @@ pub fn main() {
                 right_side_assignment: AssignName::Discard("_rest".into()),
             },
             &mut bound,
+            &mut free,
         );
 
         assert_eq!(bound, std::collections::HashSet::new());
+        assert_eq!(free.names, Vec::<String>::new());
     }
 
     #[test]
@@ -472,6 +510,63 @@ pub fn main() {
             ),
             vec!["value".to_string(), "size".to_string()],
         );
+    }
+
+    #[test]
+    fn anonymous_free_variables_distinguish_outer_and_prior_bit_array_pattern_sizes() {
+        assert_eq!(
+            anonymous_function_free_variables(
+                r#"
+pub fn main() {
+  let outer_size = 8
+  fn(bits) {
+    case bits {
+      <<size, outer:size(outer_size), inner:size(size)>> -> outer + inner
+      _ -> 0
+    }
+  }
+  1
+}
+"#,
+            ),
+            vec!["outer_size".to_string()],
+        );
+    }
+
+    #[test]
+    fn anonymous_free_variables_visit_bit_array_alternatives_and_size_arithmetic() {
+        assert_eq!(
+            anonymous_function_free_variables(
+                r#"
+pub fn main() {
+  let outer_size = 8
+  fn(bits) {
+    case bits {
+      <<size, value:size(size)>> | <<size, value:size({ outer_size + 0 })>> -> value
+      _ -> 0
+    }
+  }
+  1
+}
+"#,
+            ),
+            vec!["outer_size".to_string()],
+        );
+    }
+
+    #[test]
+    fn direct_bit_array_size_pattern_collects_its_variable() {
+        let pattern = Pattern::BitArraySize(BitArraySize::Variable {
+            location: dummy_span(),
+            name: "size".into(),
+            constructor: None,
+            type_: type_::int(),
+        });
+        let mut free = super::FreeVariables::new();
+
+        super::collect_pattern(&pattern, &mut std::collections::HashSet::new(), &mut free);
+
+        assert_eq!(free.names, vec!["size".to_string()]);
     }
 
     #[test]

--- a/src/planner/pattern.rs
+++ b/src/planner/pattern.rs
@@ -1,0 +1,3 @@
+mod bit_array;
+
+pub(in crate::planner) use bit_array::plan_bit_array_pattern;

--- a/src/planner/pattern/bit_array.rs
+++ b/src/planner/pattern/bit_array.rs
@@ -1,0 +1,1387 @@
+use crate::plan::{
+    BitArrayBindingPattern, BitArrayLocalId, BitArrayPattern, BitArrayPatternSegment,
+    BitArrayPatternSize, BitArrayPatternSizeExpr, BitArrayPatternValue, BitArrayStringPattern,
+    Endianness, FloatLocalId, IntLocalId, LocalId, PatternBinding, Signedness, StringEncoding,
+    ValueType,
+};
+use crate::planner::context::PlanContext;
+use crate::planner::error::{InvalidTypedAstReason, PlanError, UnsupportedBitArraySegmentReason};
+use gleam_core::ast::{
+    BitArrayOption, BitArraySegment, BitArraySize, Constant, IntOperator, Pattern,
+};
+use gleam_core::type_::{Type, ValueConstructor, ValueConstructorVariant};
+use std::sync::Arc;
+
+pub(in crate::planner) fn plan_bit_array_pattern(
+    segments: Vec<BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>>,
+    context: &mut PlanContext<'_>,
+) -> Result<(BitArrayPattern, bool), PlanError> {
+    let is_total = is_total_pattern(&segments);
+    let mut planned = Vec::with_capacity(segments.len());
+    let segment_count = segments.len();
+    for (index, segment) in segments.into_iter().enumerate() {
+        let segment = plan_segment(segment, context)?;
+        if index + 1 < segment_count
+            && matches!(segment, BitArrayPatternSegment::Bits { size: None, .. })
+        {
+            return Err(invalid_pattern());
+        }
+        planned.push(segment);
+    }
+    Ok((BitArrayPattern::new(planned), is_total))
+}
+
+fn plan_segment(
+    segment: BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<BitArrayPatternSegment, PlanError> {
+    if segment
+        .options
+        .iter()
+        .any(|option| matches!(option, BitArrayOption::Native { .. }))
+    {
+        return unsupported_segment(UnsupportedBitArraySegmentReason::NativeEndianness);
+    }
+    if segment.options.iter().any(|option| {
+        matches!(
+            option,
+            BitArrayOption::Utf8Codepoint { .. }
+                | BitArrayOption::Utf16Codepoint { .. }
+                | BitArrayOption::Utf32Codepoint { .. }
+        )
+    }) {
+        return unsupported_segment(UnsupportedBitArraySegmentReason::UtfCodepoint);
+    }
+
+    let kind = segment_kind(&segment)?;
+    validate_segment_options(&segment, kind)?;
+    let endianness = segment_endianness(&segment);
+    let unit = segment.unit();
+    let explicit_size = segment
+        .size()
+        .map(|size| plan_segment_size(size, unit, context))
+        .transpose()?;
+    match kind {
+        SegmentKind::Int => Ok(BitArrayPatternSegment::Int {
+            pattern: plan_int_pattern(*segment.value, context)?,
+            size: explicit_size.unwrap_or_else(|| BitArrayPatternSize::new(size_value(8), 1)),
+            endianness,
+            signedness: if segment
+                .options
+                .iter()
+                .any(|option| matches!(option, BitArrayOption::Signed { .. }))
+            {
+                Signedness::Signed
+            } else {
+                Signedness::Unsigned
+            },
+        }),
+        SegmentKind::Float => Ok(BitArrayPatternSegment::Float {
+            pattern: plan_float_pattern(*segment.value, context)?,
+            size: explicit_size.unwrap_or_else(|| BitArrayPatternSize::new(size_value(64), 1)),
+            endianness,
+        }),
+        SegmentKind::Bits => Ok(BitArrayPatternSegment::Bits {
+            pattern: plan_bits_pattern(*segment.value, context)?,
+            size: explicit_size,
+            unit,
+        }),
+        SegmentKind::String(encoding) => Ok(BitArrayPatternSegment::String {
+            pattern: plan_string_pattern(*segment.value)?,
+            encoding,
+        }),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum SegmentKind {
+    Int,
+    Float,
+    Bits,
+    String(StringEncoding),
+}
+
+fn validate_segment_options(
+    segment: &BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>,
+    kind: SegmentKind,
+) -> Result<(), PlanError> {
+    let mut kind_count = 0;
+    let mut signedness_count = 0;
+    let mut endianness_count = 0;
+    let mut size_count = 0;
+    let mut unit_count = 0;
+    let mut zero_unit = false;
+
+    for option in &segment.options {
+        match option {
+            BitArrayOption::Bytes { .. }
+            | BitArrayOption::Bits { .. }
+            | BitArrayOption::Int { .. }
+            | BitArrayOption::Float { .. }
+            | BitArrayOption::Utf8 { .. }
+            | BitArrayOption::Utf16 { .. }
+            | BitArrayOption::Utf32 { .. }
+            | BitArrayOption::Utf8Codepoint { .. }
+            | BitArrayOption::Utf16Codepoint { .. }
+            | BitArrayOption::Utf32Codepoint { .. } => kind_count += 1,
+            BitArrayOption::Signed { .. } | BitArrayOption::Unsigned { .. } => {
+                signedness_count += 1;
+            }
+            BitArrayOption::Big { .. }
+            | BitArrayOption::Little { .. }
+            | BitArrayOption::Native { .. } => endianness_count += 1,
+            BitArrayOption::Size { .. } => size_count += 1,
+            BitArrayOption::Unit { value, .. } => {
+                unit_count += 1;
+                zero_unit |= *value == 0;
+            }
+        }
+    }
+
+    let duplicate_option = kind_count
+        .max(signedness_count)
+        .max(endianness_count)
+        .max(size_count)
+        .max(unit_count)
+        > 1;
+    let invalid_unit = [unit_count > size_count, zero_unit].contains(&true);
+    let incompatible_modifier = match kind {
+        SegmentKind::Int => false,
+        SegmentKind::Float => signedness_count != 0,
+        SegmentKind::Bits => signedness_count + endianness_count != 0,
+        SegmentKind::String(StringEncoding::Utf8) => {
+            signedness_count + endianness_count + size_count + unit_count != 0
+        }
+        SegmentKind::String(StringEncoding::Utf16(_) | StringEncoding::Utf32(_)) => {
+            signedness_count + size_count + unit_count != 0
+        }
+    };
+
+    if [duplicate_option, invalid_unit, incompatible_modifier].contains(&true) {
+        Err(invalid_pattern())
+    } else {
+        Ok(())
+    }
+}
+
+fn segment_kind(
+    segment: &BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>,
+) -> Result<SegmentKind, PlanError> {
+    let mut kind = None;
+    for option in &segment.options {
+        let next = match option {
+            BitArrayOption::Bytes { .. } | BitArrayOption::Bits { .. } => Some(SegmentKind::Bits),
+            BitArrayOption::Int { .. } => Some(SegmentKind::Int),
+            BitArrayOption::Float { .. } => Some(SegmentKind::Float),
+            BitArrayOption::Utf8 { .. } => Some(SegmentKind::String(StringEncoding::Utf8)),
+            BitArrayOption::Utf16 { .. } => Some(SegmentKind::String(StringEncoding::Utf16(
+                segment_endianness(segment),
+            ))),
+            BitArrayOption::Utf32 { .. } => Some(SegmentKind::String(StringEncoding::Utf32(
+                segment_endianness(segment),
+            ))),
+            BitArrayOption::Utf8Codepoint { .. }
+            | BitArrayOption::Utf16Codepoint { .. }
+            | BitArrayOption::Utf32Codepoint { .. }
+            | BitArrayOption::Signed { .. }
+            | BitArrayOption::Unsigned { .. }
+            | BitArrayOption::Big { .. }
+            | BitArrayOption::Little { .. }
+            | BitArrayOption::Native { .. }
+            | BitArrayOption::Size { .. }
+            | BitArrayOption::Unit { .. } => None,
+        };
+        if let Some(next) = next {
+            if kind.is_some() {
+                return Err(invalid_pattern());
+            }
+            kind = Some(next);
+        }
+    }
+    if let Some(kind) = kind {
+        return Ok(kind);
+    }
+    if matches!(segment.value_unwrapping_assign(), Pattern::String { .. }) {
+        Ok(SegmentKind::String(StringEncoding::Utf8))
+    } else {
+        Ok(SegmentKind::Int)
+    }
+}
+
+fn segment_endianness(segment: &BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>) -> Endianness {
+    if segment
+        .options
+        .iter()
+        .any(|option| matches!(option, BitArrayOption::Little { .. }))
+    {
+        Endianness::Little
+    } else {
+        Endianness::Big
+    }
+}
+
+fn plan_segment_size(
+    pattern: &Pattern<Arc<Type>>,
+    unit: u8,
+    context: &mut PlanContext<'_>,
+) -> Result<BitArrayPatternSize, PlanError> {
+    let Pattern::BitArraySize(size) = pattern else {
+        return Err(invalid_pattern());
+    };
+    Ok(BitArrayPatternSize::new(plan_size(size, context)?, unit))
+}
+
+fn plan_size(
+    size: &BitArraySize<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<BitArrayPatternSizeExpr, PlanError> {
+    match size {
+        BitArraySize::Int { int_value, .. } => {
+            Ok(BitArrayPatternSizeExpr::value(int_value.clone()))
+        }
+        BitArraySize::Variable {
+            name, constructor, ..
+        } => {
+            let constructor = constructor
+                .as_deref()
+                .cloned()
+                .ok_or_else(invalid_pattern)?;
+            plan_size_variable(name.clone(), constructor, context)
+        }
+        BitArraySize::BinaryOperator {
+            operator,
+            left,
+            right,
+            ..
+        } => {
+            let left = plan_size(left, context)?;
+            let right = plan_size(right, context)?;
+            Ok(match operator {
+                IntOperator::Add => BitArrayPatternSizeExpr::add(left, right),
+                IntOperator::Subtract => BitArrayPatternSizeExpr::subtract(left, right),
+                IntOperator::Multiply => BitArrayPatternSizeExpr::multiply(left, right),
+                IntOperator::Divide => BitArrayPatternSizeExpr::divide(left, right),
+                IntOperator::Remainder => BitArrayPatternSizeExpr::remainder(left, right),
+            })
+        }
+        BitArraySize::Block { inner, .. } => plan_size(inner, context),
+    }
+}
+
+fn plan_size_variable(
+    name: ecow::EcoString,
+    constructor: ValueConstructor,
+    context: &PlanContext<'_>,
+) -> Result<BitArrayPatternSizeExpr, PlanError> {
+    match constructor.variant {
+        ValueConstructorVariant::LocalVariable { .. } => match context.lookup_local(&name) {
+            Some((LocalId::Int(local), ValueType::Int)) => {
+                Ok(BitArrayPatternSizeExpr::local_get(local, name))
+            }
+            Some(_) => Err(invalid_pattern()),
+            None => Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::UnknownLocal { name },
+            }),
+        },
+        ValueConstructorVariant::ModuleConstant {
+            module, literal, ..
+        } if module == *context.module_name => plan_size_constant(literal, context),
+        _ => Err(invalid_pattern()),
+    }
+}
+
+fn plan_size_constant(
+    constant: Constant<Arc<Type>>,
+    context: &PlanContext<'_>,
+) -> Result<BitArrayPatternSizeExpr, PlanError> {
+    match constant {
+        Constant::Int { int_value, .. } => Ok(BitArrayPatternSizeExpr::value(int_value)),
+        Constant::Var {
+            name, constructor, ..
+        } => {
+            let constructor = constructor
+                .map(|constructor| *constructor)
+                .ok_or_else(invalid_pattern)?;
+            plan_size_variable(name, constructor, context)
+        }
+        _ => Err(invalid_pattern()),
+    }
+}
+
+fn size_value(value: u8) -> BitArrayPatternSizeExpr {
+    BitArrayPatternSizeExpr::value(value.into())
+}
+
+fn plan_int_pattern(
+    pattern: Pattern<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<BitArrayPatternValue<num_bigint::BigInt, IntLocalId>, PlanError> {
+    match pattern {
+        Pattern::Int { int_value, .. } => Ok(BitArrayPatternValue::Literal(int_value)),
+        Pattern::Variable { name, type_, .. } if type_.is_int() => {
+            let local = context.define_int_local(name.clone());
+            Ok(BitArrayPatternValue::Bind(PatternBinding::new(local, name)))
+        }
+        Pattern::Discard { type_, .. } if type_.is_int() => Ok(BitArrayPatternValue::Discard),
+        Pattern::Assign { name, pattern, .. } => {
+            let pattern = plan_int_pattern(*pattern, context)?;
+            let local = context.define_int_local(name.clone());
+            Ok(BitArrayPatternValue::Alias {
+                pattern: Box::new(pattern),
+                binding: PatternBinding::new(local, name),
+            })
+        }
+        _ => Err(invalid_pattern()),
+    }
+}
+
+fn plan_float_pattern(
+    pattern: Pattern<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<BitArrayPatternValue<f64, FloatLocalId>, PlanError> {
+    match pattern {
+        Pattern::Float { float_value, .. } => {
+            Ok(BitArrayPatternValue::Literal(float_value.value()))
+        }
+        Pattern::Variable { name, type_, .. } if type_.is_float() => {
+            let local = context.define_float_local(name.clone());
+            Ok(BitArrayPatternValue::Bind(PatternBinding::new(local, name)))
+        }
+        Pattern::Discard { type_, .. } if type_.is_float() => Ok(BitArrayPatternValue::Discard),
+        Pattern::Assign { name, pattern, .. } => {
+            let pattern = plan_float_pattern(*pattern, context)?;
+            let local = context.define_float_local(name.clone());
+            Ok(BitArrayPatternValue::Alias {
+                pattern: Box::new(pattern),
+                binding: PatternBinding::new(local, name),
+            })
+        }
+        _ => Err(invalid_pattern()),
+    }
+}
+
+fn plan_bits_pattern(
+    pattern: Pattern<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<BitArrayBindingPattern<BitArrayLocalId>, PlanError> {
+    match pattern {
+        Pattern::Variable { name, type_, .. } if type_.is_bit_array() => {
+            let local = context.define_bit_array_local(name.clone());
+            Ok(BitArrayBindingPattern::Bind(PatternBinding::new(
+                local, name,
+            )))
+        }
+        Pattern::Discard { type_, .. } if type_.is_bit_array() => {
+            Ok(BitArrayBindingPattern::Discard)
+        }
+        Pattern::Assign { name, pattern, .. } => {
+            let pattern = plan_bits_pattern(*pattern, context)?;
+            let local = context.define_bit_array_local(name.clone());
+            Ok(BitArrayBindingPattern::Alias {
+                pattern: Box::new(pattern),
+                binding: PatternBinding::new(local, name),
+            })
+        }
+        _ => Err(invalid_pattern()),
+    }
+}
+
+fn plan_string_pattern(pattern: Pattern<Arc<Type>>) -> Result<BitArrayStringPattern, PlanError> {
+    match pattern {
+        Pattern::String { value, .. } => Ok(BitArrayStringPattern::Literal(value)),
+        Pattern::Discard { .. } => Ok(BitArrayStringPattern::Discard),
+        Pattern::Variable { .. } | Pattern::Assign { .. } => Err(invalid_pattern()),
+        _ => Err(invalid_pattern()),
+    }
+}
+
+fn is_total_pattern(segments: &[BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>]) -> bool {
+    segments.len() == 1
+        && segments[0].size().is_none()
+        && matches!(
+            segments[0].options.as_slice(),
+            [BitArrayOption::Bits { .. }]
+        )
+}
+
+fn unsupported_segment<T>(reason: UnsupportedBitArraySegmentReason) -> Result<T, PlanError> {
+    Err(PlanError::UnsupportedBitArraySegment { reason })
+}
+
+fn invalid_pattern() -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::InvalidPattern,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::plan::{
+        BitArrayBindingPattern, BitArrayLocalId, BitArrayPattern, BitArrayPatternSegment,
+        BitArrayPatternSizeExpr, BitArrayStringPattern, Endianness, FloatLocalId, IntLocalId,
+        PatternBinding, Signedness, StringEncoding,
+    };
+    use crate::planner::context::{AnonymousFunctions, PlanContext};
+    use crate::planner::error::{
+        InvalidTypedAstReason, PlanError, UnsupportedBitArraySegmentReason,
+    };
+    use crate::planner::support::{compile, dummy_span, expect_plan_error};
+    use gleam_core::ast::Publicity;
+    use gleam_core::ast::{BitArrayOption, BitArraySegment, Constant, Pattern};
+    use gleam_core::type_::{
+        self, Deprecation, ValueConstructor, ValueConstructorVariant, error::VariableOrigin,
+    };
+
+    #[test]
+    fn reject_profile_bit_array_pattern_native_endianness() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case <<1>> {
+    <<value:native>> -> value
+    _ -> 0
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedBitArraySegment {
+                reason: UnsupportedBitArraySegmentReason::NativeEndianness,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_profile_bit_array_pattern_utf_codepoint() {
+        assert_eq!(
+            expect_plan_error(
+                r#"
+pub fn main() {
+  case <<"A":utf8>> {
+    <<_:utf8_codepoint>> -> 1
+    _ -> 0
+  }
+}
+"#,
+            ),
+            PlanError::UnsupportedBitArraySegment {
+                reason: UnsupportedBitArraySegmentReason::UtfCodepoint,
+            },
+        );
+    }
+
+    #[test]
+    fn reject_margin_bit_array_pattern_invalid_typed_ast_shapes() {
+        let discard = |type_| Pattern::Discard {
+            location: dummy_span(),
+            name: "_".into(),
+            type_,
+        };
+        let segment = |value, options, type_| BitArraySegment {
+            location: dummy_span(),
+            value: Box::new(value),
+            options,
+            type_,
+        };
+        let alias = |name: &str, pattern: Pattern<std::sync::Arc<gleam_core::type_::Type>>| {
+            Pattern::Assign {
+                name: name.into(),
+                location: dummy_span(),
+                pattern: Box::new(pattern),
+            }
+        };
+        let local_constructor = |type_| ValueConstructor {
+            publicity: Publicity::Private,
+            deprecation: Deprecation::NotDeprecated,
+            type_,
+            variant: ValueConstructorVariant::LocalVariable {
+                location: dummy_span(),
+                origin: VariableOrigin::generated(),
+            },
+        };
+        let size = |value| BitArrayOption::Size {
+            location: dummy_span(),
+            value: Box::new(Pattern::BitArraySize(value)),
+            short_form: false,
+        };
+        let int_size = || gleam_core::ast::BitArraySize::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: 1.into(),
+        };
+        let missing_constructor = || gleam_core::ast::BitArraySize::Variable {
+            location: dummy_span(),
+            name: "missing".into(),
+            constructor: None,
+            type_: type_::int(),
+        };
+        let invalid = || {
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::InvalidPattern,
+            })
+        };
+        let mut cases = Vec::new();
+
+        for options in [
+            vec![
+                BitArrayOption::Int {
+                    location: dummy_span(),
+                },
+                BitArrayOption::Int {
+                    location: dummy_span(),
+                },
+            ],
+            vec![BitArrayOption::Unit {
+                location: dummy_span(),
+                value: 2,
+            }],
+            vec![
+                BitArrayOption::Size {
+                    location: dummy_span(),
+                    value: Box::new(Pattern::BitArraySize(gleam_core::ast::BitArraySize::Int {
+                        location: dummy_span(),
+                        value: "1".into(),
+                        int_value: 1.into(),
+                    })),
+                    short_form: false,
+                },
+                BitArrayOption::Unit {
+                    location: dummy_span(),
+                    value: 0,
+                },
+            ],
+            vec![
+                BitArrayOption::Float {
+                    location: dummy_span(),
+                },
+                BitArrayOption::Signed {
+                    location: dummy_span(),
+                },
+            ],
+            vec![
+                BitArrayOption::Bits {
+                    location: dummy_span(),
+                },
+                BitArrayOption::Little {
+                    location: dummy_span(),
+                },
+            ],
+            vec![
+                BitArrayOption::Utf8 {
+                    location: dummy_span(),
+                },
+                BitArrayOption::Big {
+                    location: dummy_span(),
+                },
+            ],
+            vec![
+                BitArrayOption::Utf16 {
+                    location: dummy_span(),
+                },
+                BitArrayOption::Signed {
+                    location: dummy_span(),
+                },
+            ],
+        ] {
+            cases.push((
+                vec![segment(discard(type_::int()), options, type_::int())],
+                invalid(),
+            ));
+        }
+        cases.push((
+            vec![segment(
+                Pattern::Variable {
+                    location: dummy_span(),
+                    name: "value".into(),
+                    type_: type_::string(),
+                    origin: gleam_core::type_::error::VariableOrigin::generated(),
+                },
+                vec![BitArrayOption::Utf8 {
+                    location: dummy_span(),
+                }],
+                type_::string(),
+            )],
+            invalid(),
+        ));
+        cases.push((
+            vec![
+                segment(
+                    discard(type_::bit_array()),
+                    vec![BitArrayOption::Bits {
+                        location: dummy_span(),
+                    }],
+                    type_::bit_array(),
+                ),
+                segment(
+                    discard(type_::int()),
+                    vec![BitArrayOption::Int {
+                        location: dummy_span(),
+                    }],
+                    type_::int(),
+                ),
+            ],
+            invalid(),
+        ));
+
+        for (value, options, type_, expected) in [
+            (
+                discard(type_::int()),
+                vec![BitArrayOption::Size {
+                    location: dummy_span(),
+                    value: Box::new(discard(type_::int())),
+                    short_form: false,
+                }],
+                type_::int(),
+                super::invalid_pattern(),
+            ),
+            (
+                discard(type_::string()),
+                vec![BitArrayOption::Int {
+                    location: dummy_span(),
+                }],
+                type_::int(),
+                super::invalid_pattern(),
+            ),
+            (
+                discard(type_::int()),
+                vec![BitArrayOption::Float {
+                    location: dummy_span(),
+                }],
+                type_::float(),
+                super::invalid_pattern(),
+            ),
+            (
+                discard(type_::int()),
+                vec![BitArrayOption::Bits {
+                    location: dummy_span(),
+                }],
+                type_::bit_array(),
+                super::invalid_pattern(),
+            ),
+            (
+                Pattern::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                },
+                vec![BitArrayOption::Utf8 {
+                    location: dummy_span(),
+                }],
+                type_::string(),
+                super::invalid_pattern(),
+            ),
+            (
+                alias("int_alias", discard(type_::string())),
+                vec![BitArrayOption::Int {
+                    location: dummy_span(),
+                }],
+                type_::int(),
+                super::invalid_pattern(),
+            ),
+            (
+                alias("float_alias", discard(type_::int())),
+                vec![BitArrayOption::Float {
+                    location: dummy_span(),
+                }],
+                type_::float(),
+                super::invalid_pattern(),
+            ),
+            (
+                alias("bits_alias", discard(type_::int())),
+                vec![BitArrayOption::Bits {
+                    location: dummy_span(),
+                }],
+                type_::bit_array(),
+                super::invalid_pattern(),
+            ),
+            (
+                discard(type_::int()),
+                vec![size(missing_constructor())],
+                type_::int(),
+                super::invalid_pattern(),
+            ),
+            (
+                discard(type_::int()),
+                vec![size(gleam_core::ast::BitArraySize::Variable {
+                    location: dummy_span(),
+                    name: "unknown".into(),
+                    constructor: Some(Box::new(local_constructor(type_::int()))),
+                    type_: type_::int(),
+                })],
+                type_::int(),
+                PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::UnknownLocal {
+                        name: "unknown".into(),
+                    },
+                },
+            ),
+            (
+                discard(type_::int()),
+                vec![size(gleam_core::ast::BitArraySize::Variable {
+                    location: dummy_span(),
+                    name: "string_size".into(),
+                    constructor: Some(Box::new(local_constructor(type_::string()))),
+                    type_: type_::int(),
+                })],
+                type_::int(),
+                super::invalid_pattern(),
+            ),
+            (
+                discard(type_::int()),
+                vec![size(gleam_core::ast::BitArraySize::BinaryOperator {
+                    location: dummy_span(),
+                    operator: gleam_core::ast::IntOperator::Add,
+                    left: Box::new(missing_constructor()),
+                    right: Box::new(int_size()),
+                })],
+                type_::int(),
+                super::invalid_pattern(),
+            ),
+            (
+                discard(type_::int()),
+                vec![size(gleam_core::ast::BitArraySize::BinaryOperator {
+                    location: dummy_span(),
+                    operator: gleam_core::ast::IntOperator::Add,
+                    left: Box::new(int_size()),
+                    right: Box::new(missing_constructor()),
+                })],
+                type_::int(),
+                super::invalid_pattern(),
+            ),
+        ] {
+            cases.push((vec![segment(value, options, type_)], Err(expected)));
+        }
+
+        for (segments, expected) in cases {
+            let module_name = "main".into();
+            let functions = std::collections::HashMap::new();
+            let mut anonymous = AnonymousFunctions::default();
+            let mut context = PlanContext::new(&module_name, &functions, &mut anonymous);
+            context.define_int_local("int_size".into());
+            context.define_string_local("string_size".into());
+
+            assert_eq!(
+                super::plan_bit_array_pattern(segments, &mut context),
+                expected,
+            );
+        }
+    }
+
+    #[test]
+    fn plan_bit_array_pattern_preserves_supported_segment_shapes() {
+        let discard = |type_| Pattern::Discard {
+            location: dummy_span(),
+            name: "_".into(),
+            type_,
+        };
+        let segment = |value, options, type_| BitArraySegment {
+            location: dummy_span(),
+            value: Box::new(value),
+            options,
+            type_,
+        };
+        let alias = |name: &str, pattern: Pattern<std::sync::Arc<gleam_core::type_::Type>>| {
+            Pattern::Assign {
+                name: name.into(),
+                location: dummy_span(),
+                pattern: Box::new(pattern),
+            }
+        };
+        let local_constructor = |type_| ValueConstructor {
+            publicity: Publicity::Private,
+            deprecation: Deprecation::NotDeprecated,
+            type_,
+            variant: ValueConstructorVariant::LocalVariable {
+                location: dummy_span(),
+                origin: VariableOrigin::generated(),
+            },
+        };
+        let size = |value| BitArrayOption::Size {
+            location: dummy_span(),
+            value: Box::new(Pattern::BitArraySize(value)),
+            short_form: false,
+        };
+        let int_size = || gleam_core::ast::BitArraySize::Int {
+            location: dummy_span(),
+            value: "1".into(),
+            int_value: 1.into(),
+        };
+        let mut cases = Vec::new();
+
+        cases.push((
+            vec![segment(
+                discard(type_::bit_array()),
+                vec![BitArrayOption::Bits {
+                    location: dummy_span(),
+                }],
+                type_::bit_array(),
+            )],
+            Ok((
+                BitArrayPattern::new(vec![BitArrayPatternSegment::Bits {
+                    pattern: BitArrayBindingPattern::Discard,
+                    size: None,
+                    unit: 1,
+                }]),
+                true,
+            )),
+        ));
+        cases.push((
+            vec![
+                segment(
+                    Pattern::Float {
+                        location: dummy_span(),
+                        value: "1.0".into(),
+                        float_value: gleam_core::parse::LiteralFloatValue::ONE,
+                    },
+                    vec![BitArrayOption::Float {
+                        location: dummy_span(),
+                    }],
+                    type_::float(),
+                ),
+                segment(
+                    Pattern::String {
+                        location: dummy_span(),
+                        value: "A".into(),
+                    },
+                    Vec::new(),
+                    type_::string(),
+                ),
+            ],
+            Ok((
+                BitArrayPattern::new(vec![
+                    BitArrayPatternSegment::Float {
+                        pattern: crate::plan::BitArrayPatternValue::Literal(1.0),
+                        size: crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(64.into()),
+                            1,
+                        ),
+                        endianness: crate::plan::Endianness::Big,
+                    },
+                    BitArrayPatternSegment::String {
+                        pattern: BitArrayStringPattern::Literal("A".into()),
+                        encoding: StringEncoding::Utf8,
+                    },
+                ]),
+                false,
+            )),
+        ));
+        let explicit_size = |value| {
+            vec![BitArrayOption::Size {
+                location: dummy_span(),
+                value: Box::new(Pattern::BitArraySize(value)),
+                short_form: false,
+            }]
+        };
+        cases.push((
+            vec![
+                segment(
+                    Pattern::Int {
+                        location: dummy_span(),
+                        value: "258".into(),
+                        int_value: 258.into(),
+                    },
+                    vec![
+                        BitArrayOption::Int {
+                            location: dummy_span(),
+                        },
+                        BitArrayOption::Signed {
+                            location: dummy_span(),
+                        },
+                        BitArrayOption::Little {
+                            location: dummy_span(),
+                        },
+                        size(int_size()),
+                    ],
+                    type_::int(),
+                ),
+                segment(
+                    Pattern::Variable {
+                        location: dummy_span(),
+                        name: "integer".into(),
+                        type_: type_::int(),
+                        origin: VariableOrigin::generated(),
+                    },
+                    Vec::new(),
+                    type_::int(),
+                ),
+                segment(discard(type_::int()), Vec::new(), type_::int()),
+                segment(
+                    alias("integer_alias", discard(type_::int())),
+                    Vec::new(),
+                    type_::int(),
+                ),
+            ],
+            Ok((
+                BitArrayPattern::new(vec![
+                    BitArrayPatternSegment::Int {
+                        pattern: crate::plan::BitArrayPatternValue::Literal(258.into()),
+                        size: crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(1.into()),
+                            1,
+                        ),
+                        endianness: Endianness::Little,
+                        signedness: Signedness::Signed,
+                    },
+                    BitArrayPatternSegment::Int {
+                        pattern: crate::plan::BitArrayPatternValue::Bind(PatternBinding::new(
+                            IntLocalId(1),
+                            "integer".into(),
+                        )),
+                        size: crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(8.into()),
+                            1,
+                        ),
+                        endianness: Endianness::Big,
+                        signedness: Signedness::Unsigned,
+                    },
+                    BitArrayPatternSegment::Int {
+                        pattern: crate::plan::BitArrayPatternValue::Discard,
+                        size: crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(8.into()),
+                            1,
+                        ),
+                        endianness: Endianness::Big,
+                        signedness: Signedness::Unsigned,
+                    },
+                    BitArrayPatternSegment::Int {
+                        pattern: crate::plan::BitArrayPatternValue::Alias {
+                            pattern: Box::new(crate::plan::BitArrayPatternValue::Discard),
+                            binding: PatternBinding::new(IntLocalId(2), "integer_alias".into()),
+                        },
+                        size: crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(8.into()),
+                            1,
+                        ),
+                        endianness: Endianness::Big,
+                        signedness: Signedness::Unsigned,
+                    },
+                ]),
+                false,
+            )),
+        ));
+        cases.push((
+            vec![
+                segment(
+                    Pattern::Variable {
+                        location: dummy_span(),
+                        name: "float".into(),
+                        type_: type_::float(),
+                        origin: VariableOrigin::generated(),
+                    },
+                    vec![
+                        BitArrayOption::Float {
+                            location: dummy_span(),
+                        },
+                        BitArrayOption::Little {
+                            location: dummy_span(),
+                        },
+                        size(int_size()),
+                    ],
+                    type_::float(),
+                ),
+                segment(
+                    discard(type_::float()),
+                    vec![BitArrayOption::Float {
+                        location: dummy_span(),
+                    }],
+                    type_::float(),
+                ),
+                segment(
+                    alias("float_alias", discard(type_::float())),
+                    vec![BitArrayOption::Float {
+                        location: dummy_span(),
+                    }],
+                    type_::float(),
+                ),
+            ],
+            Ok((
+                BitArrayPattern::new(vec![
+                    BitArrayPatternSegment::Float {
+                        pattern: crate::plan::BitArrayPatternValue::Bind(PatternBinding::new(
+                            FloatLocalId(0),
+                            "float".into(),
+                        )),
+                        size: crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(1.into()),
+                            1,
+                        ),
+                        endianness: Endianness::Little,
+                    },
+                    BitArrayPatternSegment::Float {
+                        pattern: crate::plan::BitArrayPatternValue::Discard,
+                        size: crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(64.into()),
+                            1,
+                        ),
+                        endianness: Endianness::Big,
+                    },
+                    BitArrayPatternSegment::Float {
+                        pattern: crate::plan::BitArrayPatternValue::Alias {
+                            pattern: Box::new(crate::plan::BitArrayPatternValue::Discard),
+                            binding: PatternBinding::new(FloatLocalId(1), "float_alias".into()),
+                        },
+                        size: crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(64.into()),
+                            1,
+                        ),
+                        endianness: Endianness::Big,
+                    },
+                ]),
+                false,
+            )),
+        ));
+        cases.push((
+            vec![
+                segment(
+                    Pattern::Variable {
+                        location: dummy_span(),
+                        name: "head".into(),
+                        type_: type_::bit_array(),
+                        origin: VariableOrigin::generated(),
+                    },
+                    vec![
+                        BitArrayOption::Bits {
+                            location: dummy_span(),
+                        },
+                        size(int_size()),
+                    ],
+                    type_::bit_array(),
+                ),
+                segment(
+                    discard(type_::bit_array()),
+                    vec![
+                        BitArrayOption::Bytes {
+                            location: dummy_span(),
+                        },
+                        size(int_size()),
+                    ],
+                    type_::bit_array(),
+                ),
+                segment(
+                    alias("tail", discard(type_::bit_array())),
+                    vec![BitArrayOption::Bits {
+                        location: dummy_span(),
+                    }],
+                    type_::bit_array(),
+                ),
+            ],
+            Ok((
+                BitArrayPattern::new(vec![
+                    BitArrayPatternSegment::Bits {
+                        pattern: BitArrayBindingPattern::Bind(PatternBinding::new(
+                            BitArrayLocalId(0),
+                            "head".into(),
+                        )),
+                        size: Some(crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(1.into()),
+                            1,
+                        )),
+                        unit: 1,
+                    },
+                    BitArrayPatternSegment::Bits {
+                        pattern: BitArrayBindingPattern::Discard,
+                        size: Some(crate::plan::BitArrayPatternSize::new(
+                            BitArrayPatternSizeExpr::value(1.into()),
+                            8,
+                        )),
+                        unit: 8,
+                    },
+                    BitArrayPatternSegment::Bits {
+                        pattern: BitArrayBindingPattern::Alias {
+                            pattern: Box::new(BitArrayBindingPattern::Discard),
+                            binding: PatternBinding::new(BitArrayLocalId(1), "tail".into()),
+                        },
+                        size: None,
+                        unit: 1,
+                    },
+                ]),
+                false,
+            )),
+        ));
+        cases.push((
+            vec![
+                segment(
+                    discard(type_::string()),
+                    vec![BitArrayOption::Utf8 {
+                        location: dummy_span(),
+                    }],
+                    type_::string(),
+                ),
+                segment(
+                    Pattern::String {
+                        location: dummy_span(),
+                        value: "A".into(),
+                    },
+                    vec![
+                        BitArrayOption::Utf16 {
+                            location: dummy_span(),
+                        },
+                        BitArrayOption::Little {
+                            location: dummy_span(),
+                        },
+                    ],
+                    type_::string(),
+                ),
+                segment(
+                    Pattern::String {
+                        location: dummy_span(),
+                        value: "B".into(),
+                    },
+                    vec![
+                        BitArrayOption::Utf32 {
+                            location: dummy_span(),
+                        },
+                        BitArrayOption::Big {
+                            location: dummy_span(),
+                        },
+                    ],
+                    type_::string(),
+                ),
+            ],
+            Ok((
+                BitArrayPattern::new(vec![
+                    BitArrayPatternSegment::String {
+                        pattern: BitArrayStringPattern::Discard,
+                        encoding: StringEncoding::Utf8,
+                    },
+                    BitArrayPatternSegment::String {
+                        pattern: BitArrayStringPattern::Literal("A".into()),
+                        encoding: StringEncoding::Utf16(Endianness::Little),
+                    },
+                    BitArrayPatternSegment::String {
+                        pattern: BitArrayStringPattern::Literal("B".into()),
+                        encoding: StringEncoding::Utf32(Endianness::Big),
+                    },
+                ]),
+                false,
+            )),
+        ));
+
+        let arithmetic_size = gleam_core::ast::BitArraySize::Block {
+            location: dummy_span(),
+            inner: Box::new(gleam_core::ast::BitArraySize::BinaryOperator {
+                location: dummy_span(),
+                operator: gleam_core::ast::IntOperator::Add,
+                left: Box::new(gleam_core::ast::BitArraySize::BinaryOperator {
+                    location: dummy_span(),
+                    operator: gleam_core::ast::IntOperator::Subtract,
+                    left: Box::new(gleam_core::ast::BitArraySize::Variable {
+                        location: dummy_span(),
+                        name: "int_size".into(),
+                        constructor: Some(Box::new(local_constructor(type_::int()))),
+                        type_: type_::int(),
+                    }),
+                    right: Box::new(int_size()),
+                }),
+                right: Box::new(gleam_core::ast::BitArraySize::BinaryOperator {
+                    location: dummy_span(),
+                    operator: gleam_core::ast::IntOperator::Multiply,
+                    left: Box::new(gleam_core::ast::BitArraySize::BinaryOperator {
+                        location: dummy_span(),
+                        operator: gleam_core::ast::IntOperator::Divide,
+                        left: Box::new(int_size()),
+                        right: Box::new(int_size()),
+                    }),
+                    right: Box::new(gleam_core::ast::BitArraySize::BinaryOperator {
+                        location: dummy_span(),
+                        operator: gleam_core::ast::IntOperator::Remainder,
+                        left: Box::new(int_size()),
+                        right: Box::new(int_size()),
+                    }),
+                }),
+            }),
+        };
+        cases.push((
+            vec![segment(
+                discard(type_::int()),
+                explicit_size(arithmetic_size),
+                type_::int(),
+            )],
+            Ok((
+                BitArrayPattern::new(vec![BitArrayPatternSegment::Int {
+                    pattern: crate::plan::BitArrayPatternValue::Discard,
+                    size: crate::plan::BitArrayPatternSize::new(
+                        BitArrayPatternSizeExpr::add(
+                            BitArrayPatternSizeExpr::subtract(
+                                BitArrayPatternSizeExpr::local_get(
+                                    IntLocalId(0),
+                                    "int_size".into(),
+                                ),
+                                BitArrayPatternSizeExpr::value(1.into()),
+                            ),
+                            BitArrayPatternSizeExpr::multiply(
+                                BitArrayPatternSizeExpr::divide(
+                                    BitArrayPatternSizeExpr::value(1.into()),
+                                    BitArrayPatternSizeExpr::value(1.into()),
+                                ),
+                                BitArrayPatternSizeExpr::remainder(
+                                    BitArrayPatternSizeExpr::value(1.into()),
+                                    BitArrayPatternSizeExpr::value(1.into()),
+                                ),
+                            ),
+                        ),
+                        1,
+                    ),
+                    endianness: Endianness::Big,
+                    signedness: Signedness::Unsigned,
+                }]),
+                false,
+            )),
+        ));
+
+        for (segments, expected) in cases {
+            let module_name = "main".into();
+            let functions = std::collections::HashMap::new();
+            let mut anonymous = AnonymousFunctions::default();
+            let mut context = PlanContext::new(&module_name, &functions, &mut anonymous);
+            context.define_int_local("int_size".into());
+            context.define_string_local("string_size".into());
+
+            assert_eq!(
+                super::plan_bit_array_pattern(segments, &mut context),
+                expected,
+            );
+        }
+    }
+
+    #[test]
+    fn plan_bit_array_pattern_size_module_constant_aliases() {
+        let module = compile(
+            r#"
+const size = 8
+const alias = size
+pub fn main() { 0 }
+"#,
+        );
+        let module_constant = |name: &str, module_name: &str, literal| {
+            let constant = module
+                .definitions
+                .constants
+                .iter()
+                .find(|constant| constant.name == name)
+                .expect("module constant should exist");
+
+            ValueConstructor {
+                publicity: constant.publicity,
+                deprecation: constant.deprecation.clone(),
+                type_: constant.type_.clone(),
+                variant: ValueConstructorVariant::ModuleConstant {
+                    documentation: None,
+                    location: constant.location,
+                    module: module_name.into(),
+                    name: name.into(),
+                    literal,
+                    implementations: constant.implementations,
+                },
+            }
+        };
+        let constant_value = |name: &str| {
+            module
+                .definitions
+                .constants
+                .iter()
+                .find(|constant| constant.name == name)
+                .expect("module constant should exist")
+                .value
+                .as_ref()
+                .clone()
+        };
+        let direct = module_constant("size", "main", constant_value("size"));
+        let alias = module_constant("alias", "main", constant_value("alias"));
+
+        let module_name = "main".into();
+        let functions = std::collections::HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let context = PlanContext::new(&module_name, &functions, &mut anonymous);
+
+        assert_eq!(
+            super::plan_size_variable("size".into(), direct, &context),
+            Ok(BitArrayPatternSizeExpr::value(8.into())),
+        );
+        assert_eq!(
+            super::plan_size_variable("alias".into(), alias, &context),
+            Ok(BitArrayPatternSizeExpr::value(8.into())),
+        );
+    }
+
+    #[test]
+    fn reject_margin_bit_array_pattern_size_invalid_constant_constructors() {
+        let module = compile(
+            r#"
+const size = 8
+const alias = size
+pub fn main() { 0 }
+"#,
+        );
+        let module_constant = |name: &str, module_name: &str, literal| {
+            let constant = module
+                .definitions
+                .constants
+                .iter()
+                .find(|constant| constant.name == name)
+                .expect("module constant should exist");
+
+            ValueConstructor {
+                publicity: constant.publicity,
+                deprecation: constant.deprecation.clone(),
+                type_: constant.type_.clone(),
+                variant: ValueConstructorVariant::ModuleConstant {
+                    documentation: None,
+                    location: constant.location,
+                    module: module_name.into(),
+                    name: name.into(),
+                    literal,
+                    implementations: constant.implementations,
+                },
+            }
+        };
+        let constant_value = |name: &str| {
+            module
+                .definitions
+                .constants
+                .iter()
+                .find(|constant| constant.name == name)
+                .expect("module constant should exist")
+                .value
+                .as_ref()
+                .clone()
+        };
+        let missing_alias = module_constant(
+            "alias",
+            "main",
+            Constant::Var {
+                location: dummy_span(),
+                module: None,
+                name: "missing".into(),
+                constructor: None,
+                type_: type_::int(),
+            },
+        );
+        let string = module_constant(
+            "size",
+            "main",
+            Constant::String {
+                location: dummy_span(),
+                value: "wrong".into(),
+            },
+        );
+        let external = module_constant("size", "other", constant_value("size"));
+        let module_name = "main".into();
+        let functions = std::collections::HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let context = PlanContext::new(&module_name, &functions, &mut anonymous);
+
+        assert_eq!(
+            super::plan_size_variable("missing_alias".into(), missing_alias, &context),
+            Err(super::invalid_pattern()),
+        );
+        assert_eq!(
+            super::plan_size_variable("string".into(), string, &context),
+            Err(super::invalid_pattern()),
+        );
+        assert_eq!(
+            super::plan_size_variable("external".into(), external, &context),
+            Err(super::invalid_pattern()),
+        );
+    }
+}

--- a/src/planner/statement/assignment.rs
+++ b/src/planner/statement/assignment.rs
@@ -493,11 +493,58 @@ pub(super) fn plan_binding_pattern(pattern: TypedPattern) -> Result<BindingPatte
             type_,
             ..
         } => plan_tail_only_list_binding_pattern(elements, tail.map(|tail| *tail), type_),
+        Pattern::BitArray { segments, .. } => plan_total_bit_array_binding_pattern(segments),
         Pattern::Assign { name, pattern, .. } => Ok(BindingPattern::Alias {
             pattern: Box::new(plan_binding_pattern(*pattern)?),
             name,
         }),
         pattern => Err(non_variable_pattern_error(&pattern)),
+    }
+}
+
+fn plan_total_bit_array_binding_pattern(
+    segments: Vec<
+        gleam_core::ast::BitArraySegment<TypedPattern, std::sync::Arc<gleam_core::type_::Type>>,
+    >,
+) -> Result<BindingPattern, PlanError> {
+    let mut segments = segments.into_iter();
+    let segment = segments.next().ok_or_else(invalid_binding_pattern)?;
+    if segments.next().is_some()
+        || !segment.type_.is_bit_array()
+        || segment.size().is_some()
+        || !matches!(
+            segment.options.as_slice(),
+            [gleam_core::ast::BitArrayOption::Bits { .. }]
+        )
+    {
+        return Err(invalid_binding_pattern());
+    }
+    plan_total_bit_array_binding_value_pattern(*segment.value)
+}
+
+fn plan_total_bit_array_binding_value_pattern(
+    pattern: TypedPattern,
+) -> Result<BindingPattern, PlanError> {
+    match pattern {
+        Pattern::Variable { name, type_, .. } if type_.is_bit_array() => {
+            Ok(BindingPattern::Named(name))
+        }
+        Pattern::Discard { type_, .. } if type_.is_bit_array() => Ok(BindingPattern::Discard),
+        Pattern::Assign { name, pattern, .. } => {
+            plan_total_bit_array_binding_value_pattern(*pattern).map(|pattern| {
+                BindingPattern::Alias {
+                    pattern: Box::new(pattern),
+                    name,
+                }
+            })
+        }
+        _ => Err(invalid_binding_pattern()),
+    }
+}
+
+fn invalid_binding_pattern() -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::InvalidPattern,
     }
 }
 
@@ -608,8 +655,8 @@ mod tests {
     };
     use gleam_core::analyse::Inferred;
     use gleam_core::ast::{
-        AssignName, AssignmentKind, BitArraySize, Pattern, Statement, TailPattern, TypedAssignment,
-        TypedExpr,
+        AssignName, AssignmentKind, BitArrayOption, BitArraySegment, BitArraySize, Pattern,
+        Statement, TailPattern, TypedAssignment, TypedExpr,
     };
     use gleam_core::exhaustiveness::CompiledCase;
     use gleam_core::parse::LiteralFloatValue;
@@ -1749,6 +1796,50 @@ pub fn main() {
                 element_type: ValueType::Int,
             }),
         );
+        assert_eq!(
+            plan_binding_pattern(Pattern::BitArray {
+                location: dummy_span(),
+                segments: vec![BitArraySegment {
+                    location: dummy_span(),
+                    value: Box::new(Pattern::Variable {
+                        location: dummy_span(),
+                        name: "bits".into(),
+                        type_: type_::bit_array(),
+                        origin: VariableOrigin::generated(),
+                    }),
+                    options: vec![BitArrayOption::Bits {
+                        location: dummy_span(),
+                    }],
+                    type_: type_::bit_array(),
+                }],
+            }),
+            Ok(BindingPattern::Named("bits".into())),
+        );
+        assert_eq!(
+            plan_binding_pattern(Pattern::BitArray {
+                location: dummy_span(),
+                segments: vec![BitArraySegment {
+                    location: dummy_span(),
+                    value: Box::new(Pattern::Assign {
+                        location: dummy_span(),
+                        name: "alias".into(),
+                        pattern: Box::new(Pattern::Discard {
+                            location: dummy_span(),
+                            name: "_".into(),
+                            type_: type_::bit_array(),
+                        }),
+                    }),
+                    options: vec![BitArrayOption::Bits {
+                        location: dummy_span(),
+                    }],
+                    type_: type_::bit_array(),
+                }],
+            }),
+            Ok(BindingPattern::Alias {
+                pattern: Box::new(BindingPattern::Discard),
+                name: "alias".into(),
+            }),
+        );
     }
 
     #[test]
@@ -1916,6 +2007,82 @@ pub fn main() {
                 }),
             );
         }
+        assert_eq!(
+            plan_binding_pattern(Pattern::BitArray {
+                location: dummy_span(),
+                segments: vec![BitArraySegment {
+                    location: dummy_span(),
+                    value: Box::new(Pattern::Discard {
+                        location: dummy_span(),
+                        name: "_".into(),
+                        type_: type_::bit_array(),
+                    }),
+                    options: vec![
+                        BitArrayOption::Bits {
+                            location: dummy_span(),
+                        },
+                        BitArrayOption::Bytes {
+                            location: dummy_span(),
+                        },
+                    ],
+                    type_: type_::bit_array(),
+                }],
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::InvalidPattern,
+            }),
+        );
+        for (segment_type, binding_type) in [
+            (type_::int(), type_::bit_array()),
+            (type_::bit_array(), type_::int()),
+        ] {
+            assert_eq!(
+                plan_binding_pattern(Pattern::BitArray {
+                    location: dummy_span(),
+                    segments: vec![BitArraySegment {
+                        location: dummy_span(),
+                        value: Box::new(Pattern::Variable {
+                            location: dummy_span(),
+                            name: "bits".into(),
+                            type_: binding_type,
+                            origin: VariableOrigin::generated(),
+                        }),
+                        options: vec![BitArrayOption::Bits {
+                            location: dummy_span(),
+                        }],
+                        type_: segment_type,
+                    }],
+                }),
+                Err(PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::InvalidPattern,
+                }),
+            );
+        }
+        assert_eq!(
+            plan_binding_pattern(Pattern::BitArray {
+                location: dummy_span(),
+                segments: vec![BitArraySegment {
+                    location: dummy_span(),
+                    value: Box::new(Pattern::Assign {
+                        location: dummy_span(),
+                        name: "alias".into(),
+                        pattern: Box::new(Pattern::Variable {
+                            location: dummy_span(),
+                            name: "bits".into(),
+                            type_: type_::int(),
+                            origin: VariableOrigin::generated(),
+                        }),
+                    }),
+                    options: vec![BitArrayOption::Bits {
+                        location: dummy_span(),
+                    }],
+                    type_: type_::bit_array(),
+                }],
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::InvalidPattern,
+            }),
+        );
     }
 
     #[test]

--- a/src/planner/statement/assignment/assert.rs
+++ b/src/planner/statement/assignment/assert.rs
@@ -3,8 +3,8 @@ use super::{
     plan_bound_assignment, plan_ordinary_assignment_value, value_type_expression_type,
 };
 use crate::plan::{
-    AssertBinding, AssertPattern, Expr, ListAssertPattern, ListAssertTail, ListExpr, ListLocal,
-    ParamLocal, Step, StringExpr, ValueType,
+    AssertBinding, AssertPattern, BitArrayExpr, Expr, ListAssertPattern, ListAssertTail, ListExpr,
+    ListLocal, ParamLocal, Step, StringExpr, ValueType,
 };
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
@@ -21,6 +21,9 @@ pub(super) fn plan_assert_assignment(
     message: Option<TypedExpr>,
     context: &mut PlanContext<'_>,
 ) -> Result<PlannedAssignment, PlanError> {
+    if assert_bit_array_pattern(&pattern) {
+        return plan_assert_bit_array_assignment(location, pattern, value, message, context);
+    }
     let Some(pattern_type) = assert_list_pattern_type(&pattern) else {
         let pattern = plan_assert_exhaustive_pattern(pattern)?;
         let value = plan_ordinary_assignment_value(&pattern, value, context)?;
@@ -68,13 +71,44 @@ pub(super) fn plan_assert_assignment_steps(
     message: Option<TypedExpr>,
     context: &mut PlanContext<'_>,
 ) -> Result<Vec<Step>, PlanError> {
-    if assert_list_pattern_type(&pattern).is_some() {
+    if assert_list_pattern_type(&pattern).is_some() || assert_bit_array_pattern(&pattern) {
         return Ok(plan_assert_assignment(location, pattern, value, message, context)?.steps);
     }
 
     let pattern = plan_assert_exhaustive_pattern(pattern)?;
     let value = plan_ordinary_assignment_value(&pattern, value, context)?;
     plan_assignment_steps(pattern, value, context)
+}
+
+fn plan_assert_bit_array_assignment(
+    location: SrcSpan,
+    pattern: TypedPattern,
+    value: TypedExpr,
+    message: Option<TypedExpr>,
+    context: &mut PlanContext<'_>,
+) -> Result<PlannedAssignment, PlanError> {
+    let value = plan_expr(value, context)?;
+    let actual = value.value_type();
+    let value = value
+        .into_bit_array()
+        .ok_or_else(|| bit_array_assert_value_must_be_bit_array(actual))?;
+    let message = message
+        .map(|message| plan_assert_message(message, context))
+        .transpose()?;
+    let local = context.define_internal_bit_array_local();
+    let name = internal_bit_array_name(local);
+    let local_value = BitArrayExpr::local_get(local, name.clone());
+    let site = context.panic_site(location);
+    let pattern_span = pattern.location().into();
+    let pattern = plan_assert_pattern(pattern, context)?;
+
+    Ok(PlannedAssignment {
+        steps: vec![
+            Step::let_bit_array(local, name, value),
+            Step::assert_bit_array_at(local, pattern, message, site, pattern_span),
+        ],
+        value: Expr::bit_array(local_value),
+    })
 }
 
 fn plan_assert_exhaustive_pattern(pattern: TypedPattern) -> Result<BindingPattern, PlanError> {
@@ -154,6 +188,10 @@ fn plan_assert_pattern(
             .collect::<Result<Vec<_>, _>>()
             .map(AssertPattern::Tuple),
         Pattern::List { .. } => plan_assert_list_pattern(pattern, context).map(AssertPattern::list),
+        Pattern::BitArray { segments, .. } => {
+            let (pattern, _) = crate::planner::pattern::plan_bit_array_pattern(segments, context)?;
+            Ok(AssertPattern::bit_array(pattern))
+        }
         Pattern::Assign { name, pattern, .. } => {
             let type_ = pattern_type(&pattern)?;
             let pattern = plan_assert_pattern(*pattern, context)?;
@@ -292,7 +330,16 @@ fn pattern_type(
             Ok(gleam_core::type_::tuple(elements))
         }
         Pattern::Assign { pattern, .. } => pattern_type(pattern),
+        Pattern::BitArray { .. } => Ok(gleam_core::type_::bit_array()),
         pattern => Err(unsupported_assert_pattern_error(pattern)),
+    }
+}
+
+fn assert_bit_array_pattern(pattern: &TypedPattern) -> bool {
+    match pattern {
+        Pattern::BitArray { .. } => true,
+        Pattern::Assign { pattern, .. } => assert_bit_array_pattern(pattern),
+        _ => false,
     }
 }
 
@@ -326,9 +373,6 @@ fn unsupported_assert_pattern_error(pattern: &TypedPattern) -> PlanError {
                 kind: UnsupportedPatternKind::Literal,
             }
         }
-        Pattern::BitArray { .. } | Pattern::BitArraySize(_) => PlanError::UnsupportedPattern {
-            kind: UnsupportedPatternKind::BitArray,
-        },
         Pattern::Constructor { .. } => PlanError::UnsupportedPattern {
             kind: UnsupportedPatternKind::Constructor,
         },
@@ -337,6 +381,8 @@ fn unsupported_assert_pattern_error(pattern: &TypedPattern) -> PlanError {
         },
         Pattern::Assign { pattern, .. } => unsupported_assert_pattern_error(pattern),
         Pattern::Invalid { .. }
+        | Pattern::BitArray { .. }
+        | Pattern::BitArraySize(_)
         | Pattern::Discard { .. }
         | Pattern::Variable { .. }
         | Pattern::Tuple { .. } => PlanError::InvalidTypedAst {
@@ -363,6 +409,10 @@ fn internal_list_name(local: &ListLocal) -> EcoString {
     format!("<list:{}:{}>", local.family_name(), local.index()).into()
 }
 
+fn internal_bit_array_name(local: crate::plan::BitArrayLocalId) -> EcoString {
+    format!("<bit_array:{}>", local.0).into()
+}
+
 fn list_assert_value_must_be_list(actual: ValueType) -> PlanError {
     PlanError::InvalidTypedAst {
         reason: InvalidTypedAstReason::ExpressionType {
@@ -372,29 +422,42 @@ fn list_assert_value_must_be_list(actual: ValueType) -> PlanError {
     }
 }
 
+fn bit_array_assert_value_must_be_bit_array(actual: ValueType) -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionType {
+            expected: InvalidExpressionType::BitArray,
+            actual: value_type_expression_type(actual),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        AssertBinding, AssertPattern, BitArrayFunctionLocalId, BitArrayLocalId,
-        BoolFunctionLocalId, BoolLocalId, FloatFunctionLocalId, FloatLocalId,
-        FunctionFunctionLocalId, FunctionType, IntFunctionLocalId, IntListLocalId, IntLocalId,
-        ListAssertPattern, ListAssertTail, ListLocal, NilFunctionLocalId, NilLocalId, PanicSite,
-        ParamLocal, SourceSpan, Step, StringExpr, StringFunctionLocalId, StringLocalId,
+        AssertBinding, AssertPattern, BitArrayExpr, BitArrayFunctionLocalId, BitArrayListLocalId,
+        BitArrayLocalId, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
+        BitArrayPatternSizeExpr, BitArrayPatternValue, BitArraySegment, BoolFunctionLocalId,
+        BoolLocalId, Endianness, FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId,
+        FunctionType, IntExpr, IntFunctionLocalId, IntListLocalId, IntLocalId, ListAssertPattern,
+        ListAssertTail, ListLocal, NilFunctionLocalId, NilLocalId, PanicSite, ParamLocal,
+        Signedness, SourceSpan, Step, StringExpr, StringFunctionLocalId, StringLocalId,
         TupleFunctionLocalId, TupleLocalId, ValueType,
     };
     use crate::planner::context::{AnonymousFunctions, PlanContext};
     use crate::planner::dsl::{
-        function, int, let_list_step, let_tuple_step, list, local_int, local_tuple, module, tuple,
+        bit_array, function, int, let_list_step, let_tuple_step, list, local_int, local_tuple,
+        module, tuple,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, dummy_span, expect_plan_error};
     use crate::planner::{
-        InvalidExpressionType, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
-        UnsupportedPatternKind,
+        InvalidExpressionShapeKind, InvalidExpressionType, InvalidTypedAstReason, PlanError,
+        UnsupportedExpressionKind, UnsupportedPatternKind,
     };
     use gleam_core::analyse::Inferred;
     use gleam_core::ast::{
-        AssignName, AssignmentKind, Pattern, TailPattern, TypedAssignment, TypedExpr,
+        AssignName, AssignmentKind, BitArraySegment as BitArrayPatternSegmentAst, Pattern,
+        Statement, TailPattern, TypedAssignment, TypedExpr,
     };
     use gleam_core::exhaustiveness::CompiledCase;
     use gleam_core::type_::{self, error::VariableOrigin};
@@ -646,20 +709,207 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_let_assert_bit_array_pattern() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
+    fn plan_let_assert_bit_array_pattern_checks_internal_subject_once() {
+        let actual = plan_module(compile(
+            r#"
 pub fn main() {
   let assert <<first>> = <<1>>
   first
 }
 "#,
-            ),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::BitArray,
-            },
+        ))
+        .expect("source should plan");
+        let pattern = BitArrayPattern::new(vec![BitArrayPatternSegment::Int {
+            pattern: BitArrayPatternValue::Bind(crate::plan::PatternBinding::new(
+                IntLocalId(0),
+                "first".into(),
+            )),
+            size: BitArrayPatternSize::new(BitArrayPatternSizeExpr::value(8.into()), 1),
+            endianness: Endianness::Big,
+            signedness: Signedness::Unsigned,
+        }]);
+        let expected = module(
+            "main",
+            function("main", local_int(0, "first"))
+                .step(Step::let_bit_array(
+                    BitArrayLocalId(0),
+                    "<bit_array:0>".into(),
+                    BitArrayExpr::value(vec![BitArraySegment::Int {
+                        value: IntExpr::value(1.into()),
+                        bit_size: 8,
+                        endianness: Endianness::Big,
+                    }]),
+                ))
+                .step(Step::assert_bit_array_at(
+                    BitArrayLocalId(0),
+                    AssertPattern::BitArray(pattern),
+                    None,
+                    PanicSite::new("main".into(), "main".into(), SourceSpan::new(19, 29)),
+                    SourceSpan::new(30, 39),
+                )),
+            [],
         );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_list_assert_bit_array_pattern_preserves_nested_pattern_type() {
+        let actual = plan_module(compile(
+            r#"
+pub fn main() {
+  let assert [<<first>>] = [<<1>>]
+  first
+}
+"#,
+        ))
+        .expect("source should plan");
+        let pattern = BitArrayPattern::new(vec![BitArrayPatternSegment::Int {
+            pattern: BitArrayPatternValue::Bind(crate::plan::PatternBinding::new(
+                IntLocalId(0),
+                "first".into(),
+            )),
+            size: BitArrayPatternSize::new(BitArrayPatternSizeExpr::value(8.into()), 1),
+            endianness: Endianness::Big,
+            signedness: Signedness::Unsigned,
+        }]);
+        let expected = module(
+            "main",
+            function("main", local_int(0, "first"))
+                .step(let_list_step(
+                    0,
+                    "<list:bit array:0>",
+                    list(
+                        [bit_array([BitArraySegment::Int {
+                            value: IntExpr::value(1.into()),
+                            bit_size: 8,
+                            endianness: Endianness::Big,
+                        }])],
+                        ValueType::BitArray,
+                    ),
+                ))
+                .step(Step::assert_list_at(
+                    ListLocal::bit_array(BitArrayListLocalId(0)),
+                    AssertPattern::list(ListAssertPattern::new(
+                        ValueType::BitArray,
+                        vec![AssertPattern::BitArray(pattern)],
+                        None,
+                    )),
+                    None,
+                    PanicSite::new("main".into(), "main".into(), SourceSpan::new(19, 29)),
+                    SourceSpan::new(30, 41),
+                )),
+            [],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn reject_margin_let_assert_bit_array_value_must_be_bit_array() {
+        let mut invalid = compile(
+            r#"
+pub fn main() {
+  let assert <<1>> = <<1>>
+  1
+}
+"#,
+        );
+        let assignment = expect_assignment_mut(&mut invalid.definitions.functions[0].body[0]);
+        assignment.value = typed_int_expr(1);
+
+        assert_eq!(
+            plan_module(invalid),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::BitArray,
+                    actual: InvalidExpressionType::Int,
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn reject_margin_bit_array_assert_propagates_expression_and_pattern_errors() {
+        let invalid_expr = || TypedExpr::Invalid {
+            location: dummy_span(),
+            type_: type_::bit_array(),
+            extra_information: None,
+        };
+        let invalid_segment = || BitArrayPatternSegmentAst {
+            location: dummy_span(),
+            value: Box::new(Pattern::Int {
+                location: dummy_span(),
+                value: "1".into(),
+                int_value: 1.into(),
+            }),
+            options: vec![gleam_core::ast::BitArrayOption::Bits {
+                location: dummy_span(),
+            }],
+            type_: type_::bit_array(),
+        };
+        let source = r#"
+pub fn main() {
+  let assert <<1>> = <<1>>
+  1
+}
+"#;
+        let mut invalid_value = compile(source);
+        expect_assignment_mut(&mut invalid_value.definitions.functions[0].body[0]).value =
+            invalid_expr();
+
+        let mut invalid_message = compile(source);
+        expect_assignment_mut(&mut invalid_message.definitions.functions[0].body[0]).kind =
+            AssignmentKind::Assert {
+                location: dummy_span(),
+                assert_keyword_start: 0,
+                message: Some(invalid_expr()),
+            };
+
+        let mut invalid_pattern = compile(source);
+        expect_assignment_mut(&mut invalid_pattern.definitions.functions[0].body[0]).pattern =
+            Pattern::BitArray {
+                location: dummy_span(),
+                segments: vec![invalid_segment()],
+            };
+
+        let mut invalid_nested_pattern = compile(
+            r#"
+pub fn main() {
+  let assert [<<1>>] = [<<1>>]
+  1
+}
+"#,
+        );
+        expect_assignment_mut(&mut invalid_nested_pattern.definitions.functions[0].body[0])
+            .pattern = Pattern::List {
+            location: dummy_span(),
+            elements: vec![Pattern::BitArray {
+                location: dummy_span(),
+                segments: vec![invalid_segment()],
+            }],
+            tail: None,
+            type_: type_::list(type_::bit_array()),
+        };
+
+        for invalid in [invalid_value, invalid_message] {
+            assert_eq!(
+                plan_module(invalid),
+                Err(PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::ExpressionShape {
+                        kind: InvalidExpressionShapeKind::Invalid,
+                    },
+                }),
+            );
+        }
+        for invalid in [invalid_pattern, invalid_nested_pattern] {
+            assert_eq!(
+                plan_module(invalid),
+                Err(PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::InvalidPattern,
+                }),
+            );
+        }
     }
 
     #[test]
@@ -1441,6 +1691,13 @@ pub fn main() {
         assert_eq!(super::pattern_type(&list), Ok(type_::list(type_::int())),);
         assert_eq!(super::pattern_type(&constructor), Ok(type_::bool()));
         assert_eq!(
+            super::pattern_type(&Pattern::BitArray {
+                location: dummy_span(),
+                segments: Vec::new(),
+            }),
+            Ok(type_::bit_array()),
+        );
+        assert_eq!(
             super::pattern_type(&tuple),
             Ok(type_::tuple(vec![type_::int(), type_::string()])),
         );
@@ -1484,10 +1741,6 @@ pub fn main() {
             tail: None,
             type_: type_::list(type_::int()),
         };
-        let bit_array = Pattern::BitArray {
-            location: dummy_span(),
-            segments: Vec::new(),
-        };
         let string_prefix = Pattern::StringPrefix {
             location: dummy_span(),
             left_location: dummy_span(),
@@ -1510,12 +1763,6 @@ pub fn main() {
             super::unsupported_assert_pattern_error(&list),
             PlanError::UnsupportedPattern {
                 kind: UnsupportedPatternKind::List,
-            },
-        );
-        assert_eq!(
-            super::unsupported_assert_pattern_error(&bit_array),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::BitArray,
             },
         );
         assert_eq!(
@@ -1590,5 +1837,21 @@ pub fn main() {
             value: value.to_string().into(),
             int_value: BigInt::from(value),
         }
+    }
+
+    fn expect_assignment_mut(
+        statement: &mut gleam_core::ast::TypedStatement,
+    ) -> &mut TypedAssignment {
+        let Statement::Assignment(assignment) = statement else {
+            panic!("expected assignment statement");
+        };
+        assignment
+    }
+
+    #[test]
+    #[should_panic(expected = "expected assignment statement")]
+    fn assignment_shape_guard_rejects_expression_statements() {
+        let mut statement = Statement::Expression(typed_int_expr(1));
+        let _ = expect_assignment_mut(&mut statement);
     }
 }

--- a/src/planner/statement/use_.rs
+++ b/src/planner/statement/use_.rs
@@ -25,9 +25,10 @@ fn validate_use_assignment_pattern(pattern: &TypedPattern) -> Result<(), PlanErr
         Pattern::Variable { .. } => Err(invalid_use_shape(
             InvalidUseShapeReason::UnexpectedVariableAssignment,
         )),
-        Pattern::Tuple { .. } | Pattern::List { .. } | Pattern::Assign { .. } => {
-            plan_binding_pattern(pattern.clone()).map(|_| ())
-        }
+        Pattern::Tuple { .. }
+        | Pattern::List { .. }
+        | Pattern::BitArray { .. }
+        | Pattern::Assign { .. } => plan_binding_pattern(pattern.clone()).map(|_| ()),
         pattern => Err(non_variable_pattern_error(pattern)),
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,6 +4,7 @@ mod expression;
 mod frame;
 mod function;
 mod materialize;
+mod pattern;
 mod state;
 mod value;
 

--- a/src/runtime/evaluated.rs
+++ b/src/runtime/evaluated.rs
@@ -21,7 +21,9 @@ pub(in crate::runtime) struct EvaluatedBitArray {
 }
 
 impl EvaluatedBitArray {
-    pub(in crate::runtime) fn new(bits: BitVec<u8, Msb0>) -> Self {
+    pub(in crate::runtime) fn new(mut bits: BitVec<u8, Msb0>) -> Self {
+        bits.force_align();
+        bits.set_uninitialized(false);
         Self {
             bits: Rc::new(bits),
         }
@@ -813,6 +815,8 @@ mod tests {
         StringLocalId, TupleFunctionId, TupleFunctionLocalId, TupleListLocalId, TupleLocalId,
     };
     use crate::runtime::state::{ListValueId, RuntimeState};
+    use bitvec::order::Msb0;
+    use bitvec::view::BitView;
 
     const EVERY_LIST_FAMILY_SOURCE: &str = r#"
 fn ints() -> List(Int) { [] }
@@ -826,6 +830,15 @@ fn lists() -> List(List(Int)) { [] }
 fn functions() -> List(fn() -> Int) { [] }
 pub fn main() { 0 }
 "#;
+
+    #[test]
+    fn evaluated_bit_array_aligns_owned_slices() {
+        let source = [0x77u8];
+        let value = EvaluatedBitArray::new(source.view_bits::<Msb0>()[4..6].to_bitvec());
+
+        assert_eq!(value.bits.as_raw_slice(), &[0b0100_0000]);
+        assert_eq!(value.bits.len(), 2);
+    }
 
     #[test]
     fn evaluated_value_type_preserves_every_runtime_family() {

--- a/src/runtime/expression/bool.rs
+++ b/src/runtime/expression/bool.rs
@@ -1,6 +1,6 @@
 use super::{
-    eval_expr, eval_float_expr, eval_int_expr, eval_list_expr, eval_panic_expr, eval_string_expr,
-    project_bool_list_expr, project_tuple_expr,
+    eval_bit_array_expr, eval_expr, eval_float_expr, eval_int_expr, eval_list_expr,
+    eval_panic_expr, eval_string_expr, project_bool_list_expr, project_tuple_expr,
 };
 use crate::plan::ValueType;
 use crate::plan::execution::ExecutionPlan;
@@ -89,6 +89,12 @@ pub(in crate::runtime) fn eval_bool_expr(
             let value = eval_list_expr(plan, state, frame, value)?;
             Ok(state.list_len(&value) >= *length)
         }
+        BoolExprKind::BitArrayMatches { value, pattern } => {
+            let value = eval_bit_array_expr(plan, state, frame, value)?;
+            Ok(crate::runtime::pattern::match_bit_array_pattern(
+                frame, &value, pattern,
+            ))
+        }
         BoolExprKind::And { left, right } => {
             let left = eval_bool_expr(plan, state, frame, left)?;
             eval_and(left, || eval_bool_expr(plan, state, frame, right))
@@ -171,8 +177,9 @@ fn eval_or(
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        BoolExpr, BoolFunctionId, Expr, FloatExpr, FunctionId, FunctionPlan, IntExpr, ListExpr,
-        ModulePlan, PanicExpr, PanicSite, ReturnExpr, Step, StringExpr, TupleExpr, ValueType,
+        BitArrayExpr, BitArrayPattern, BoolExpr, BoolFunctionId, Expr, FloatExpr, FunctionId,
+        FunctionPlan, IntExpr, ListExpr, ModulePlan, PanicExpr, PanicSite, ReturnExpr, Step,
+        StringExpr, TupleExpr, ValueType,
     };
     use crate::runtime::{ExecutionError, run_main};
 
@@ -271,6 +278,7 @@ pub fn main() {
             "case fail_int() { 0 -> False _ -> True }",
             "case fail_string() { \"zero\" -> False _ -> True }",
             "case fail_float() { 0.0 -> False _ -> True }",
+            "case fail_bit_array() { <<1>> -> True _ -> False }",
             "{ let _ = fail_int() True }",
             "{ let function = fail_bool function() }",
         ];
@@ -282,6 +290,7 @@ fn fail_bool() -> Bool {{ panic }}
 fn fail_int() -> Int {{ panic }}
 fn fail_string() -> String {{ panic }}
 fn fail_float() -> Float {{ panic }}
+fn fail_bit_array() -> BitArray {{ panic }}
 fn fail_int_list() -> List(Int) {{ panic }}
 pub fn main() -> Bool {{ {expression} }}
 "#,
@@ -302,6 +311,10 @@ pub fn main() -> Bool {{ {expression} }}
             BoolExpr::string_starts_with(StringExpr::panic(panic()), "prefix".into()),
             BoolExpr::list_length_equals(ListExpr::panic(panic(), ValueType::Int), 1),
             BoolExpr::list_length_at_least(ListExpr::panic(panic(), ValueType::Int), 1),
+            BoolExpr::bit_array_matches(
+                BitArrayExpr::panic(panic()),
+                BitArrayPattern::new(Vec::new()),
+            ),
             BoolExpr::bool_case(
                 BoolExpr::panic(panic()),
                 BoolExpr::value(true),

--- a/src/runtime/function/steps.rs
+++ b/src/runtime/function/steps.rs
@@ -114,6 +114,7 @@ pub(in crate::runtime) fn execute_steps(
                 if match_assert_pattern(
                     plan,
                     state,
+                    frame,
                     pattern,
                     &EvaluatedValue::List(value.clone()),
                     &mut bindings,
@@ -132,6 +133,45 @@ pub(in crate::runtime) fn execute_steps(
                             plan,
                             state,
                             EvaluatedValue::List(value),
+                        ),
+                        *pattern_span,
+                    ));
+                }
+                for binding in bindings {
+                    frame_set_binding(frame, binding);
+                }
+            }
+            StepKind::AssertBitArray {
+                local,
+                pattern,
+                message,
+                site,
+                pattern_span,
+            } => {
+                let value = frame.get_bit_array(*local);
+                let mut bindings = Vec::new();
+                if match_assert_pattern(
+                    plan,
+                    state,
+                    frame,
+                    pattern,
+                    &EvaluatedValue::BitArray(value.clone()),
+                    &mut bindings,
+                )
+                .is_none()
+                {
+                    let message = match message {
+                        Some(message) => Some(eval_string_expr(plan, state, frame, message)?),
+                        None => None,
+                    };
+                    return Err(ExecutionError::let_assert_panic(
+                        plan.source_context(),
+                        message,
+                        site.clone(),
+                        crate::runtime::materialize::value(
+                            plan,
+                            state,
+                            EvaluatedValue::BitArray(value),
                         ),
                         *pattern_span,
                     ));
@@ -192,6 +232,7 @@ enum PendingBinding {
 fn match_list_assert_pattern(
     plan: &ExecutionPlan,
     state: &mut RuntimeState,
+    frame: &mut Frame,
     pattern: &ListAssertPattern,
     value: &ListValueId,
 ) -> Option<Vec<PendingBinding>> {
@@ -201,7 +242,8 @@ fn match_list_assert_pattern(
             return None;
         }
 
-        let mut bindings = match_prefix_assert_patterns(plan, state, pattern.elements(), &values)?;
+        let mut bindings =
+            match_prefix_assert_patterns(plan, state, frame, pattern.elements(), &values)?;
         if let ListAssertTail::Bind(binding) = tail {
             bindings.push(PendingBinding::List(pending_list_binding(
                 binding.local().clone(),
@@ -214,19 +256,20 @@ fn match_list_assert_pattern(
             return None;
         }
 
-        match_prefix_assert_patterns(plan, state, pattern.elements(), &values)
+        match_prefix_assert_patterns(plan, state, frame, pattern.elements(), &values)
     }
 }
 
 fn match_prefix_assert_patterns(
     plan: &ExecutionPlan,
     state: &mut RuntimeState,
+    frame: &mut Frame,
     patterns: &[AssertPattern],
     values: &[EvaluatedValue],
 ) -> Option<Vec<PendingBinding>> {
     let mut bindings = Vec::new();
     for (pattern, value) in patterns.iter().zip(values) {
-        match_assert_pattern(plan, state, pattern, value, &mut bindings)?;
+        match_assert_pattern(plan, state, frame, pattern, value, &mut bindings)?;
     }
     Some(bindings)
 }
@@ -234,6 +277,7 @@ fn match_prefix_assert_patterns(
 fn match_assert_pattern(
     plan: &ExecutionPlan,
     state: &mut RuntimeState,
+    frame: &mut Frame,
     pattern: &AssertPattern,
     value: &EvaluatedValue,
     bindings: &mut Vec<PendingBinding>,
@@ -252,7 +296,7 @@ fn match_assert_pattern(
                 return None;
             }
             for (pattern, value) in patterns.iter().zip(values) {
-                match_assert_pattern(plan, state, pattern, value, bindings)?;
+                match_assert_pattern(plan, state, frame, pattern, value, bindings)?;
             }
             Some(())
         }
@@ -260,11 +304,23 @@ fn match_assert_pattern(
             let EvaluatedValue::List(value) = value else {
                 return None;
             };
-            bindings.extend(match_list_assert_pattern(plan, state, pattern, value)?);
+            bindings.extend(match_list_assert_pattern(
+                plan, state, frame, pattern, value,
+            )?);
             Some(())
         }
+        AssertPattern::BitArray(pattern) => {
+            let EvaluatedValue::BitArray(value) = value else {
+                return None;
+            };
+            if crate::runtime::pattern::match_bit_array_pattern(frame, value, pattern) {
+                Some(())
+            } else {
+                None
+            }
+        }
         AssertPattern::Alias { pattern, binding } => {
-            match_assert_pattern(plan, state, pattern, value, bindings)?;
+            match_assert_pattern(plan, state, frame, pattern, value, bindings)?;
             bindings.push(pending_binding(plan, binding, value)?);
             Some(())
         }
@@ -486,6 +542,7 @@ mod tests {
         AssertPattern, FunctionFunctionId, IntFunctionFunctionId, IntFunctionId, IntListLocalId,
         IntLocalId, ListAssertPattern, StepKind,
     };
+    use crate::runtime::frame::Frame;
     use crate::runtime::state::{IntListValueId, ListValueId};
     use crate::runtime::{
         EvaluatedFunctionFunction, EvaluatedFunctionValue, EvaluatedListCapture, EvaluatedValue,
@@ -545,6 +602,22 @@ mod tests {
                 ),
                 crate::runtime::Value::Bool(true),
             ),
+            (
+                include_str!(
+                    "../../../tests/fixtures/execution/bindings/let_assert_bit_array_patterns.gleam"
+                ),
+                crate::runtime::Value::Tuple(vec![
+                    crate::runtime::Value::Int(16.into()),
+                    crate::runtime::Value::BitArray(crate::BitArrayValue::from_bytes(vec![1, 2])),
+                    crate::runtime::Value::BitArray(crate::BitArrayValue::from_bytes(vec![3])),
+                    crate::runtime::Value::BitArray(crate::BitArrayValue::from_bytes(vec![4])),
+                    crate::runtime::Value::BitArray(crate::BitArrayValue::from_bytes(vec![
+                        16, 1, 2, 3, 4,
+                    ])),
+                    crate::runtime::Value::Int(1.into()),
+                    crate::runtime::Value::BitArray(crate::BitArrayValue::from_bytes(vec![2])),
+                ]),
+            ),
         ];
 
         for (source, expected) in cases {
@@ -595,6 +668,10 @@ pub fn main() {{
             (
                 "pub fn main() { let values: List(Int) = [] let assert [first] = values as \"missing\" first }",
                 "let_assert: missing",
+            ),
+            (
+                "pub fn main() { let assert <<1>> = <<2>> 0 }",
+                "let_assert: Pattern match failed, no pattern matched the value.",
             ),
             (
                 "pub fn main() { assert False Nil }",
@@ -664,7 +741,7 @@ pub fn main() {{
 
     #[test]
     fn let_assert_message_errors_propagate_after_mismatch() {
-        let source = r#"
+        let list_source = r#"
 fn fail_message() -> String { panic as "message" }
 pub fn main() {
   let values: List(Int) = []
@@ -674,7 +751,20 @@ pub fn main() {
 "#;
 
         assert_eq!(
-            crate::runtime::run_src_error(source).to_string(),
+            crate::runtime::run_src_error(list_source).to_string(),
+            "panic: message",
+        );
+        assert_eq!(
+            crate::runtime::run_src_error(
+                r#"
+fn fail_message() -> String { panic as "message" }
+pub fn main() {
+  let assert <<1>> = <<2>> as fail_message()
+  1
+}
+"#,
+            )
+            .to_string(),
             "panic: message",
         );
     }
@@ -711,11 +801,13 @@ pub fn main() {
             })
             .expect("source should lower an assert-list step");
         let tuple_pattern = &expect_list_assert_pattern(pattern).elements()[0];
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
         let mut bindings = Vec::new();
         assert_eq!(
             match_assert_pattern(
                 &tuple_plan,
                 &mut state,
+                &mut frame,
                 tuple_pattern,
                 &EvaluatedValue::Int(1.into()),
                 &mut bindings
@@ -727,8 +819,41 @@ pub fn main() {
             match_assert_pattern(
                 &tuple_plan,
                 &mut state,
+                &mut frame,
                 tuple_pattern,
                 &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
+                &mut bindings,
+            ),
+            None,
+        );
+        assert_eq!(bindings, Vec::new());
+
+        let bit_array_plan = crate::runtime::plan_src(
+            r#"
+pub fn main() {
+  let assert [<<1>>] = [<<1>>]
+  1
+}
+"#,
+        );
+        let function = bit_array_plan.int_function(IntFunctionId(0));
+        let pattern = function
+            .steps()
+            .iter()
+            .find_map(|step| match step.kind() {
+                StepKind::AssertList { pattern, .. } => Some(pattern),
+                _ => None,
+            })
+            .expect("source should lower an assert-list step");
+        let bit_array_pattern = &expect_list_assert_pattern(pattern).elements()[0];
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        assert_eq!(
+            match_assert_pattern(
+                &bit_array_plan,
+                &mut state,
+                &mut frame,
+                bit_array_pattern,
+                &EvaluatedValue::Int(1.into()),
                 &mut bindings,
             ),
             None,
@@ -753,10 +878,12 @@ pub fn main() {
             })
             .expect("source should lower an assert-list step");
         let nested_pattern = &expect_list_assert_pattern(pattern).elements()[0];
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             match_assert_pattern(
                 &list_plan,
                 &mut state,
+                &mut frame,
                 nested_pattern,
                 &EvaluatedValue::Int(1.into()),
                 &mut bindings,
@@ -783,10 +910,12 @@ pub fn main() {
             })
             .expect("source should lower an assert-list step");
         let binding = &expect_list_assert_pattern(pattern).elements()[0];
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             match_assert_pattern(
                 &binding_plan,
                 &mut state,
+                &mut frame,
                 binding,
                 &EvaluatedValue::String("wrong".into()),
                 &mut bindings,
@@ -807,8 +936,8 @@ pub fn main() {
 }
 "#,
         );
-        let function = plan.int_list_function(plan.int_list_function_id(0));
-        let pattern = function
+        let list_function = plan.int_list_function(plan.int_list_function_id(0));
+        let pattern = list_function
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
@@ -826,8 +955,8 @@ pub fn main() {
 }
 "#,
         );
-        let function = ignored_plan.int_function(IntFunctionId(0));
-        let ignored_tail = function
+        let ignored_function = ignored_plan.int_function(IntFunctionId(0));
+        let ignored_tail = ignored_function
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
@@ -840,16 +969,30 @@ pub fn main() {
             plan.int_list_function_id(0).type_id(),
             vec![1.into(), 2.into(), 3.into()],
         );
+        let mut frame = Frame::new(list_function.frame_layout(), &mut state);
 
-        let bindings = match_list_assert_pattern(&plan, &mut state, pattern, &value.clone().into())
-            .expect("list pattern should match");
+        let bindings = match_list_assert_pattern(
+            &plan,
+            &mut state,
+            &mut frame,
+            pattern,
+            &value.clone().into(),
+        )
+        .expect("list pattern should match");
         assert_eq!(bindings[0], PendingBinding::Int(IntLocalId(0), 1.into()));
         assert_eq!(int_list_binding(&bindings[0]), None);
         let (local, tail) = int_list_binding(&bindings[1]).expect("tail must bind List(Int)");
         assert_eq!(local, IntListLocalId(1));
         assert_eq!(state.int_values(tail), &[2.into(), 3.into()]);
+        let mut ignored_frame = Frame::new(ignored_function.frame_layout(), &mut state);
         assert_eq!(
-            match_list_assert_pattern(&ignored_plan, &mut state, ignored_tail, &value.into(),),
+            match_list_assert_pattern(
+                &ignored_plan,
+                &mut state,
+                &mut ignored_frame,
+                ignored_tail,
+                &value.into(),
+            ),
             Some(vec![PendingBinding::Int(IntLocalId(0), 1.into())]),
         );
     }
@@ -875,11 +1018,13 @@ pub fn main() {
             })
             .expect("source should lower an assert-list step");
         let tuple_pattern = &expect_list_assert_pattern(pattern).elements()[0];
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
         let mut bindings = Vec::new();
         assert_eq!(
             match_assert_pattern(
                 &nested_plan,
                 &mut state,
+                &mut frame,
                 tuple_pattern,
                 &EvaluatedValue::Tuple(vec![
                     EvaluatedValue::Int(1.into()),
@@ -909,11 +1054,13 @@ pub fn main() {
             })
             .expect("source should lower an assert-list step");
         let alias_pattern = &expect_list_assert_pattern(pattern).elements()[0];
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
         bindings.clear();
         assert_eq!(
             match_assert_pattern(
                 &alias_plan,
                 &mut state,
+                &mut frame,
                 alias_pattern,
                 &EvaluatedValue::Int(1.into()),
                 &mut bindings,
@@ -941,6 +1088,7 @@ pub fn main() {
             })
             .expect("source should lower an assert-list step");
         let alias_pattern = &expect_list_assert_pattern(pattern).elements()[0];
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
         let wrong_kind = EvaluatedFunctionValue::from(EvaluatedFunctionFunction::new(
             FunctionFunctionId::Int(IntFunctionFunctionId(0)),
             Vec::new(),
@@ -954,6 +1102,7 @@ pub fn main() {
             match_assert_pattern(
                 &function_alias_plan,
                 &mut state,
+                &mut frame,
                 alias_pattern,
                 &EvaluatedValue::Function(wrong_kind),
                 &mut bindings,
@@ -992,11 +1141,13 @@ pub fn main() {
             plan.string_list_function_id(0).type_id(),
             vec!["wrong".into()],
         );
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
 
         assert_eq!(
             match_list_assert_pattern(
                 &plan,
                 &mut state,
+                &mut frame,
                 patterns[0],
                 &ListValueId::String(wrong_list.clone()),
             ),
@@ -1008,6 +1159,7 @@ pub fn main() {
             match_assert_pattern(
                 &plan,
                 &mut state,
+                &mut frame,
                 &patterns[1].elements()[0],
                 &EvaluatedValue::List(ListValueId::String(wrong_list)),
                 &mut bindings,
@@ -1030,6 +1182,7 @@ pub fn main() {
             match_assert_pattern(
                 &plan,
                 &mut state,
+                &mut frame,
                 &patterns[2].elements()[0],
                 &EvaluatedValue::Function(wrong_function),
                 &mut bindings,

--- a/src/runtime/pattern.rs
+++ b/src/runtime/pattern.rs
@@ -1,0 +1,3 @@
+mod bit_array;
+
+pub(super) use bit_array::match_bit_array_pattern;

--- a/src/runtime/pattern/bit_array.rs
+++ b/src/runtime/pattern/bit_array.rs
@@ -1,0 +1,777 @@
+use bitvec::order::Msb0;
+use bitvec::slice::BitSlice;
+use bitvec::vec::BitVec;
+use bitvec::view::BitView;
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+use crate::plan::execution::{
+    BitArrayBindingPattern, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
+    BitArrayPatternSizeExpr, BitArrayPatternValue, BitArrayStringPattern, Endianness, Signedness,
+    StringEncoding,
+};
+use crate::runtime::evaluated::EvaluatedBitArray;
+use crate::runtime::frame::Frame;
+
+pub(in crate::runtime) fn match_bit_array_pattern(
+    frame: &mut Frame,
+    subject: &EvaluatedBitArray,
+    pattern: &BitArrayPattern,
+) -> bool {
+    let mut cursor = 0;
+    for segment in pattern.segments() {
+        let matched = match segment {
+            BitArrayPatternSegment::Int {
+                pattern,
+                size,
+                endianness,
+                signedness,
+            } => match_int_segment(
+                frame,
+                subject.bits(),
+                &mut cursor,
+                pattern,
+                size,
+                *endianness,
+                *signedness,
+            ),
+            BitArrayPatternSegment::Float {
+                pattern,
+                size,
+                endianness,
+            } => match_float_segment(
+                frame,
+                subject.bits(),
+                &mut cursor,
+                pattern,
+                size,
+                *endianness,
+            ),
+            BitArrayPatternSegment::Bits {
+                pattern,
+                size,
+                unit,
+            } => match_bits_segment(
+                frame,
+                subject.bits(),
+                &mut cursor,
+                pattern,
+                size.as_ref(),
+                *unit,
+            ),
+            BitArrayPatternSegment::String { pattern, encoding } => {
+                match_string_segment(subject.bits(), &mut cursor, pattern, *encoding)
+            }
+        };
+        if !matched {
+            return false;
+        }
+    }
+
+    cursor == subject.bits().len()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn match_int_segment(
+    frame: &mut Frame,
+    subject: &BitSlice<u8, Msb0>,
+    cursor: &mut usize,
+    pattern: &BitArrayPatternValue<BigInt, crate::plan::execution::IntLocalId>,
+    size: &BitArrayPatternSize,
+    endianness: Endianness,
+    signedness: Signedness,
+) -> bool {
+    let Some(bit_size) = eval_size(frame, size) else {
+        return false;
+    };
+    let Some(bits) = take_bits(subject, cursor, bit_size) else {
+        return false;
+    };
+    let value = decode_integer(bits, endianness, signedness);
+    match_int_pattern(frame, pattern, &value)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn match_float_segment(
+    frame: &mut Frame,
+    subject: &BitSlice<u8, Msb0>,
+    cursor: &mut usize,
+    pattern: &BitArrayPatternValue<f64, crate::plan::execution::FloatLocalId>,
+    size: &BitArrayPatternSize,
+    endianness: Endianness,
+) -> bool {
+    let Some(bit_size) = eval_size(frame, size) else {
+        return false;
+    };
+    let width = match bit_size {
+        16 => FloatWidth::Sixteen,
+        32 => FloatWidth::ThirtyTwo,
+        64 => FloatWidth::SixtyFour,
+        _ => return false,
+    };
+    let Some(bits) = take_bits(subject, cursor, width.bit_size()) else {
+        return false;
+    };
+    let value = decode_float(bits, width, endianness);
+    match_float_pattern(frame, pattern, value)
+}
+
+fn match_bits_segment(
+    frame: &mut Frame,
+    subject: &BitSlice<u8, Msb0>,
+    cursor: &mut usize,
+    pattern: &BitArrayBindingPattern<crate::plan::execution::BitArrayLocalId>,
+    size: Option<&BitArrayPatternSize>,
+    unit: u8,
+) -> bool {
+    let bit_size = match size {
+        Some(size) => {
+            let Some(size) = eval_size(frame, size) else {
+                return false;
+            };
+            size
+        }
+        None => {
+            let remaining = subject.len() - *cursor;
+            if !remaining.is_multiple_of(usize::from(unit)) {
+                return false;
+            }
+            remaining
+        }
+    };
+    let Some(bits) = take_bits(subject, cursor, bit_size) else {
+        return false;
+    };
+    let value = EvaluatedBitArray::new(BitVec::from_bitslice(bits));
+    bind_bits_pattern(frame, pattern, &value);
+    true
+}
+
+fn match_string_segment(
+    subject: &BitSlice<u8, Msb0>,
+    cursor: &mut usize,
+    pattern: &BitArrayStringPattern,
+    encoding: StringEncoding,
+) -> bool {
+    match pattern {
+        BitArrayStringPattern::Literal(literal) => {
+            let encoded = encode_string(literal, encoding);
+            let Some(bits) = take_bits(subject, cursor, encoded.len()) else {
+                return false;
+            };
+            if bits != encoded.as_bitslice() {
+                return false;
+            }
+            true
+        }
+        BitArrayStringPattern::Discard => {
+            let Some((_, bit_size)) = decode_one_string(&subject[*cursor..], encoding) else {
+                return false;
+            };
+            *cursor += bit_size;
+            true
+        }
+    }
+}
+
+fn eval_size(frame: &Frame, size: &BitArrayPatternSize) -> Option<usize> {
+    let value = eval_size_expr(frame, size.value());
+    let Ok(value) = usize::try_from(value) else {
+        return None;
+    };
+    if value == 0 {
+        return None;
+    }
+    value.checked_mul(usize::from(size.unit()))
+}
+
+fn eval_size_expr(frame: &Frame, expression: &BitArrayPatternSizeExpr) -> BigInt {
+    match expression {
+        BitArrayPatternSizeExpr::Value(value) => value.clone(),
+        BitArrayPatternSizeExpr::LocalGet(local) => frame.get_int(*local),
+        BitArrayPatternSizeExpr::Add { left, right } => {
+            eval_size_expr(frame, left) + eval_size_expr(frame, right)
+        }
+        BitArrayPatternSizeExpr::Subtract { left, right } => {
+            eval_size_expr(frame, left) - eval_size_expr(frame, right)
+        }
+        BitArrayPatternSizeExpr::Multiply { left, right } => {
+            eval_size_expr(frame, left) * eval_size_expr(frame, right)
+        }
+        BitArrayPatternSizeExpr::Divide { left, right } => {
+            let right = eval_size_expr(frame, right);
+            if right == BigInt::from(0) {
+                BigInt::from(0)
+            } else {
+                eval_size_expr(frame, left) / right
+            }
+        }
+        BitArrayPatternSizeExpr::Remainder { left, right } => {
+            let right = eval_size_expr(frame, right);
+            if right == BigInt::from(0) {
+                BigInt::from(0)
+            } else {
+                eval_size_expr(frame, left) % right
+            }
+        }
+    }
+}
+
+fn take_bits<'a>(
+    subject: &'a BitSlice<u8, Msb0>,
+    cursor: &mut usize,
+    bit_size: usize,
+) -> Option<&'a BitSlice<u8, Msb0>> {
+    let end = cursor.checked_add(bit_size)?;
+    let bits = subject.get(*cursor..end)?;
+    *cursor = end;
+    Some(bits)
+}
+
+fn decode_integer(
+    bits: &BitSlice<u8, Msb0>,
+    endianness: Endianness,
+    signedness: Signedness,
+) -> BigInt {
+    let mut value = BigInt::from(0u8);
+    match endianness {
+        Endianness::Big => {
+            for bit in bits {
+                value = (value << 1) + BigInt::from(u8::from(*bit));
+            }
+        }
+        Endianness::Little => {
+            for (index, chunk) in bits.chunks(8).enumerate() {
+                let mut byte = 0u8;
+                for bit in chunk {
+                    byte = (byte << 1) | u8::from(*bit);
+                }
+                value += BigInt::from(byte) << (index * 8);
+            }
+        }
+    }
+
+    if signedness == Signedness::Signed && !bits.is_empty() {
+        let sign_bit = BigInt::from(1u8) << (bits.len() - 1);
+        if (&value & sign_bit) != BigInt::from(0u8) {
+            value -= BigInt::from(1u8) << bits.len();
+        }
+    }
+    value
+}
+
+#[derive(Clone, Copy)]
+enum FloatWidth {
+    Sixteen,
+    ThirtyTwo,
+    SixtyFour,
+}
+
+impl FloatWidth {
+    fn bit_size(self) -> usize {
+        match self {
+            Self::Sixteen => 16,
+            Self::ThirtyTwo => 32,
+            Self::SixtyFour => 64,
+        }
+    }
+}
+
+fn decode_float(bits: &BitSlice<u8, Msb0>, width: FloatWidth, endianness: Endianness) -> f64 {
+    let mut bytes = vec![0u8; bits.len() / 8];
+    bytes.view_bits_mut::<Msb0>().copy_from_bitslice(bits);
+    match (width, endianness) {
+        (FloatWidth::Sixteen, Endianness::Big) => {
+            half::f16::from_be_bytes([bytes[0], bytes[1]]).to_f64()
+        }
+        (FloatWidth::Sixteen, Endianness::Little) => {
+            half::f16::from_le_bytes([bytes[0], bytes[1]]).to_f64()
+        }
+        (FloatWidth::ThirtyTwo, Endianness::Big) => {
+            f32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as f64
+        }
+        (FloatWidth::ThirtyTwo, Endianness::Little) => {
+            f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as f64
+        }
+        (FloatWidth::SixtyFour, Endianness::Big) => f64::from_be_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+        ]),
+        (FloatWidth::SixtyFour, Endianness::Little) => f64::from_le_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+        ]),
+    }
+}
+
+fn encode_string(value: &str, encoding: StringEncoding) -> BitVec<u8, Msb0> {
+    let mut bits = BitVec::new();
+    match encoding {
+        StringEncoding::Utf8 => bits.extend_from_bitslice(value.as_bytes().view_bits::<Msb0>()),
+        StringEncoding::Utf16(endianness) => {
+            for code in value.encode_utf16() {
+                let bytes = match endianness {
+                    Endianness::Big => code.to_be_bytes(),
+                    Endianness::Little => code.to_le_bytes(),
+                };
+                bits.extend_from_bitslice(bytes.view_bits::<Msb0>());
+            }
+        }
+        StringEncoding::Utf32(endianness) => {
+            for character in value.chars() {
+                let bytes = match endianness {
+                    Endianness::Big => u32::from(character).to_be_bytes(),
+                    Endianness::Little => u32::from(character).to_le_bytes(),
+                };
+                bits.extend_from_bitslice(bytes.view_bits::<Msb0>());
+            }
+        }
+    }
+    bits
+}
+
+fn decode_one_string(
+    bits: &BitSlice<u8, Msb0>,
+    encoding: StringEncoding,
+) -> Option<(EcoString, usize)> {
+    match encoding {
+        StringEncoding::Utf8 => decode_utf8(bits),
+        StringEncoding::Utf16(endianness) => decode_utf16(bits, endianness),
+        StringEncoding::Utf32(endianness) => decode_utf32(bits, endianness),
+    }
+}
+
+fn decode_utf8(bits: &BitSlice<u8, Msb0>) -> Option<(EcoString, usize)> {
+    let first = read_byte(bits, 0)?;
+    let bytes = match first {
+        0x00..=0x7f => 1,
+        0xc2..=0xdf => 2,
+        0xe0..=0xef => 3,
+        0xf0..=0xf4 => 4,
+        _ => return None,
+    };
+    let mut encoded = Vec::with_capacity(bytes);
+    for index in 0..bytes {
+        encoded.push(read_byte(bits, index * 8)?);
+    }
+    let Ok(value) = std::str::from_utf8(&encoded) else {
+        return None;
+    };
+    Some((value.into(), bytes * 8))
+}
+
+fn decode_utf16(bits: &BitSlice<u8, Msb0>, endianness: Endianness) -> Option<(EcoString, usize)> {
+    let first = read_u16(bits, 0, endianness)?;
+    let (codepoint, bit_size) = if (0xd800..=0xdbff).contains(&first) {
+        let second = read_u16(bits, 16, endianness)?;
+        if !(0xdc00..=0xdfff).contains(&second) {
+            return None;
+        }
+        let high = u32::from(first - 0xd800);
+        let low = u32::from(second - 0xdc00);
+        (0x10000 + (high << 10) + low, 32)
+    } else {
+        (u32::from(first), 16)
+    };
+    let character = char::from_u32(codepoint)?;
+    Some((character.to_string().into(), bit_size))
+}
+
+fn decode_utf32(bits: &BitSlice<u8, Msb0>, endianness: Endianness) -> Option<(EcoString, usize)> {
+    let bytes = [
+        read_byte(bits, 0)?,
+        read_byte(bits, 8)?,
+        read_byte(bits, 16)?,
+        read_byte(bits, 24)?,
+    ];
+    let value = match endianness {
+        Endianness::Big => u32::from_be_bytes(bytes),
+        Endianness::Little => u32::from_le_bytes(bytes),
+    };
+    Some((char::from_u32(value)?.to_string().into(), 32))
+}
+
+fn read_u16(bits: &BitSlice<u8, Msb0>, offset: usize, endianness: Endianness) -> Option<u16> {
+    let bytes = [read_byte(bits, offset)?, read_byte(bits, offset + 8)?];
+    Some(match endianness {
+        Endianness::Big => u16::from_be_bytes(bytes),
+        Endianness::Little => u16::from_le_bytes(bytes),
+    })
+}
+
+fn read_byte(bits: &BitSlice<u8, Msb0>, offset: usize) -> Option<u8> {
+    let end = offset.checked_add(8)?;
+    let bits = bits.get(offset..end)?;
+    let mut byte = 0;
+    for bit in bits {
+        byte = (byte << 1) | u8::from(*bit);
+    }
+    Some(byte)
+}
+
+fn match_int_pattern(
+    frame: &mut Frame,
+    pattern: &BitArrayPatternValue<BigInt, crate::plan::execution::IntLocalId>,
+    value: &BigInt,
+) -> bool {
+    match pattern {
+        BitArrayPatternValue::Literal(expected) => expected == value,
+        BitArrayPatternValue::Bind(binding) => {
+            frame.set_int(*binding.local(), value.clone());
+            true
+        }
+        BitArrayPatternValue::Discard => true,
+        BitArrayPatternValue::Alias { pattern, binding } => {
+            if !match_int_pattern(frame, pattern, value) {
+                return false;
+            }
+            frame.set_int(*binding.local(), value.clone());
+            true
+        }
+    }
+}
+
+fn match_float_pattern(
+    frame: &mut Frame,
+    pattern: &BitArrayPatternValue<f64, crate::plan::execution::FloatLocalId>,
+    value: f64,
+) -> bool {
+    match pattern {
+        BitArrayPatternValue::Literal(expected) => *expected == value,
+        BitArrayPatternValue::Bind(binding) => {
+            frame.set_float(*binding.local(), value);
+            true
+        }
+        BitArrayPatternValue::Discard => true,
+        BitArrayPatternValue::Alias { pattern, binding } => {
+            if !match_float_pattern(frame, pattern, value) {
+                return false;
+            }
+            frame.set_float(*binding.local(), value);
+            true
+        }
+    }
+}
+
+fn bind_bits_pattern(
+    frame: &mut Frame,
+    pattern: &BitArrayBindingPattern<crate::plan::execution::BitArrayLocalId>,
+    value: &EvaluatedBitArray,
+) {
+    match pattern {
+        BitArrayBindingPattern::Bind(binding) => {
+            frame.set_bit_array(*binding.local(), value.clone());
+        }
+        BitArrayBindingPattern::Discard => {}
+        BitArrayBindingPattern::Alias { pattern, binding } => {
+            bind_bits_pattern(frame, pattern, value);
+            frame.set_bit_array(*binding.local(), value.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        FloatWidth, decode_float, decode_integer, decode_utf8, decode_utf16, decode_utf32,
+        read_byte, read_u16, take_bits,
+    };
+    use crate::plan::execution::{Endianness, Signedness};
+    use crate::runtime::Value;
+    use bitvec::order::Msb0;
+    use bitvec::view::BitView;
+
+    #[test]
+    fn source_matcher_handles_every_segment_binding_family_and_miss() {
+        let source = r#"
+pub fn main() {
+  #(
+    case <<1>> {
+      <<value>> -> value
+      _ -> 0
+    },
+    case <<1>> {
+      <<1 as alias>> -> alias
+      _ -> 0
+    },
+    case <<1>> {
+      <<_>> -> True
+      _ -> False
+    },
+    case <<1.5:float-size(16)>> {
+      <<value:float-size(16)>> -> value
+      _ -> 0.0
+    },
+    case <<1.5:float-size(16)>> {
+      <<1.5 as alias:float-size(16)>> -> alias
+      _ -> 0.0
+    },
+    case <<1.5:float-size(16)>> {
+      <<_:float-size(16)>> -> True
+      _ -> False
+    },
+    case <<1, 2>> {
+      <<first:bytes-size(1), _ as rest:bits>> -> #(first, rest)
+      _ -> #(<<>>, <<>>)
+    },
+    case <<"A":utf16-big>> {
+      <<_:utf16-big>> -> True
+      _ -> False
+    },
+    case <<"A":utf8>> {
+      <<"A":utf8>> -> True
+      _ -> False
+    },
+    case <<255>> {
+      <<_:utf8>> -> True
+      _ -> False
+    },
+  )
+}
+"#;
+
+        assert_eq!(
+            crate::runtime::run_src(source),
+            Value::Tuple(vec![
+                Value::Int(1.into()),
+                Value::Int(1.into()),
+                Value::Bool(true),
+                Value::Float(1.5),
+                Value::Float(1.5),
+                Value::Bool(true),
+                Value::Tuple(vec![
+                    Value::BitArray(crate::BitArrayValue::from_bytes(vec![1])),
+                    Value::BitArray(crate::BitArrayValue::from_bytes(vec![2])),
+                ]),
+                Value::Bool(true),
+                Value::Bool(true),
+                Value::Bool(false),
+            ]),
+        );
+    }
+
+    #[test]
+    fn source_matcher_evaluates_every_size_operator_and_boundary() {
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../tests/fixtures/execution/control_flow/case/bit_array_pattern_integers.gleam"
+            )),
+            Value::Tuple(vec![
+                Value::Int((-2).into()),
+                Value::Int(4094.into()),
+                Value::Int(564.into()),
+                Value::Int(564.into()),
+                Value::Int(564.into()),
+                Value::Int(0.into()),
+                Value::Int(0.into()),
+                Value::Int(0.into()),
+                Value::Int(0.into()),
+                Value::Int(0.into()),
+                Value::Int(15.into()),
+            ]),
+        );
+        assert_eq!(
+            crate::runtime::run_src(
+                r#"
+pub fn main() {
+  #(
+    case <<>> {
+      <<_:bits-size(1 / 0)>> -> 1
+      _ -> 0
+    },
+    case <<>> {
+      <<_:bits-size(1 % 0)>> -> 1
+      _ -> 0
+    },
+  )
+}
+"#,
+            ),
+            Value::Tuple(vec![Value::Int(0.into()), Value::Int(0.into())]),
+        );
+    }
+
+    #[test]
+    fn integer_decoder_preserves_signedness_endianness_and_unaligned_bits() {
+        assert_eq!(
+            decode_integer(
+                [0xfe].view_bits::<Msb0>(),
+                Endianness::Big,
+                Signedness::Signed,
+            ),
+            (-2).into(),
+        );
+        assert_eq!(
+            decode_integer(
+                &[0x34, 0x20].view_bits::<Msb0>()[..12],
+                Endianness::Little,
+                Signedness::Unsigned,
+            ),
+            0x234.into(),
+        );
+        assert_eq!(
+            decode_integer(
+                &[0xfe, 0xf0].view_bits::<Msb0>()[..12],
+                Endianness::Little,
+                Signedness::Signed,
+            ),
+            (-2).into(),
+        );
+        assert_eq!(
+            decode_integer(
+                [0x7f].view_bits::<Msb0>(),
+                Endianness::Big,
+                Signedness::Signed,
+            ),
+            127.into(),
+        );
+    }
+
+    #[test]
+    fn float_decoder_accepts_every_supported_width_and_endianness() {
+        assert_eq!(FloatWidth::Sixteen.bit_size(), 16);
+        assert_eq!(FloatWidth::ThirtyTwo.bit_size(), 32);
+        assert_eq!(FloatWidth::SixtyFour.bit_size(), 64);
+        assert_eq!(
+            decode_float(
+                [0x3e, 0x00].view_bits::<Msb0>(),
+                FloatWidth::Sixteen,
+                Endianness::Big,
+            ),
+            1.5,
+        );
+        assert_eq!(
+            decode_float(
+                [0x00, 0x3e].view_bits::<Msb0>(),
+                FloatWidth::Sixteen,
+                Endianness::Little,
+            ),
+            1.5,
+        );
+        assert_eq!(
+            decode_float(
+                [0x3f, 0xc0, 0x00, 0x00].view_bits::<Msb0>(),
+                FloatWidth::ThirtyTwo,
+                Endianness::Big,
+            ),
+            1.5,
+        );
+        assert_eq!(
+            decode_float(
+                [0x00, 0x00, 0xc0, 0x3f].view_bits::<Msb0>(),
+                FloatWidth::ThirtyTwo,
+                Endianness::Little,
+            ),
+            1.5,
+        );
+        assert_eq!(
+            decode_float(
+                [0x3f, 0xf8, 0, 0, 0, 0, 0, 0].view_bits::<Msb0>(),
+                FloatWidth::SixtyFour,
+                Endianness::Big,
+            ),
+            1.5,
+        );
+        assert_eq!(
+            decode_float(
+                [0, 0, 0, 0, 0, 0, 0xf8, 0x3f].view_bits::<Msb0>(),
+                FloatWidth::SixtyFour,
+                Endianness::Little,
+            ),
+            1.5,
+        );
+    }
+
+    #[test]
+    fn string_decoders_accept_one_scalar_and_reject_invalid_encoding() {
+        assert_eq!(decode_utf8([].view_bits::<Msb0>()), None);
+        assert_eq!(
+            decode_utf8([b'A'].view_bits::<Msb0>()),
+            Some(("A".into(), 8)),
+        );
+        assert_eq!(
+            decode_utf8([0xc2, 0xa2].view_bits::<Msb0>()),
+            Some(("¢".into(), 16)),
+        );
+        assert_eq!(
+            decode_utf8("안".as_bytes().view_bits::<Msb0>()),
+            Some(("안".into(), 24)),
+        );
+        assert_eq!(
+            decode_utf8([0xf0, 0x9f, 0x98, 0x80].view_bits::<Msb0>()),
+            Some(("😀".into(), 32)),
+        );
+        assert_eq!(decode_utf8([0xc2].view_bits::<Msb0>()), None);
+        assert_eq!(decode_utf8([0xc2, 0x20].view_bits::<Msb0>()), None);
+        assert_eq!(decode_utf8([0xff].view_bits::<Msb0>()), None);
+        assert_eq!(decode_utf16([].view_bits::<Msb0>(), Endianness::Big), None);
+        assert_eq!(
+            decode_utf16([0, 0x41].view_bits::<Msb0>(), Endianness::Big),
+            Some(("A".into(), 16)),
+        );
+        assert_eq!(
+            decode_utf16([0x41, 0].view_bits::<Msb0>(), Endianness::Little),
+            Some(("A".into(), 16)),
+        );
+        assert_eq!(
+            decode_utf16(
+                [0xd8, 0x3d, 0xde, 0x00].view_bits::<Msb0>(),
+                Endianness::Big
+            ),
+            Some(("😀".into(), 32)),
+        );
+        assert_eq!(
+            decode_utf16([0xd8, 0x00].view_bits::<Msb0>(), Endianness::Big),
+            None,
+        );
+        assert_eq!(
+            decode_utf16(
+                [0xd8, 0x00, 0x00, 0x41].view_bits::<Msb0>(),
+                Endianness::Big,
+            ),
+            None,
+        );
+        assert_eq!(
+            decode_utf16([0xdc, 0x00].view_bits::<Msb0>(), Endianness::Big),
+            None,
+        );
+        assert_eq!(decode_utf32([].view_bits::<Msb0>(), Endianness::Big), None);
+        assert_eq!(decode_utf32([0].view_bits::<Msb0>(), Endianness::Big), None,);
+        assert_eq!(
+            decode_utf32([0, 0].view_bits::<Msb0>(), Endianness::Big),
+            None,
+        );
+        assert_eq!(
+            decode_utf32([0, 0, 0].view_bits::<Msb0>(), Endianness::Big),
+            None,
+        );
+        assert_eq!(
+            decode_utf32([0, 0, 0, 0x41].view_bits::<Msb0>(), Endianness::Big),
+            Some(("A".into(), 32)),
+        );
+        assert_eq!(
+            decode_utf32([0x41, 0, 0, 0].view_bits::<Msb0>(), Endianness::Little),
+            Some(("A".into(), 32)),
+        );
+        assert_eq!(
+            decode_utf32([0, 0x11, 0, 0].view_bits::<Msb0>(), Endianness::Big),
+            None,
+        );
+        assert_eq!(read_u16([0].view_bits::<Msb0>(), 0, Endianness::Big), None);
+        assert_eq!(
+            read_u16([0x41, 0].view_bits::<Msb0>(), 0, Endianness::Little),
+            Some(0x41),
+        );
+        assert_eq!(read_byte([0].view_bits::<Msb0>(), usize::MAX), None);
+    }
+
+    #[test]
+    fn bit_cursor_advances_only_for_available_ranges() {
+        let bits = [0xaa].view_bits::<Msb0>();
+        let mut cursor = 0;
+        assert_eq!(take_bits(bits, &mut cursor, 4), bits.get(0..4));
+        assert_eq!(cursor, 4);
+        assert_eq!(take_bits(bits, &mut cursor, usize::MAX), None);
+        assert_eq!(cursor, 4);
+        assert_eq!(take_bits(bits, &mut cursor, 5), None);
+        assert_eq!(cursor, 4);
+    }
+}

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -102,6 +102,9 @@ mod bindings {
         nested_pattern_alias_assignment,
         list_tail_assignment,
         let_assert_bit_array_list,
+        let_assert_bit_array_pattern,
+        let_assert_bit_array_patterns,
+        bit_array_total_pattern,
         let_assert_list_destructuring,
         let_assert_fixed_list,
         let_assert_empty_list,
@@ -228,6 +231,17 @@ mod control_flow {
             multiple_subject_closure_capture,
             bit_array_subject,
             multiple_subject_bit_array_subject,
+            bit_array_pattern,
+            bit_array_pattern_options,
+            bit_array_pattern_integers,
+            bit_array_pattern_bits,
+            bit_array_pattern_dynamic_bytes,
+            bit_array_pattern_floats,
+            bit_array_pattern_strings,
+            bit_array_pattern_composition,
+            tuple_inner_bit_array_pattern,
+            list_inner_bit_array_pattern,
+            list_inner_bit_array_pattern_fallthrough,
         );
     }
 }
@@ -393,6 +407,7 @@ mod functions {
             use_list_value,
             use_tuple_assignment,
             use_list_tail_assignment,
+            use_bit_array_total_pattern,
             use_pattern_alias_assignment,
             use_nested_tuple_alias_assignment,
             use_block_scope,
@@ -465,6 +480,7 @@ mod execution_errors {
             let_assert_fixed_length,
             let_assert_empty_list,
             let_assert_message,
+            let_assert_bit_array_pattern,
         );
     }
 
@@ -532,7 +548,6 @@ mod rejection {
         rejection_cases!("patterns";
             let_assert_literal_pattern,
             let_assert_constructor_pattern,
-            let_assert_bit_array_pattern,
             let_assert_string_prefix_pattern,
             let_assert_nested_list_pattern,
         );
@@ -541,10 +556,8 @@ mod rejection {
     mod case_patterns {
         rejection_cases!("case_patterns";
             result_subject,
-            bit_array_pattern,
-            tuple_inner_bit_array_pattern,
-            list_inner_bit_array_pattern,
-            bit_array_pattern_options,
+            bit_array_pattern_utf_codepoint,
+            bit_array_pattern_native_endian,
         );
     }
 

--- a/tests/fixtures/execution/bindings/bit_array_total_pattern.gleam
+++ b/tests/fixtures/execution/bindings/bit_array_total_pattern.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  let <<all:bits>> = <<1, 2>>
+  let #(<<nested:bits>>, value) = #(<<3>>, 4)
+  let <<_ as inner:bits>> = <<5>>
+  #(all, nested, value, inner)
+}
+
+// geam:expect Tuple([BitArray(bytes=[1, 2], bit_len=16), BitArray(bytes=[3], bit_len=8), Int(4), BitArray(bytes=[5], bit_len=8)])

--- a/tests/fixtures/execution/bindings/let_assert_bit_array_pattern.gleam
+++ b/tests/fixtures/execution/bindings/let_assert_bit_array_pattern.gleam
@@ -2,3 +2,5 @@ pub fn main() {
   let assert <<first>> = <<1>>
   first
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/bindings/let_assert_bit_array_patterns.gleam
+++ b/tests/fixtures/execution/bindings/let_assert_bit_array_patterns.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  let assert <<size, payload:bits-size(size), _ as alias:bits-size(8), rest:bits>> as whole =
+    <<16, 1, 2, 3, 4>>
+  let assert [<<1 as first, nested_rest:bits>>] = [<<1, 2>>]
+  #(size, payload, alias, rest, whole, first, nested_rest)
+}
+
+// geam:expect Tuple([Int(16), BitArray(bytes=[1, 2], bit_len=16), BitArray(bytes=[3], bit_len=8), BitArray(bytes=[4], bit_len=8), BitArray(bytes=[16, 1, 2, 3, 4], bit_len=40), Int(1), BitArray(bytes=[2], bit_len=8)])

--- a/tests/fixtures/execution/control_flow/case/bit_array_pattern.gleam
+++ b/tests/fixtures/execution/control_flow/case/bit_array_pattern.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case <<1>> {
+    <<1>> -> 1
+    _ -> 0
+  }
+}
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/control_flow/case/bit_array_pattern_bits.gleam
+++ b/tests/fixtures/execution/control_flow/case/bit_array_pattern_bits.gleam
@@ -1,0 +1,28 @@
+pub fn main() {
+  #(
+    case <<1, 2, 3>> {
+      <<_, rest:bytes>> -> rest
+      _ -> <<>>
+    },
+    case <<0x77:size(7)>> {
+      <<_:size(4), middle:bits-size(2), _:size(1)>> -> middle
+      _ -> <<>>
+    },
+    case <<1, 2, 3>> {
+      <<head:bytes-size(2), rest:bits>> -> #(head, rest)
+      _ -> #(<<>>, <<>>)
+    },
+    case <<0x7:size(4)>> {
+      <<_:bytes>> -> 1
+      _ -> 0
+    },
+    case <<1>> {
+      <<all:bits>> -> all
+    },
+    case <<1>> {
+      <<_ as inner:bits>> as whole -> #(inner, whole)
+    },
+  )
+}
+
+// geam:expect Tuple([BitArray(bytes=[2, 3], bit_len=16), BitArray(bytes=[192], bit_len=2), Tuple([BitArray(bytes=[1, 2], bit_len=16), BitArray(bytes=[3], bit_len=8)]), Int(0), BitArray(bytes=[1], bit_len=8), Tuple([BitArray(bytes=[1], bit_len=8), BitArray(bytes=[1], bit_len=8)])])

--- a/tests/fixtures/execution/control_flow/case/bit_array_pattern_composition.gleam
+++ b/tests/fixtures/execution/control_flow/case/bit_array_pattern_composition.gleam
@@ -1,0 +1,39 @@
+pub fn main() {
+  let closure = case <<2, 9>> {
+    <<1, value>> | <<2, value>> if value > 5 -> fn() { value }
+    _ -> fn() { 0 }
+  }
+  let outer_size = 8
+  let outer_size_closure = fn(bits) {
+    case bits {
+      <<value:size(outer_size)>> -> value
+      _ -> 0
+    }
+  }
+  let segment_size_closure = fn(bits) {
+    case bits {
+      <<size, value:size(size)>> -> value
+      _ -> 0
+    }
+  }
+
+  #(
+    case <<1>> {
+      <<1 as segment>> as whole -> #(segment, whole)
+      _ -> #(0, <<>>)
+    },
+    case <<1>>, <<2>> {
+      <<1>>, <<value>> -> value
+      _, _ -> 0
+    },
+    case <<1>> {
+      <<2 as value>> -> value
+      _ -> 0
+    },
+    closure(),
+    outer_size_closure(<<42>>),
+    segment_size_closure(<<8, 43>>),
+  )
+}
+
+// geam:expect Tuple([Tuple([Int(1), BitArray(bytes=[1], bit_len=8)]), Int(2), Int(0), Int(9), Int(42), Int(43)])

--- a/tests/fixtures/execution/control_flow/case/bit_array_pattern_dynamic_bytes.gleam
+++ b/tests/fixtures/execution/control_flow/case/bit_array_pattern_dynamic_bytes.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case <<3, 10, 20, 30>> {
+    <<length, payload:bytes-size(length)>> -> payload
+    _ -> <<>>
+  }
+}
+
+// geam:expect BitArray(bytes=[10, 20, 30], bit_len=24)

--- a/tests/fixtures/execution/control_flow/case/bit_array_pattern_floats.gleam
+++ b/tests/fixtures/execution/control_flow/case/bit_array_pattern_floats.gleam
@@ -1,0 +1,56 @@
+pub fn main() {
+  let invalid_float_size = 24
+  let zero_size = 0
+  #(
+    case <<1.5:float-size(16)-big>> {
+      <<1.5 as alias:float-size(16)-big>> -> alias +. alias
+      _ -> 0.0
+    },
+    case <<1.5:float-size(32)-little>> {
+      <<value:float-size(32)-little>> -> value
+      _ -> 0.0
+    },
+    case <<1.5:float-size(16)-little>> {
+      <<value:float-size(16)-little>> -> value
+      _ -> 0.0
+    },
+    case <<1.5:float-size(32)-big>> {
+      <<value:float-size(32)-big>> -> value
+      _ -> 0.0
+    },
+    case <<1.5:float-size(64)-big>> {
+      <<value:float-size(64)-big>> -> value
+      _ -> 0.0
+    },
+    case <<1.5:float-size(64)-little>> {
+      <<value:float-size(64)-little>> -> value
+      _ -> 0.0
+    },
+    case <<1.5:float-size(16)>> {
+      <<1.5:float-size(16)>> -> True
+      _ -> False
+    },
+    case <<1.5:float-size(16)>> {
+      <<_:float-size(16)>> -> True
+      _ -> False
+    },
+    case <<1.5:float-size(16)>> {
+      <<2.0 as alias:float-size(16)>> -> alias
+      _ -> 0.0
+    },
+    case <<1.5:float-size(32)>> {
+      <<_:float-size(invalid_float_size)>> -> True
+      _ -> False
+    },
+    case <<1.5:float-size(16)>> {
+      <<_:float-size(zero_size)>> -> True
+      _ -> False
+    },
+    case <<1.5:float-size(16)>> {
+      <<_:float-size(64)>> -> True
+      _ -> False
+    },
+  )
+}
+
+// geam:expect Tuple([Float(3.0), Float(1.5), Float(1.5), Float(1.5), Float(1.5), Float(1.5), Bool(true), Bool(true), Float(0.0), Bool(false), Bool(false), Bool(false)])

--- a/tests/fixtures/execution/control_flow/case/bit_array_pattern_integers.gleam
+++ b/tests/fixtures/execution/control_flow/case/bit_array_pattern_integers.gleam
@@ -1,0 +1,64 @@
+const base_pattern_size = 8
+const pattern_size = base_pattern_size
+
+pub fn main() {
+  let outer_size = 12
+  let negative_size = -1
+  let zero_size = 0
+  let huge_size = 184467440737095516160
+
+  #(
+    case <<-2:size(12)>> {
+      <<value:signed-size(12)>> -> value
+      _ -> 0
+    },
+    case <<-2:size(12)>> {
+      <<value:unsigned-size(12)>> -> value
+      _ -> 0
+    },
+    case <<0x234:little-size(12)>> {
+      <<value:little-size(12)>> -> value
+      _ -> 0
+    },
+    case <<0x234:size(12)>> {
+      <<value:size(outer_size)>> -> value
+      _ -> 0
+    },
+    case <<12, 0x234:size(12)>> {
+      <<size, value:size(size)>> -> value
+      _ -> 0
+    },
+    case <<>> {
+      <<_:bits-size(negative_size)>> -> 1
+      _ -> 0
+    },
+    case <<>> {
+      <<_:bits-size(huge_size)>> -> 1
+      _ -> 0
+    },
+    case <<1>> {
+      <<_:bits-size(16)>> -> 1
+      _ -> 0
+    },
+    case <<1>> {
+      <<_:size(16)>> -> 1
+      _ -> 0
+    },
+    case <<>> {
+      <<value:size(zero_size)>> if value == 0 -> 1
+      _ -> 0
+    },
+    case <<1, 2, 3, 4, 5>> {
+      <<
+        one:size(pattern_size),
+        two:size(outer_size - 4),
+        three:size(outer_size * 2 / 3),
+        four:size(outer_size % 5 + 6),
+        five:size({ outer_size - 4 }),
+      >> -> one + two + three + four + five
+      _ -> 0
+    },
+  )
+}
+
+// geam:expect Tuple([Int(-2), Int(4094), Int(564), Int(564), Int(564), Int(0), Int(0), Int(0), Int(0), Int(0), Int(15)])

--- a/tests/fixtures/execution/control_flow/case/bit_array_pattern_options.gleam
+++ b/tests/fixtures/execution/control_flow/case/bit_array_pattern_options.gleam
@@ -4,3 +4,5 @@ pub fn main() {
     _ -> <<>>
   }
 }
+
+// geam:expect BitArray(bytes=[1], bit_len=8)

--- a/tests/fixtures/execution/control_flow/case/bit_array_pattern_strings.gleam
+++ b/tests/fixtures/execution/control_flow/case/bit_array_pattern_strings.gleam
@@ -1,0 +1,58 @@
+pub fn main() {
+  #(
+    case <<"A">> {
+      <<"A">> -> 1
+      _ -> 0
+    },
+    case <<"안":utf8>> {
+      <<"안":utf8>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf16-big>> {
+      <<_:utf16-big>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf16-big>> {
+      <<"A":utf16-big>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf16-little>> {
+      <<"A":utf16-little>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf16-little>> {
+      <<_:utf16-little>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf32-big>> {
+      <<_:utf32-big>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf32-big>> {
+      <<"A":utf32-big>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf32-little>> {
+      <<"A":utf32-little>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf32-little>> {
+      <<_:utf32-little>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf8>> {
+      <<"B":utf8>> -> 1
+      _ -> 0
+    },
+    case <<"A":utf8>> {
+      <<"AB":utf8>> -> 1
+      _ -> 0
+    },
+    case <<255>> {
+      <<_:utf8>> -> 1
+      _ -> 0
+    },
+  )
+}
+
+// geam:expect Tuple([Int(1), Int(1), Int(1), Int(1), Int(1), Int(1), Int(1), Int(1), Int(1), Int(1), Int(0), Int(0), Int(0)])

--- a/tests/fixtures/execution/control_flow/case/list_inner_bit_array_pattern.gleam
+++ b/tests/fixtures/execution/control_flow/case/list_inner_bit_array_pattern.gleam
@@ -4,3 +4,5 @@ pub fn main() {
     _ -> 0
   }
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/control_flow/case/list_inner_bit_array_pattern_fallthrough.gleam
+++ b/tests/fixtures/execution/control_flow/case/list_inner_bit_array_pattern_fallthrough.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case [] {
+    [<<1>>] -> 1
+    _ -> 0
+  }
+}
+
+// geam:expect Int(0)

--- a/tests/fixtures/execution/control_flow/case/tuple_inner_bit_array_pattern.gleam
+++ b/tests/fixtures/execution/control_flow/case/tuple_inner_bit_array_pattern.gleam
@@ -4,3 +4,5 @@ pub fn main() {
     _ -> 0
   }
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/functions/use/use_bit_array_total_pattern.gleam
+++ b/tests/fixtures/execution/functions/use/use_bit_array_total_pattern.gleam
@@ -1,0 +1,13 @@
+fn with_bits(continue: fn(BitArray) -> Int) {
+  continue(<<1, 2>>)
+}
+
+pub fn main() {
+  use <<all:bits>> <- with_bits
+  case all {
+    <<1, 2>> -> 1
+    _ -> 0
+  }
+}
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution_errors/patterns/let_assert_bit_array_pattern.gleam
+++ b/tests/fixtures/execution_errors/patterns/let_assert_bit_array_pattern.gleam
@@ -1,0 +1,18 @@
+pub fn main() {
+  let assert <<1, rest:bits>> = <<2, 3>> as "wrong bits"
+  rest
+}
+
+// geam:expect-error
+// geam::let_assert
+//
+//   x let_assert: wrong bits
+//    ,-[tests/fixtures/execution_errors/patterns/let_assert_bit_array_pattern.gleam:2:3]
+//  1 | pub fn main() {
+//  2 |   let assert <<1, rest:bits>> = <<2, 3>> as "wrong bits"
+//    :   ^^^^^|^^^^ ^^^^^^^^|^^^^^^^
+//    :        |             `-- pattern
+//    :        `-- let assert in main.main
+//  3 |   rest
+//    `----
+//   help: failed value: BitArray(bytes=[2, 3], bit_len=16)

--- a/tests/fixtures/rejection/case_patterns/bit_array_pattern_native_endian.gleam
+++ b/tests/fixtures/rejection/case_patterns/bit_array_pattern_native_endian.gleam
@@ -1,6 +1,6 @@
 pub fn main() {
   case <<1>> {
-    <<1>> -> 1
+    <<value:native>> -> value
     _ -> 0
   }
 }

--- a/tests/fixtures/rejection/case_patterns/bit_array_pattern_utf_codepoint.gleam
+++ b/tests/fixtures/rejection/case_patterns/bit_array_pattern_utf_codepoint.gleam
@@ -1,0 +1,6 @@
+pub fn main() {
+  case <<"A":utf8>> {
+    <<_:utf8_codepoint>> -> 1
+    _ -> 0
+  }
+}


### PR DESCRIPTION
- Plan and lower typed BitArray segment patterns across module and execution IR.
- Match integer, float, string, bits, and bytes segments with dynamic sizes.
- Support BitArray patterns in case, let assert, ordinary bindings, and nested patterns.
