### PR TITLE
Support UtfCodepoint value family

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -27,7 +27,9 @@ pub(crate) use module::{
     StringFunctionExprKind, StringFunctionReference, StringFunctionReturn, StringListExpr,
     StringListItem, StringReturn, TupleExprKind, TupleFunctionExprKind, TupleFunctionReference,
     TupleFunctionReturn, TupleListExpr, TupleListItem, TupleReturn, TypedListExpr,
-    TypedListExprKind, TypedListReturnKind,
+    TypedListExprKind, TypedListReturnKind, UtfCodepointExprKind, UtfCodepointFunctionExprKind,
+    UtfCodepointFunctionReference, UtfCodepointFunctionReturn, UtfCodepointListExpr,
+    UtfCodepointListItem, UtfCodepointReturn,
 };
 pub use module::{
     BitArrayExpr, BitArrayFunctionExpr, BitArrayFunctionFunctionId, BitArrayFunctionId,
@@ -51,12 +53,15 @@ pub use module::{
     StringListFunctionFunctionId, StringListFunctionId, StringListFunctionLocalId,
     StringListLocalId, StringLocalId, TupleExpr, TupleFunctionExpr, TupleFunctionFunctionId,
     TupleFunctionId, TupleFunctionLocalId, TupleListFunctionFunctionId, TupleListFunctionId,
-    TupleListFunctionLocalId, TupleListLocalId, TupleLocalId,
+    TupleListFunctionLocalId, TupleListLocalId, TupleLocalId, UtfCodepointExpr,
+    UtfCodepointFunctionExpr, UtfCodepointFunctionFunctionId, UtfCodepointFunctionId,
+    UtfCodepointFunctionLocalId, UtfCodepointListFunctionFunctionId, UtfCodepointListFunctionId,
+    UtfCodepointListFunctionLocalId, UtfCodepointListLocalId, UtfCodepointLocalId,
 };
 #[cfg(test)]
 pub(crate) use module::{
     BitArrayListReturn, BoolListReturn, FloatListReturn, FunctionListReturn, IntListReturn,
-    ListListReturn, NilListReturn, StringListReturn, TupleListReturn,
+    ListListReturn, NilListReturn, StringListReturn, TupleListReturn, UtfCodepointListReturn,
 };
 pub use source::{PanicSite, SourceContext, SourceSpan};
 pub use value_type::{FunctionType, ValueType};

--- a/src/plan/execution.rs
+++ b/src/plan/execution.rs
@@ -24,7 +24,9 @@ pub(crate) use expression::{
     NilFunctionExprKind, NilListExpr, NilListItem, PanicExpr, PanicExprKind, StringEncoding,
     StringExpr, StringExprKind, StringFunctionExpr, StringFunctionExprKind, StringListExpr,
     StringListItem, TupleExpr, TupleExprKind, TupleFunctionExpr, TupleFunctionExprKind,
-    TupleListExpr, TupleListItem, TypedListExpr, TypedListExprKind,
+    TupleListExpr, TupleListItem, TypedListExpr, TypedListExprKind, UtfCodepointExpr,
+    UtfCodepointExprKind, UtfCodepointFunctionExpr, UtfCodepointFunctionExprKind,
+    UtfCodepointListExpr, UtfCodepointListItem,
 };
 pub(crate) use frame::FrameLayout;
 pub(crate) use id::{
@@ -46,7 +48,10 @@ pub(crate) use id::{
     StringListFunctionFunctionId, StringListFunctionId, StringListFunctionLocalId,
     StringListLocalId, StringLocalId, TupleFunctionFunctionId, TupleFunctionId,
     TupleFunctionLocalId, TupleListFunctionFunctionId, TupleListFunctionId,
-    TupleListFunctionLocalId, TupleListLocalId, TupleLocalId,
+    TupleListFunctionLocalId, TupleListLocalId, TupleLocalId, UtfCodepointFunctionFunctionId,
+    UtfCodepointFunctionId, UtfCodepointFunctionLocalId, UtfCodepointListFunctionFunctionId,
+    UtfCodepointListFunctionId, UtfCodepointListFunctionLocalId, UtfCodepointListLocalId,
+    UtfCodepointLocalId,
 };
 pub(crate) use param::ParamLocal;
 pub(crate) use pattern::{
@@ -61,7 +66,7 @@ pub(crate) use return_::{
     FunctionListReturn, IntFunctionReturn, IntListReturn, IntReturn, ListFunctionReturn,
     ListListReturn, NilFunctionReturn, NilListReturn, NilReturn, ReturnBody, ReturnBodyKind,
     StringFunctionReturn, StringListReturn, StringReturn, TupleFunctionReturn, TupleListReturn,
-    TupleReturn,
+    TupleReturn, UtfCodepointFunctionReturn, UtfCodepointListReturn, UtfCodepointReturn,
 };
 pub(crate) use step::{
     AssertBinding, AssertPattern, ListAssertPattern, ListAssertTail, Step, StepKind,
@@ -69,7 +74,7 @@ pub(crate) use step::{
 pub(crate) use value_type::{
     BitArrayListTypeId, BoolListTypeId, FloatListTypeId, FunctionListTypeId, FunctionType,
     IntListTypeId, ListListTypeId, ListStorageTypeId, ListTypeId, NilListTypeId, StringListTypeId,
-    TupleListTypeId, ValueType,
+    TupleListTypeId, UtfCodepointListTypeId, ValueType,
 };
 
 use self::function::ExecutableFunction;
@@ -156,6 +161,13 @@ impl ExecutionPlan {
         self.functions.bit_array_function(id)
     }
 
+    pub(crate) fn utf_codepoint_function(
+        &self,
+        id: UtfCodepointFunctionId,
+    ) -> &ExecutableFunction<UtfCodepointReturn> {
+        self.functions.utf_codepoint_function(id)
+    }
+
     pub(crate) fn bool_function(&self, id: BoolFunctionId) -> &ExecutableFunction<BoolReturn> {
         self.functions.bool_function(id)
     }
@@ -188,6 +200,14 @@ impl ExecutionPlan {
     #[cfg(test)]
     pub(crate) fn bit_array_list_function_id(&self, index: usize) -> BitArrayListFunctionId {
         self.functions.bit_array_list_function_id(index)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn utf_codepoint_list_function_id(
+        &self,
+        index: usize,
+    ) -> UtfCodepointListFunctionId {
+        self.functions.utf_codepoint_list_function_id(index)
     }
 
     #[cfg(test)]
@@ -232,6 +252,13 @@ impl ExecutionPlan {
         id: BitArrayListFunctionId,
     ) -> &ExecutableFunction<BitArrayListReturn> {
         self.functions.bit_array_list_function(id)
+    }
+
+    pub(crate) fn utf_codepoint_list_function(
+        &self,
+        id: UtfCodepointListFunctionId,
+    ) -> &ExecutableFunction<UtfCodepointListReturn> {
+        self.functions.utf_codepoint_list_function(id)
     }
 
     pub(crate) fn float_list_function(
@@ -302,6 +329,13 @@ impl ExecutionPlan {
         id: BitArrayFunctionFunctionId,
     ) -> &ExecutableFunction<BitArrayFunctionReturn> {
         self.functions.bit_array_function_function(id)
+    }
+
+    pub(crate) fn utf_codepoint_function_function(
+        &self,
+        id: UtfCodepointFunctionFunctionId,
+    ) -> &ExecutableFunction<UtfCodepointFunctionReturn> {
+        self.functions.utf_codepoint_function_function(id)
     }
 
     pub(crate) fn bool_function_function(

--- a/src/plan/execution/expression.rs
+++ b/src/plan/execution/expression.rs
@@ -9,6 +9,7 @@ mod nil;
 mod panic;
 mod string;
 mod tuple;
+mod utf_codepoint;
 
 pub use self::{
     arg::CallArg,
@@ -18,12 +19,13 @@ pub use self::{
     function::{
         BitArrayFunctionExpr, BoolFunctionExpr, FloatFunctionExpr, FunctionExpr,
         FunctionFunctionExpr, IntFunctionExpr, ListFunctionExpr, NilFunctionExpr,
-        StringFunctionExpr, TupleFunctionExpr,
+        StringFunctionExpr, TupleFunctionExpr, UtfCodepointFunctionExpr,
     },
     int::IntExpr,
     nil::NilExpr,
     string::StringExpr,
     tuple::TupleExpr,
+    utf_codepoint::UtfCodepointExpr,
 };
 pub(crate) use self::{
     arg::{CallArgKind, CaptureArg, CaptureArgKind},
@@ -33,7 +35,7 @@ pub(crate) use self::{
     function::{
         BitArrayFunctionExprKind, BoolFunctionExprKind, FloatFunctionExprKind, FunctionExprKind,
         FunctionFunctionExprKind, IntFunctionExprKind, ListFunctionExprKind, NilFunctionExprKind,
-        StringFunctionExprKind, TupleFunctionExprKind,
+        StringFunctionExprKind, TupleFunctionExprKind, UtfCodepointFunctionExprKind,
     },
     int::IntExprKind,
     list::{
@@ -41,12 +43,13 @@ pub(crate) use self::{
         FloatListItem, FunctionListExpr, FunctionListItem, IntListExpr, IntListItem, ListExpr,
         ListIndexSource, ListItem, ListListExpr, ListListItem, ListLocalExpr, NilListExpr,
         NilListItem, StringListExpr, StringListItem, TupleListExpr, TupleListItem, TypedListExpr,
-        TypedListExprKind,
+        TypedListExprKind, UtfCodepointListExpr, UtfCodepointListItem,
     },
     nil::NilExprKind,
     panic::{PanicExpr, PanicExprKind},
     string::StringExprKind,
     tuple::TupleExprKind,
+    utf_codepoint::UtfCodepointExprKind,
 };
 
 pub struct Expr {
@@ -57,6 +60,7 @@ pub(crate) enum ExprKind {
     Int(IntExpr),
     String(StringExpr),
     BitArray(BitArrayExpr),
+    UtfCodepoint(UtfCodepointExpr),
     Float(FloatExpr),
     Bool(BoolExpr),
     Nil(NilExpr),

--- a/src/plan/execution/expression/arg.rs
+++ b/src/plan/execution/expression/arg.rs
@@ -2,12 +2,13 @@ use super::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr,
     FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListFunctionExpr, ListLocalExpr, NilExpr,
     NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr, TupleFunctionExpr,
+    UtfCodepointExpr, UtfCodepointFunctionExpr,
 };
 use crate::plan::execution::{
     BitArrayFunctionLocalId, BitArrayLocalId, BoolFunctionLocalId, BoolLocalId,
     FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId, IntFunctionLocalId, IntLocalId,
     ListFunctionLocal, NilFunctionLocalId, NilLocalId, StringFunctionLocalId, StringLocalId,
-    TupleFunctionLocalId, TupleLocalId,
+    TupleFunctionLocalId, TupleLocalId, UtfCodepointFunctionLocalId, UtfCodepointLocalId,
 };
 
 pub struct CallArg {
@@ -26,6 +27,10 @@ pub(crate) enum CallArgKind {
     BitArray {
         local: BitArrayLocalId,
         value: BitArrayExpr,
+    },
+    UtfCodepoint {
+        local: UtfCodepointLocalId,
+        value: UtfCodepointExpr,
     },
     Float {
         local: FloatLocalId,
@@ -55,6 +60,10 @@ pub(crate) enum CallArgKind {
     BitArrayFunction {
         local: BitArrayFunctionLocalId,
         value: BitArrayFunctionExpr,
+    },
+    UtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
+        value: UtfCodepointFunctionExpr,
     },
     FloatFunction {
         local: FloatFunctionLocalId,
@@ -99,6 +108,10 @@ pub(crate) enum CaptureArgKind {
         local: BitArrayLocalId,
         value: BitArrayExpr,
     },
+    UtfCodepoint {
+        local: UtfCodepointLocalId,
+        value: UtfCodepointExpr,
+    },
     Float {
         local: FloatLocalId,
         value: FloatExpr,
@@ -127,6 +140,10 @@ pub(crate) enum CaptureArgKind {
     BitArrayFunction {
         local: BitArrayFunctionLocalId,
         value: BitArrayFunctionExpr,
+    },
+    UtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
+        value: UtfCodepointFunctionExpr,
     },
     FloatFunction {
         local: FloatFunctionLocalId,

--- a/src/plan/execution/expression/bit_array.rs
+++ b/src/plan/execution/expression/bit_array.rs
@@ -1,6 +1,6 @@
 use super::{
     BitArrayFunctionExpr, BitArrayListExpr, BoolExpr, CallArg, FloatExpr, IntExpr, PanicExpr,
-    StringExpr, TupleExpr,
+    StringExpr, TupleExpr, UtfCodepointExpr,
 };
 use crate::plan::execution::{BitArrayFunctionId, BitArrayLocalId, Step};
 use ecow::EcoString;
@@ -39,6 +39,10 @@ pub(crate) enum BitArraySegment {
     },
     String {
         value: StringExpr,
+        encoding: StringEncoding,
+    },
+    UtfCodepoint {
+        value: UtfCodepointExpr,
         encoding: StringEncoding,
     },
     Bits(BitArrayExpr),

--- a/src/plan/execution/expression/function.rs
+++ b/src/plan/execution/expression/function.rs
@@ -7,17 +7,19 @@ mod nil;
 mod returning_function;
 mod string;
 mod tuple;
+mod utf_codepoint;
 
 pub use self::{
     bit_array::BitArrayFunctionExpr, bool::BoolFunctionExpr, float::FloatFunctionExpr,
     int::IntFunctionExpr, list::ListFunctionExpr, nil::NilFunctionExpr,
     returning_function::FunctionFunctionExpr, string::StringFunctionExpr, tuple::TupleFunctionExpr,
+    utf_codepoint::UtfCodepointFunctionExpr,
 };
 pub(crate) use self::{
     bit_array::BitArrayFunctionExprKind, bool::BoolFunctionExprKind, float::FloatFunctionExprKind,
     int::IntFunctionExprKind, list::ListFunctionExprKind, nil::NilFunctionExprKind,
     returning_function::FunctionFunctionExprKind, string::StringFunctionExprKind,
-    tuple::TupleFunctionExprKind,
+    tuple::TupleFunctionExprKind, utf_codepoint::UtfCodepointFunctionExprKind,
 };
 
 pub struct FunctionExpr {
@@ -28,6 +30,7 @@ pub(crate) enum FunctionExprKind {
     Int(IntFunctionExpr),
     String(StringFunctionExpr),
     BitArray(BitArrayFunctionExpr),
+    UtfCodepoint(UtfCodepointFunctionExpr),
     Float(FloatFunctionExpr),
     Bool(BoolFunctionExpr),
     Nil(NilFunctionExpr),

--- a/src/plan/execution/expression/function/utf_codepoint.rs
+++ b/src/plan/execution/expression/function/utf_codepoint.rs
@@ -1,0 +1,73 @@
+use crate::plan::execution::FunctionType;
+use crate::plan::execution::{
+    BoolExpr, ClosureTemplate, FloatExpr, FunctionFunctionExpr, FunctionListExpr,
+    FunctionReference, IntExpr, PanicExpr, Step, StringExpr, TupleExpr,
+    UtfCodepointFunctionFunctionId, UtfCodepointFunctionId, UtfCodepointFunctionLocalId,
+};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+pub struct UtfCodepointFunctionExpr {
+    kind: UtfCodepointFunctionExprKind,
+}
+
+pub(crate) enum UtfCodepointFunctionExprKind {
+    Reference(FunctionReference<UtfCodepointFunctionId>),
+    Closure(ClosureTemplate<UtfCodepointFunctionId>),
+    LocalGet {
+        local: UtfCodepointFunctionLocalId,
+    },
+    Call {
+        function: UtfCodepointFunctionFunctionId,
+        args: Vec<crate::plan::execution::CallArg>,
+    },
+    FunctionCall {
+        function: Box<FunctionFunctionExpr>,
+        args: Vec<crate::plan::execution::CallArg>,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
+        type_: FunctionType,
+    },
+    ListIndex {
+        list: Box<FunctionListExpr>,
+        index: usize,
+        type_: FunctionType,
+    },
+    Panic(PanicExpr),
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<UtfCodepointFunctionExpr>,
+        false_: Box<UtfCodepointFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, UtfCodepointFunctionExpr)>,
+        fallback: Box<UtfCodepointFunctionExpr>,
+    },
+    StringCase {
+        subject: Box<StringExpr>,
+        clauses: Vec<(EcoString, UtfCodepointFunctionExpr)>,
+        fallback: Box<UtfCodepointFunctionExpr>,
+    },
+    FloatCase {
+        subject: Box<FloatExpr>,
+        clauses: Vec<(f64, UtfCodepointFunctionExpr)>,
+        fallback: Box<UtfCodepointFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<UtfCodepointFunctionExpr>,
+    },
+}
+
+impl UtfCodepointFunctionExpr {
+    pub(in crate::plan::execution) fn from_kind(kind: UtfCodepointFunctionExprKind) -> Self {
+        Self { kind }
+    }
+
+    pub(crate) fn kind(&self) -> &UtfCodepointFunctionExprKind {
+        &self.kind
+    }
+}

--- a/src/plan/execution/expression/list.rs
+++ b/src/plan/execution/expression/list.rs
@@ -5,7 +5,7 @@ mod typed;
 pub(crate) use self::{
     item::{
         BitArrayListItem, BoolListItem, FloatListItem, FunctionListItem, IntListItem, ListItem,
-        ListListItem, NilListItem, StringListItem, TupleListItem,
+        ListListItem, NilListItem, StringListItem, TupleListItem, UtfCodepointListItem,
     },
     local::ListLocalExpr,
     typed::{ListIndexSource, TypedListExpr, TypedListExprKind},
@@ -15,6 +15,7 @@ pub(crate) enum ListExpr {
     Int(IntListExpr),
     String(StringListExpr),
     BitArray(BitArrayListExpr),
+    UtfCodepoint(UtfCodepointListExpr),
     Float(FloatListExpr),
     Bool(BoolListExpr),
     Nil(NilListExpr),
@@ -26,6 +27,7 @@ pub(crate) enum ListExpr {
 pub(crate) type IntListExpr = TypedListExpr<IntListItem>;
 pub(crate) type StringListExpr = TypedListExpr<StringListItem>;
 pub(crate) type BitArrayListExpr = TypedListExpr<BitArrayListItem>;
+pub(crate) type UtfCodepointListExpr = TypedListExpr<UtfCodepointListItem>;
 pub(crate) type FloatListExpr = TypedListExpr<FloatListItem>;
 pub(crate) type BoolListExpr = TypedListExpr<BoolListItem>;
 pub(crate) type NilListExpr = TypedListExpr<NilListItem>;

--- a/src/plan/execution/expression/list/item.rs
+++ b/src/plan/execution/expression/list/item.rs
@@ -7,6 +7,7 @@ use crate::plan::execution::{
     ListListFunctionId, ListListLocalId, ListListTypeId, ListTypeId, NilExpr, NilListFunctionId,
     NilListLocalId, NilListTypeId, StringExpr, StringListFunctionId, StringListLocalId,
     StringListTypeId, TupleExpr, TupleListFunctionId, TupleListLocalId, TupleListTypeId,
+    UtfCodepointExpr, UtfCodepointListFunctionId, UtfCodepointListLocalId, UtfCodepointListTypeId,
 };
 pub(crate) trait ListItem {
     type ElementExpr;
@@ -26,6 +27,10 @@ pub(crate) struct StringListItem {
 
 pub(crate) struct BitArrayListItem {
     type_id: BitArrayListTypeId,
+}
+
+pub(crate) struct UtfCodepointListItem {
+    type_id: UtfCodepointListTypeId,
 }
 
 pub(crate) struct FloatListItem {
@@ -69,6 +74,7 @@ macro_rules! list_item {
 list_item!(IntListItem, IntListTypeId);
 list_item!(StringListItem, StringListTypeId);
 list_item!(BitArrayListItem, BitArrayListTypeId);
+list_item!(UtfCodepointListItem, UtfCodepointListTypeId);
 list_item!(FloatListItem, FloatListTypeId);
 list_item!(BoolListItem, BoolListTypeId);
 list_item!(NilListItem, NilListTypeId);
@@ -100,6 +106,16 @@ impl ListItem for BitArrayListItem {
     type ElementExpr = BitArrayExpr;
     type Local = BitArrayListLocalId;
     type Function = BitArrayListFunctionId;
+
+    fn list_type(&self) -> ListTypeId {
+        self.type_id.list_type()
+    }
+}
+
+impl ListItem for UtfCodepointListItem {
+    type ElementExpr = UtfCodepointExpr;
+    type Local = UtfCodepointListLocalId;
+    type Function = UtfCodepointListFunctionId;
 
     fn list_type(&self) -> ListTypeId {
         self.type_id.list_type()

--- a/src/plan/execution/expression/list/local.rs
+++ b/src/plan/execution/expression/list/local.rs
@@ -1,10 +1,10 @@
 use super::{
     BitArrayListExpr, BoolListExpr, FloatListExpr, FunctionListExpr, IntListExpr, ListListExpr,
-    NilListExpr, StringListExpr, TupleListExpr,
+    NilListExpr, StringListExpr, TupleListExpr, UtfCodepointListExpr,
 };
 use crate::plan::execution::{
     BitArrayListLocalId, BoolListLocalId, FloatListLocalId, FunctionListLocalId, IntListLocalId,
-    ListListLocalId, NilListLocalId, StringListLocalId, TupleListLocalId,
+    ListListLocalId, NilListLocalId, StringListLocalId, TupleListLocalId, UtfCodepointListLocalId,
 };
 
 pub(crate) enum ListLocalExpr {
@@ -19,6 +19,10 @@ pub(crate) enum ListLocalExpr {
     BitArray {
         local: BitArrayListLocalId,
         value: BitArrayListExpr,
+    },
+    UtfCodepoint {
+        local: UtfCodepointListLocalId,
+        value: UtfCodepointListExpr,
     },
     Float {
         local: FloatListLocalId,

--- a/src/plan/execution/expression/utf_codepoint.rs
+++ b/src/plan/execution/expression/utf_codepoint.rs
@@ -1,0 +1,68 @@
+use super::{
+    BoolExpr, CallArg, FloatExpr, IntExpr, PanicExpr, StringExpr, TupleExpr,
+    UtfCodepointFunctionExpr, UtfCodepointListExpr,
+};
+use crate::plan::execution::{Step, UtfCodepointFunctionId, UtfCodepointLocalId};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+pub struct UtfCodepointExpr {
+    kind: UtfCodepointExprKind,
+}
+
+pub(crate) enum UtfCodepointExprKind {
+    LocalGet {
+        local: UtfCodepointLocalId,
+    },
+    Call {
+        function: UtfCodepointFunctionId,
+        args: Vec<CallArg>,
+    },
+    FunctionCall {
+        function: Box<UtfCodepointFunctionExpr>,
+        args: Vec<CallArg>,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
+    },
+    ListIndex {
+        list: Box<UtfCodepointListExpr>,
+        index: usize,
+    },
+    Panic(PanicExpr),
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<UtfCodepointExpr>,
+        false_: Box<UtfCodepointExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, UtfCodepointExpr)>,
+        fallback: Box<UtfCodepointExpr>,
+    },
+    StringCase {
+        subject: Box<StringExpr>,
+        clauses: Vec<(EcoString, UtfCodepointExpr)>,
+        fallback: Box<UtfCodepointExpr>,
+    },
+    FloatCase {
+        subject: Box<FloatExpr>,
+        clauses: Vec<(f64, UtfCodepointExpr)>,
+        fallback: Box<UtfCodepointExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<UtfCodepointExpr>,
+    },
+}
+
+impl UtfCodepointExpr {
+    pub(in crate::plan::execution) fn from_kind(kind: UtfCodepointExprKind) -> Self {
+        Self { kind }
+    }
+
+    pub(crate) fn kind(&self) -> &UtfCodepointExprKind {
+        &self.kind
+    }
+}

--- a/src/plan/execution/frame.rs
+++ b/src/plan/execution/frame.rs
@@ -1,6 +1,7 @@
 use super::{
     BitArrayListTypeId, BoolListTypeId, FloatListTypeId, FunctionListTypeId, IntListTypeId,
     ListFunctionLocal, ListListTypeId, NilListTypeId, StringListTypeId, TupleListTypeId,
+    UtfCodepointListTypeId,
 };
 
 #[derive(Default)]
@@ -14,11 +15,13 @@ pub(super) struct FrameSlots {
     pub(super) floats: usize,
     pub(super) strings: usize,
     pub(super) bit_arrays: usize,
+    pub(super) utf_codepoints: usize,
     pub(super) bools: usize,
     pub(super) tuples: usize,
     pub(super) int_lists: Vec<IntListTypeId>,
     pub(super) string_lists: Vec<StringListTypeId>,
     pub(super) bit_array_lists: Vec<BitArrayListTypeId>,
+    pub(super) utf_codepoint_lists: Vec<UtfCodepointListTypeId>,
     pub(super) float_lists: Vec<FloatListTypeId>,
     pub(super) bool_lists: Vec<BoolListTypeId>,
     pub(super) nil_lists: Vec<NilListTypeId>,
@@ -29,6 +32,7 @@ pub(super) struct FrameSlots {
     pub(super) float_functions: usize,
     pub(super) string_functions: usize,
     pub(super) bit_array_functions: usize,
+    pub(super) utf_codepoint_functions: usize,
     pub(super) bool_functions: usize,
     pub(super) nil_functions: usize,
     pub(super) tuple_functions: usize,
@@ -57,6 +61,10 @@ impl FrameLayout {
         self.slots.bit_arrays
     }
 
+    pub(crate) fn utf_codepoints(&self) -> usize {
+        self.slots.utf_codepoints
+    }
+
     pub(crate) fn bools(&self) -> usize {
         self.slots.bools
     }
@@ -75,6 +83,10 @@ impl FrameLayout {
 
     pub(crate) fn bit_array_lists(&self) -> &[BitArrayListTypeId] {
         &self.slots.bit_array_lists
+    }
+
+    pub(crate) fn utf_codepoint_lists(&self) -> &[UtfCodepointListTypeId] {
+        &self.slots.utf_codepoint_lists
     }
 
     pub(crate) fn float_lists(&self) -> &[FloatListTypeId] {
@@ -115,6 +127,10 @@ impl FrameLayout {
 
     pub(crate) fn bit_array_functions(&self) -> usize {
         self.slots.bit_array_functions
+    }
+
+    pub(crate) fn utf_codepoint_functions(&self) -> usize {
+        self.slots.utf_codepoint_functions
     }
 
     pub(crate) fn bool_functions(&self) -> usize {

--- a/src/plan/execution/id.rs
+++ b/src/plan/execution/id.rs
@@ -1,7 +1,7 @@
 use super::{
     BitArrayListTypeId, BoolListTypeId, FloatListTypeId, FunctionListTypeId, FunctionType,
     IntListTypeId, ListListTypeId, ListTypeId, NilListTypeId, StringListTypeId, TupleListTypeId,
-    ValueType,
+    UtfCodepointListTypeId, ValueType,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,6 +15,9 @@ pub struct StringLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BitArrayLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoolLocalId(pub(crate) usize);
@@ -33,6 +36,9 @@ pub struct StringListLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BitArrayListLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointListLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FloatListLocalId(pub(crate) usize);
@@ -65,6 +71,10 @@ pub enum ListLocal {
     BitArray {
         local: BitArrayListLocalId,
         type_id: BitArrayListTypeId,
+    },
+    UtfCodepoint {
+        local: UtfCodepointListLocalId,
+        type_id: UtfCodepointListTypeId,
     },
     Float {
         local: FloatListLocalId,
@@ -105,6 +115,9 @@ pub struct StringFunctionLocalId(pub(crate) usize);
 pub struct BitArrayFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UtfCodepointFunctionLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BoolFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -121,6 +134,9 @@ pub struct StringListFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BitArrayListFunctionLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UtfCodepointListFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FloatListFunctionLocalId(pub(crate) usize);
@@ -156,6 +172,11 @@ pub enum ListFunctionLocal {
         local: BitArrayListFunctionLocalId,
         type_: FunctionType,
         list_type: BitArrayListTypeId,
+    },
+    UtfCodepoint {
+        local: UtfCodepointListFunctionLocalId,
+        type_: FunctionType,
+        list_type: UtfCodepointListTypeId,
     },
     Float {
         local: FloatListFunctionLocalId,
@@ -198,6 +219,7 @@ pub(crate) enum RuntimeFunctionId {
     Float(FloatFunctionId),
     String(StringFunctionId),
     BitArray(BitArrayFunctionId),
+    UtfCodepoint(UtfCodepointFunctionId),
     Bool(BoolFunctionId),
     Nil(NilFunctionId),
     Tuple {
@@ -222,6 +244,9 @@ pub struct StringFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BitArrayFunctionId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoolFunctionId(pub(crate) usize);
@@ -259,6 +284,7 @@ macro_rules! list_function_id {
 list_function_id!(IntListFunctionId, IntListTypeId);
 list_function_id!(StringListFunctionId, StringListTypeId);
 list_function_id!(BitArrayListFunctionId, BitArrayListTypeId);
+list_function_id!(UtfCodepointListFunctionId, UtfCodepointListTypeId);
 list_function_id!(FloatListFunctionId, FloatListTypeId);
 list_function_id!(BoolListFunctionId, BoolListTypeId);
 list_function_id!(NilListFunctionId, NilListTypeId);
@@ -271,6 +297,7 @@ pub enum ListFunctionId {
     Int(IntListFunctionId),
     String(StringListFunctionId),
     BitArray(BitArrayListFunctionId),
+    UtfCodepoint(UtfCodepointListFunctionId),
     Float(FloatListFunctionId),
     Bool(BoolListFunctionId),
     Nil(NilListFunctionId),
@@ -285,6 +312,7 @@ pub(crate) enum FunctionFunctionId {
     Float(FloatFunctionFunctionId),
     String(StringFunctionFunctionId),
     BitArray(BitArrayFunctionFunctionId),
+    UtfCodepoint(UtfCodepointFunctionFunctionId),
     Bool(BoolFunctionFunctionId),
     Nil(NilFunctionFunctionId),
     Tuple(TupleFunctionFunctionId),
@@ -298,6 +326,7 @@ pub enum FunctionReturnFamily {
     Float,
     String,
     BitArray,
+    UtfCodepoint,
     Bool,
     Nil,
     Tuple,
@@ -318,6 +347,9 @@ pub struct StringFunctionFunctionId(pub(crate) usize);
 pub struct BitArrayFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointFunctionFunctionId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoolFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -334,6 +366,9 @@ pub struct StringListFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BitArrayListFunctionFunctionId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointListFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FloatListFunctionFunctionId(pub(crate) usize);
@@ -369,6 +404,11 @@ pub enum ListFunctionFunctionId {
         id: BitArrayListFunctionFunctionId,
         type_: FunctionType,
         list_type: BitArrayListTypeId,
+    },
+    UtfCodepoint {
+        id: UtfCodepointListFunctionFunctionId,
+        type_: FunctionType,
+        list_type: UtfCodepointListTypeId,
     },
     Float {
         id: FloatListFunctionFunctionId,
@@ -412,6 +452,7 @@ impl FunctionFunctionId {
             Self::Float(_) => FunctionReturnFamily::Float,
             Self::String(_) => FunctionReturnFamily::String,
             Self::BitArray(_) => FunctionReturnFamily::BitArray,
+            Self::UtfCodepoint(_) => FunctionReturnFamily::UtfCodepoint,
             Self::Bool(_) => FunctionReturnFamily::Bool,
             Self::Nil(_) => FunctionReturnFamily::Nil,
             Self::Tuple(_) => FunctionReturnFamily::Tuple,
@@ -437,6 +478,13 @@ impl FunctionFunctionId {
     pub(crate) fn bit_array(&self) -> Option<BitArrayFunctionFunctionId> {
         match self {
             Self::BitArray(id) => Some(*id),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn utf_codepoint(&self) -> Option<UtfCodepointFunctionFunctionId> {
+        match self {
+            Self::UtfCodepoint(id) => Some(*id),
             _ => None,
         }
     }
@@ -490,6 +538,7 @@ impl ListFunctionLocal {
             Self::Int { type_, .. }
             | Self::String { type_, .. }
             | Self::BitArray { type_, .. }
+            | Self::UtfCodepoint { type_, .. }
             | Self::Float { type_, .. }
             | Self::Bool { type_, .. }
             | Self::Nil { type_, .. }
@@ -505,6 +554,7 @@ impl ListFunctionLocal {
             Self::Int { list_type, .. } => list_type.list_type(),
             Self::String { list_type, .. } => list_type.list_type(),
             Self::BitArray { list_type, .. } => list_type.list_type(),
+            Self::UtfCodepoint { list_type, .. } => list_type.list_type(),
             Self::Float { list_type, .. } => list_type.list_type(),
             Self::Bool { list_type, .. } => list_type.list_type(),
             Self::Nil { list_type, .. } => list_type.list_type(),
@@ -521,6 +571,7 @@ impl ListFunctionId {
             Self::Int(id) => id.type_id().list_type(),
             Self::String(id) => id.type_id().list_type(),
             Self::BitArray(id) => id.type_id().list_type(),
+            Self::UtfCodepoint(id) => id.type_id().list_type(),
             Self::Float(id) => id.type_id().list_type(),
             Self::Bool(id) => id.type_id().list_type(),
             Self::Nil(id) => id.type_id().list_type(),
@@ -537,6 +588,7 @@ impl ListFunctionFunctionId {
             Self::Int { type_, .. }
             | Self::String { type_, .. }
             | Self::BitArray { type_, .. }
+            | Self::UtfCodepoint { type_, .. }
             | Self::Float { type_, .. }
             | Self::Bool { type_, .. }
             | Self::Nil { type_, .. }
@@ -553,6 +605,7 @@ impl ListLocal {
             Self::Int { type_id, .. } => type_id.list_type(),
             Self::String { type_id, .. } => type_id.list_type(),
             Self::BitArray { type_id, .. } => type_id.list_type(),
+            Self::UtfCodepoint { type_id, .. } => type_id.list_type(),
             Self::Float { type_id, .. } => type_id.list_type(),
             Self::Bool { type_id, .. } => type_id.list_type(),
             Self::Nil { type_id, .. } => type_id.list_type(),
@@ -570,6 +623,7 @@ impl std::fmt::Display for FunctionReturnFamily {
             Self::Float => f.write_str("Float"),
             Self::String => f.write_str("String"),
             Self::BitArray => f.write_str("BitArray"),
+            Self::UtfCodepoint => f.write_str("UtfCodepoint"),
             Self::Bool => f.write_str("Bool"),
             Self::Nil => f.write_str("Nil"),
             Self::Tuple => f.write_str("Tuple"),
@@ -585,7 +639,8 @@ mod tests {
         BitArrayFunctionFunctionId, BitArrayListLocalId, BoolListLocalId, FloatListLocalId,
         FunctionFunctionId, FunctionListLocalId, FunctionReturnFamily, IntFunctionFunctionId,
         IntListLocalId, ListFunctionFunctionId, ListListLocalId, ListLocal, NilListLocalId,
-        RuntimeFunctionId, StringListLocalId, TupleListLocalId,
+        RuntimeFunctionId, StringListLocalId, TupleListLocalId, UtfCodepointFunctionFunctionId,
+        UtfCodepointListLocalId,
     };
     use crate::plan::ValueType;
 
@@ -596,6 +651,7 @@ mod tests {
 fn int_values(values: List(Int)) { values }
 fn string_values(values: List(String)) { values }
 fn bit_array_values(values: List(BitArray)) { values }
+fn utf_codepoint_values(values: List(UtfCodepoint)) { values }
 fn float_values(values: List(Float)) { values }
 fn bool_values(values: List(Bool)) { values }
 fn nil_values(values: List(Nil)) { values }
@@ -603,6 +659,7 @@ fn tuple_values(values: List(#(Int))) { values }
 fn list_values(values: List(List(Int))) { values }
 fn function_values(values: List(fn() -> Int)) { values }
 fn bit_array_function_value(function: fn() -> List(BitArray)) { function() }
+fn utf_codepoint_function_value(function: fn() -> List(UtfCodepoint)) { function() }
 
 pub fn main() { Nil }
 "#,
@@ -619,6 +676,10 @@ pub fn main() { Nil }
             .bit_array_list_function(plan.bit_array_list_function_id(0))
             .frame_layout()
             .bit_array_lists()[0];
+        let utf_codepoint = plan
+            .utf_codepoint_list_function(plan.utf_codepoint_list_function_id(0))
+            .frame_layout()
+            .utf_codepoint_lists()[0];
         let float = plan
             .float_list_function(plan.float_list_function_id(0))
             .frame_layout()
@@ -656,6 +717,10 @@ pub fn main() { Nil }
                 local: BitArrayListLocalId(0),
                 type_id: bit_array,
             },
+            ListLocal::UtfCodepoint {
+                local: UtfCodepointListLocalId(0),
+                type_id: utf_codepoint,
+            },
             ListLocal::Float {
                 local: FloatListLocalId(0),
                 type_id: float,
@@ -691,6 +756,7 @@ pub fn main() { Nil }
                 ValueType::List(Box::new(ValueType::Int)),
                 ValueType::List(Box::new(ValueType::String)),
                 ValueType::List(Box::new(ValueType::BitArray)),
+                ValueType::List(Box::new(ValueType::UtfCodepoint)),
                 ValueType::List(Box::new(ValueType::Float)),
                 ValueType::List(Box::new(ValueType::Bool)),
                 ValueType::List(Box::new(ValueType::Nil)),
@@ -711,6 +777,23 @@ pub fn main() { Nil }
             plan.list_value_type(bit_array_function_local.list_type()),
             ValueType::List(Box::new(ValueType::BitArray)),
         );
+
+        let utf_codepoint_function_local = plan
+            .utf_codepoint_list_function(plan.utf_codepoint_list_function_id(1))
+            .frame_layout()
+            .list_functions()[0]
+            .clone();
+        assert_eq!(
+            plan.list_value_type(utf_codepoint_function_local.list_type()),
+            ValueType::List(Box::new(ValueType::UtfCodepoint)),
+        );
+        assert_eq!(
+            plan.function_type(utf_codepoint_function_local.type_()),
+            crate::plan::FunctionType::new(
+                Vec::new(),
+                ValueType::List(Box::new(ValueType::UtfCodepoint)),
+            ),
+        );
     }
 
     #[test]
@@ -721,6 +804,7 @@ pub fn main() { Nil }
                 FunctionReturnFamily::Float,
                 FunctionReturnFamily::String,
                 FunctionReturnFamily::BitArray,
+                FunctionReturnFamily::UtfCodepoint,
                 FunctionReturnFamily::Bool,
                 FunctionReturnFamily::Nil,
                 FunctionReturnFamily::Tuple,
@@ -729,7 +813,16 @@ pub fn main() { Nil }
             ]
             .map(|family| family.to_string()),
             [
-                "Int", "Float", "String", "BitArray", "Bool", "Nil", "Tuple", "List", "Function",
+                "Int",
+                "Float",
+                "String",
+                "BitArray",
+                "UtfCodepoint",
+                "Bool",
+                "Nil",
+                "Tuple",
+                "List",
+                "Function",
             ],
         );
     }
@@ -741,6 +834,17 @@ pub fn main() { Nil }
         assert_eq!(id.bit_array(), Some(BitArrayFunctionFunctionId(2)));
         assert_eq!(
             FunctionFunctionId::Int(IntFunctionFunctionId(0)).bit_array(),
+            None,
+        );
+    }
+
+    #[test]
+    fn utf_codepoint_function_function_id_projection_is_typed() {
+        let id = FunctionFunctionId::UtfCodepoint(UtfCodepointFunctionFunctionId(2));
+
+        assert_eq!(id.utf_codepoint(), Some(UtfCodepointFunctionFunctionId(2)),);
+        assert_eq!(
+            FunctionFunctionId::Int(IntFunctionFunctionId(0)).utf_codepoint(),
             None,
         );
     }
@@ -772,6 +876,36 @@ pub fn main() { Nil }
             crate::plan::FunctionType::new(
                 Vec::new(),
                 crate::plan::ValueType::List(Box::new(crate::plan::ValueType::BitArray)),
+            ),
+        );
+    }
+
+    #[test]
+    fn utf_codepoint_list_function_function_id_preserves_exact_return_type() {
+        let plan = execution_plan("pub fn main() -> fn() -> List(UtfCodepoint) { fn() { [] } }");
+        let list_type = plan.utf_codepoint_list_function_id(0).type_id();
+        let return_type = crate::plan::execution::FunctionType::new(
+            Vec::new(),
+            crate::plan::execution::ValueType::List(list_type.list_type()),
+        );
+        let id = ListFunctionFunctionId::UtfCodepoint {
+            id: super::UtfCodepointListFunctionFunctionId(0),
+            type_: return_type.clone(),
+            list_type,
+        };
+
+        assert_eq!(
+            plan.main_runtime(),
+            RuntimeFunctionId::Function {
+                id: FunctionFunctionId::List(id.clone()),
+                return_type: return_type.clone(),
+            },
+        );
+        assert_eq!(
+            plan.function_type(id.type_()),
+            crate::plan::FunctionType::new(
+                Vec::new(),
+                crate::plan::ValueType::List(Box::new(crate::plan::ValueType::UtfCodepoint)),
             ),
         );
     }

--- a/src/plan/execution/lowering.rs
+++ b/src/plan/execution/lowering.rs
@@ -38,6 +38,10 @@ impl LoweringContext {
         self.list_types.bit_array_list_type()
     }
 
+    fn utf_codepoint_list_type(&mut self) -> super::UtfCodepointListTypeId {
+        self.list_types.utf_codepoint_list_type()
+    }
+
     fn float_list_type(&mut self) -> super::FloatListTypeId {
         self.list_types.float_list_type()
     }

--- a/src/plan/execution/lowering/expression.rs
+++ b/src/plan/execution/lowering/expression.rs
@@ -7,6 +7,7 @@ mod list;
 mod nil;
 mod string;
 mod tuple;
+mod utf_codepoint;
 
 use super::id::list_function_local;
 use crate::plan::module;
@@ -16,16 +17,18 @@ pub(super) use float::float_expr;
 pub(super) use function::{
     bit_array_function_expr, bool_function_expr, float_function_expr, function_expr,
     function_function_expr, int_function_expr, list_function_expr, nil_function_expr,
-    string_function_expr, tuple_function_expr,
+    string_function_expr, tuple_function_expr, utf_codepoint_function_expr,
 };
 pub(super) use int::int_expr;
 pub(super) use list::{
     bit_array_list_expr, bool_list_expr, float_list_expr, function_list_expr, int_list_expr,
     list_expr, list_list_expr, list_local_expr, nil_list_expr, string_list_expr, tuple_list_expr,
+    utf_codepoint_list_expr,
 };
 pub(super) use nil::nil_expr;
 pub(super) use string::string_expr;
 pub(super) use tuple::tuple_expr;
+pub(super) use utf_codepoint::utf_codepoint_expr;
 
 use super::super as execution;
 
@@ -42,6 +45,9 @@ pub(super) fn expr(
         }
         module::ExprKind::BitArray(expression) => {
             execution::ExprKind::BitArray(bit_array_expr(expression, context))
+        }
+        module::ExprKind::UtfCodepoint(expression) => {
+            execution::ExprKind::UtfCodepoint(utf_codepoint_expr(expression, context))
         }
         module::ExprKind::Float(expression) => {
             execution::ExprKind::Float(float_expr(expression, context))
@@ -110,6 +116,10 @@ pub(super) fn call_arg(
             local: execution::BitArrayLocalId(local.0),
             value: bit_array_expr(value, context),
         },
+        M::UtfCodepoint { local, value } => E::UtfCodepoint {
+            local: execution::UtfCodepointLocalId(local.0),
+            value: utf_codepoint_expr(value, context),
+        },
         M::Float { local, value } => E::Float {
             local: execution::FloatLocalId(local.0),
             value: float_expr(value, context),
@@ -138,6 +148,10 @@ pub(super) fn call_arg(
         M::BitArrayFunction { local, value } => E::BitArrayFunction {
             local: execution::BitArrayFunctionLocalId(local.0),
             value: bit_array_function_expr(value, context),
+        },
+        M::UtfCodepointFunction { local, value } => E::UtfCodepointFunction {
+            local: execution::UtfCodepointFunctionLocalId(local.0),
+            value: utf_codepoint_function_expr(value, context),
         },
         M::FloatFunction { local, value } => E::FloatFunction {
             local: execution::FloatFunctionLocalId(local.0),
@@ -195,6 +209,10 @@ fn capture_arg(
             local: execution::BitArrayLocalId(local.0),
             value: bit_array_expr(value, context),
         },
+        M::UtfCodepoint { local, value } => E::UtfCodepoint {
+            local: execution::UtfCodepointLocalId(local.0),
+            value: utf_codepoint_expr(value, context),
+        },
         M::Float { local, value } => E::Float {
             local: execution::FloatLocalId(local.0),
             value: float_expr(value, context),
@@ -223,6 +241,10 @@ fn capture_arg(
         M::BitArrayFunction { local, value } => E::BitArrayFunction {
             local: execution::BitArrayFunctionLocalId(local.0),
             value: bit_array_function_expr(value, context),
+        },
+        M::UtfCodepointFunction { local, value } => E::UtfCodepointFunction {
+            local: execution::UtfCodepointFunctionLocalId(local.0),
+            value: utf_codepoint_function_expr(value, context),
         },
         M::FloatFunction { local, value } => E::FloatFunction {
             local: execution::FloatFunctionLocalId(local.0),

--- a/src/plan/execution/lowering/expression/bit_array.rs
+++ b/src/plan/execution/lowering/expression/bit_array.rs
@@ -125,6 +125,12 @@ fn bit_array_segment(
                 }
             },
         },
+        module::BitArraySegment::UtfCodepoint { value, encoding } => {
+            execution::BitArraySegment::UtfCodepoint {
+                value: super::utf_codepoint_expr(value, context),
+                encoding: encoding.into(),
+            }
+        }
         module::BitArraySegment::Bits(value) => {
             execution::BitArraySegment::Bits(bit_array_expr(value, context))
         }

--- a/src/plan/execution/lowering/expression/function.rs
+++ b/src/plan/execution/lowering/expression/function.rs
@@ -7,6 +7,7 @@ mod nil;
 mod returning_function;
 mod string;
 mod tuple;
+mod utf_codepoint;
 
 pub(in crate::plan::execution::lowering) use bit_array::bit_array_function_expr;
 pub(in crate::plan::execution::lowering) use bool::bool_function_expr;
@@ -17,6 +18,7 @@ pub(in crate::plan::execution::lowering) use nil::nil_function_expr;
 pub(in crate::plan::execution::lowering) use returning_function::function_function_expr;
 pub(in crate::plan::execution::lowering) use string::string_function_expr;
 pub(in crate::plan::execution::lowering) use tuple::tuple_function_expr;
+pub(in crate::plan::execution::lowering) use utf_codepoint::utf_codepoint_function_expr;
 
 use crate::plan::{execution, module};
 
@@ -65,6 +67,11 @@ pub(in crate::plan::execution::lowering) fn function_expr(
         }
         module::FunctionExprKind::BitArray(expression) => {
             execution::FunctionExprKind::BitArray(bit_array_function_expr(expression, context))
+        }
+        module::FunctionExprKind::UtfCodepoint(expression) => {
+            execution::FunctionExprKind::UtfCodepoint(utf_codepoint_function_expr(
+                expression, context,
+            ))
         }
         module::FunctionExprKind::Float(expression) => {
             execution::FunctionExprKind::Float(float_function_expr(expression, context))

--- a/src/plan/execution/lowering/expression/function/utf_codepoint.rs
+++ b/src/plan/execution/lowering/expression/function/utf_codepoint.rs
@@ -1,0 +1,113 @@
+use super::function_function_expr;
+use crate::plan::{execution, module};
+
+pub(in crate::plan::execution::lowering) fn utf_codepoint_function_expr(
+    expression: module::UtfCodepointFunctionExpr,
+    context: &mut super::super::super::LoweringContext,
+) -> execution::UtfCodepointFunctionExpr {
+    use execution::UtfCodepointFunctionExprKind as E;
+    use module::UtfCodepointFunctionExprKind as M;
+
+    let (_, kind) = expression.into_parts();
+    let kind = match kind {
+        M::Reference(value) => E::Reference(super::function_reference(value, context, |id, _| {
+            execution::UtfCodepointFunctionId(id.0)
+        })),
+        M::Closure {
+            runtime_id,
+            params,
+            captures,
+        } => E::Closure(super::closure_template(
+            runtime_id,
+            params,
+            captures,
+            context,
+            |id, _| execution::UtfCodepointFunctionId(id.0),
+        )),
+        M::LocalGet { local, name: _ } => E::LocalGet {
+            local: execution::UtfCodepointFunctionLocalId(local.0),
+        },
+        M::Call {
+            function,
+            args,
+            type_: _,
+        } => E::Call {
+            function: execution::UtfCodepointFunctionFunctionId(function.0),
+            args: super::super::call_args(args, context),
+        },
+        M::FunctionCall {
+            function,
+            args,
+            type_: _,
+        } => E::FunctionCall {
+            function: Box::new(function_function_expr(*function, context)),
+            args: super::super::call_args(args, context),
+        },
+        M::TupleIndex {
+            tuple,
+            index,
+            type_,
+        } => E::TupleIndex {
+            tuple: Box::new(super::super::tuple_expr(*tuple, context)),
+            index,
+            type_: context.function_type(type_),
+        },
+        M::ListIndex { list, index, type_ } => E::ListIndex {
+            list: Box::new(super::super::function_list_expr(*list, context)),
+            index,
+            type_: context.function_type(type_),
+        },
+        M::Panic(value) => E::Panic(super::super::panic_expr(value, context)),
+        M::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => E::BoolCase {
+            subject: Box::new(super::super::bool_expr(*subject, context)),
+            true_: Box::new(utf_codepoint_function_expr(*true_, context)),
+            false_: Box::new(utf_codepoint_function_expr(*false_, context)),
+        },
+        M::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => E::IntCase {
+            subject: Box::new(super::super::int_expr(*subject, context)),
+            clauses: clauses
+                .into_iter()
+                .map(|(pattern, branch)| (pattern, utf_codepoint_function_expr(branch, context)))
+                .collect(),
+            fallback: Box::new(utf_codepoint_function_expr(*fallback, context)),
+        },
+        M::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => E::StringCase {
+            subject: Box::new(super::super::string_expr(*subject, context)),
+            clauses: clauses
+                .into_iter()
+                .map(|(pattern, branch)| (pattern, utf_codepoint_function_expr(branch, context)))
+                .collect(),
+            fallback: Box::new(utf_codepoint_function_expr(*fallback, context)),
+        },
+        M::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => E::FloatCase {
+            subject: Box::new(super::super::float_expr(*subject, context)),
+            clauses: clauses
+                .into_iter()
+                .map(|(pattern, branch)| (pattern, utf_codepoint_function_expr(branch, context)))
+                .collect(),
+            fallback: Box::new(utf_codepoint_function_expr(*fallback, context)),
+        },
+        M::Block { steps, return_ } => E::Block {
+            steps: crate::plan::execution::lowering::step::steps(steps, context),
+            return_: Box::new(utf_codepoint_function_expr(*return_, context)),
+        },
+    };
+
+    execution::UtfCodepointFunctionExpr::from_kind(kind)
+}

--- a/src/plan/execution/lowering/expression/list.rs
+++ b/src/plan/execution/lowering/expression/list.rs
@@ -1,7 +1,7 @@
 use super::super::super as execution;
 use super::{
     bit_array_expr, bool_expr, call_args, float_expr, function_expr, int_expr, list_function_expr,
-    panic_expr, string_expr, tuple_expr,
+    panic_expr, string_expr, tuple_expr, utf_codepoint_expr,
 };
 use crate::plan::execution::lowering::LoweringContext;
 use crate::plan::module;
@@ -38,6 +38,9 @@ pub(in crate::plan::execution::lowering) fn list_expr(
         }
         module::ListExpr::BitArray(expression) => {
             execution::ListExpr::BitArray(bit_array_list_expr(expression, context))
+        }
+        module::ListExpr::UtfCodepoint(expression) => {
+            execution::ListExpr::UtfCodepoint(utf_codepoint_list_expr(expression, context))
         }
         module::ListExpr::Float(expression) => {
             execution::ListExpr::Float(float_list_expr(expression, context))
@@ -78,6 +81,13 @@ pub(in crate::plan::execution::lowering) fn bit_array_list_expr(
     expression: module::BitArrayListExpr,
     context: &mut LoweringContext,
 ) -> execution::BitArrayListExpr {
+    typed_list_expr(expression, context)
+}
+
+pub(in crate::plan::execution::lowering) fn utf_codepoint_list_expr(
+    expression: module::UtfCodepointListExpr,
+    context: &mut LoweringContext,
+) -> execution::UtfCodepointListExpr {
     typed_list_expr(expression, context)
 }
 
@@ -257,6 +267,12 @@ pub(in crate::plan::execution::lowering) fn list_local_expr(
             local: execution::BitArrayListLocalId(local.0),
             value: bit_array_list_expr(value, context),
         },
+        module::ListLocalExpr::UtfCodepoint { local, value } => {
+            execution::ListLocalExpr::UtfCodepoint {
+                local: execution::UtfCodepointListLocalId(local.0),
+                value: utf_codepoint_list_expr(value, context),
+            }
+        }
         module::ListLocalExpr::Float { local, value } => execution::ListLocalExpr::Float {
             local: execution::FloatListLocalId(local.0),
             value: float_list_expr(value, context),
@@ -383,6 +399,36 @@ impl LowerListItem for module::BitArrayListItem {
         _context: &mut LoweringContext,
     ) -> execution::BitArrayListFunctionId {
         execution::BitArrayListFunctionId::new(function.0, item.type_id())
+    }
+}
+
+impl LowerListItem for module::UtfCodepointListItem {
+    type Execution = execution::UtfCodepointListItem;
+
+    fn lower_item(self, context: &mut LoweringContext) -> Self::Execution {
+        execution::UtfCodepointListItem::new(context.utf_codepoint_list_type())
+    }
+
+    fn lower_element(
+        element: Self::ElementExpr,
+        context: &mut LoweringContext,
+    ) -> execution::UtfCodepointExpr {
+        utf_codepoint_expr(element, context)
+    }
+
+    fn lower_local(
+        local: Self::Local,
+        _context: &mut LoweringContext,
+    ) -> execution::UtfCodepointListLocalId {
+        execution::UtfCodepointListLocalId(local.0)
+    }
+
+    fn lower_function(
+        function: Self::Function,
+        item: &Self::Execution,
+        _context: &mut LoweringContext,
+    ) -> execution::UtfCodepointListFunctionId {
+        execution::UtfCodepointListFunctionId::new(function.0, item.type_id())
     }
 }
 

--- a/src/plan/execution/lowering/expression/utf_codepoint.rs
+++ b/src/plan/execution/lowering/expression/utf_codepoint.rs
@@ -1,0 +1,85 @@
+use super::{
+    bool_expr, call_args, float_expr, int_expr, panic_expr, string_expr, tuple_expr,
+    utf_codepoint_function_expr, utf_codepoint_list_expr,
+};
+use crate::plan::{execution, module};
+
+pub(in crate::plan::execution::lowering) fn utf_codepoint_expr(
+    expression: module::UtfCodepointExpr,
+    context: &mut super::super::LoweringContext,
+) -> execution::UtfCodepointExpr {
+    use execution::UtfCodepointExprKind as E;
+    use module::UtfCodepointExprKind as M;
+
+    execution::UtfCodepointExpr::from_kind(match expression.into_kind() {
+        M::LocalGet { local, name: _ } => E::LocalGet {
+            local: execution::UtfCodepointLocalId(local.0),
+        },
+        M::Call { function, args } => E::Call {
+            function: execution::UtfCodepointFunctionId(function.0),
+            args: call_args(args, context),
+        },
+        M::FunctionCall { function, args } => E::FunctionCall {
+            function: Box::new(utf_codepoint_function_expr(*function, context)),
+            args: call_args(args, context),
+        },
+        M::TupleIndex { tuple, index } => E::TupleIndex {
+            tuple: Box::new(tuple_expr(*tuple, context)),
+            index,
+        },
+        M::ListIndex { list, index } => E::ListIndex {
+            list: Box::new(utf_codepoint_list_expr(*list, context)),
+            index,
+        },
+        M::Panic(value) => E::Panic(panic_expr(value, context)),
+        M::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => E::BoolCase {
+            subject: Box::new(bool_expr(*subject, context)),
+            true_: Box::new(utf_codepoint_expr(*true_, context)),
+            false_: Box::new(utf_codepoint_expr(*false_, context)),
+        },
+        M::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => E::IntCase {
+            subject: Box::new(int_expr(*subject, context)),
+            clauses: clauses
+                .into_iter()
+                .map(|(pattern, branch)| (pattern, utf_codepoint_expr(branch, context)))
+                .collect(),
+            fallback: Box::new(utf_codepoint_expr(*fallback, context)),
+        },
+        M::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => E::StringCase {
+            subject: Box::new(string_expr(*subject, context)),
+            clauses: clauses
+                .into_iter()
+                .map(|(pattern, branch)| (pattern, utf_codepoint_expr(branch, context)))
+                .collect(),
+            fallback: Box::new(utf_codepoint_expr(*fallback, context)),
+        },
+        M::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => E::FloatCase {
+            subject: Box::new(float_expr(*subject, context)),
+            clauses: clauses
+                .into_iter()
+                .map(|(pattern, branch)| (pattern, utf_codepoint_expr(branch, context)))
+                .collect(),
+            fallback: Box::new(utf_codepoint_expr(*fallback, context)),
+        },
+        M::Block { steps, return_ } => E::Block {
+            steps: super::super::step::steps(steps, context),
+            return_: Box::new(utf_codepoint_expr(*return_, context)),
+        },
+    })
+}

--- a/src/plan/execution/lowering/frame.rs
+++ b/src/plan/execution/lowering/frame.rs
@@ -13,6 +13,7 @@ pub(super) fn frame_layout(
         floats: parts.floats,
         strings: parts.strings,
         bit_arrays: parts.bit_arrays,
+        utf_codepoints: parts.utf_codepoints,
         bools: parts.bools,
         tuples: parts.tuples,
         int_lists: (0..parts.int_lists)
@@ -23,6 +24,9 @@ pub(super) fn frame_layout(
             .collect(),
         bit_array_lists: (0..parts.bit_array_lists)
             .map(|_| context.bit_array_list_type())
+            .collect(),
+        utf_codepoint_lists: (0..parts.utf_codepoint_lists)
+            .map(|_| context.utf_codepoint_list_type())
             .collect(),
         float_lists: (0..parts.float_lists)
             .map(|_| context.float_list_type())
@@ -52,6 +56,7 @@ pub(super) fn frame_layout(
         float_functions: parts.float_functions,
         string_functions: parts.string_functions,
         bit_array_functions: parts.bit_array_functions,
+        utf_codepoint_functions: parts.utf_codepoint_functions,
         bool_functions: parts.bool_functions,
         nil_functions: parts.nil_functions,
         tuple_functions: parts.tuple_functions,
@@ -77,12 +82,14 @@ fn all_slots(
   float: Float,
   string: String,
   bit_array: BitArray,
+  utf_codepoint: UtfCodepoint,
   bool: Bool,
   nil: Nil,
   tuple: #(Int),
   int_list: List(Int),
   string_list: List(String),
   bit_array_list: List(BitArray),
+  utf_codepoint_list: List(UtfCodepoint),
   float_list: List(Float),
   bool_list: List(Bool),
   nil_list: List(Nil),
@@ -93,12 +100,14 @@ fn all_slots(
   float_function: fn() -> Float,
   string_function: fn() -> String,
   bit_array_function: fn() -> BitArray,
+  utf_codepoint_function: fn() -> UtfCodepoint,
   bool_function: fn() -> Bool,
   nil_function: fn() -> Nil,
   tuple_function: fn() -> #(Int),
   int_list_function: fn() -> List(Int),
   string_list_function: fn() -> List(String),
   bit_array_list_function: fn() -> List(BitArray),
+  utf_codepoint_list_function: fn() -> List(UtfCodepoint),
   float_list_function: fn() -> List(Float),
   bool_list_function: fn() -> List(Bool),
   nil_list_function: fn() -> List(Nil),
@@ -122,11 +131,13 @@ pub fn main() { 0 }
         assert_eq!(layout.floats(), 1);
         assert_eq!(layout.strings(), 1);
         assert_eq!(layout.bit_arrays(), 1);
+        assert_eq!(layout.utf_codepoints(), 1);
         assert_eq!(layout.bools(), 1);
         assert_eq!(layout.tuples(), 1);
         assert_eq!(layout.int_lists().len(), 1);
         assert_eq!(layout.string_lists().len(), 1);
         assert_eq!(layout.bit_array_lists().len(), 1);
+        assert_eq!(layout.utf_codepoint_lists().len(), 1);
         assert_eq!(layout.float_lists().len(), 1);
         assert_eq!(layout.bool_lists().len(), 1);
         assert_eq!(layout.nil_lists().len(), 1);
@@ -149,6 +160,7 @@ pub fn main() { 0 }
         assert_eq!(layout.float_functions(), 1);
         assert_eq!(layout.string_functions(), 1);
         assert_eq!(layout.bit_array_functions(), 1);
+        assert_eq!(layout.utf_codepoint_functions(), 1);
         assert_eq!(layout.bool_functions(), 1);
         assert_eq!(layout.nil_functions(), 1);
         assert_eq!(layout.tuple_functions(), 1);
@@ -159,6 +171,7 @@ pub fn main() { 0 }
             ValueType::List(Box::new(ValueType::Int)),
             ValueType::List(Box::new(ValueType::String)),
             ValueType::List(Box::new(ValueType::BitArray)),
+            ValueType::List(Box::new(ValueType::UtfCodepoint)),
             ValueType::List(Box::new(ValueType::Float)),
             ValueType::List(Box::new(ValueType::Bool)),
             ValueType::List(Box::new(ValueType::Nil)),

--- a/src/plan/execution/lowering/id.rs
+++ b/src/plan/execution/lowering/id.rs
@@ -21,6 +21,10 @@ pub(super) fn list_local(
             local: execution::BitArrayListLocalId(local.0),
             type_id: context.bit_array_list_type(),
         },
+        module::ListLocal::UtfCodepoint(local) => execution::ListLocal::UtfCodepoint {
+            local: execution::UtfCodepointListLocalId(local.0),
+            type_id: context.utf_codepoint_list_type(),
+        },
         module::ListLocal::Float(local) => execution::ListLocal::Float {
             local: execution::FloatListLocalId(local.0),
             type_id: context.float_list_type(),
@@ -72,6 +76,13 @@ pub(super) fn list_function_local(
                 local: execution::BitArrayListFunctionLocalId(local.0),
                 type_: context.function_type(type_),
                 list_type: context.bit_array_list_type(),
+            }
+        }
+        module::ListFunctionLocal::UtfCodepoint { local, type_ } => {
+            execution::ListFunctionLocal::UtfCodepoint {
+                local: execution::UtfCodepointListFunctionLocalId(local.0),
+                type_: context.function_type(type_),
+                list_type: context.utf_codepoint_list_type(),
             }
         }
         module::ListFunctionLocal::Float { local, type_ } => execution::ListFunctionLocal::Float {
@@ -135,6 +146,9 @@ pub(super) fn list_function_id(
         module::ListFunctionId::BitArray(id) => execution::ListFunctionId::BitArray(
             execution::BitArrayListFunctionId::new(id.0, context.bit_array_list_type()),
         ),
+        module::ListFunctionId::UtfCodepoint(id) => execution::ListFunctionId::UtfCodepoint(
+            execution::UtfCodepointListFunctionId::new(id.0, context.utf_codepoint_list_type()),
+        ),
         module::ListFunctionId::Float(id) => execution::ListFunctionId::Float(
             execution::FloatListFunctionId::new(id.0, context.float_list_type()),
         ),
@@ -174,6 +188,11 @@ pub(super) fn function_function_id(
         }
         module::FunctionFunctionId::BitArray(id) => {
             execution::FunctionFunctionId::BitArray(execution::BitArrayFunctionFunctionId(id.0))
+        }
+        module::FunctionFunctionId::UtfCodepoint(id) => {
+            execution::FunctionFunctionId::UtfCodepoint(execution::UtfCodepointFunctionFunctionId(
+                id.0,
+            ))
         }
         module::FunctionFunctionId::Bool(id) => {
             execution::FunctionFunctionId::Bool(execution::BoolFunctionFunctionId(id.0))
@@ -219,6 +238,13 @@ pub(super) fn list_function_function_id(
                 id: execution::BitArrayListFunctionFunctionId(id.0),
                 type_: context.function_type(type_),
                 list_type: context.bit_array_list_type(),
+            }
+        }
+        module::ListFunctionFunctionId::UtfCodepoint { id, type_ } => {
+            execution::ListFunctionFunctionId::UtfCodepoint {
+                id: execution::UtfCodepointListFunctionFunctionId(id.0),
+                type_: context.function_type(type_),
+                list_type: context.utf_codepoint_list_type(),
             }
         }
         module::ListFunctionFunctionId::Float { id, type_ } => {

--- a/src/plan/execution/lowering/param.rs
+++ b/src/plan/execution/lowering/param.rs
@@ -20,6 +20,9 @@ pub(super) fn param_local(
         module::ParamLocal::BitArray(local) => {
             execution::ParamLocal::BitArray(execution::BitArrayLocalId(local.0))
         }
+        module::ParamLocal::UtfCodepoint(local) => {
+            execution::ParamLocal::UtfCodepoint(execution::UtfCodepointLocalId(local.0))
+        }
         module::ParamLocal::Bool(local) => {
             execution::ParamLocal::Bool(execution::BoolLocalId(local.0))
         }
@@ -53,6 +56,12 @@ pub(super) fn param_local(
         module::ParamLocal::BitArrayFunction { local, type_ } => {
             execution::ParamLocal::BitArrayFunction {
                 local: execution::BitArrayFunctionLocalId(local.0),
+                type_: context.function_type(type_),
+            }
+        }
+        module::ParamLocal::UtfCodepointFunction { local, type_ } => {
+            execution::ParamLocal::UtfCodepointFunction {
+                local: execution::UtfCodepointFunctionLocalId(local.0),
                 type_: context.function_type(type_),
             }
         }

--- a/src/plan/execution/lowering/pattern.rs
+++ b/src/plan/execution/lowering/pattern.rs
@@ -53,6 +53,10 @@ fn bit_array_segment(segment: module::BitArrayPatternSegment) -> execution::BitA
             },
             encoding: encoding.into(),
         },
+        M::UtfCodepoint { pattern, encoding } => E::UtfCodepoint {
+            pattern: binding_pattern(pattern, |local| execution::UtfCodepointLocalId(local.0)),
+            encoding: encoding.into(),
+        },
     }
 }
 

--- a/src/plan/execution/lowering/return_.rs
+++ b/src/plan/execution/lowering/return_.rs
@@ -5,6 +5,7 @@ use super::expression::{
     function_function_expr, function_list_expr, int_expr, int_function_expr, int_list_expr,
     list_function_expr, list_list_expr, nil_expr, nil_function_expr, nil_list_expr, string_expr,
     string_function_expr, string_list_expr, tuple_expr, tuple_function_expr, tuple_list_expr,
+    utf_codepoint_expr, utf_codepoint_function_expr, utf_codepoint_list_expr,
 };
 use super::id::list_function_function_id;
 use crate::plan::{execution, module};
@@ -42,6 +43,15 @@ pub(super) fn bit_array_return(
 ) -> execution::BitArrayReturn {
     return_body(body, context, bit_array_expr, |id, _| {
         execution::BitArrayFunctionId(id.0)
+    })
+}
+
+pub(super) fn utf_codepoint_return(
+    body: module::UtfCodepointReturn,
+    context: &mut LoweringContext,
+) -> execution::UtfCodepointReturn {
+    return_body(body, context, utf_codepoint_expr, |id, _| {
+        execution::UtfCodepointFunctionId(id.0)
     })
 }
 
@@ -98,6 +108,16 @@ pub(super) fn bit_array_list_return(
     let type_id = context.bit_array_list_type();
     return_body(body, context, bit_array_list_expr, move |id, _| {
         execution::BitArrayListFunctionId::new(id.0, type_id)
+    })
+}
+
+pub(super) fn utf_codepoint_list_return(
+    body: module::UtfCodepointListReturn,
+    context: &mut LoweringContext,
+) -> execution::UtfCodepointListReturn {
+    let type_id = context.utf_codepoint_list_type();
+    return_body(body, context, utf_codepoint_list_expr, move |id, _| {
+        execution::UtfCodepointListFunctionId::new(id.0, type_id)
     })
 }
 
@@ -193,6 +213,15 @@ pub(super) fn bit_array_function_return(
 ) -> execution::BitArrayFunctionReturn {
     return_body(body, context, bit_array_function_expr, |id, _| {
         execution::BitArrayFunctionFunctionId(id.0)
+    })
+}
+
+pub(super) fn utf_codepoint_function_return(
+    body: module::UtfCodepointFunctionReturn,
+    context: &mut LoweringContext,
+) -> execution::UtfCodepointFunctionReturn {
+    return_body(body, context, utf_codepoint_function_expr, |id, _| {
+        execution::UtfCodepointFunctionFunctionId(id.0)
     })
 }
 

--- a/src/plan/execution/lowering/step.rs
+++ b/src/plan/execution/lowering/step.rs
@@ -1,7 +1,8 @@
 use super::expression::{
     bit_array_expr, bit_array_function_expr, bool_expr, expr, float_expr, function_function_expr,
     int_expr, int_function_expr, list_function_expr, nil_expr, nil_function_expr, string_expr,
-    string_function_expr, tuple_expr, tuple_function_expr,
+    string_function_expr, tuple_expr, tuple_function_expr, utf_codepoint_expr,
+    utf_codepoint_function_expr,
 };
 use super::id::{list_function_local, list_local};
 use super::param::param_local;
@@ -53,6 +54,14 @@ fn lower_step(step: module::Step, context: &mut super::LoweringContext) -> execu
         } => E::LetBitArray {
             local: execution::BitArrayLocalId(local.0),
             value: bit_array_expr(value, context),
+        },
+        M::LetUtfCodepoint {
+            local,
+            name: _,
+            value,
+        } => E::LetUtfCodepoint {
+            local: execution::UtfCodepointLocalId(local.0),
+            value: utf_codepoint_expr(value, context),
         },
         M::LetBool {
             local,
@@ -112,6 +121,14 @@ fn lower_step(step: module::Step, context: &mut super::LoweringContext) -> execu
         } => E::LetBitArrayFunction {
             local: execution::BitArrayFunctionLocalId(local.0),
             value: bit_array_function_expr(value, context),
+        },
+        M::LetUtfCodepointFunction {
+            local,
+            name: _,
+            value,
+        } => E::LetUtfCodepointFunction {
+            local: execution::UtfCodepointFunctionLocalId(local.0),
+            value: utf_codepoint_function_expr(value, context),
         },
         M::LetBoolFunction {
             local,

--- a/src/plan/execution/lowering/table.rs
+++ b/src/plan/execution/lowering/table.rs
@@ -12,7 +12,9 @@ use super::super::{
     NilListFunctionId, NilListReturn, NilReturn, RuntimeFunctionId, StringFunctionFunctionId,
     StringFunctionId, StringFunctionReturn, StringListFunctionId, StringListReturn, StringReturn,
     TupleFunctionFunctionId, TupleFunctionId, TupleFunctionReturn, TupleListFunctionId,
-    TupleListReturn, TupleReturn,
+    TupleListReturn, TupleReturn, UtfCodepointFunctionFunctionId, UtfCodepointFunctionId,
+    UtfCodepointFunctionReturn, UtfCodepointListFunctionId, UtfCodepointListReturn,
+    UtfCodepointReturn,
 };
 use super::LoweringContext;
 use crate::plan::module;
@@ -23,6 +25,7 @@ pub(super) struct FunctionTableBuilder {
     float_functions: Vec<(usize, ExecutableFunction<FloatReturn>)>,
     string_functions: Vec<(usize, ExecutableFunction<StringReturn>)>,
     bit_array_functions: Vec<(usize, ExecutableFunction<BitArrayReturn>)>,
+    utf_codepoint_functions: Vec<(usize, ExecutableFunction<UtfCodepointReturn>)>,
     bool_functions: Vec<(usize, ExecutableFunction<BoolReturn>)>,
     nil_functions: Vec<(usize, ExecutableFunction<NilReturn>)>,
     tuple_functions: Vec<(usize, ExecutableFunction<TupleReturn>)>,
@@ -31,6 +34,10 @@ pub(super) struct FunctionTableBuilder {
     bit_array_list_functions: Vec<(
         BitArrayListFunctionId,
         ExecutableFunction<BitArrayListReturn>,
+    )>,
+    utf_codepoint_list_functions: Vec<(
+        UtfCodepointListFunctionId,
+        ExecutableFunction<UtfCodepointListReturn>,
     )>,
     float_list_functions: Vec<(FloatListFunctionId, ExecutableFunction<FloatListReturn>)>,
     bool_list_functions: Vec<(BoolListFunctionId, ExecutableFunction<BoolListReturn>)>,
@@ -45,12 +52,14 @@ pub(super) struct FunctionTableBuilder {
     float_function_functions: Vec<(usize, ExecutableFunction<FloatFunctionReturn>)>,
     string_function_functions: Vec<(usize, ExecutableFunction<StringFunctionReturn>)>,
     bit_array_function_functions: Vec<(usize, ExecutableFunction<BitArrayFunctionReturn>)>,
+    utf_codepoint_function_functions: Vec<(usize, ExecutableFunction<UtfCodepointFunctionReturn>)>,
     bool_function_functions: Vec<(usize, ExecutableFunction<BoolFunctionReturn>)>,
     nil_function_functions: Vec<(usize, ExecutableFunction<NilFunctionReturn>)>,
     tuple_function_functions: Vec<(usize, ExecutableFunction<TupleFunctionReturn>)>,
     int_list_function_functions: Vec<(usize, ExecutableFunction<ListFunctionReturn>)>,
     string_list_function_functions: Vec<(usize, ExecutableFunction<ListFunctionReturn>)>,
     bit_array_list_function_functions: Vec<(usize, ExecutableFunction<ListFunctionReturn>)>,
+    utf_codepoint_list_function_functions: Vec<(usize, ExecutableFunction<ListFunctionReturn>)>,
     float_list_function_functions: Vec<(usize, ExecutableFunction<ListFunctionReturn>)>,
     bool_list_function_functions: Vec<(usize, ExecutableFunction<ListFunctionReturn>)>,
     nil_list_function_functions: Vec<(usize, ExecutableFunction<ListFunctionReturn>)>,
@@ -122,6 +131,18 @@ impl FunctionTableBuilder {
                     ),
                 ));
                 RuntimeFunctionId::BitArray(id)
+            }
+            module::ReturnExprKind::UtfCodepoint { runtime_id, body } => {
+                let id = UtfCodepointFunctionId(runtime_id.0);
+                self.utf_codepoint_functions.push((
+                    runtime_id.0,
+                    ExecutableFunction::new(
+                        frame_layout,
+                        steps,
+                        super::return_::utf_codepoint_return(body, context),
+                    ),
+                ));
+                RuntimeFunctionId::UtfCodepoint(id)
             }
             module::ReturnExprKind::Bool { runtime_id, body } => {
                 let id = BoolFunctionId(runtime_id.0);
@@ -204,6 +225,21 @@ impl FunctionTableBuilder {
                     ),
                 ));
                 RuntimeFunctionId::List(ListFunctionId::BitArray(id))
+            }
+            module::ReturnExprKind::UtfCodepointList { runtime_id, body } => {
+                let id = UtfCodepointListFunctionId::new(
+                    runtime_id.0,
+                    context.utf_codepoint_list_type(),
+                );
+                self.utf_codepoint_list_functions.push((
+                    id,
+                    ExecutableFunction::new(
+                        frame_layout,
+                        steps,
+                        super::return_::utf_codepoint_list_return(body, context),
+                    ),
+                ));
+                RuntimeFunctionId::List(ListFunctionId::UtfCodepoint(id))
             }
             module::ReturnExprKind::FloatList { runtime_id, body } => {
                 let id = FloatListFunctionId::new(runtime_id.0, context.float_list_type());
@@ -368,6 +404,25 @@ impl FunctionTableBuilder {
                     return_type: context.function_type(type_),
                 }
             }
+            module::ReturnExprKind::UtfCodepointFunction {
+                runtime_id,
+                type_,
+                body,
+            } => {
+                let id = UtfCodepointFunctionFunctionId(runtime_id.0);
+                self.utf_codepoint_function_functions.push((
+                    runtime_id.0,
+                    ExecutableFunction::new(
+                        frame_layout,
+                        steps,
+                        super::return_::utf_codepoint_function_return(body, context),
+                    ),
+                ));
+                RuntimeFunctionId::Function {
+                    id: FunctionFunctionId::UtfCodepoint(id),
+                    return_type: context.function_type(type_),
+                }
+            }
             module::ReturnExprKind::BoolFunction {
                 runtime_id,
                 type_,
@@ -479,6 +534,10 @@ impl FunctionTableBuilder {
                 self.bit_array_list_function_functions
                     .push((id.0, function));
             }
+            ListFunctionFunctionId::UtfCodepoint { id, .. } => {
+                self.utf_codepoint_list_function_functions
+                    .push((id.0, function));
+            }
             ListFunctionFunctionId::Float { id, .. } => {
                 self.float_list_function_functions.push((id.0, function));
             }
@@ -506,6 +565,7 @@ impl FunctionTableBuilder {
             float_functions: sort_functions(self.float_functions),
             string_functions: sort_functions(self.string_functions),
             bit_array_functions: sort_functions(self.bit_array_functions),
+            utf_codepoint_functions: sort_functions(self.utf_codepoint_functions),
             bool_functions: sort_functions(self.bool_functions),
             nil_functions: sort_functions(self.nil_functions),
             tuple_functions: sort_functions(self.tuple_functions),
@@ -514,6 +574,10 @@ impl FunctionTableBuilder {
             bit_array_list_functions: sort_list_functions(self.bit_array_list_functions, |id| {
                 id.index()
             }),
+            utf_codepoint_list_functions: sort_list_functions(
+                self.utf_codepoint_list_functions,
+                |id| id.index(),
+            ),
             float_list_functions: sort_list_functions(self.float_list_functions, |id| id.index()),
             bool_list_functions: sort_list_functions(self.bool_list_functions, |id| id.index()),
             nil_list_functions: sort_list_functions(self.nil_list_functions, |id| id.index()),
@@ -526,6 +590,7 @@ impl FunctionTableBuilder {
             float_function_functions: sort_functions(self.float_function_functions),
             string_function_functions: sort_functions(self.string_function_functions),
             bit_array_function_functions: sort_functions(self.bit_array_function_functions),
+            utf_codepoint_function_functions: sort_functions(self.utf_codepoint_function_functions),
             bool_function_functions: sort_functions(self.bool_function_functions),
             nil_function_functions: sort_functions(self.nil_function_functions),
             tuple_function_functions: sort_functions(self.tuple_function_functions),
@@ -533,6 +598,9 @@ impl FunctionTableBuilder {
             string_list_function_functions: sort_functions(self.string_list_function_functions),
             bit_array_list_function_functions: sort_functions(
                 self.bit_array_list_function_functions,
+            ),
+            utf_codepoint_list_function_functions: sort_functions(
+                self.utf_codepoint_list_function_functions,
             ),
             float_list_function_functions: sort_functions(self.float_list_function_functions),
             bool_list_function_functions: sort_functions(self.bool_list_function_functions),
@@ -573,12 +641,19 @@ mod tests {
 fn int_value() { 1 }
 fn float_value() { 1.0 }
 fn string_value() { "one" }
+fn bit_array_value() { <<1>> }
+fn utf_codepoint_value() -> UtfCodepoint {
+  let assert <<value:utf8_codepoint>> = <<65>>
+  value
+}
 fn bool_value() { True }
 fn nil_value() { Nil }
 fn tuple_value() { #(1) }
 
 fn int_list() { [1] }
 fn string_list() { ["one"] }
+fn bit_array_list() { [<<1>>] }
+fn utf_codepoint_list() { [utf_codepoint_value()] }
 fn float_list() { [1.0] }
 fn bool_list() { [True] }
 fn nil_list() { [Nil] }
@@ -589,11 +664,15 @@ fn function_list() { [int_value] }
 fn int_function() { int_value }
 fn float_function() { float_value }
 fn string_function() { string_value }
+fn bit_array_function() { bit_array_value }
+fn utf_codepoint_function() { utf_codepoint_value }
 fn bool_function() { bool_value }
 fn nil_function() { nil_value }
 fn tuple_function() { tuple_value }
 fn int_list_function() { int_list }
 fn string_list_function() { string_list }
+fn bit_array_list_function() { bit_array_list }
+fn utf_codepoint_list_function() { utf_codepoint_list }
 fn float_list_function() { float_list }
 fn bool_list_function() { bool_list }
 fn nil_list_function() { nil_list }
@@ -616,11 +695,15 @@ pub fn main() { int_value() }
         assert_eq!(plan.functions.int_functions.len(), 2);
         assert_eq!(plan.functions.float_functions.len(), 1);
         assert_eq!(plan.functions.string_functions.len(), 1);
+        assert_eq!(plan.functions.bit_array_functions.len(), 1);
+        assert_eq!(plan.functions.utf_codepoint_functions.len(), 1);
         assert_eq!(plan.functions.bool_functions.len(), 1);
         assert_eq!(plan.functions.nil_functions.len(), 1);
         assert_eq!(plan.functions.tuple_functions.len(), 1);
         assert_eq!(plan.functions.int_list_functions.len(), 1);
         assert_eq!(plan.functions.string_list_functions.len(), 1);
+        assert_eq!(plan.functions.bit_array_list_functions.len(), 1);
+        assert_eq!(plan.functions.utf_codepoint_list_functions.len(), 1);
         assert_eq!(plan.functions.float_list_functions.len(), 1);
         assert_eq!(plan.functions.bool_list_functions.len(), 1);
         assert_eq!(plan.functions.nil_list_functions.len(), 1);
@@ -630,11 +713,18 @@ pub fn main() { int_value() }
         assert_eq!(plan.functions.int_function_functions.len(), 1);
         assert_eq!(plan.functions.float_function_functions.len(), 1);
         assert_eq!(plan.functions.string_function_functions.len(), 1);
+        assert_eq!(plan.functions.bit_array_function_functions.len(), 1);
+        assert_eq!(plan.functions.utf_codepoint_function_functions.len(), 1);
         assert_eq!(plan.functions.bool_function_functions.len(), 1);
         assert_eq!(plan.functions.nil_function_functions.len(), 1);
         assert_eq!(plan.functions.tuple_function_functions.len(), 1);
         assert_eq!(plan.functions.int_list_function_functions.len(), 1);
         assert_eq!(plan.functions.string_list_function_functions.len(), 1);
+        assert_eq!(plan.functions.bit_array_list_function_functions.len(), 1);
+        assert_eq!(
+            plan.functions.utf_codepoint_list_function_functions.len(),
+            1
+        );
         assert_eq!(plan.functions.float_list_function_functions.len(), 1);
         assert_eq!(plan.functions.bool_list_function_functions.len(), 1);
         assert_eq!(plan.functions.nil_list_function_functions.len(), 1);

--- a/src/plan/execution/lowering/value_type.rs
+++ b/src/plan/execution/lowering/value_type.rs
@@ -4,7 +4,7 @@ use crate::plan;
 use crate::plan::execution::{
     BitArrayListTypeId, BoolListTypeId, FloatListTypeId, FunctionListTypeId, FunctionType,
     IntListTypeId, ListListTypeId, ListStorageTypeId, ListTypeId, NilListTypeId, StringListTypeId,
-    TupleListTypeId, ValueType,
+    TupleListTypeId, UtfCodepointListTypeId, ValueType,
 };
 
 use super::super::value_type::ListTypeTable;
@@ -27,6 +27,7 @@ impl ListTypeInterner {
             plan::ValueType::Float => ValueType::Float,
             plan::ValueType::String => ValueType::String,
             plan::ValueType::BitArray => ValueType::BitArray,
+            plan::ValueType::UtfCodepoint => ValueType::UtfCodepoint,
             plan::ValueType::Bool => ValueType::Bool,
             plan::ValueType::Nil => ValueType::Nil,
             plan::ValueType::Tuple(elements) => ValueType::Tuple(
@@ -59,6 +60,7 @@ impl ListTypeInterner {
             plan::ValueType::Int => self.int_list_type().list_type(),
             plan::ValueType::String => self.string_list_type().list_type(),
             plan::ValueType::BitArray => self.bit_array_list_type().list_type(),
+            plan::ValueType::UtfCodepoint => self.utf_codepoint_list_type().list_type(),
             plan::ValueType::Float => self.float_list_type().list_type(),
             plan::ValueType::Bool => self.bool_list_type().list_type(),
             plan::ValueType::Nil => self.nil_list_type().list_type(),
@@ -103,6 +105,13 @@ impl ListTypeInterner {
             ListStorageTypeId::BitArray(BitArrayListTypeId::new(list_type))
         });
         BitArrayListTypeId::new(list_type)
+    }
+
+    pub(super) fn utf_codepoint_list_type(&mut self) -> UtfCodepointListTypeId {
+        let list_type = self.intern_primitive(plan::ValueType::UtfCodepoint, |list_type| {
+            ListStorageTypeId::UtfCodepoint(UtfCodepointListTypeId::new(list_type))
+        });
+        UtfCodepointListTypeId::new(list_type)
     }
 
     pub(super) fn float_list_type(&mut self) -> FloatListTypeId {

--- a/src/plan/execution/param.rs
+++ b/src/plan/execution/param.rs
@@ -2,7 +2,8 @@ use super::{
     BitArrayFunctionLocalId, BitArrayLocalId, BoolFunctionLocalId, BoolLocalId,
     FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId, FunctionType, IntFunctionLocalId,
     IntLocalId, ListFunctionLocal, ListLocal, NilFunctionLocalId, NilLocalId,
-    StringFunctionLocalId, StringLocalId, TupleFunctionLocalId, TupleLocalId, ValueType,
+    StringFunctionLocalId, StringLocalId, TupleFunctionLocalId, TupleLocalId,
+    UtfCodepointFunctionLocalId, UtfCodepointLocalId, ValueType,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,6 +12,7 @@ pub(crate) enum ParamLocal {
     Float(FloatLocalId),
     String(StringLocalId),
     BitArray(BitArrayLocalId),
+    UtfCodepoint(UtfCodepointLocalId),
     Bool(BoolLocalId),
     Nil(NilLocalId),
     Tuple {
@@ -32,6 +34,10 @@ pub(crate) enum ParamLocal {
     },
     BitArrayFunction {
         local: BitArrayFunctionLocalId,
+        type_: FunctionType,
+    },
+    UtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
         type_: FunctionType,
     },
     BoolFunction {
@@ -60,6 +66,7 @@ impl ParamLocal {
             Self::Float(_) => ValueType::Float,
             Self::String(_) => ValueType::String,
             Self::BitArray(_) => ValueType::BitArray,
+            Self::UtfCodepoint(_) => ValueType::UtfCodepoint,
             Self::Bool(_) => ValueType::Bool,
             Self::Nil(_) => ValueType::Nil,
             Self::Tuple { type_, .. } => ValueType::Tuple(type_.clone()),
@@ -68,6 +75,7 @@ impl ParamLocal {
             | Self::FloatFunction { type_, .. }
             | Self::StringFunction { type_, .. }
             | Self::BitArrayFunction { type_, .. }
+            | Self::UtfCodepointFunction { type_, .. }
             | Self::BoolFunction { type_, .. }
             | Self::NilFunction { type_, .. }
             | Self::TupleFunction { type_, .. }

--- a/src/plan/execution/pattern/bit_array.rs
+++ b/src/plan/execution/pattern/bit_array.rs
@@ -1,5 +1,5 @@
 use crate::plan::execution::{
-    BitArrayLocalId, Endianness, FloatLocalId, IntLocalId, StringEncoding,
+    BitArrayLocalId, Endianness, FloatLocalId, IntLocalId, StringEncoding, UtfCodepointLocalId,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -27,6 +27,10 @@ pub(crate) enum BitArrayPatternSegment {
     },
     String {
         pattern: BitArrayStringPattern,
+        encoding: StringEncoding,
+    },
+    UtfCodepoint {
+        pattern: BitArrayBindingPattern<UtfCodepointLocalId>,
         encoding: StringEncoding,
     },
 }

--- a/src/plan/execution/return_.rs
+++ b/src/plan/execution/return_.rs
@@ -9,7 +9,9 @@ use super::{
     NilFunctionExpr, NilFunctionFunctionId, NilFunctionId, NilListExpr, NilListFunctionId, Step,
     StringExpr, StringFunctionExpr, StringFunctionFunctionId, StringFunctionId, StringListExpr,
     StringListFunctionId, TupleExpr, TupleFunctionExpr, TupleFunctionFunctionId, TupleFunctionId,
-    TupleListExpr, TupleListFunctionId,
+    TupleListExpr, TupleListFunctionId, UtfCodepointExpr, UtfCodepointFunctionExpr,
+    UtfCodepointFunctionFunctionId, UtfCodepointFunctionId, UtfCodepointListExpr,
+    UtfCodepointListFunctionId,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -18,6 +20,7 @@ pub(crate) type IntReturn = ReturnBody<IntExpr, IntFunctionId>;
 pub(crate) type FloatReturn = ReturnBody<FloatExpr, FloatFunctionId>;
 pub(crate) type StringReturn = ReturnBody<StringExpr, StringFunctionId>;
 pub(crate) type BitArrayReturn = ReturnBody<BitArrayExpr, BitArrayFunctionId>;
+pub(crate) type UtfCodepointReturn = ReturnBody<UtfCodepointExpr, UtfCodepointFunctionId>;
 pub(crate) type BoolReturn = ReturnBody<BoolExpr, BoolFunctionId>;
 pub(crate) type NilReturn = ReturnBody<NilExpr, NilFunctionId>;
 pub(crate) type TupleReturn = ReturnBody<TupleExpr, TupleFunctionId>;
@@ -25,6 +28,8 @@ pub(crate) type IntListReturn = ReturnBody<IntListExpr, IntListFunctionId>;
 pub(crate) type FloatListReturn = ReturnBody<FloatListExpr, FloatListFunctionId>;
 pub(crate) type StringListReturn = ReturnBody<StringListExpr, StringListFunctionId>;
 pub(crate) type BitArrayListReturn = ReturnBody<BitArrayListExpr, BitArrayListFunctionId>;
+pub(crate) type UtfCodepointListReturn =
+    ReturnBody<UtfCodepointListExpr, UtfCodepointListFunctionId>;
 pub(crate) type BoolListReturn = ReturnBody<BoolListExpr, BoolListFunctionId>;
 pub(crate) type NilListReturn = ReturnBody<NilListExpr, NilListFunctionId>;
 pub(crate) type TupleListReturn = ReturnBody<TupleListExpr, TupleListFunctionId>;
@@ -35,6 +40,8 @@ pub(crate) type FloatFunctionReturn = ReturnBody<FloatFunctionExpr, FloatFunctio
 pub(crate) type StringFunctionReturn = ReturnBody<StringFunctionExpr, StringFunctionFunctionId>;
 pub(crate) type BitArrayFunctionReturn =
     ReturnBody<BitArrayFunctionExpr, BitArrayFunctionFunctionId>;
+pub(crate) type UtfCodepointFunctionReturn =
+    ReturnBody<UtfCodepointFunctionExpr, UtfCodepointFunctionFunctionId>;
 pub(crate) type BoolFunctionReturn = ReturnBody<BoolFunctionExpr, BoolFunctionFunctionId>;
 pub(crate) type NilFunctionReturn = ReturnBody<NilFunctionExpr, NilFunctionFunctionId>;
 pub(crate) type TupleFunctionReturn = ReturnBody<TupleFunctionExpr, TupleFunctionFunctionId>;

--- a/src/plan/execution/step.rs
+++ b/src/plan/execution/step.rs
@@ -3,13 +3,14 @@ use super::expression::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, Expr, FloatExpr,
     FloatFunctionExpr, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListFunctionExpr,
     ListLocalExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr,
-    TupleFunctionExpr,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr,
 };
 use super::id::{
     BitArrayFunctionLocalId, BitArrayLocalId, BoolFunctionLocalId, BoolLocalId,
     FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId, IntFunctionLocalId, IntLocalId,
     ListFunctionLocal, ListLocal, NilFunctionLocalId, NilLocalId, StringFunctionLocalId,
-    StringLocalId, TupleFunctionLocalId, TupleLocalId,
+    StringLocalId, TupleFunctionLocalId, TupleLocalId, UtfCodepointFunctionLocalId,
+    UtfCodepointLocalId,
 };
 use crate::plan::execution::BitArrayPattern;
 use crate::plan::{PanicSite, SourceSpan};
@@ -65,6 +66,10 @@ pub(crate) enum StepKind {
         local: BitArrayLocalId,
         value: BitArrayExpr,
     },
+    LetUtfCodepoint {
+        local: UtfCodepointLocalId,
+        value: UtfCodepointExpr,
+    },
     LetBool {
         local: BoolLocalId,
         value: BoolExpr,
@@ -95,6 +100,10 @@ pub(crate) enum StepKind {
     LetBitArrayFunction {
         local: BitArrayFunctionLocalId,
         value: BitArrayFunctionExpr,
+    },
+    LetUtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
+        value: UtfCodepointFunctionExpr,
     },
     LetBoolFunction {
         local: BoolFunctionLocalId,

--- a/src/plan/execution/table.rs
+++ b/src/plan/execution/table.rs
@@ -11,6 +11,8 @@ use super::{
     NilReturn, StringFunctionFunctionId, StringFunctionId, StringFunctionReturn,
     StringListFunctionId, StringListReturn, StringReturn, TupleFunctionFunctionId, TupleFunctionId,
     TupleFunctionReturn, TupleListFunctionId, TupleListReturn, TupleReturn,
+    UtfCodepointFunctionFunctionId, UtfCodepointFunctionId, UtfCodepointFunctionReturn,
+    UtfCodepointListFunctionId, UtfCodepointListReturn, UtfCodepointReturn,
 };
 
 #[cfg(test)]
@@ -21,6 +23,7 @@ pub(super) struct FunctionTables {
     pub(super) float_functions: Vec<ExecutableFunction<FloatReturn>>,
     pub(super) string_functions: Vec<ExecutableFunction<StringReturn>>,
     pub(super) bit_array_functions: Vec<ExecutableFunction<BitArrayReturn>>,
+    pub(super) utf_codepoint_functions: Vec<ExecutableFunction<UtfCodepointReturn>>,
     pub(super) bool_functions: Vec<ExecutableFunction<BoolReturn>>,
     pub(super) nil_functions: Vec<ExecutableFunction<NilReturn>>,
     pub(super) tuple_functions: Vec<ExecutableFunction<TupleReturn>>,
@@ -30,6 +33,10 @@ pub(super) struct FunctionTables {
     pub(super) bit_array_list_functions: Vec<(
         BitArrayListFunctionId,
         ExecutableFunction<BitArrayListReturn>,
+    )>,
+    pub(super) utf_codepoint_list_functions: Vec<(
+        UtfCodepointListFunctionId,
+        ExecutableFunction<UtfCodepointListReturn>,
     )>,
     pub(super) float_list_functions:
         Vec<(FloatListFunctionId, ExecutableFunction<FloatListReturn>)>,
@@ -46,12 +53,15 @@ pub(super) struct FunctionTables {
     pub(super) float_function_functions: Vec<ExecutableFunction<FloatFunctionReturn>>,
     pub(super) string_function_functions: Vec<ExecutableFunction<StringFunctionReturn>>,
     pub(super) bit_array_function_functions: Vec<ExecutableFunction<BitArrayFunctionReturn>>,
+    pub(super) utf_codepoint_function_functions:
+        Vec<ExecutableFunction<UtfCodepointFunctionReturn>>,
     pub(super) bool_function_functions: Vec<ExecutableFunction<BoolFunctionReturn>>,
     pub(super) nil_function_functions: Vec<ExecutableFunction<NilFunctionReturn>>,
     pub(super) tuple_function_functions: Vec<ExecutableFunction<TupleFunctionReturn>>,
     pub(super) int_list_function_functions: Vec<ExecutableFunction<ListFunctionReturn>>,
     pub(super) string_list_function_functions: Vec<ExecutableFunction<ListFunctionReturn>>,
     pub(super) bit_array_list_function_functions: Vec<ExecutableFunction<ListFunctionReturn>>,
+    pub(super) utf_codepoint_list_function_functions: Vec<ExecutableFunction<ListFunctionReturn>>,
     pub(super) float_list_function_functions: Vec<ExecutableFunction<ListFunctionReturn>>,
     pub(super) bool_list_function_functions: Vec<ExecutableFunction<ListFunctionReturn>>,
     pub(super) nil_list_function_functions: Vec<ExecutableFunction<ListFunctionReturn>>,
@@ -75,6 +85,14 @@ impl FunctionTables {
     #[cfg(test)]
     pub(super) fn bit_array_list_function_id(&self, index: usize) -> BitArrayListFunctionId {
         self.bit_array_list_functions[index].0
+    }
+
+    #[cfg(test)]
+    pub(super) fn utf_codepoint_list_function_id(
+        &self,
+        index: usize,
+    ) -> UtfCodepointListFunctionId {
+        self.utf_codepoint_list_functions[index].0
     }
 
     #[cfg(test)]
@@ -137,6 +155,13 @@ impl FunctionTables {
         &self.bit_array_functions[id.0]
     }
 
+    pub(super) fn utf_codepoint_function(
+        &self,
+        id: UtfCodepointFunctionId,
+    ) -> &ExecutableFunction<UtfCodepointReturn> {
+        &self.utf_codepoint_functions[id.0]
+    }
+
     pub(super) fn bool_function(&self, id: BoolFunctionId) -> &ExecutableFunction<BoolReturn> {
         &self.bool_functions[id.0]
     }
@@ -168,6 +193,13 @@ impl FunctionTables {
         id: BitArrayListFunctionId,
     ) -> &ExecutableFunction<BitArrayListReturn> {
         &self.bit_array_list_functions[id.index()].1
+    }
+
+    pub(super) fn utf_codepoint_list_function(
+        &self,
+        id: UtfCodepointListFunctionId,
+    ) -> &ExecutableFunction<UtfCodepointListReturn> {
+        &self.utf_codepoint_list_functions[id.index()].1
     }
 
     pub(super) fn float_list_function(
@@ -240,6 +272,13 @@ impl FunctionTables {
         &self.bit_array_function_functions[id.0]
     }
 
+    pub(super) fn utf_codepoint_function_function(
+        &self,
+        id: UtfCodepointFunctionFunctionId,
+    ) -> &ExecutableFunction<UtfCodepointFunctionReturn> {
+        &self.utf_codepoint_function_functions[id.0]
+    }
+
     pub(super) fn bool_function_function(
         &self,
         id: BoolFunctionFunctionId,
@@ -270,6 +309,9 @@ impl FunctionTables {
             ListFunctionFunctionId::String { id, .. } => &self.string_list_function_functions[id.0],
             ListFunctionFunctionId::BitArray { id, .. } => {
                 &self.bit_array_list_function_functions[id.0]
+            }
+            ListFunctionFunctionId::UtfCodepoint { id, .. } => {
+                &self.utf_codepoint_list_function_functions[id.0]
             }
             ListFunctionFunctionId::Float { id, .. } => &self.float_list_function_functions[id.0],
             ListFunctionFunctionId::Bool { id, .. } => &self.bool_list_function_functions[id.0],
@@ -305,6 +347,14 @@ mod tests {
             (
                 "pub fn main() -> fn() -> List(String) { fn() { [] } }",
                 ValueType::String,
+            ),
+            (
+                "pub fn main() -> fn() -> List(BitArray) { fn() { [] } }",
+                ValueType::BitArray,
+            ),
+            (
+                "pub fn main() -> fn() -> List(UtfCodepoint) { fn() { [] } }",
+                ValueType::UtfCodepoint,
             ),
             (
                 "pub fn main() -> fn() -> List(Float) { fn() { [] } }",

--- a/src/plan/execution/value_type.rs
+++ b/src/plan/execution/value_type.rs
@@ -21,6 +21,7 @@ macro_rules! primitive_list_type_id {
 primitive_list_type_id!(IntListTypeId);
 primitive_list_type_id!(StringListTypeId);
 primitive_list_type_id!(BitArrayListTypeId);
+primitive_list_type_id!(UtfCodepointListTypeId);
 primitive_list_type_id!(FloatListTypeId);
 primitive_list_type_id!(BoolListTypeId);
 primitive_list_type_id!(NilListTypeId);
@@ -54,6 +55,7 @@ pub(crate) enum ListStorageTypeId {
     Int(IntListTypeId),
     String(StringListTypeId),
     BitArray(BitArrayListTypeId),
+    UtfCodepoint(UtfCodepointListTypeId),
     Float(FloatListTypeId),
     Bool(BoolListTypeId),
     Nil(NilListTypeId),
@@ -68,6 +70,7 @@ pub(crate) enum ValueType {
     Float,
     String,
     BitArray,
+    UtfCodepoint,
     Bool,
     Nil,
     Tuple(Vec<ValueType>),
@@ -111,6 +114,7 @@ macro_rules! list_type_id {
 list_type_id!(IntListTypeId);
 list_type_id!(StringListTypeId);
 list_type_id!(BitArrayListTypeId);
+list_type_id!(UtfCodepointListTypeId);
 list_type_id!(FloatListTypeId);
 list_type_id!(BoolListTypeId);
 list_type_id!(NilListTypeId);
@@ -202,6 +206,7 @@ impl ListTypeTable {
             ValueType::Float => plan::ValueType::Float,
             ValueType::String => plan::ValueType::String,
             ValueType::BitArray => plan::ValueType::BitArray,
+            ValueType::UtfCodepoint => plan::ValueType::UtfCodepoint,
             ValueType::Bool => plan::ValueType::Bool,
             ValueType::Nil => plan::ValueType::Nil,
             ValueType::Tuple(elements) => plan::ValueType::Tuple(
@@ -237,6 +242,7 @@ impl ListTypeTable {
             ListStorageTypeId::Int(_) => plan::ValueType::Int,
             ListStorageTypeId::String(_) => plan::ValueType::String,
             ListStorageTypeId::BitArray(_) => plan::ValueType::BitArray,
+            ListStorageTypeId::UtfCodepoint(_) => plan::ValueType::UtfCodepoint,
             ListStorageTypeId::Float(_) => plan::ValueType::Float,
             ListStorageTypeId::Bool(_) => plan::ValueType::Bool,
             ListStorageTypeId::Nil(_) => plan::ValueType::Nil,

--- a/src/plan/module.rs
+++ b/src/plan/module.rs
@@ -13,7 +13,7 @@ pub use expression::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, CallArg, Expr, FloatExpr,
     FloatFunctionExpr, FunctionExpr, FunctionFunctionExpr, IntExpr, IntFunctionExpr,
     ListFunctionExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr,
-    TupleFunctionExpr,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr,
 };
 pub(crate) use expression::{
     BitArrayExprKind, BitArrayFunctionExprKind, BitArraySegment, BoolCaseBranches, BoolExprKind,
@@ -22,14 +22,15 @@ pub(crate) use expression::{
     FunctionFunctionExprKind, IntCaseBranches, IntExprKind, IntFunctionExprKind, ListElements,
     ListFunctionExprKind, NilExprKind, NilFunctionExprKind, PanicExpr, PanicExprKind,
     StringCaseBranches, StringEncoding, StringExprKind, StringFunctionExprKind, TupleExprKind,
-    TupleFunctionExprKind,
+    TupleFunctionExprKind, UtfCodepointExprKind, UtfCodepointFunctionExprKind,
 };
 pub(crate) use expression::{
     BitArrayListExpr, BitArrayListItem, BoolListCaseBranches, BoolListExpr, BoolListItem,
     FloatListExpr, FloatListItem, FunctionListExpr, FunctionListItem, IntListExpr, IntListItem,
     ListCaseBranches, ListExpr, ListItem, ListListExpr, ListListItem, ListLocalExpr,
     ListSpreadElements, NilListExpr, NilListItem, StringListExpr, StringListItem, TupleListExpr,
-    TupleListItem, TypedListExpr, TypedListExprKind, TypedListReturnKind,
+    TupleListItem, TypedListExpr, TypedListExprKind, TypedListReturnKind, UtfCodepointListExpr,
+    UtfCodepointListItem,
 };
 pub(crate) use frame::FrameLayout;
 #[cfg(test)]
@@ -40,7 +41,8 @@ pub(crate) use function::{
     FunctionFunctionReturn, FunctionListReturn, IntFunctionReturn, IntListReturn, IntReturn,
     ListFunctionReturn, ListListReturn, NilFunctionReturn, NilListReturn, NilReturn, ParamLocal,
     ReturnBody, ReturnBodyKind, ReturnExprKind, StringFunctionReturn, StringListReturn,
-    StringReturn, TupleFunctionReturn, TupleListReturn, TupleReturn,
+    StringReturn, TupleFunctionReturn, TupleListReturn, TupleReturn, UtfCodepointFunctionReturn,
+    UtfCodepointListReturn, UtfCodepointReturn,
 };
 pub use function::{FunctionPlan, Param, ParamBinding, ReturnExpr};
 pub use id::{
@@ -62,7 +64,10 @@ pub use id::{
     StringListFunctionFunctionId, StringListFunctionId, StringListFunctionLocalId,
     StringListLocalId, StringLocalId, TupleFunctionFunctionId, TupleFunctionId,
     TupleFunctionLocalId, TupleListFunctionFunctionId, TupleListFunctionId,
-    TupleListFunctionLocalId, TupleListLocalId, TupleLocalId,
+    TupleListFunctionLocalId, TupleListLocalId, TupleLocalId, UtfCodepointFunctionFunctionId,
+    UtfCodepointFunctionId, UtfCodepointFunctionLocalId, UtfCodepointListFunctionFunctionId,
+    UtfCodepointListFunctionId, UtfCodepointListFunctionLocalId, UtfCodepointListLocalId,
+    UtfCodepointLocalId,
 };
 pub(crate) use id::{FunctionFunctionId, RuntimeFunctionId};
 pub(crate) use pattern::{
@@ -74,6 +79,7 @@ pub(crate) use reference::{
     BitArrayFunctionReference, BoolFunctionReference, FloatFunctionReference,
     FunctionFunctionReference, FunctionReference, IntFunctionReference, ListFunctionReference,
     NilFunctionReference, StringFunctionReference, TupleFunctionReference, TypedFunctionReference,
+    UtfCodepointFunctionReference,
 };
 pub use step::Step;
 pub(crate) use step::{AssertBinding, AssertPattern, ListAssertPattern, ListAssertTail, StepKind};

--- a/src/plan/module/expression.rs
+++ b/src/plan/module/expression.rs
@@ -10,6 +10,7 @@ mod nil;
 mod panic;
 mod string;
 mod tuple;
+mod utf_codepoint;
 
 use crate::plan::ValueType;
 
@@ -24,12 +25,13 @@ pub use self::{
     function::{
         BitArrayFunctionExpr, BoolFunctionExpr, FloatFunctionExpr, FunctionExpr,
         FunctionFunctionExpr, IntFunctionExpr, ListFunctionExpr, NilFunctionExpr,
-        StringFunctionExpr, TupleFunctionExpr,
+        StringFunctionExpr, TupleFunctionExpr, UtfCodepointFunctionExpr,
     },
     int::IntExpr,
     nil::NilExpr,
     string::StringExpr,
     tuple::TupleExpr,
+    utf_codepoint::UtfCodepointExpr,
 };
 pub(crate) use self::{
     arg::{CallArgKind, CaptureArg, CaptureArgKind},
@@ -39,7 +41,7 @@ pub(crate) use self::{
     function::{
         BitArrayFunctionExprKind, BoolFunctionExprKind, FloatFunctionExprKind, FunctionExprKind,
         FunctionFunctionExprKind, IntFunctionExprKind, ListFunctionExprKind, NilFunctionExprKind,
-        StringFunctionExprKind, TupleFunctionExprKind,
+        StringFunctionExprKind, TupleFunctionExprKind, UtfCodepointFunctionExprKind,
     },
     int::IntExprKind,
     list::{
@@ -48,12 +50,13 @@ pub(crate) use self::{
         ListCaseBranches, ListElements, ListExpr, ListItem, ListListExpr, ListListItem,
         ListLocalExpr, ListSpreadElements, NilListExpr, NilListItem, StringListExpr,
         StringListItem, TupleListExpr, TupleListItem, TypedListExpr, TypedListExprKind,
-        TypedListReturnKind,
+        TypedListReturnKind, UtfCodepointListExpr, UtfCodepointListItem,
     },
     nil::NilExprKind,
     panic::{PanicExpr, PanicExprKind},
     string::StringExprKind,
     tuple::TupleExprKind,
+    utf_codepoint::UtfCodepointExprKind,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -66,6 +69,7 @@ pub(crate) enum ExprKind {
     Int(IntExpr),
     String(StringExpr),
     BitArray(BitArrayExpr),
+    UtfCodepoint(UtfCodepointExpr),
     Float(FloatExpr),
     Bool(BoolExpr),
     Nil(NilExpr),
@@ -90,6 +94,12 @@ impl Expr {
     pub(crate) fn bit_array(expression: BitArrayExpr) -> Self {
         Self {
             kind: ExprKind::BitArray(expression),
+        }
+    }
+
+    pub(crate) fn utf_codepoint(expression: UtfCodepointExpr) -> Self {
+        Self {
+            kind: ExprKind::UtfCodepoint(expression),
         }
     }
 
@@ -140,6 +150,9 @@ impl Expr {
             BoolCaseBranches::BitArray { true_, false_ } => {
                 Self::bit_array(BitArrayExpr::bool_case(subject, true_, false_))
             }
+            BoolCaseBranches::UtfCodepoint { true_, false_ } => {
+                Self::utf_codepoint(UtfCodepointExpr::bool_case(subject, true_, false_))
+            }
             BoolCaseBranches::Float { true_, false_ } => {
                 Self::float(FloatExpr::bool_case(subject, true_, false_))
             }
@@ -162,6 +175,11 @@ impl Expr {
             BoolCaseBranches::BitArrayFunction { true_, false_ } => Self::function(
                 FunctionExpr::bit_array(BitArrayFunctionExpr::bool_case(subject, true_, false_)),
             ),
+            BoolCaseBranches::UtfCodepointFunction { true_, false_ } => {
+                Self::function(FunctionExpr::utf_codepoint(
+                    UtfCodepointFunctionExpr::bool_case(subject, true_, false_),
+                ))
+            }
             BoolCaseBranches::FloatFunction { true_, false_ } => Self::function(
                 FunctionExpr::float(FloatFunctionExpr::bool_case(subject, true_, false_)),
             ),
@@ -194,6 +212,9 @@ impl Expr {
             IntCaseBranches::BitArray { clauses, fallback } => {
                 Self::bit_array(BitArrayExpr::int_case(subject, clauses, fallback))
             }
+            IntCaseBranches::UtfCodepoint { clauses, fallback } => {
+                Self::utf_codepoint(UtfCodepointExpr::int_case(subject, clauses, fallback))
+            }
             IntCaseBranches::Float { clauses, fallback } => {
                 Self::float(FloatExpr::int_case(subject, clauses, fallback))
             }
@@ -216,6 +237,11 @@ impl Expr {
             IntCaseBranches::BitArrayFunction { clauses, fallback } => Self::function(
                 FunctionExpr::bit_array(BitArrayFunctionExpr::int_case(subject, clauses, fallback)),
             ),
+            IntCaseBranches::UtfCodepointFunction { clauses, fallback } => {
+                Self::function(FunctionExpr::utf_codepoint(
+                    UtfCodepointFunctionExpr::int_case(subject, clauses, fallback),
+                ))
+            }
             IntCaseBranches::FloatFunction { clauses, fallback } => Self::function(
                 FunctionExpr::float(FloatFunctionExpr::int_case(subject, clauses, fallback)),
             ),
@@ -248,6 +274,9 @@ impl Expr {
             StringCaseBranches::BitArray { clauses, fallback } => {
                 Self::bit_array(BitArrayExpr::string_case(subject, clauses, fallback))
             }
+            StringCaseBranches::UtfCodepoint { clauses, fallback } => {
+                Self::utf_codepoint(UtfCodepointExpr::string_case(subject, clauses, fallback))
+            }
             StringCaseBranches::Float { clauses, fallback } => {
                 Self::float(FloatExpr::string_case(subject, clauses, fallback))
             }
@@ -273,6 +302,11 @@ impl Expr {
                 Self::function(FunctionExpr::bit_array(BitArrayFunctionExpr::string_case(
                     subject, clauses, fallback,
                 )))
+            }
+            StringCaseBranches::UtfCodepointFunction { clauses, fallback } => {
+                Self::function(FunctionExpr::utf_codepoint(
+                    UtfCodepointFunctionExpr::string_case(subject, clauses, fallback),
+                ))
             }
             StringCaseBranches::FloatFunction { clauses, fallback } => Self::function(
                 FunctionExpr::float(FloatFunctionExpr::string_case(subject, clauses, fallback)),
@@ -308,6 +342,9 @@ impl Expr {
             FloatCaseBranches::BitArray { clauses, fallback } => {
                 Self::bit_array(BitArrayExpr::float_case(subject, clauses, fallback))
             }
+            FloatCaseBranches::UtfCodepoint { clauses, fallback } => {
+                Self::utf_codepoint(UtfCodepointExpr::float_case(subject, clauses, fallback))
+            }
             FloatCaseBranches::Float { clauses, fallback } => {
                 Self::float(FloatExpr::float_case(subject, clauses, fallback))
             }
@@ -333,6 +370,11 @@ impl Expr {
                 Self::function(FunctionExpr::bit_array(BitArrayFunctionExpr::float_case(
                     subject, clauses, fallback,
                 )))
+            }
+            FloatCaseBranches::UtfCodepointFunction { clauses, fallback } => {
+                Self::function(FunctionExpr::utf_codepoint(
+                    UtfCodepointFunctionExpr::float_case(subject, clauses, fallback),
+                ))
             }
             FloatCaseBranches::FloatFunction { clauses, fallback } => Self::function(
                 FunctionExpr::float(FloatFunctionExpr::float_case(subject, clauses, fallback)),
@@ -386,6 +428,13 @@ impl Expr {
         }
     }
 
+    pub(crate) fn into_utf_codepoint(self) -> Option<UtfCodepointExpr> {
+        match self.kind {
+            ExprKind::UtfCodepoint(expression) => Some(expression),
+            _ => None,
+        }
+    }
+
     pub(crate) fn into_float(self) -> Option<FloatExpr> {
         match self.kind {
             ExprKind::Float(expression) => Some(expression),
@@ -434,6 +483,7 @@ impl Expr {
             ExprKind::Int(_) => ValueType::Int,
             ExprKind::String(_) => ValueType::String,
             ExprKind::BitArray(_) => ValueType::BitArray,
+            ExprKind::UtfCodepoint(_) => ValueType::UtfCodepoint,
             ExprKind::Float(_) => ValueType::Float,
             ExprKind::Bool(_) => ValueType::Bool,
             ExprKind::Nil(_) => ValueType::Nil,
@@ -455,6 +505,7 @@ mod tests {
         FloatCaseBranches, FloatExpr, FloatFunctionExpr, FunctionExpr, FunctionFunctionExpr,
         IntCaseBranches, IntExpr, IntFunctionExpr, ListCaseBranches, ListExpr, ListFunctionExpr,
         NilExpr, NilFunctionExpr, StringCaseBranches, StringExpr, StringFunctionExpr, TupleExpr,
+        UtfCodepointExpr,
     };
     use crate::plan::{
         BoolFunctionId, BoolFunctionReference, BoolLocalId, FloatFunctionId,
@@ -462,7 +513,7 @@ mod tests {
         FunctionReference, FunctionType, IntFunctionFunctionId, IntFunctionId,
         IntFunctionReference, IntListLocalId, IntLocalId, ListFunctionId, ListFunctionReference,
         ListLocal, NilFunctionId, NilFunctionReference, NilLocalId, ParamLocal, RuntimeFunctionId,
-        StringFunctionId, StringFunctionReference, StringLocalId, ValueType,
+        StringFunctionId, StringFunctionReference, StringLocalId, UtfCodepointLocalId, ValueType,
     };
     use num_bigint::BigInt;
 
@@ -1116,6 +1167,15 @@ mod tests {
         assert_eq!(
             Expr::string(StringExpr::value("geam".into())).into_string(),
             Some(StringExpr::value("geam".into())),
+        );
+        let codepoint = UtfCodepointExpr::local_get(UtfCodepointLocalId(0), "codepoint".into());
+        assert_eq!(
+            Expr::utf_codepoint(codepoint.clone()).into_utf_codepoint(),
+            Some(codepoint),
+        );
+        assert_eq!(
+            Expr::int(IntExpr::value(BigInt::from(1))).into_utf_codepoint(),
+            None,
         );
         assert_eq!(
             Expr::float(FloatExpr::value(1.5)).into_float(),

--- a/src/plan/module/expression/arg.rs
+++ b/src/plan/module/expression/arg.rs
@@ -2,13 +2,14 @@ use super::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, Expr, ExprKind, FloatExpr,
     FloatFunctionExpr, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr, ListFunctionExpr,
     ListLocalExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr,
-    TupleFunctionExpr,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr,
 };
 use crate::plan::{
     BitArrayFunctionLocalId, BitArrayLocalId, BoolFunctionLocalId, BoolLocalId,
     FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId, IntFunctionLocalId, IntLocalId,
     ListFunctionLocal, ListLocal, NilFunctionLocalId, NilLocalId, ParamLocal,
     StringFunctionLocalId, StringLocalId, TupleFunctionLocalId, TupleLocalId,
+    UtfCodepointFunctionLocalId, UtfCodepointLocalId,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -29,6 +30,10 @@ pub(crate) enum CallArgKind {
     BitArray {
         local: BitArrayLocalId,
         value: BitArrayExpr,
+    },
+    UtfCodepoint {
+        local: UtfCodepointLocalId,
+        value: UtfCodepointExpr,
     },
     Float {
         local: FloatLocalId,
@@ -58,6 +63,10 @@ pub(crate) enum CallArgKind {
     BitArrayFunction {
         local: BitArrayFunctionLocalId,
         value: BitArrayFunctionExpr,
+    },
+    UtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
+        value: UtfCodepointFunctionExpr,
     },
     FloatFunction {
         local: FloatFunctionLocalId,
@@ -104,6 +113,10 @@ pub(crate) enum CaptureArgKind {
         local: BitArrayLocalId,
         value: BitArrayExpr,
     },
+    UtfCodepoint {
+        local: UtfCodepointLocalId,
+        value: UtfCodepointExpr,
+    },
     Float {
         local: FloatLocalId,
         value: FloatExpr,
@@ -132,6 +145,10 @@ pub(crate) enum CaptureArgKind {
     BitArrayFunction {
         local: BitArrayFunctionLocalId,
         value: BitArrayFunctionExpr,
+    },
+    UtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
+        value: UtfCodepointFunctionExpr,
     },
     FloatFunction {
         local: FloatFunctionLocalId,
@@ -169,6 +186,9 @@ impl Expr {
             (ParamLocal::BitArray(local), ExprKind::BitArray(value)) => {
                 Some(CallArg::bit_array(*local, value))
             }
+            (ParamLocal::UtfCodepoint(local), ExprKind::UtfCodepoint(value)) => {
+                Some(CallArg::utf_codepoint(*local, value))
+            }
             (ParamLocal::Float(local), ExprKind::Float(value)) => {
                 Some(CallArg::float(*local, value))
             }
@@ -198,6 +218,13 @@ impl Expr {
                 ParamLocal::List(ListLocal::BitArray(local)),
                 ExprKind::List(ListExpr::BitArray(value)),
             ) => Some(CallArg::list(ListLocalExpr::BitArray {
+                local: *local,
+                value,
+            })),
+            (
+                ParamLocal::List(ListLocal::UtfCodepoint(local)),
+                ExprKind::List(ListExpr::UtfCodepoint(value)),
+            ) => Some(CallArg::list(ListLocalExpr::UtfCodepoint {
                 local: *local,
                 value,
             })),
@@ -277,6 +304,15 @@ impl Expr {
                 .into_bit_array()
                 .map(|value| CallArg::bit_array_function(*local, value)),
             (
+                ParamLocal::UtfCodepointFunction {
+                    local,
+                    type_: expected,
+                },
+                ExprKind::Function(value),
+            ) if value.type_() == expected => value
+                .into_utf_codepoint()
+                .map(|value| CallArg::utf_codepoint_function(*local, value)),
+            (
                 ParamLocal::FloatFunction {
                     local,
                     type_: expected,
@@ -352,6 +388,12 @@ impl CallArg {
         }
     }
 
+    pub(crate) fn utf_codepoint(local: UtfCodepointLocalId, value: UtfCodepointExpr) -> Self {
+        Self {
+            kind: CallArgKind::UtfCodepoint { local, value },
+        }
+    }
+
     pub(crate) fn float(local: FloatLocalId, value: FloatExpr) -> Self {
         Self {
             kind: CallArgKind::Float { local, value },
@@ -400,6 +442,15 @@ impl CallArg {
     ) -> Self {
         Self {
             kind: CallArgKind::BitArrayFunction { local, value },
+        }
+    }
+
+    pub(crate) fn utf_codepoint_function(
+        local: UtfCodepointFunctionLocalId,
+        value: UtfCodepointFunctionExpr,
+    ) -> Self {
+        Self {
+            kind: CallArgKind::UtfCodepointFunction { local, value },
         }
     }
 
@@ -470,6 +521,12 @@ impl CaptureArg {
         }
     }
 
+    pub(crate) fn utf_codepoint(local: UtfCodepointLocalId, value: UtfCodepointExpr) -> Self {
+        Self {
+            kind: CaptureArgKind::UtfCodepoint { local, value },
+        }
+    }
+
     pub(crate) fn float(local: FloatLocalId, value: FloatExpr) -> Self {
         Self {
             kind: CaptureArgKind::Float { local, value },
@@ -518,6 +575,15 @@ impl CaptureArg {
     ) -> Self {
         Self {
             kind: CaptureArgKind::BitArrayFunction { local, value },
+        }
+    }
+
+    pub(crate) fn utf_codepoint_function(
+        local: UtfCodepointFunctionLocalId,
+        value: UtfCodepointFunctionExpr,
+    ) -> Self {
+        Self {
+            kind: CaptureArgKind::UtfCodepointFunction { local, value },
         }
     }
 

--- a/src/plan/module/expression/bit_array.rs
+++ b/src/plan/module/expression/bit_array.rs
@@ -1,6 +1,6 @@
 use super::{
     BitArrayFunctionExpr, BitArrayListExpr, BoolExpr, CallArg, FloatExpr, IntExpr, PanicExpr,
-    StringExpr, TupleExpr,
+    StringExpr, TupleExpr, UtfCodepointExpr,
 };
 use crate::plan::{BitArrayFunctionId, BitArrayLocalId, Step};
 use ecow::EcoString;
@@ -40,6 +40,10 @@ pub enum BitArraySegment {
     },
     String {
         value: StringExpr,
+        encoding: StringEncoding,
+    },
+    UtfCodepoint {
+        value: UtfCodepointExpr,
         encoding: StringEncoding,
     },
     Bits(BitArrayExpr),

--- a/src/plan/module/expression/case.rs
+++ b/src/plan/module/expression/case.rs
@@ -2,7 +2,7 @@ use super::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, BoolListCaseBranches,
     FloatExpr, FloatFunctionExpr, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListCaseBranches,
     ListFunctionExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr,
-    TupleFunctionExpr,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -20,6 +20,10 @@ pub(crate) enum BoolCaseBranches {
     BitArray {
         true_: BitArrayExpr,
         false_: BitArrayExpr,
+    },
+    UtfCodepoint {
+        true_: UtfCodepointExpr,
+        false_: UtfCodepointExpr,
     },
     Float {
         true_: FloatExpr,
@@ -49,6 +53,10 @@ pub(crate) enum BoolCaseBranches {
     BitArrayFunction {
         true_: BitArrayFunctionExpr,
         false_: BitArrayFunctionExpr,
+    },
+    UtfCodepointFunction {
+        true_: UtfCodepointFunctionExpr,
+        false_: UtfCodepointFunctionExpr,
     },
     FloatFunction {
         true_: FloatFunctionExpr,
@@ -90,6 +98,10 @@ pub(crate) enum IntCaseBranches {
         clauses: Vec<(BigInt, BitArrayExpr)>,
         fallback: BitArrayExpr,
     },
+    UtfCodepoint {
+        clauses: Vec<(BigInt, UtfCodepointExpr)>,
+        fallback: UtfCodepointExpr,
+    },
     Float {
         clauses: Vec<(BigInt, FloatExpr)>,
         fallback: FloatExpr,
@@ -118,6 +130,10 @@ pub(crate) enum IntCaseBranches {
     BitArrayFunction {
         clauses: Vec<(BigInt, BitArrayFunctionExpr)>,
         fallback: BitArrayFunctionExpr,
+    },
+    UtfCodepointFunction {
+        clauses: Vec<(BigInt, UtfCodepointFunctionExpr)>,
+        fallback: UtfCodepointFunctionExpr,
     },
     FloatFunction {
         clauses: Vec<(BigInt, FloatFunctionExpr)>,
@@ -159,6 +175,10 @@ pub(crate) enum StringCaseBranches {
         clauses: Vec<(EcoString, BitArrayExpr)>,
         fallback: BitArrayExpr,
     },
+    UtfCodepoint {
+        clauses: Vec<(EcoString, UtfCodepointExpr)>,
+        fallback: UtfCodepointExpr,
+    },
     Float {
         clauses: Vec<(EcoString, FloatExpr)>,
         fallback: FloatExpr,
@@ -187,6 +207,10 @@ pub(crate) enum StringCaseBranches {
     BitArrayFunction {
         clauses: Vec<(EcoString, BitArrayFunctionExpr)>,
         fallback: BitArrayFunctionExpr,
+    },
+    UtfCodepointFunction {
+        clauses: Vec<(EcoString, UtfCodepointFunctionExpr)>,
+        fallback: UtfCodepointFunctionExpr,
     },
     FloatFunction {
         clauses: Vec<(EcoString, FloatFunctionExpr)>,
@@ -228,6 +252,10 @@ pub(crate) enum FloatCaseBranches {
         clauses: Vec<(f64, BitArrayExpr)>,
         fallback: BitArrayExpr,
     },
+    UtfCodepoint {
+        clauses: Vec<(f64, UtfCodepointExpr)>,
+        fallback: UtfCodepointExpr,
+    },
     Float {
         clauses: Vec<(f64, FloatExpr)>,
         fallback: FloatExpr,
@@ -256,6 +284,10 @@ pub(crate) enum FloatCaseBranches {
     BitArrayFunction {
         clauses: Vec<(f64, BitArrayFunctionExpr)>,
         fallback: BitArrayFunctionExpr,
+    },
+    UtfCodepointFunction {
+        clauses: Vec<(f64, UtfCodepointFunctionExpr)>,
+        fallback: UtfCodepointFunctionExpr,
     },
     FloatFunction {
         clauses: Vec<(f64, FloatFunctionExpr)>,

--- a/src/plan/module/expression/function.rs
+++ b/src/plan/module/expression/function.rs
@@ -7,24 +7,26 @@ mod nil;
 mod returning_function;
 mod string;
 mod tuple;
+mod utf_codepoint;
 
 use crate::plan::{
     BitArrayFunctionReference, BoolFunctionReference, FloatFunctionReference,
     FunctionFunctionReference, FunctionReference, FunctionType, IntFunctionReference,
     ListFunctionReference, NilFunctionReference, RuntimeFunctionId, StringFunctionReference,
-    TupleFunctionReference,
+    TupleFunctionReference, UtfCodepointFunctionReference,
 };
 
 pub use self::{
     bit_array::BitArrayFunctionExpr, bool::BoolFunctionExpr, float::FloatFunctionExpr,
     int::IntFunctionExpr, list::ListFunctionExpr, nil::NilFunctionExpr,
     returning_function::FunctionFunctionExpr, string::StringFunctionExpr, tuple::TupleFunctionExpr,
+    utf_codepoint::UtfCodepointFunctionExpr,
 };
 pub(crate) use self::{
     bit_array::BitArrayFunctionExprKind, bool::BoolFunctionExprKind, float::FloatFunctionExprKind,
     int::IntFunctionExprKind, list::ListFunctionExprKind, nil::NilFunctionExprKind,
     returning_function::FunctionFunctionExprKind, string::StringFunctionExprKind,
-    tuple::TupleFunctionExprKind,
+    tuple::TupleFunctionExprKind, utf_codepoint::UtfCodepointFunctionExprKind,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -37,6 +39,7 @@ pub(crate) enum FunctionExprKind {
     Int(IntFunctionExpr),
     String(StringFunctionExpr),
     BitArray(BitArrayFunctionExpr),
+    UtfCodepoint(UtfCodepointFunctionExpr),
     Float(FloatFunctionExpr),
     Bool(BoolFunctionExpr),
     Nil(NilFunctionExpr),
@@ -61,6 +64,9 @@ impl FunctionExpr {
             RuntimeFunctionId::BitArray(id) => Self::bit_array(BitArrayFunctionExpr::reference(
                 BitArrayFunctionReference::new(id, params),
             )),
+            RuntimeFunctionId::UtfCodepoint(id) => Self::utf_codepoint(
+                UtfCodepointFunctionExpr::reference(UtfCodepointFunctionReference::new(id, params)),
+            ),
             RuntimeFunctionId::Bool(id) => Self::bool(BoolFunctionExpr::reference(
                 BoolFunctionReference::new(id, params),
             )),
@@ -97,6 +103,12 @@ impl FunctionExpr {
     pub(crate) fn bit_array(expression: BitArrayFunctionExpr) -> Self {
         Self {
             kind: FunctionExprKind::BitArray(expression),
+        }
+    }
+
+    pub(crate) fn utf_codepoint(expression: UtfCodepointFunctionExpr) -> Self {
+        Self {
+            kind: FunctionExprKind::UtfCodepoint(expression),
         }
     }
 
@@ -141,6 +153,7 @@ impl FunctionExpr {
             FunctionExprKind::Int(expression) => expression.type_(),
             FunctionExprKind::String(expression) => expression.type_(),
             FunctionExprKind::BitArray(expression) => expression.type_(),
+            FunctionExprKind::UtfCodepoint(expression) => expression.type_(),
             FunctionExprKind::Float(expression) => expression.type_(),
             FunctionExprKind::Bool(expression) => expression.type_(),
             FunctionExprKind::Nil(expression) => expression.type_(),
@@ -175,6 +188,13 @@ impl FunctionExpr {
     pub(crate) fn into_bit_array(self) -> Option<BitArrayFunctionExpr> {
         match self.kind {
             FunctionExprKind::BitArray(expression) => Some(expression),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn into_utf_codepoint(self) -> Option<UtfCodepointFunctionExpr> {
+        match self.kind {
+            FunctionExprKind::UtfCodepoint(expression) => Some(expression),
             _ => None,
         }
     }
@@ -240,6 +260,12 @@ impl From<BitArrayFunctionExpr> for FunctionExpr {
     }
 }
 
+impl From<UtfCodepointFunctionExpr> for FunctionExpr {
+    fn from(expression: UtfCodepointFunctionExpr) -> Self {
+        Self::utf_codepoint(expression)
+    }
+}
+
 impl From<FloatFunctionExpr> for FunctionExpr {
     fn from(expression: FloatFunctionExpr) -> Self {
         Self::float(expression)
@@ -281,7 +307,7 @@ mod tests {
     use super::{
         BitArrayFunctionExpr, BoolFunctionExpr, FloatFunctionExpr, FunctionExpr, FunctionExprKind,
         FunctionFunctionExpr, IntFunctionExpr, ListFunctionExpr, NilFunctionExpr,
-        StringFunctionExpr, TupleFunctionExpr,
+        StringFunctionExpr, TupleFunctionExpr, UtfCodepointFunctionExpr,
     };
     use crate::plan::{
         BitArrayFunctionId, BitArrayFunctionReference, BoolFunctionId, BoolFunctionReference,
@@ -289,7 +315,8 @@ mod tests {
         FunctionReference, FunctionType, IntFunctionFunctionId, IntFunctionId,
         IntFunctionReference, ListFunctionId, ListFunctionReference, NilFunctionId,
         NilFunctionReference, ParamLocal, RuntimeFunctionId, StringFunctionId,
-        StringFunctionReference, TupleFunctionId, TupleFunctionReference, ValueType,
+        StringFunctionReference, TupleFunctionId, TupleFunctionReference, UtfCodepointFunctionId,
+        UtfCodepointFunctionReference, ValueType,
     };
 
     #[test]
@@ -305,6 +332,10 @@ mod tests {
         assert_eq!(
             FunctionExpr::bit_array(bit_array_function_value()).kind(),
             &FunctionExprKind::BitArray(bit_array_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::utf_codepoint(utf_codepoint_function_value()).kind(),
+            &FunctionExprKind::UtfCodepoint(utf_codepoint_function_value()),
         );
         assert_eq!(
             FunctionExpr::float(float_function_value()).kind(),
@@ -347,6 +378,10 @@ mod tests {
             &FunctionExprKind::BitArray(bit_array_function_value()),
         );
         assert_eq!(
+            FunctionExpr::reference(utf_codepoint_function_reference()).kind(),
+            &FunctionExprKind::UtfCodepoint(utf_codepoint_function_value()),
+        );
+        assert_eq!(
             FunctionExpr::reference(float_function_reference()).kind(),
             &FunctionExprKind::Float(float_function_value()),
         );
@@ -387,6 +422,10 @@ mod tests {
             &bit_array_function_type(),
         );
         assert_eq!(
+            FunctionExpr::utf_codepoint(utf_codepoint_function_value()).type_(),
+            &utf_codepoint_function_type(),
+        );
+        assert_eq!(
             FunctionExpr::float(float_function_value()).type_(),
             &float_function_type(),
         );
@@ -424,6 +463,10 @@ mod tests {
             Some(bit_array_function_value()),
         );
         assert_eq!(
+            FunctionExpr::utf_codepoint(utf_codepoint_function_value()).into_utf_codepoint(),
+            Some(utf_codepoint_function_value()),
+        );
+        assert_eq!(
             FunctionExpr::float(float_function_value()).into_float(),
             Some(float_function_value()),
         );
@@ -457,6 +500,10 @@ mod tests {
             FunctionExpr::int(int_function_value()).into_bit_array(),
             None
         );
+        assert_eq!(
+            FunctionExpr::int(int_function_value()).into_utf_codepoint(),
+            None,
+        );
         assert_eq!(FunctionExpr::int(int_function_value()).into_float(), None);
         assert_eq!(FunctionExpr::int(int_function_value()).into_bool(), None);
         assert_eq!(FunctionExpr::int(int_function_value()).into_nil(), None);
@@ -478,6 +525,10 @@ mod tests {
         assert_eq!(
             FunctionExpr::from(bit_array_function_value()),
             FunctionExpr::bit_array(bit_array_function_value()),
+        );
+        assert_eq!(
+            FunctionExpr::from(utf_codepoint_function_value()),
+            FunctionExpr::utf_codepoint(utf_codepoint_function_value()),
         );
         assert_eq!(
             FunctionExpr::from(float_function_value()),
@@ -523,6 +574,15 @@ mod tests {
         FunctionReference::new(
             RuntimeFunctionId::BitArray(BitArrayFunctionId(0)),
             vec![ParamLocal::bit_array(crate::plan::BitArrayLocalId(0))],
+        )
+    }
+
+    fn utf_codepoint_function_reference() -> FunctionReference {
+        FunctionReference::new(
+            RuntimeFunctionId::UtfCodepoint(UtfCodepointFunctionId(0)),
+            vec![ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(
+                0,
+            ))],
         )
     }
 
@@ -603,6 +663,15 @@ mod tests {
         ))
     }
 
+    fn utf_codepoint_function_value() -> UtfCodepointFunctionExpr {
+        UtfCodepointFunctionExpr::reference(UtfCodepointFunctionReference::new(
+            UtfCodepointFunctionId(0),
+            vec![ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(
+                0,
+            ))],
+        ))
+    }
+
     fn float_function_value() -> FloatFunctionExpr {
         FloatFunctionExpr::reference(FloatFunctionReference::new(
             FloatFunctionId(0),
@@ -666,6 +735,10 @@ mod tests {
 
     fn bit_array_function_type() -> FunctionType {
         FunctionType::new(vec![ValueType::BitArray], ValueType::BitArray)
+    }
+
+    fn utf_codepoint_function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::UtfCodepoint], ValueType::UtfCodepoint)
     }
 
     fn float_function_type() -> FunctionType {

--- a/src/plan/module/expression/function/utf_codepoint.rs
+++ b/src/plan/module/expression/function/utf_codepoint.rs
@@ -1,0 +1,437 @@
+use crate::plan::{
+    BoolExpr, CaptureArg, FloatExpr, FunctionFunctionExpr, FunctionListExpr, FunctionType, IntExpr,
+    PanicExpr, ParamLocal, Step, StringExpr, TupleExpr, UtfCodepointFunctionFunctionId,
+    UtfCodepointFunctionId, UtfCodepointFunctionLocalId, UtfCodepointFunctionReference,
+};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UtfCodepointFunctionExpr {
+    type_: FunctionType,
+    kind: UtfCodepointFunctionExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum UtfCodepointFunctionExprKind {
+    Reference(UtfCodepointFunctionReference),
+    Closure {
+        runtime_id: UtfCodepointFunctionId,
+        params: Vec<ParamLocal>,
+        captures: Vec<CaptureArg>,
+    },
+    LocalGet {
+        local: UtfCodepointFunctionLocalId,
+        name: EcoString,
+    },
+    Call {
+        function: UtfCodepointFunctionFunctionId,
+        args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    FunctionCall {
+        function: Box<FunctionFunctionExpr>,
+        args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
+        type_: FunctionType,
+    },
+    ListIndex {
+        list: Box<FunctionListExpr>,
+        index: usize,
+        type_: FunctionType,
+    },
+    Panic(PanicExpr),
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<UtfCodepointFunctionExpr>,
+        false_: Box<UtfCodepointFunctionExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, UtfCodepointFunctionExpr)>,
+        fallback: Box<UtfCodepointFunctionExpr>,
+    },
+    StringCase {
+        subject: Box<StringExpr>,
+        clauses: Vec<(EcoString, UtfCodepointFunctionExpr)>,
+        fallback: Box<UtfCodepointFunctionExpr>,
+    },
+    FloatCase {
+        subject: Box<FloatExpr>,
+        clauses: Vec<(f64, UtfCodepointFunctionExpr)>,
+        fallback: Box<UtfCodepointFunctionExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<UtfCodepointFunctionExpr>,
+    },
+}
+
+impl UtfCodepointFunctionExpr {
+    pub(crate) fn reference(value: UtfCodepointFunctionReference) -> Self {
+        let type_ = FunctionType::new(
+            value.params().iter().map(ParamLocal::value_type).collect(),
+            crate::plan::ValueType::UtfCodepoint,
+        );
+        Self {
+            type_,
+            kind: UtfCodepointFunctionExprKind::Reference(value),
+        }
+    }
+
+    pub(crate) fn closure(
+        runtime_id: UtfCodepointFunctionId,
+        params: Vec<ParamLocal>,
+        captures: Vec<CaptureArg>,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: UtfCodepointFunctionExprKind::Closure {
+                runtime_id,
+                params,
+                captures,
+            },
+        }
+    }
+
+    pub(crate) fn local_get(
+        local: UtfCodepointFunctionLocalId,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_,
+            kind: UtfCodepointFunctionExprKind::LocalGet { local, name },
+        }
+    }
+
+    pub(crate) fn call(
+        function: UtfCodepointFunctionFunctionId,
+        args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: UtfCodepointFunctionExprKind::Call {
+                function,
+                args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn function_call(
+        function: FunctionFunctionExpr,
+        args: Vec<crate::plan::CallArg>,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: UtfCodepointFunctionExprKind::FunctionCall {
+                function: Box::new(function),
+                args,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize, type_: FunctionType) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: UtfCodepointFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple),
+                index,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn list_index(
+        list: impl Into<FunctionListExpr>,
+        index: usize,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            type_: type_.clone(),
+            kind: UtfCodepointFunctionExprKind::ListIndex {
+                list: Box::new(list.into()),
+                index,
+                type_,
+            },
+        }
+    }
+
+    pub(crate) fn panic(panic: PanicExpr, type_: FunctionType) -> Self {
+        Self {
+            type_,
+            kind: UtfCodepointFunctionExprKind::Panic(panic),
+        }
+    }
+
+    pub(crate) fn bool_case(
+        subject: BoolExpr,
+        true_: UtfCodepointFunctionExpr,
+        false_: UtfCodepointFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: true_.type_.clone(),
+            kind: UtfCodepointFunctionExprKind::BoolCase {
+                subject: Box::new(subject),
+                true_: Box::new(true_),
+                false_: Box::new(false_),
+            },
+        }
+    }
+
+    pub(crate) fn int_case(
+        subject: IntExpr,
+        clauses: Vec<(BigInt, UtfCodepointFunctionExpr)>,
+        fallback: UtfCodepointFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: UtfCodepointFunctionExprKind::IntCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn string_case(
+        subject: StringExpr,
+        clauses: Vec<(EcoString, UtfCodepointFunctionExpr)>,
+        fallback: UtfCodepointFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: UtfCodepointFunctionExprKind::StringCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn float_case(
+        subject: FloatExpr,
+        clauses: Vec<(f64, UtfCodepointFunctionExpr)>,
+        fallback: UtfCodepointFunctionExpr,
+    ) -> Self {
+        Self {
+            type_: fallback.type_.clone(),
+            kind: UtfCodepointFunctionExprKind::FloatCase {
+                subject: Box::new(subject),
+                clauses,
+                fallback: Box::new(fallback),
+            },
+        }
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: UtfCodepointFunctionExpr) -> Self {
+        Self {
+            type_: return_.type_.clone(),
+            kind: UtfCodepointFunctionExprKind::Block {
+                steps,
+                return_: Box::new(return_),
+            },
+        }
+    }
+
+    pub fn type_(&self) -> &FunctionType {
+        &self.type_
+    }
+
+    pub(crate) fn kind(&self) -> &UtfCodepointFunctionExprKind {
+        &self.kind
+    }
+
+    pub(crate) fn into_parts(self) -> (FunctionType, UtfCodepointFunctionExprKind) {
+        (self.type_, self.kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UtfCodepointFunctionExpr, UtfCodepointFunctionExprKind};
+    use crate::plan::{
+        BoolExpr, Expr, FunctionFunctionExpr, FunctionFunctionId, FunctionFunctionReference,
+        FunctionType, IntExpr, ParamLocal, Step, StringExpr, UtfCodepointFunctionFunctionId,
+        UtfCodepointFunctionId, UtfCodepointFunctionLocalId, UtfCodepointFunctionReference,
+        UtfCodepointLocalId, ValueType,
+    };
+
+    #[test]
+    fn utf_codepoint_function_expr_kind_accessors() {
+        assert_eq!(
+            function_value().kind(),
+            &UtfCodepointFunctionExprKind::Reference(UtfCodepointFunctionReference::new(
+                UtfCodepointFunctionId(0),
+                vec![ParamLocal::utf_codepoint(UtfCodepointLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::closure(
+                UtfCodepointFunctionId(0),
+                vec![ParamLocal::utf_codepoint(UtfCodepointLocalId(0))],
+                Vec::new(),
+                function_type(),
+            )
+            .kind(),
+            &UtfCodepointFunctionExprKind::Closure {
+                runtime_id: UtfCodepointFunctionId(0),
+                params: vec![ParamLocal::utf_codepoint(UtfCodepointLocalId(0))],
+                captures: Vec::new(),
+            },
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::local_get(
+                UtfCodepointFunctionLocalId(0),
+                "f".into(),
+                function_type(),
+            )
+            .kind(),
+            &UtfCodepointFunctionExprKind::LocalGet {
+                local: UtfCodepointFunctionLocalId(0),
+                name: "f".into(),
+            },
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::call(
+                UtfCodepointFunctionFunctionId(0),
+                Vec::new(),
+                function_type(),
+            )
+            .kind(),
+            &UtfCodepointFunctionExprKind::Call {
+                function: UtfCodepointFunctionFunctionId(0),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::function_call(
+                function_function_value(),
+                Vec::new(),
+                function_type(),
+            )
+            .kind(),
+            &UtfCodepointFunctionExprKind::FunctionCall {
+                function: Box::new(function_function_value()),
+                args: Vec::new(),
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::tuple_index(tuple_expr(), 0, function_type()).kind(),
+            &UtfCodepointFunctionExprKind::TupleIndex {
+                tuple: Box::new(tuple_expr()),
+                index: 0,
+                type_: function_type(),
+            },
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::bool_case(
+                BoolExpr::value(true),
+                function_value(),
+                function_value(),
+            )
+            .kind(),
+            &UtfCodepointFunctionExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(function_value()),
+                false_: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), function_value())],
+                function_value(),
+            )
+            .kind(),
+            &UtfCodepointFunctionExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), function_value())],
+                function_value(),
+            )
+            .kind(),
+            &UtfCodepointFunctionExprKind::StringCase {
+                subject: Box::new(StringExpr::value("one".into())),
+                clauses: vec![("one".into(), function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::float_case(
+                crate::plan::FloatExpr::value(1.0),
+                vec![(1.0, function_value())],
+                function_value(),
+            )
+            .kind(),
+            &UtfCodepointFunctionExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, function_value())],
+                fallback: Box::new(function_value()),
+            },
+        );
+        assert_eq!(
+            UtfCodepointFunctionExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(0.into())))],
+                function_value(),
+            )
+            .kind(),
+            &UtfCodepointFunctionExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(0.into())))],
+                return_: Box::new(function_value()),
+            },
+        );
+    }
+
+    #[test]
+    fn utf_codepoint_function_expr_type() {
+        assert_eq!(function_value().type_(), &function_type());
+    }
+
+    fn function_value() -> UtfCodepointFunctionExpr {
+        UtfCodepointFunctionExpr::reference(UtfCodepointFunctionReference::new(
+            UtfCodepointFunctionId(0),
+            vec![ParamLocal::utf_codepoint(UtfCodepointLocalId(0))],
+        ))
+    }
+
+    fn function_type() -> FunctionType {
+        FunctionType::new(vec![ValueType::UtfCodepoint], ValueType::UtfCodepoint)
+    }
+
+    fn function_function_value() -> FunctionFunctionExpr {
+        FunctionFunctionExpr::reference(
+            FunctionFunctionReference::new(
+                FunctionFunctionId::UtfCodepoint(UtfCodepointFunctionFunctionId(0)),
+                Vec::new(),
+            ),
+            function_type(),
+        )
+    }
+
+    fn tuple_expr() -> crate::plan::TupleExpr {
+        crate::plan::TupleExpr::value(
+            vec![Expr::function(crate::plan::FunctionExpr::utf_codepoint(
+                function_value(),
+            ))],
+            vec![ValueType::Function(Box::new(function_type()))],
+        )
+    }
+}

--- a/src/plan/module/expression/list.rs
+++ b/src/plan/module/expression/list.rs
@@ -9,7 +9,7 @@ pub(crate) use self::{
     elements::{ListElementTypeMismatch, ListElements, ListSpreadElements},
     item::{
         BitArrayListItem, BoolListItem, FloatListItem, FunctionListItem, IntListItem, ListItem,
-        ListListItem, NilListItem, StringListItem, TupleListItem,
+        ListListItem, NilListItem, StringListItem, TupleListItem, UtfCodepointListItem,
     },
     local::ListLocalExpr,
     typed::{ListIndexSource, TypedListExpr, TypedListExprKind, TypedListReturnKind},
@@ -26,6 +26,7 @@ pub(crate) enum ListExpr {
     Int(IntListExpr),
     String(StringListExpr),
     BitArray(BitArrayListExpr),
+    UtfCodepoint(UtfCodepointListExpr),
     Float(FloatListExpr),
     Bool(BoolListExpr),
     Nil(NilListExpr),
@@ -37,6 +38,7 @@ pub(crate) enum ListExpr {
 pub(crate) type IntListExpr = TypedListExpr<IntListItem>;
 pub(crate) type StringListExpr = TypedListExpr<StringListItem>;
 pub(crate) type BitArrayListExpr = TypedListExpr<BitArrayListItem>;
+pub(crate) type UtfCodepointListExpr = TypedListExpr<UtfCodepointListItem>;
 pub(crate) type FloatListExpr = TypedListExpr<FloatListItem>;
 pub(crate) type BoolListExpr = TypedListExpr<BoolListItem>;
 pub(crate) type NilListExpr = TypedListExpr<NilListItem>;
@@ -60,6 +62,9 @@ impl ListExpr {
             }
             ListElements::BitArray(values) => {
                 Self::BitArray(BitArrayListExpr::value(BitArrayListItem, values))
+            }
+            ListElements::UtfCodepoint(values) => {
+                Self::UtfCodepoint(UtfCodepointListExpr::value(UtfCodepointListItem, values))
             }
             ListElements::Float(values) => Self::Float(FloatListExpr::value(FloatListItem, values)),
             ListElements::Bool(values) => Self::Bool(BoolListExpr::value(BoolListItem, values)),
@@ -89,6 +94,9 @@ impl ListExpr {
             }
             ListSpreadElements::BitArray { values, tail } => {
                 Self::BitArray(BitArrayListExpr::spread(values, tail))
+            }
+            ListSpreadElements::UtfCodepoint { values, tail } => {
+                Self::UtfCodepoint(UtfCodepointListExpr::spread(values, tail))
             }
             ListSpreadElements::Float { values, tail } => {
                 Self::Float(FloatListExpr::spread(values, tail))
@@ -120,6 +128,11 @@ impl ListExpr {
             ListLocal::BitArray(local) => {
                 Self::BitArray(BitArrayListExpr::local_get(BitArrayListItem, local, name))
             }
+            ListLocal::UtfCodepoint(local) => Self::UtfCodepoint(UtfCodepointListExpr::local_get(
+                UtfCodepointListItem,
+                local,
+                name,
+            )),
             ListLocal::Float(local) => {
                 Self::Float(FloatListExpr::local_get(FloatListItem, local, name))
             }
@@ -153,6 +166,9 @@ impl ListExpr {
             ListFunctionId::BitArray(function) => {
                 Self::BitArray(BitArrayListExpr::call(BitArrayListItem, function, args))
             }
+            ListFunctionId::UtfCodepoint(function) => Self::UtfCodepoint(
+                UtfCodepointListExpr::call(UtfCodepointListItem, function, args),
+            ),
             ListFunctionId::Float(function) => {
                 Self::Float(FloatListExpr::call(FloatListItem, function, args))
             }
@@ -187,6 +203,11 @@ impl ListExpr {
             )),
             ValueType::BitArray => Self::BitArray(BitArrayListExpr::function_call(
                 BitArrayListItem,
+                function,
+                args,
+            )),
+            ValueType::UtfCodepoint => Self::UtfCodepoint(UtfCodepointListExpr::function_call(
+                UtfCodepointListItem,
                 function,
                 args,
             )),
@@ -225,6 +246,11 @@ impl ListExpr {
                 tuple,
                 index,
             )),
+            ValueType::UtfCodepoint => Self::UtfCodepoint(UtfCodepointListExpr::tuple_index(
+                UtfCodepointListItem,
+                tuple,
+                index,
+            )),
             ValueType::Float => {
                 Self::Float(FloatListExpr::tuple_index(FloatListItem, tuple, index))
             }
@@ -260,6 +286,10 @@ impl ListExpr {
             )),
             ValueType::BitArray => Self::BitArray(BitArrayListExpr::from_list_index(
                 BitArrayListItem,
+                ListIndexSource::new(list, index),
+            )),
+            ValueType::UtfCodepoint => Self::UtfCodepoint(UtfCodepointListExpr::from_list_index(
+                UtfCodepointListItem,
                 ListIndexSource::new(list, index),
             )),
             ValueType::Float => Self::Float(FloatListExpr::from_list_index(
@@ -305,6 +335,9 @@ impl ListExpr {
             Self::Int(list) => Self::Int(IntListExpr::drop_first(list, count)),
             Self::String(list) => Self::String(StringListExpr::drop_first(list, count)),
             Self::BitArray(list) => Self::BitArray(BitArrayListExpr::drop_first(list, count)),
+            Self::UtfCodepoint(list) => {
+                Self::UtfCodepoint(UtfCodepointListExpr::drop_first(list, count))
+            }
             Self::Float(list) => Self::Float(FloatListExpr::drop_first(list, count)),
             Self::Bool(list) => Self::Bool(BoolListExpr::drop_first(list, count)),
             Self::Nil(list) => Self::Nil(NilListExpr::drop_first(list, count)),
@@ -319,6 +352,9 @@ impl ListExpr {
             ValueType::Int => Self::Int(IntListExpr::panic(IntListItem, panic)),
             ValueType::String => Self::String(StringListExpr::panic(StringListItem, panic)),
             ValueType::BitArray => Self::BitArray(BitArrayListExpr::panic(BitArrayListItem, panic)),
+            ValueType::UtfCodepoint => {
+                Self::UtfCodepoint(UtfCodepointListExpr::panic(UtfCodepointListItem, panic))
+            }
             ValueType::Float => Self::Float(FloatListExpr::panic(FloatListItem, panic)),
             ValueType::Bool => Self::Bool(BoolListExpr::panic(BoolListItem, panic)),
             ValueType::Nil => Self::Nil(NilListExpr::panic(NilListItem, panic)),
@@ -347,6 +383,9 @@ impl ListExpr {
             }
             BoolListCaseBranches::BitArray { true_, false_ } => {
                 Self::BitArray(BitArrayListExpr::bool_case(subject, true_, false_))
+            }
+            BoolListCaseBranches::UtfCodepoint { true_, false_ } => {
+                Self::UtfCodepoint(UtfCodepointListExpr::bool_case(subject, true_, false_))
             }
             BoolListCaseBranches::Float { true_, false_ } => {
                 Self::Float(FloatListExpr::bool_case(subject, true_, false_))
@@ -380,6 +419,9 @@ impl ListExpr {
             ListCaseBranches::BitArray { clauses, fallback } => {
                 Self::BitArray(BitArrayListExpr::int_case(subject, clauses, fallback))
             }
+            ListCaseBranches::UtfCodepoint { clauses, fallback } => {
+                Self::UtfCodepoint(UtfCodepointListExpr::int_case(subject, clauses, fallback))
+            }
             ListCaseBranches::Float { clauses, fallback } => {
                 Self::Float(FloatListExpr::int_case(subject, clauses, fallback))
             }
@@ -412,6 +454,9 @@ impl ListExpr {
             ListCaseBranches::BitArray { clauses, fallback } => {
                 Self::BitArray(BitArrayListExpr::string_case(subject, clauses, fallback))
             }
+            ListCaseBranches::UtfCodepoint { clauses, fallback } => Self::UtfCodepoint(
+                UtfCodepointListExpr::string_case(subject, clauses, fallback),
+            ),
             ListCaseBranches::Float { clauses, fallback } => {
                 Self::Float(FloatListExpr::string_case(subject, clauses, fallback))
             }
@@ -444,6 +489,9 @@ impl ListExpr {
             ListCaseBranches::BitArray { clauses, fallback } => {
                 Self::BitArray(BitArrayListExpr::float_case(subject, clauses, fallback))
             }
+            ListCaseBranches::UtfCodepoint { clauses, fallback } => {
+                Self::UtfCodepoint(UtfCodepointListExpr::float_case(subject, clauses, fallback))
+            }
             ListCaseBranches::Float { clauses, fallback } => {
                 Self::Float(FloatListExpr::float_case(subject, clauses, fallback))
             }
@@ -470,6 +518,9 @@ impl ListExpr {
             Self::Int(return_) => Self::Int(IntListExpr::block(steps, return_)),
             Self::String(return_) => Self::String(StringListExpr::block(steps, return_)),
             Self::BitArray(return_) => Self::BitArray(BitArrayListExpr::block(steps, return_)),
+            Self::UtfCodepoint(return_) => {
+                Self::UtfCodepoint(UtfCodepointListExpr::block(steps, return_))
+            }
             Self::Float(return_) => Self::Float(FloatListExpr::block(steps, return_)),
             Self::Bool(return_) => Self::Bool(BoolListExpr::block(steps, return_)),
             Self::Nil(return_) => Self::Nil(NilListExpr::block(steps, return_)),
@@ -484,6 +535,7 @@ impl ListExpr {
             Self::Int(expression) => expression.element_type(),
             Self::String(expression) => expression.element_type(),
             Self::BitArray(expression) => expression.element_type(),
+            Self::UtfCodepoint(expression) => expression.element_type(),
             Self::Float(expression) => expression.element_type(),
             Self::Bool(expression) => expression.element_type(),
             Self::Nil(expression) => expression.element_type(),
@@ -510,6 +562,13 @@ impl ListExpr {
     pub(crate) fn into_bit_array(self) -> Option<BitArrayListExpr> {
         match self {
             Self::BitArray(expression) => Some(expression),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn into_utf_codepoint(self) -> Option<UtfCodepointListExpr> {
+        match self {
+            Self::UtfCodepoint(expression) => Some(expression),
             _ => None,
         }
     }
@@ -585,13 +644,14 @@ mod tests {
         FloatListExpr, FloatListItem, FunctionListExpr, FunctionListItem, IntListExpr, IntListItem,
         ListCaseBranches, ListElementTypeMismatch, ListElements, ListExpr, ListIndexSource,
         ListListExpr, ListListItem, NilListExpr, NilListItem, StringListExpr, StringListItem,
-        TupleListExpr, TupleListItem,
+        TupleListExpr, TupleListItem, UtfCodepointListExpr, UtfCodepointListItem,
     };
     use crate::plan::{
         BitArrayExpr, BoolExpr, Expr, FloatExpr, FunctionExpr, FunctionReference, FunctionType,
         IntExpr, IntFunctionId, IntListFunctionId, IntListLocalId, ListFunctionExpr,
         ListFunctionId, ListFunctionReference, ListLocal, NilExpr, PanicExpr, PanicSite,
-        RuntimeFunctionId, Step, StringExpr, TupleExpr, ValueType,
+        RuntimeFunctionId, Step, StringExpr, TupleExpr, UtfCodepointExpr, UtfCodepointLocalId,
+        ValueType,
     };
     use num_bigint::BigInt;
 
@@ -626,6 +686,17 @@ mod tests {
             ListExpr::Bool(BoolListExpr::value(
                 BoolListItem,
                 vec![BoolExpr::value(true)],
+            )),
+        );
+        let codepoint = UtfCodepointExpr::local_get(UtfCodepointLocalId(0), "codepoint".into());
+        assert_eq!(
+            ListExpr::value(
+                vec![Expr::utf_codepoint(codepoint.clone())],
+                ValueType::UtfCodepoint,
+            ),
+            ListExpr::UtfCodepoint(UtfCodepointListExpr::value(
+                UtfCodepointListItem,
+                vec![codepoint],
             )),
         );
         assert_eq!(
@@ -753,6 +824,7 @@ mod tests {
         let int_list = ListExpr::value(vec![Expr::int(IntExpr::value(1.into()))], ValueType::Int);
         assert_eq!(int_list.clone().into_string(), None);
         assert_eq!(int_list.clone().into_bit_array(), None);
+        assert_eq!(int_list.clone().into_utf_codepoint(), None);
         assert_eq!(int_list.clone().into_float(), None);
         assert_eq!(int_list.clone().into_bool(), None);
         assert_eq!(int_list.clone().into_nil(), None);
@@ -900,6 +972,7 @@ mod tests {
             ValueType::Int,
             ValueType::String,
             ValueType::BitArray,
+            ValueType::UtfCodepoint,
             ValueType::Float,
             ValueType::Bool,
             ValueType::Nil,
@@ -1010,6 +1083,7 @@ mod tests {
             ValueType::Int,
             ValueType::String,
             ValueType::BitArray,
+            ValueType::UtfCodepoint,
             ValueType::Float,
             ValueType::Bool,
             ValueType::Nil,
@@ -1038,6 +1112,12 @@ mod tests {
                     BitArrayListItem,
                     ListIndexSource::new(list.clone(), 3),
                 )),
+                ValueType::UtfCodepoint => {
+                    ListExpr::UtfCodepoint(UtfCodepointListExpr::from_list_index(
+                        UtfCodepointListItem,
+                        ListIndexSource::new(list.clone(), 3),
+                    ))
+                }
                 ValueType::Float => ListExpr::Float(FloatListExpr::from_list_index(
                     FloatListItem,
                     ListIndexSource::new(list.clone(), 3),
@@ -1092,6 +1172,18 @@ mod tests {
             )
             .element_type(),
             ValueType::BitArray,
+        );
+        assert_eq!(
+            ListExpr::spread(
+                vec![Expr::utf_codepoint(UtfCodepointExpr::local_get(
+                    UtfCodepointLocalId(0),
+                    "codepoint".into(),
+                ))],
+                ListExpr::value(Vec::new(), ValueType::UtfCodepoint),
+                ValueType::UtfCodepoint,
+            )
+            .element_type(),
+            ValueType::UtfCodepoint,
         );
         assert_eq!(
             ListExpr::spread(

--- a/src/plan/module/expression/list/case.rs
+++ b/src/plan/module/expression/list/case.rs
@@ -1,6 +1,6 @@
 use super::{
     BitArrayListExpr, BoolListExpr, FloatListExpr, FunctionListExpr, IntListExpr, ListExpr,
-    ListListExpr, NilListExpr, StringListExpr, TupleListExpr,
+    ListListExpr, NilListExpr, StringListExpr, TupleListExpr, UtfCodepointListExpr,
 };
 use crate::plan::ValueType;
 
@@ -17,6 +17,10 @@ pub(crate) enum BoolListCaseBranches {
     BitArray {
         true_: BitArrayListExpr,
         false_: BitArrayListExpr,
+    },
+    UtfCodepoint {
+        true_: UtfCodepointListExpr,
+        false_: UtfCodepointListExpr,
     },
     Float {
         true_: FloatListExpr,
@@ -57,6 +61,10 @@ pub(crate) enum ListCaseBranches<Pattern> {
     BitArray {
         clauses: Vec<(Pattern, BitArrayListExpr)>,
         fallback: BitArrayListExpr,
+    },
+    UtfCodepoint {
+        clauses: Vec<(Pattern, UtfCodepointListExpr)>,
+        fallback: UtfCodepointListExpr,
     },
     Float {
         clauses: Vec<(Pattern, FloatListExpr)>,
@@ -106,6 +114,10 @@ impl<Pattern> ListCaseBranches<Pattern> {
             }),
             ListExpr::BitArray(fallback) => Ok(Self::BitArray {
                 clauses: typed_bit_array_clauses(clauses)?,
+                fallback,
+            }),
+            ListExpr::UtfCodepoint(fallback) => Ok(Self::UtfCodepoint {
+                clauses: typed_utf_codepoint_clauses(clauses)?,
                 fallback,
             }),
             ListExpr::Float(fallback) => Ok(Self::Float {
@@ -179,6 +191,23 @@ fn typed_bit_array_clauses<Pattern>(
         let actual = branch.element_type();
         let Some(branch) = branch.into_bit_array() else {
             return Err(list_case_branch_type_mismatch(ValueType::BitArray, actual));
+        };
+        typed_clauses.push((pattern, branch));
+    }
+    Ok(typed_clauses)
+}
+
+fn typed_utf_codepoint_clauses<Pattern>(
+    clauses: Vec<(Pattern, ListExpr)>,
+) -> Result<Vec<(Pattern, UtfCodepointListExpr)>, ListCaseBranchTypeMismatch> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (pattern, branch) in clauses {
+        let actual = branch.element_type();
+        let Some(branch) = branch.into_utf_codepoint() else {
+            return Err(list_case_branch_type_mismatch(
+                ValueType::UtfCodepoint,
+                actual,
+            ));
         };
         typed_clauses.push((pattern, branch));
     }
@@ -336,6 +365,21 @@ mod tests {
         assert_eq!(
             ListExpr::bool_case(
                 BoolExpr::value(true),
+                BoolListCaseBranches::UtfCodepoint {
+                    true_: ListExpr::value(Vec::new(), ValueType::UtfCodepoint)
+                        .into_utf_codepoint()
+                        .expect("utf codepoint list"),
+                    false_: ListExpr::value(Vec::new(), ValueType::UtfCodepoint)
+                        .into_utf_codepoint()
+                        .expect("utf codepoint list"),
+                },
+            )
+            .element_type(),
+            ValueType::UtfCodepoint,
+        );
+        assert_eq!(
+            ListExpr::bool_case(
+                BoolExpr::value(true),
                 BoolListCaseBranches::Float {
                     true_: ListExpr::value(Vec::new(), ValueType::Float)
                         .into_float()
@@ -463,6 +507,18 @@ mod tests {
                 fallback: ListExpr::value(Vec::new(), ValueType::BitArray)
                     .into_bit_array()
                     .expect("bit array list"),
+            }),
+        );
+        assert_eq!(
+            ListCaseBranches::<BigInt>::from_exprs(
+                Vec::new(),
+                ListExpr::value(Vec::new(), ValueType::UtfCodepoint),
+            ),
+            Ok(ListCaseBranches::UtfCodepoint {
+                clauses: Vec::new(),
+                fallback: ListExpr::value(Vec::new(), ValueType::UtfCodepoint)
+                    .into_utf_codepoint()
+                    .expect("utf codepoint list"),
             }),
         );
         assert_eq!(
@@ -646,6 +702,16 @@ mod tests {
             ),
             Err(ListCaseBranchTypeMismatch {
                 expected: ValueType::BitArray,
+                actual: ValueType::Int,
+            }),
+        );
+        assert_eq!(
+            ListCaseBranches::from_exprs(
+                vec![(BigInt::from(1), ListExpr::value(Vec::new(), ValueType::Int))],
+                ListExpr::value(Vec::new(), ValueType::UtfCodepoint),
+            ),
+            Err(ListCaseBranchTypeMismatch {
+                expected: ValueType::UtfCodepoint,
                 actual: ValueType::Int,
             }),
         );

--- a/src/plan/module/expression/list/elements.rs
+++ b/src/plan/module/expression/list/elements.rs
@@ -2,11 +2,11 @@ use super::{
     BitArrayListExpr, BitArrayListItem, BoolListExpr, BoolListItem, FloatListExpr, FloatListItem,
     FunctionListExpr, FunctionListItem, IntListExpr, IntListItem, ListExpr, ListItem, ListListExpr,
     ListListItem, NilListExpr, NilListItem, StringListExpr, StringListItem, TupleListExpr,
-    TupleListItem,
+    TupleListItem, UtfCodepointListExpr, UtfCodepointListItem,
 };
 use crate::plan::{
     BitArrayExpr, BoolExpr, Expr, FloatExpr, FunctionExpr, FunctionType, IntExpr, NilExpr,
-    StringExpr, TupleExpr, ValueType,
+    StringExpr, TupleExpr, UtfCodepointExpr, ValueType,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -14,6 +14,7 @@ pub(crate) enum ListElements {
     Int(Vec<IntExpr>),
     String(Vec<StringExpr>),
     BitArray(Vec<BitArrayExpr>),
+    UtfCodepoint(Vec<UtfCodepointExpr>),
     Float(Vec<FloatExpr>),
     Bool(Vec<BoolExpr>),
     Nil(Vec<NilExpr>),
@@ -44,6 +45,10 @@ pub(crate) enum ListSpreadElements {
     BitArray {
         values: Vec<BitArrayExpr>,
         tail: BitArrayListExpr,
+    },
+    UtfCodepoint {
+        values: Vec<UtfCodepointExpr>,
+        tail: UtfCodepointListExpr,
     },
     Float {
         values: Vec<FloatExpr>,
@@ -86,6 +91,7 @@ impl ListElements {
             ValueType::Int => list_elements_from_exprs(IntListItem, values),
             ValueType::String => list_elements_from_exprs(StringListItem, values),
             ValueType::BitArray => list_elements_from_exprs(BitArrayListItem, values),
+            ValueType::UtfCodepoint => list_elements_from_exprs(UtfCodepointListItem, values),
             ValueType::Float => list_elements_from_exprs(FloatListItem, values),
             ValueType::Bool => list_elements_from_exprs(BoolListItem, values),
             ValueType::Nil => list_elements_from_exprs(NilListItem, values),
@@ -109,6 +115,7 @@ impl ListElements {
             Self::Int(_) => ValueType::Int,
             Self::String(_) => ValueType::String,
             Self::BitArray(_) => ValueType::BitArray,
+            Self::UtfCodepoint(_) => ValueType::UtfCodepoint,
             Self::Float(_) => ValueType::Float,
             Self::Bool(_) => ValueType::Bool,
             Self::Nil(_) => ValueType::Nil,
@@ -145,6 +152,12 @@ impl ListSpreadElements {
                     return Err(ListElementTypeMismatch { expected, actual });
                 };
                 Ok(Self::BitArray { values, tail })
+            }
+            ListElements::UtfCodepoint(values) => {
+                let Some(tail) = tail.into_utf_codepoint() else {
+                    return Err(ListElementTypeMismatch { expected, actual });
+                };
+                Ok(Self::UtfCodepoint { values, tail })
             }
             ListElements::Float(values) => {
                 let Some(tail) = tail.into_float() else {
@@ -226,7 +239,8 @@ mod tests {
     use super::{ListElementTypeMismatch, ListElements, ListSpreadElements};
     use crate::plan::{
         BitArrayExpr, BoolExpr, Expr, FloatExpr, FunctionExpr, FunctionReference, FunctionType,
-        IntExpr, ListExpr, NilExpr, RuntimeFunctionId, StringExpr, TupleExpr, ValueType,
+        IntExpr, ListExpr, NilExpr, RuntimeFunctionId, StringExpr, TupleExpr, UtfCodepointExpr,
+        UtfCodepointLocalId, ValueType,
     };
 
     #[test]
@@ -305,6 +319,14 @@ mod tests {
             ValueType::BitArray,
         );
         assert_eq!(
+            ListElements::UtfCodepoint(vec![UtfCodepointExpr::local_get(
+                UtfCodepointLocalId(0),
+                "codepoint".into(),
+            )])
+            .item_type(),
+            ValueType::UtfCodepoint,
+        );
+        assert_eq!(
             ListElements::Tuple {
                 item_type: vec![ValueType::String],
                 values: Vec::new(),
@@ -349,6 +371,19 @@ mod tests {
             ),
             Err(ListElementTypeMismatch {
                 expected: ValueType::BitArray,
+                actual: ValueType::Int,
+            }),
+        );
+        assert_eq!(
+            ListSpreadElements::from_parts(
+                ListElements::UtfCodepoint(vec![UtfCodepointExpr::local_get(
+                    UtfCodepointLocalId(0),
+                    "codepoint".into(),
+                )]),
+                ListExpr::value(Vec::new(), ValueType::Int),
+            ),
+            Err(ListElementTypeMismatch {
+                expected: ValueType::UtfCodepoint,
                 actual: ValueType::Int,
             }),
         );

--- a/src/plan/module/expression/list/item.rs
+++ b/src/plan/module/expression/list/item.rs
@@ -5,7 +5,8 @@ use crate::plan::{
     FunctionExpr, FunctionListFunctionId, FunctionListLocalId, FunctionType, IntExpr,
     IntListFunctionId, IntListLocalId, ListListFunctionId, ListListLocalId, ListLocal, NilExpr,
     NilListFunctionId, NilListLocalId, StringExpr, StringListFunctionId, StringListLocalId,
-    TupleExpr, TupleListFunctionId, TupleListLocalId, ValueType,
+    TupleExpr, TupleListFunctionId, TupleListLocalId, UtfCodepointExpr, UtfCodepointListFunctionId,
+    UtfCodepointListLocalId, ValueType,
 };
 use std::fmt::Debug;
 
@@ -38,6 +39,9 @@ pub(crate) struct StringListItem;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BitArrayListItem;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UtfCodepointListItem;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FloatListItem;
@@ -193,6 +197,18 @@ primitive_list_item!(
     BitArray,
     ListExpr::BitArray,
     ListLocal::BitArray
+);
+
+primitive_list_item!(
+    UtfCodepointListItem,
+    UtfCodepointExpr,
+    UtfCodepointListLocalId,
+    UtfCodepointListFunctionId,
+    ValueType::UtfCodepoint,
+    ExprKind::UtfCodepoint(value) => value,
+    UtfCodepoint,
+    ListExpr::UtfCodepoint,
+    ListLocal::UtfCodepoint
 );
 
 primitive_list_item!(

--- a/src/plan/module/expression/list/local.rs
+++ b/src/plan/module/expression/list/local.rs
@@ -1,11 +1,11 @@
 use super::{
     BitArrayListExpr, BoolListExpr, FloatListExpr, FunctionListExpr, IntListExpr, ListListExpr,
-    NilListExpr, StringListExpr, TupleListExpr,
+    NilListExpr, StringListExpr, TupleListExpr, UtfCodepointListExpr,
 };
 use crate::plan::{
     BitArrayListLocalId, BoolListLocalId, FloatListLocalId, FunctionListLocalId, FunctionType,
     IntListLocalId, ListListLocalId, NilListLocalId, StringListLocalId, TupleListLocalId,
-    ValueType,
+    UtfCodepointListLocalId, ValueType,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -21,6 +21,10 @@ pub(crate) enum ListLocalExpr {
     BitArray {
         local: BitArrayListLocalId,
         value: BitArrayListExpr,
+    },
+    UtfCodepoint {
+        local: UtfCodepointListLocalId,
+        value: UtfCodepointListExpr,
     },
     Float {
         local: FloatListLocalId,

--- a/src/plan/module/expression/list/typed.rs
+++ b/src/plan/module/expression/list/typed.rs
@@ -393,6 +393,12 @@ impl_typed_list_expr_from_facade!(super::StringListExpr, into_string, "string");
 #[cfg(test)]
 impl_typed_list_expr_from_facade!(super::BitArrayListExpr, into_bit_array, "bit array");
 #[cfg(test)]
+impl_typed_list_expr_from_facade!(
+    super::UtfCodepointListExpr,
+    into_utf_codepoint,
+    "utf codepoint"
+);
+#[cfg(test)]
 impl_typed_list_expr_from_facade!(super::FloatListExpr, into_float, "float");
 #[cfg(test)]
 impl_typed_list_expr_from_facade!(super::BoolListExpr, into_bool, "bool");

--- a/src/plan/module/expression/utf_codepoint.rs
+++ b/src/plan/module/expression/utf_codepoint.rs
@@ -1,0 +1,295 @@
+use super::{
+    BoolExpr, CallArg, FloatExpr, IntExpr, PanicExpr, StringExpr, TupleExpr,
+    UtfCodepointFunctionExpr, UtfCodepointListExpr,
+};
+use crate::plan::{Step, UtfCodepointFunctionId, UtfCodepointLocalId};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UtfCodepointExpr {
+    kind: UtfCodepointExprKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum UtfCodepointExprKind {
+    LocalGet {
+        local: UtfCodepointLocalId,
+        name: EcoString,
+    },
+    Call {
+        function: UtfCodepointFunctionId,
+        args: Vec<CallArg>,
+    },
+    FunctionCall {
+        function: Box<UtfCodepointFunctionExpr>,
+        args: Vec<CallArg>,
+    },
+    TupleIndex {
+        tuple: Box<TupleExpr>,
+        index: usize,
+    },
+    ListIndex {
+        list: Box<UtfCodepointListExpr>,
+        index: usize,
+    },
+    Panic(PanicExpr),
+    BoolCase {
+        subject: Box<BoolExpr>,
+        true_: Box<UtfCodepointExpr>,
+        false_: Box<UtfCodepointExpr>,
+    },
+    IntCase {
+        subject: Box<IntExpr>,
+        clauses: Vec<(BigInt, UtfCodepointExpr)>,
+        fallback: Box<UtfCodepointExpr>,
+    },
+    StringCase {
+        subject: Box<StringExpr>,
+        clauses: Vec<(EcoString, UtfCodepointExpr)>,
+        fallback: Box<UtfCodepointExpr>,
+    },
+    FloatCase {
+        subject: Box<FloatExpr>,
+        clauses: Vec<(f64, UtfCodepointExpr)>,
+        fallback: Box<UtfCodepointExpr>,
+    },
+    Block {
+        steps: Vec<Step>,
+        return_: Box<UtfCodepointExpr>,
+    },
+}
+
+impl UtfCodepointExpr {
+    pub(crate) fn local_get(local: UtfCodepointLocalId, name: EcoString) -> Self {
+        Self::new(UtfCodepointExprKind::LocalGet { local, name })
+    }
+
+    pub(crate) fn call(function: UtfCodepointFunctionId, args: Vec<CallArg>) -> Self {
+        Self::new(UtfCodepointExprKind::Call { function, args })
+    }
+
+    pub(crate) fn function_call(function: UtfCodepointFunctionExpr, args: Vec<CallArg>) -> Self {
+        Self::new(UtfCodepointExprKind::FunctionCall {
+            function: Box::new(function),
+            args,
+        })
+    }
+
+    pub(crate) fn tuple_index(tuple: TupleExpr, index: usize) -> Self {
+        Self::new(UtfCodepointExprKind::TupleIndex {
+            tuple: Box::new(tuple),
+            index,
+        })
+    }
+
+    pub(crate) fn list_index(list: UtfCodepointListExpr, index: usize) -> Self {
+        Self::new(UtfCodepointExprKind::ListIndex {
+            list: Box::new(list),
+            index,
+        })
+    }
+
+    pub(crate) fn panic(panic: PanicExpr) -> Self {
+        Self::new(UtfCodepointExprKind::Panic(panic))
+    }
+
+    pub(crate) fn bool_case(subject: BoolExpr, true_: Self, false_: Self) -> Self {
+        Self::new(UtfCodepointExprKind::BoolCase {
+            subject: Box::new(subject),
+            true_: Box::new(true_),
+            false_: Box::new(false_),
+        })
+    }
+
+    pub(crate) fn int_case(subject: IntExpr, clauses: Vec<(BigInt, Self)>, fallback: Self) -> Self {
+        Self::new(UtfCodepointExprKind::IntCase {
+            subject: Box::new(subject),
+            clauses,
+            fallback: Box::new(fallback),
+        })
+    }
+
+    pub(crate) fn string_case(
+        subject: StringExpr,
+        clauses: Vec<(EcoString, Self)>,
+        fallback: Self,
+    ) -> Self {
+        Self::new(UtfCodepointExprKind::StringCase {
+            subject: Box::new(subject),
+            clauses,
+            fallback: Box::new(fallback),
+        })
+    }
+
+    pub(crate) fn float_case(
+        subject: FloatExpr,
+        clauses: Vec<(f64, Self)>,
+        fallback: Self,
+    ) -> Self {
+        Self::new(UtfCodepointExprKind::FloatCase {
+            subject: Box::new(subject),
+            clauses,
+            fallback: Box::new(fallback),
+        })
+    }
+
+    pub(crate) fn block(steps: Vec<Step>, return_: Self) -> Self {
+        Self::new(UtfCodepointExprKind::Block {
+            steps,
+            return_: Box::new(return_),
+        })
+    }
+
+    pub(crate) fn kind(&self) -> &UtfCodepointExprKind {
+        &self.kind
+    }
+
+    pub(crate) fn into_kind(self) -> UtfCodepointExprKind {
+        self.kind
+    }
+
+    fn new(kind: UtfCodepointExprKind) -> Self {
+        Self { kind }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UtfCodepointExpr, UtfCodepointExprKind};
+    use crate::plan::{
+        BoolExpr, Expr, IntExpr, PanicExpr, PanicSite, ParamLocal, Step, StringExpr, TupleExpr,
+        TupleLocalId, UtfCodepointFunctionExpr, UtfCodepointFunctionId,
+        UtfCodepointFunctionReference, UtfCodepointListExpr, UtfCodepointListItem,
+        UtfCodepointListLocalId, UtfCodepointLocalId, ValueType,
+    };
+
+    #[test]
+    fn utf_codepoint_expr_kind_accessors() {
+        assert_eq!(
+            value().kind(),
+            &UtfCodepointExprKind::LocalGet {
+                local: UtfCodepointLocalId(0),
+                name: "value".into(),
+            },
+        );
+        assert_eq!(
+            UtfCodepointExpr::call(UtfCodepointFunctionId(0), Vec::new()).kind(),
+            &UtfCodepointExprKind::Call {
+                function: UtfCodepointFunctionId(0),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            UtfCodepointExpr::function_call(function(), Vec::new()).kind(),
+            &UtfCodepointExprKind::FunctionCall {
+                function: Box::new(function()),
+                args: Vec::new(),
+            },
+        );
+        assert_eq!(
+            UtfCodepointExpr::tuple_index(tuple(), 0).kind(),
+            &UtfCodepointExprKind::TupleIndex {
+                tuple: Box::new(tuple()),
+                index: 0,
+            },
+        );
+        assert_eq!(
+            UtfCodepointExpr::list_index(list(), 0).kind(),
+            &UtfCodepointExprKind::ListIndex {
+                list: Box::new(list()),
+                index: 0,
+            },
+        );
+        let panic = PanicExpr::panic_at(None, PanicSite::unknown());
+        assert_eq!(
+            UtfCodepointExpr::panic(panic.clone()).kind(),
+            &UtfCodepointExprKind::Panic(panic),
+        );
+        assert_eq!(
+            UtfCodepointExpr::bool_case(BoolExpr::value(true), value(), value()).kind(),
+            &UtfCodepointExprKind::BoolCase {
+                subject: Box::new(BoolExpr::value(true)),
+                true_: Box::new(value()),
+                false_: Box::new(value()),
+            },
+        );
+        assert_eq!(
+            UtfCodepointExpr::int_case(
+                IntExpr::value(1.into()),
+                vec![(1.into(), value())],
+                value(),
+            )
+            .kind(),
+            &UtfCodepointExprKind::IntCase {
+                subject: Box::new(IntExpr::value(1.into())),
+                clauses: vec![(1.into(), value())],
+                fallback: Box::new(value()),
+            },
+        );
+        assert_eq!(
+            UtfCodepointExpr::string_case(
+                StringExpr::value("one".into()),
+                vec![("one".into(), value())],
+                value(),
+            )
+            .kind(),
+            &UtfCodepointExprKind::StringCase {
+                subject: Box::new(StringExpr::value("one".into())),
+                clauses: vec![("one".into(), value())],
+                fallback: Box::new(value()),
+            },
+        );
+        assert_eq!(
+            UtfCodepointExpr::float_case(
+                crate::plan::FloatExpr::value(1.0),
+                vec![(1.0, value())],
+                value(),
+            )
+            .kind(),
+            &UtfCodepointExprKind::FloatCase {
+                subject: Box::new(crate::plan::FloatExpr::value(1.0)),
+                clauses: vec![(1.0, value())],
+                fallback: Box::new(value()),
+            },
+        );
+        assert_eq!(
+            UtfCodepointExpr::block(
+                vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                value(),
+            )
+            .kind(),
+            &UtfCodepointExprKind::Block {
+                steps: vec![Step::evaluate(Expr::int(IntExpr::value(1.into())))],
+                return_: Box::new(value()),
+            },
+        );
+    }
+
+    fn value() -> UtfCodepointExpr {
+        UtfCodepointExpr::local_get(UtfCodepointLocalId(0), "value".into())
+    }
+
+    fn function() -> UtfCodepointFunctionExpr {
+        UtfCodepointFunctionExpr::reference(UtfCodepointFunctionReference::new(
+            UtfCodepointFunctionId(0),
+            vec![ParamLocal::utf_codepoint(UtfCodepointLocalId(0))],
+        ))
+    }
+
+    fn tuple() -> TupleExpr {
+        TupleExpr::local_get(
+            TupleLocalId(0),
+            "pair".into(),
+            vec![ValueType::UtfCodepoint],
+        )
+    }
+
+    fn list() -> UtfCodepointListExpr {
+        UtfCodepointListExpr::local_get(
+            UtfCodepointListItem,
+            UtfCodepointListLocalId(0),
+            "values".into(),
+        )
+    }
+}

--- a/src/plan/module/frame.rs
+++ b/src/plan/module/frame.rs
@@ -13,7 +13,8 @@ use super::id::{
     FunctionFunctionLocalId, FunctionListLocalId, IntFunctionLocalId, IntListLocalId, IntLocalId,
     ListFunctionLocal, ListListLocalId, ListLocal, NilFunctionLocalId, NilListLocalId, NilLocalId,
     StringFunctionLocalId, StringListLocalId, StringLocalId, TupleFunctionLocalId,
-    TupleListLocalId, TupleLocalId,
+    TupleListLocalId, TupleLocalId, UtfCodepointFunctionLocalId, UtfCodepointListLocalId,
+    UtfCodepointLocalId,
 };
 use super::step::Step;
 use crate::plan::{FunctionType, ValueType};
@@ -24,12 +25,14 @@ pub(crate) struct FrameLayout {
     floats: usize,
     strings: usize,
     bit_arrays: usize,
+    utf_codepoints: usize,
     bools: usize,
     nils: usize,
     tuples: usize,
     int_lists: usize,
     string_lists: usize,
     bit_array_lists: usize,
+    utf_codepoint_lists: usize,
     float_lists: usize,
     bool_lists: usize,
     nil_lists: usize,
@@ -40,6 +43,7 @@ pub(crate) struct FrameLayout {
     float_functions: usize,
     string_functions: usize,
     bit_array_functions: usize,
+    utf_codepoint_functions: usize,
     bool_functions: usize,
     nil_functions: usize,
     tuple_functions: usize,
@@ -52,12 +56,14 @@ pub(crate) struct FrameLayoutParts {
     pub(crate) floats: usize,
     pub(crate) strings: usize,
     pub(crate) bit_arrays: usize,
+    pub(crate) utf_codepoints: usize,
     pub(crate) bools: usize,
     pub(crate) nils: usize,
     pub(crate) tuples: usize,
     pub(crate) int_lists: usize,
     pub(crate) string_lists: usize,
     pub(crate) bit_array_lists: usize,
+    pub(crate) utf_codepoint_lists: usize,
     pub(crate) float_lists: usize,
     pub(crate) bool_lists: usize,
     pub(crate) nil_lists: usize,
@@ -68,6 +74,7 @@ pub(crate) struct FrameLayoutParts {
     pub(crate) float_functions: usize,
     pub(crate) string_functions: usize,
     pub(crate) bit_array_functions: usize,
+    pub(crate) utf_codepoint_functions: usize,
     pub(crate) bool_functions: usize,
     pub(crate) nil_functions: usize,
     pub(crate) tuple_functions: usize,
@@ -82,12 +89,14 @@ impl FrameLayout {
             floats: self.floats,
             strings: self.strings,
             bit_arrays: self.bit_arrays,
+            utf_codepoints: self.utf_codepoints,
             bools: self.bools,
             nils: self.nils,
             tuples: self.tuples,
             int_lists: self.int_lists,
             string_lists: self.string_lists,
             bit_array_lists: self.bit_array_lists,
+            utf_codepoint_lists: self.utf_codepoint_lists,
             float_lists: self.float_lists,
             bool_lists: self.bool_lists,
             nil_lists: self.nil_lists,
@@ -98,6 +107,7 @@ impl FrameLayout {
             float_functions: self.float_functions,
             string_functions: self.string_functions,
             bit_array_functions: self.bit_array_functions,
+            utf_codepoint_functions: self.utf_codepoint_functions,
             bool_functions: self.bool_functions,
             nil_functions: self.nil_functions,
             tuple_functions: self.tuple_functions,
@@ -128,6 +138,7 @@ impl FrameLayout {
             ParamLocal::Float(local) => self.include_float(*local),
             ParamLocal::String(local) => self.include_string(*local),
             ParamLocal::BitArray(local) => self.include_bit_array(*local),
+            ParamLocal::UtfCodepoint(local) => self.include_utf_codepoint(*local),
             ParamLocal::Bool(local) => self.include_bool(*local),
             ParamLocal::Nil(local) => self.include_nil(*local),
             ParamLocal::Tuple { local, .. } => self.include_tuple(*local),
@@ -136,6 +147,9 @@ impl FrameLayout {
             ParamLocal::FloatFunction { local, .. } => self.include_float_function(*local),
             ParamLocal::StringFunction { local, .. } => self.include_string_function(*local),
             ParamLocal::BitArrayFunction { local, .. } => self.include_bit_array_function(*local),
+            ParamLocal::UtfCodepointFunction { local, .. } => {
+                self.include_utf_codepoint_function(*local)
+            }
             ParamLocal::BoolFunction { local, .. } => self.include_bool_function(*local),
             ParamLocal::NilFunction { local, .. } => self.include_nil_function(*local),
             ParamLocal::TupleFunction { local, .. } => self.include_tuple_function(*local),
@@ -160,6 +174,10 @@ impl FrameLayout {
         self.bit_arrays = self.bit_arrays.max(local.0 + 1);
     }
 
+    pub(crate) fn include_utf_codepoint(&mut self, local: UtfCodepointLocalId) {
+        self.utf_codepoints = self.utf_codepoints.max(local.0 + 1);
+    }
+
     pub(crate) fn include_bool(&mut self, local: BoolLocalId) {
         self.bools = self.bools.max(local.0 + 1);
     }
@@ -178,6 +196,7 @@ impl FrameLayout {
             ListLocal::Int(local) => self.include_int_list(*local),
             ListLocal::String(local) => self.include_string_list(*local),
             ListLocal::BitArray(local) => self.include_bit_array_list(*local),
+            ListLocal::UtfCodepoint(local) => self.include_utf_codepoint_list(*local),
             ListLocal::Float(local) => self.include_float_list(*local),
             ListLocal::Bool(local) => self.include_bool_list(*local),
             ListLocal::Nil(local) => self.include_nil_list(*local),
@@ -203,6 +222,10 @@ impl FrameLayout {
 
     pub(crate) fn include_bit_array_list(&mut self, local: BitArrayListLocalId) {
         self.bit_array_lists = self.bit_array_lists.max(local.0 + 1);
+    }
+
+    pub(crate) fn include_utf_codepoint_list(&mut self, local: UtfCodepointListLocalId) {
+        self.utf_codepoint_lists = self.utf_codepoint_lists.max(local.0 + 1);
     }
 
     pub(crate) fn include_float_list(&mut self, local: FloatListLocalId) {
@@ -261,6 +284,10 @@ impl FrameLayout {
 
     pub(crate) fn include_bit_array_function(&mut self, local: BitArrayFunctionLocalId) {
         self.bit_array_functions = self.bit_array_functions.max(local.0 + 1);
+    }
+
+    pub(crate) fn include_utf_codepoint_function(&mut self, local: UtfCodepointFunctionLocalId) {
+        self.utf_codepoint_functions = self.utf_codepoint_functions.max(local.0 + 1);
     }
 
     pub(crate) fn include_bool_function(&mut self, local: BoolFunctionLocalId) {
@@ -466,7 +493,7 @@ mod tests {
         assert_eq!(layout, cloned);
         assert_eq!(
             format!("{layout:?}"),
-            "FrameLayout { ints: 0, floats: 0, strings: 0, bit_arrays: 0, bools: 0, nils: 0, tuples: 0, int_lists: 0, string_lists: 0, bit_array_lists: 0, float_lists: 0, bool_lists: 0, nil_lists: 0, tuple_lists: [], list_lists: [], function_lists: [], int_functions: 0, float_functions: 0, string_functions: 0, bit_array_functions: 0, bool_functions: 0, nil_functions: 0, tuple_functions: 0, list_functions: [], function_functions: 0 }",
+            "FrameLayout { ints: 0, floats: 0, strings: 0, bit_arrays: 0, utf_codepoints: 0, bools: 0, nils: 0, tuples: 0, int_lists: 0, string_lists: 0, bit_array_lists: 0, utf_codepoint_lists: 0, float_lists: 0, bool_lists: 0, nil_lists: 0, tuple_lists: [], list_lists: [], function_lists: [], int_functions: 0, float_functions: 0, string_functions: 0, bit_array_functions: 0, utf_codepoint_functions: 0, bool_functions: 0, nil_functions: 0, tuple_functions: 0, list_functions: [], function_functions: 0 }",
         );
     }
 

--- a/src/plan/module/frame/args.rs
+++ b/src/plan/module/frame/args.rs
@@ -8,6 +8,7 @@ impl FrameLayout {
                 CallArgKind::Int { value, .. } => self.include_int_expr(value),
                 CallArgKind::String { value, .. } => self.include_string_expr(value),
                 CallArgKind::BitArray { value, .. } => self.include_bit_array_expr(value),
+                CallArgKind::UtfCodepoint { value, .. } => self.include_utf_codepoint_expr(value),
                 CallArgKind::Float { value, .. } => self.include_float_expr(value),
                 CallArgKind::Bool { value, .. } => self.include_bool_expr(value),
                 CallArgKind::Nil { value, .. } => self.include_nil_expr(value),
@@ -19,6 +20,9 @@ impl FrameLayout {
                 }
                 CallArgKind::BitArrayFunction { value, .. } => {
                     self.include_bit_array_function_expr(value);
+                }
+                CallArgKind::UtfCodepointFunction { value, .. } => {
+                    self.include_utf_codepoint_function_expr(value);
                 }
                 CallArgKind::FloatFunction { value, .. } => {
                     self.include_float_function_expr(value);
@@ -44,6 +48,9 @@ impl FrameLayout {
                 CaptureArgKind::Int { value, .. } => self.include_int_expr(value),
                 CaptureArgKind::String { value, .. } => self.include_string_expr(value),
                 CaptureArgKind::BitArray { value, .. } => self.include_bit_array_expr(value),
+                CaptureArgKind::UtfCodepoint { value, .. } => {
+                    self.include_utf_codepoint_expr(value)
+                }
                 CaptureArgKind::Float { value, .. } => self.include_float_expr(value),
                 CaptureArgKind::Bool { value, .. } => self.include_bool_expr(value),
                 CaptureArgKind::Nil { value, .. } => self.include_nil_expr(value),
@@ -55,6 +62,9 @@ impl FrameLayout {
                 }
                 CaptureArgKind::BitArrayFunction { value, .. } => {
                     self.include_bit_array_function_expr(value);
+                }
+                CaptureArgKind::UtfCodepointFunction { value, .. } => {
+                    self.include_utf_codepoint_function_expr(value);
                 }
                 CaptureArgKind::FloatFunction { value, .. } => {
                     self.include_float_function_expr(value);

--- a/src/plan/module/frame/expression.rs
+++ b/src/plan/module/frame/expression.rs
@@ -3,7 +3,7 @@ use crate::plan::{
     BitArrayExpr, BitArrayExprKind, BitArraySegment, BoolExpr, BoolExprKind, Expr, ExprKind,
     FloatExpr, FloatExprKind, IntExpr, IntExprKind, ListElements, ListExpr, ListItem,
     ListLocalExpr, NilExpr, NilExprKind, PanicExpr, StringExpr, StringExprKind, TupleExpr,
-    TupleExprKind, TypedListExpr, TypedListExprKind,
+    TupleExprKind, TypedListExpr, TypedListExprKind, UtfCodepointExpr, UtfCodepointExprKind,
 };
 
 impl FrameLayout {
@@ -12,6 +12,7 @@ impl FrameLayout {
             ExprKind::Int(expression) => self.include_int_expr(expression),
             ExprKind::String(expression) => self.include_string_expr(expression),
             ExprKind::BitArray(expression) => self.include_bit_array_expr(expression),
+            ExprKind::UtfCodepoint(expression) => self.include_utf_codepoint_expr(expression),
             ExprKind::Float(expression) => self.include_float_expr(expression),
             ExprKind::Bool(expression) => self.include_bool_expr(expression),
             ExprKind::Nil(expression) => self.include_nil_expr(expression),
@@ -174,6 +175,9 @@ impl FrameLayout {
                         BitArraySegment::Int { value, .. } => self.include_int_expr(value),
                         BitArraySegment::Float { value, .. } => self.include_float_expr(value),
                         BitArraySegment::String { value, .. } => self.include_string_expr(value),
+                        BitArraySegment::UtfCodepoint { value, .. } => {
+                            self.include_utf_codepoint_expr(value)
+                        }
                         BitArraySegment::Bits(value) => self.include_bit_array_expr(value),
                     }
                 }
@@ -232,6 +236,69 @@ impl FrameLayout {
             BitArrayExprKind::Block { steps, return_ } => {
                 self.include_steps(steps);
                 self.include_bit_array_expr(return_);
+            }
+        }
+    }
+
+    pub(in crate::plan::module::frame) fn include_utf_codepoint_expr(
+        &mut self,
+        expression: &UtfCodepointExpr,
+    ) {
+        match expression.kind() {
+            UtfCodepointExprKind::Panic(panic) => self.include_panic_expr(panic),
+            UtfCodepointExprKind::LocalGet { local, .. } => self.include_utf_codepoint(*local),
+            UtfCodepointExprKind::Call { args, .. } => self.include_call_args(args),
+            UtfCodepointExprKind::FunctionCall { function, args } => {
+                self.include_utf_codepoint_function_expr(function);
+                self.include_call_args(args);
+            }
+            UtfCodepointExprKind::TupleIndex { tuple, .. } => self.include_tuple_expr(tuple),
+            UtfCodepointExprKind::ListIndex { list, .. } => self.include_typed_list_expr(list),
+            UtfCodepointExprKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_utf_codepoint_expr(true_);
+                self.include_utf_codepoint_expr(false_);
+            }
+            UtfCodepointExprKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_expr(branch);
+                }
+                self.include_utf_codepoint_expr(fallback);
+            }
+            UtfCodepointExprKind::StringCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_string_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_expr(branch);
+                }
+                self.include_utf_codepoint_expr(fallback);
+            }
+            UtfCodepointExprKind::FloatCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_float_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_expr(branch);
+                }
+                self.include_utf_codepoint_expr(fallback);
+            }
+            UtfCodepointExprKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_utf_codepoint_expr(return_);
             }
         }
     }
@@ -344,6 +411,11 @@ impl FrameLayout {
                     });
                 }
                 crate::plan::BitArrayPatternSegment::String { .. } => {}
+                crate::plan::BitArrayPatternSegment::UtfCodepoint { pattern, .. } => {
+                    self.include_bit_array_binding_pattern(pattern, |layout, local| {
+                        layout.include_utf_codepoint(*local)
+                    });
+                }
             }
         }
     }
@@ -618,6 +690,7 @@ impl FrameLayout {
             ListExpr::Int(expression) => self.include_typed_list_expr(expression),
             ListExpr::String(expression) => self.include_typed_list_expr(expression),
             ListExpr::BitArray(expression) => self.include_typed_list_expr(expression),
+            ListExpr::UtfCodepoint(expression) => self.include_typed_list_expr(expression),
             ListExpr::Float(expression) => self.include_typed_list_expr(expression),
             ListExpr::Bool(expression) => self.include_typed_list_expr(expression),
             ListExpr::Nil(expression) => self.include_typed_list_expr(expression),
@@ -643,6 +716,10 @@ impl FrameLayout {
             ListLocalExpr::BitArray { local, value } => {
                 self.include_typed_list_expr(value);
                 self.include_bit_array_list(*local);
+            }
+            ListLocalExpr::UtfCodepoint { local, value } => {
+                self.include_typed_list_expr(value);
+                self.include_utf_codepoint_list(*local);
             }
             ListLocalExpr::Float { local, value } => {
                 self.include_typed_list_expr(value);
@@ -788,6 +865,11 @@ impl FrameLayout {
             ListElements::BitArray(values) => {
                 for value in values {
                     self.include_bit_array_expr(value);
+                }
+            }
+            ListElements::UtfCodepoint(values) => {
+                for value in values {
+                    self.include_utf_codepoint_expr(value);
                 }
             }
             ListElements::Float(values) => {

--- a/src/plan/module/frame/function.rs
+++ b/src/plan/module/frame/function.rs
@@ -4,7 +4,8 @@ use crate::plan::{
     FloatFunctionExpr, FloatFunctionExprKind, FunctionExpr, FunctionExprKind, FunctionFunctionExpr,
     FunctionFunctionExprKind, IntFunctionExpr, IntFunctionExprKind, ListFunctionExpr,
     ListFunctionExprKind, NilFunctionExpr, NilFunctionExprKind, StringFunctionExpr,
-    StringFunctionExprKind, TupleFunctionExpr, TupleFunctionExprKind,
+    StringFunctionExprKind, TupleFunctionExpr, TupleFunctionExprKind, UtfCodepointFunctionExpr,
+    UtfCodepointFunctionExprKind,
 };
 
 impl FrameLayout {
@@ -17,6 +18,9 @@ impl FrameLayout {
             FunctionExprKind::String(expression) => self.include_string_function_expr(expression),
             FunctionExprKind::BitArray(expression) => {
                 self.include_bit_array_function_expr(expression)
+            }
+            FunctionExprKind::UtfCodepoint(expression) => {
+                self.include_utf_codepoint_function_expr(expression)
             }
             FunctionExprKind::Float(expression) => self.include_float_function_expr(expression),
             FunctionExprKind::Bool(expression) => self.include_bool_function_expr(expression),
@@ -291,6 +295,79 @@ impl FrameLayout {
             BitArrayFunctionExprKind::Block { steps, return_ } => {
                 self.include_steps(steps);
                 self.include_bit_array_function_expr(return_);
+            }
+        }
+    }
+
+    pub(in crate::plan::module::frame) fn include_utf_codepoint_function_expr(
+        &mut self,
+        expression: &UtfCodepointFunctionExpr,
+    ) {
+        match expression.kind() {
+            UtfCodepointFunctionExprKind::Reference(_) => {}
+            UtfCodepointFunctionExprKind::Panic(panic) => self.include_panic_expr(panic),
+            UtfCodepointFunctionExprKind::Closure { captures, .. } => {
+                self.include_capture_args(captures)
+            }
+            UtfCodepointFunctionExprKind::LocalGet { local, .. } => {
+                self.include_utf_codepoint_function(*local)
+            }
+            UtfCodepointFunctionExprKind::Call { args, .. } => self.include_call_args(args),
+            UtfCodepointFunctionExprKind::FunctionCall { function, args, .. } => {
+                self.include_function_function_expr(function);
+                self.include_call_args(args);
+            }
+            UtfCodepointFunctionExprKind::TupleIndex { tuple, .. } => {
+                self.include_tuple_expr(tuple)
+            }
+            UtfCodepointFunctionExprKind::ListIndex { list, .. } => {
+                self.include_typed_list_expr(list)
+            }
+            UtfCodepointFunctionExprKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_utf_codepoint_function_expr(true_);
+                self.include_utf_codepoint_function_expr(false_);
+            }
+            UtfCodepointFunctionExprKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_function_expr(branch);
+                }
+                self.include_utf_codepoint_function_expr(fallback);
+            }
+            UtfCodepointFunctionExprKind::StringCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_string_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_function_expr(branch);
+                }
+                self.include_utf_codepoint_function_expr(fallback);
+            }
+            UtfCodepointFunctionExprKind::FloatCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_float_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_function_expr(branch);
+                }
+                self.include_utf_codepoint_function_expr(fallback);
+            }
+            UtfCodepointFunctionExprKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_utf_codepoint_function_expr(return_);
             }
         }
     }

--- a/src/plan/module/frame/return_.rs
+++ b/src/plan/module/frame/return_.rs
@@ -11,12 +11,14 @@ impl FrameLayout {
             ReturnExprKind::Float { body, .. } => self.include_float_return(body),
             ReturnExprKind::String { body, .. } => self.include_string_return(body),
             ReturnExprKind::BitArray { body, .. } => self.include_bit_array_return(body),
+            ReturnExprKind::UtfCodepoint { body, .. } => self.include_utf_codepoint_return(body),
             ReturnExprKind::Bool { body, .. } => self.include_bool_return(body),
             ReturnExprKind::Nil { body, .. } => self.include_nil_return(body),
             ReturnExprKind::Tuple { body, .. } => self.include_tuple_return(body),
             ReturnExprKind::IntList { body, .. } => self.include_typed_list_return(body),
             ReturnExprKind::StringList { body, .. } => self.include_typed_list_return(body),
             ReturnExprKind::BitArrayList { body, .. } => self.include_typed_list_return(body),
+            ReturnExprKind::UtfCodepointList { body, .. } => self.include_typed_list_return(body),
             ReturnExprKind::FloatList { body, .. } => self.include_typed_list_return(body),
             ReturnExprKind::BoolList { body, .. } => self.include_typed_list_return(body),
             ReturnExprKind::NilList { body, .. } => self.include_typed_list_return(body),
@@ -34,6 +36,9 @@ impl FrameLayout {
             }
             ReturnExprKind::BitArrayFunction { body, .. } => {
                 self.include_bit_array_function_return(body);
+            }
+            ReturnExprKind::UtfCodepointFunction { body, .. } => {
+                self.include_utf_codepoint_function_return(body);
             }
             ReturnExprKind::BoolFunction { body, .. } => {
                 self.include_bool_function_return(body);

--- a/src/plan/module/frame/return_/function.rs
+++ b/src/plan/module/frame/return_/function.rs
@@ -281,6 +281,64 @@ impl FrameLayout {
         }
     }
 
+    pub(in crate::plan::module::frame) fn include_utf_codepoint_function_return(
+        &mut self,
+        body: &crate::plan::UtfCodepointFunctionReturn,
+    ) {
+        match body.kind() {
+            ReturnBodyKind::Expr(expression) => {
+                self.include_utf_codepoint_function_expr(expression)
+            }
+            ReturnBodyKind::TailCall { args, .. } => self.include_call_args(args),
+            ReturnBodyKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_utf_codepoint_function_return(true_);
+                self.include_utf_codepoint_function_return(false_);
+            }
+            ReturnBodyKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_function_return(branch);
+                }
+                self.include_utf_codepoint_function_return(fallback);
+            }
+            ReturnBodyKind::FloatCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_float_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_function_return(branch);
+                }
+                self.include_utf_codepoint_function_return(fallback);
+            }
+            ReturnBodyKind::StringCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_string_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_function_return(branch);
+                }
+                self.include_utf_codepoint_function_return(fallback);
+            }
+            ReturnBodyKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_utf_codepoint_function_return(return_);
+            }
+        }
+    }
+
     pub(in crate::plan::module::frame) fn include_nil_function_return(
         &mut self,
         body: &crate::plan::NilFunctionReturn,

--- a/src/plan/module/frame/return_/primitive.rs
+++ b/src/plan/module/frame/return_/primitive.rs
@@ -281,6 +281,62 @@ impl FrameLayout {
         }
     }
 
+    pub(in crate::plan::module::frame) fn include_utf_codepoint_return(
+        &mut self,
+        body: &crate::plan::UtfCodepointReturn,
+    ) {
+        match body.kind() {
+            ReturnBodyKind::Expr(expression) => self.include_utf_codepoint_expr(expression),
+            ReturnBodyKind::TailCall { args, .. } => self.include_call_args(args),
+            ReturnBodyKind::BoolCase {
+                subject,
+                true_,
+                false_,
+            } => {
+                self.include_bool_expr(subject);
+                self.include_utf_codepoint_return(true_);
+                self.include_utf_codepoint_return(false_);
+            }
+            ReturnBodyKind::IntCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_int_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_return(branch);
+                }
+                self.include_utf_codepoint_return(fallback);
+            }
+            ReturnBodyKind::FloatCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_float_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_return(branch);
+                }
+                self.include_utf_codepoint_return(fallback);
+            }
+            ReturnBodyKind::StringCase {
+                subject,
+                clauses,
+                fallback,
+            } => {
+                self.include_string_expr(subject);
+                for (_, branch) in clauses {
+                    self.include_utf_codepoint_return(branch);
+                }
+                self.include_utf_codepoint_return(fallback);
+            }
+            ReturnBodyKind::Block { steps, return_ } => {
+                self.include_steps(steps);
+                self.include_utf_codepoint_return(return_);
+            }
+        }
+    }
+
     pub(in crate::plan::module::frame) fn include_nil_return(
         &mut self,
         body: &crate::plan::NilReturn,

--- a/src/plan/module/frame/step.rs
+++ b/src/plan/module/frame/step.rs
@@ -26,6 +26,10 @@ impl FrameLayout {
                 self.include_bit_array_expr(value);
                 self.include_bit_array(*local);
             }
+            StepKind::LetUtfCodepoint { local, value, .. } => {
+                self.include_utf_codepoint_expr(value);
+                self.include_utf_codepoint(*local);
+            }
             StepKind::LetBool { local, value, .. } => {
                 self.include_bool_expr(value);
                 self.include_bool(*local);
@@ -54,6 +58,10 @@ impl FrameLayout {
             StepKind::LetBitArrayFunction { local, value, .. } => {
                 self.include_bit_array_function_expr(value);
                 self.include_bit_array_function(*local);
+            }
+            StepKind::LetUtfCodepointFunction { local, value, .. } => {
+                self.include_utf_codepoint_function_expr(value);
+                self.include_utf_codepoint_function(*local);
             }
             StepKind::LetBoolFunction { local, value, .. } => {
                 self.include_bool_function_expr(value);

--- a/src/plan/module/function.rs
+++ b/src/plan/module/function.rs
@@ -2,7 +2,7 @@ use super::FrameLayout;
 use super::expression::{
     BitArrayExpr, BitArrayListExpr, BoolExpr, BoolListExpr, CallArg, FloatExpr, FloatListExpr,
     FunctionListExpr, IntExpr, IntListExpr, ListListExpr, NilExpr, NilListExpr, StringExpr,
-    StringListExpr, TupleExpr, TupleListExpr,
+    StringListExpr, TupleExpr, TupleListExpr, UtfCodepointExpr, UtfCodepointListExpr,
 };
 use super::id::{
     BitArrayFunctionFunctionId, BitArrayFunctionId, BitArrayFunctionLocalId,
@@ -15,6 +15,8 @@ use super::id::{
     NilFunctionLocalId, NilListFunctionId, NilLocalId, StringFunctionFunctionId, StringFunctionId,
     StringFunctionLocalId, StringListFunctionId, StringLocalId, TupleFunctionFunctionId,
     TupleFunctionId, TupleFunctionLocalId, TupleListFunctionId, TupleLocalId,
+    UtfCodepointFunctionFunctionId, UtfCodepointFunctionId, UtfCodepointFunctionLocalId,
+    UtfCodepointListFunctionId, UtfCodepointLocalId,
 };
 use super::step::Step;
 use crate::plan::{FunctionType, ValueType};
@@ -54,6 +56,7 @@ pub(crate) enum ParamLocal {
     Float(FloatLocalId),
     String(StringLocalId),
     BitArray(BitArrayLocalId),
+    UtfCodepoint(UtfCodepointLocalId),
     Bool(BoolLocalId),
     Nil(NilLocalId),
     Tuple {
@@ -75,6 +78,10 @@ pub(crate) enum ParamLocal {
     },
     BitArrayFunction {
         local: BitArrayFunctionLocalId,
+        type_: FunctionType,
+    },
+    UtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
         type_: FunctionType,
     },
     BoolFunction {
@@ -106,6 +113,7 @@ pub(crate) type IntReturn = ReturnBody<IntExpr, IntFunctionId>;
 pub(crate) type FloatReturn = ReturnBody<FloatExpr, FloatFunctionId>;
 pub(crate) type StringReturn = ReturnBody<StringExpr, StringFunctionId>;
 pub(crate) type BitArrayReturn = ReturnBody<BitArrayExpr, BitArrayFunctionId>;
+pub(crate) type UtfCodepointReturn = ReturnBody<UtfCodepointExpr, UtfCodepointFunctionId>;
 pub(crate) type BoolReturn = ReturnBody<BoolExpr, BoolFunctionId>;
 pub(crate) type NilReturn = ReturnBody<NilExpr, NilFunctionId>;
 pub(crate) type TupleReturn = ReturnBody<TupleExpr, TupleFunctionId>;
@@ -113,6 +121,8 @@ pub(crate) type IntListReturn = ReturnBody<IntListExpr, IntListFunctionId>;
 pub(crate) type FloatListReturn = ReturnBody<FloatListExpr, FloatListFunctionId>;
 pub(crate) type StringListReturn = ReturnBody<StringListExpr, StringListFunctionId>;
 pub(crate) type BitArrayListReturn = ReturnBody<BitArrayListExpr, BitArrayListFunctionId>;
+pub(crate) type UtfCodepointListReturn =
+    ReturnBody<UtfCodepointListExpr, UtfCodepointListFunctionId>;
 pub(crate) type BoolListReturn = ReturnBody<BoolListExpr, BoolListFunctionId>;
 pub(crate) type NilListReturn = ReturnBody<NilListExpr, NilListFunctionId>;
 pub(crate) type TupleListReturn = ReturnBody<TupleListExpr, TupleListFunctionId>;
@@ -124,6 +134,8 @@ pub(crate) type StringFunctionReturn =
     ReturnBody<super::StringFunctionExpr, StringFunctionFunctionId>;
 pub(crate) type BitArrayFunctionReturn =
     ReturnBody<super::BitArrayFunctionExpr, BitArrayFunctionFunctionId>;
+pub(crate) type UtfCodepointFunctionReturn =
+    ReturnBody<super::UtfCodepointFunctionExpr, UtfCodepointFunctionFunctionId>;
 pub(crate) type BoolFunctionReturn = ReturnBody<super::BoolFunctionExpr, BoolFunctionFunctionId>;
 pub(crate) type NilFunctionReturn = ReturnBody<super::NilFunctionExpr, NilFunctionFunctionId>;
 pub(crate) type TupleFunctionReturn = ReturnBody<super::TupleFunctionExpr, TupleFunctionFunctionId>;
@@ -138,6 +150,7 @@ pub(crate) enum ListReturn {
     Float(FloatListReturn),
     String(StringListReturn),
     BitArray(BitArrayListReturn),
+    UtfCodepoint(UtfCodepointListReturn),
     Bool(BoolListReturn),
     Nil(NilListReturn),
     Tuple {
@@ -163,6 +176,9 @@ impl ListReturn {
             ListExpr::Float(expression) => Self::Float(FloatListReturn::expr(expression)),
             ListExpr::String(expression) => Self::String(StringListReturn::expr(expression)),
             ListExpr::BitArray(expression) => Self::BitArray(BitArrayListReturn::expr(expression)),
+            ListExpr::UtfCodepoint(expression) => {
+                Self::UtfCodepoint(UtfCodepointListReturn::expr(expression))
+            }
             ListExpr::Bool(expression) => Self::Bool(BoolListReturn::expr(expression)),
             ListExpr::Nil(expression) => Self::Nil(NilListReturn::expr(expression)),
             ListExpr::Tuple(expression) => Self::Tuple {
@@ -192,6 +208,9 @@ impl ListReturn {
             }
             ListFunctionId::BitArray(function) => {
                 Self::BitArray(BitArrayListReturn::tail_call(function, args))
+            }
+            ListFunctionId::UtfCodepoint(function) => {
+                Self::UtfCodepoint(UtfCodepointListReturn::tail_call(function, args))
             }
             ListFunctionId::Bool(function) => Self::Bool(BoolListReturn::tail_call(function, args)),
             ListFunctionId::Nil(function) => Self::Nil(NilListReturn::tail_call(function, args)),
@@ -224,6 +243,9 @@ impl ListReturn {
             }
             (Self::BitArray(true_), Self::BitArray(false_)) => {
                 Self::BitArray(BitArrayListReturn::bool_case(subject, true_, false_))
+            }
+            (Self::UtfCodepoint(true_), Self::UtfCodepoint(false_)) => {
+                Self::UtfCodepoint(UtfCodepointListReturn::bool_case(subject, true_, false_))
             }
             (Self::Bool(true_), Self::Bool(false_)) => {
                 Self::Bool(BoolListReturn::bool_case(subject, true_, false_))
@@ -313,6 +335,16 @@ impl ListReturn {
                 })?,
                 fallback,
             ))),
+            Self::UtfCodepoint(fallback) => {
+                Some(Self::UtfCodepoint(UtfCodepointListReturn::int_case(
+                    subject,
+                    into_list_return_clauses(clauses, |branch| match branch {
+                        Self::UtfCodepoint(branch) => Some(branch),
+                        _ => None,
+                    })?,
+                    fallback,
+                )))
+            }
             Self::Bool(fallback) => Some(Self::Bool(BoolListReturn::int_case(
                 subject,
                 into_list_return_clauses(clauses, |branch| match branch {
@@ -419,6 +451,16 @@ impl ListReturn {
                 })?,
                 fallback,
             ))),
+            Self::UtfCodepoint(fallback) => {
+                Some(Self::UtfCodepoint(UtfCodepointListReturn::float_case(
+                    subject,
+                    into_list_return_clauses(clauses, |branch| match branch {
+                        Self::UtfCodepoint(branch) => Some(branch),
+                        _ => None,
+                    })?,
+                    fallback,
+                )))
+            }
             Self::Bool(fallback) => Some(Self::Bool(BoolListReturn::float_case(
                 subject,
                 into_list_return_clauses(clauses, |branch| match branch {
@@ -525,6 +567,16 @@ impl ListReturn {
                 })?,
                 fallback,
             ))),
+            Self::UtfCodepoint(fallback) => {
+                Some(Self::UtfCodepoint(UtfCodepointListReturn::string_case(
+                    subject,
+                    into_list_return_clauses(clauses, |branch| match branch {
+                        Self::UtfCodepoint(branch) => Some(branch),
+                        _ => None,
+                    })?,
+                    fallback,
+                )))
+            }
             Self::Bool(fallback) => Some(Self::Bool(BoolListReturn::string_case(
                 subject,
                 into_list_return_clauses(clauses, |branch| match branch {
@@ -599,6 +651,9 @@ impl ListReturn {
             Self::Float(return_) => Self::Float(FloatListReturn::block(steps, return_)),
             Self::String(return_) => Self::String(StringListReturn::block(steps, return_)),
             Self::BitArray(return_) => Self::BitArray(BitArrayListReturn::block(steps, return_)),
+            Self::UtfCodepoint(return_) => {
+                Self::UtfCodepoint(UtfCodepointListReturn::block(steps, return_))
+            }
             Self::Bool(return_) => Self::Bool(BoolListReturn::block(steps, return_)),
             Self::Nil(return_) => Self::Nil(NilListReturn::block(steps, return_)),
             Self::Tuple { item_type, body } => Self::Tuple {
@@ -689,6 +744,10 @@ pub(crate) enum ReturnExprKind {
         runtime_id: BitArrayFunctionId,
         body: BitArrayReturn,
     },
+    UtfCodepoint {
+        runtime_id: UtfCodepointFunctionId,
+        body: UtfCodepointReturn,
+    },
     Bool {
         runtime_id: BoolFunctionId,
         body: BoolReturn,
@@ -713,6 +772,10 @@ pub(crate) enum ReturnExprKind {
     BitArrayList {
         runtime_id: BitArrayListFunctionId,
         body: BitArrayListReturn,
+    },
+    UtfCodepointList {
+        runtime_id: UtfCodepointListFunctionId,
+        body: UtfCodepointListReturn,
     },
     FloatList {
         runtime_id: FloatListFunctionId,
@@ -760,6 +823,11 @@ pub(crate) enum ReturnExprKind {
         runtime_id: BitArrayFunctionFunctionId,
         type_: FunctionType,
         body: BitArrayFunctionReturn,
+    },
+    UtfCodepointFunction {
+        runtime_id: UtfCodepointFunctionFunctionId,
+        type_: FunctionType,
+        body: UtfCodepointFunctionReturn,
     },
     BoolFunction {
         runtime_id: BoolFunctionFunctionId,
@@ -886,6 +954,15 @@ impl ReturnExpr {
         }
     }
 
+    pub(crate) fn utf_codepoint_body(
+        runtime_id: UtfCodepointFunctionId,
+        body: UtfCodepointReturn,
+    ) -> Self {
+        Self {
+            kind: ReturnExprKind::UtfCodepoint { runtime_id, body },
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn bool(runtime_id: BoolFunctionId, expression: BoolExpr) -> Self {
         Self::bool_body(runtime_id, ReturnBody::expr(expression))
@@ -949,6 +1026,15 @@ impl ReturnExpr {
     ) -> Self {
         Self {
             kind: ReturnExprKind::BitArrayList { runtime_id, body },
+        }
+    }
+
+    pub(crate) fn utf_codepoint_list_body(
+        runtime_id: UtfCodepointListFunctionId,
+        body: UtfCodepointListReturn,
+    ) -> Self {
+        Self {
+            kind: ReturnExprKind::UtfCodepointList { runtime_id, body },
         }
     }
 
@@ -1104,6 +1190,20 @@ impl ReturnExpr {
         }
     }
 
+    pub(crate) fn utf_codepoint_function_body(
+        runtime_id: UtfCodepointFunctionFunctionId,
+        type_: FunctionType,
+        body: UtfCodepointFunctionReturn,
+    ) -> Self {
+        Self {
+            kind: ReturnExprKind::UtfCodepointFunction {
+                runtime_id,
+                type_,
+                body,
+            },
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn bool_function(
         runtime_id: BoolFunctionFunctionId,
@@ -1227,12 +1327,16 @@ impl ReturnExpr {
             ReturnExprKind::Float { .. } => ValueType::Float,
             ReturnExprKind::String { .. } => ValueType::String,
             ReturnExprKind::BitArray { .. } => ValueType::BitArray,
+            ReturnExprKind::UtfCodepoint { .. } => ValueType::UtfCodepoint,
             ReturnExprKind::Bool { .. } => ValueType::Bool,
             ReturnExprKind::Nil { .. } => ValueType::Nil,
             ReturnExprKind::Tuple { type_, .. } => ValueType::Tuple(type_.clone()),
             ReturnExprKind::IntList { .. } => ValueType::List(Box::new(ValueType::Int)),
             ReturnExprKind::StringList { .. } => ValueType::List(Box::new(ValueType::String)),
             ReturnExprKind::BitArrayList { .. } => ValueType::List(Box::new(ValueType::BitArray)),
+            ReturnExprKind::UtfCodepointList { .. } => {
+                ValueType::List(Box::new(ValueType::UtfCodepoint))
+            }
             ReturnExprKind::FloatList { .. } => ValueType::List(Box::new(ValueType::Float)),
             ReturnExprKind::BoolList { .. } => ValueType::List(Box::new(ValueType::Bool)),
             ReturnExprKind::NilList { .. } => ValueType::List(Box::new(ValueType::Nil)),
@@ -1249,6 +1353,7 @@ impl ReturnExpr {
             | ReturnExprKind::FloatFunction { type_, .. }
             | ReturnExprKind::StringFunction { type_, .. }
             | ReturnExprKind::BitArrayFunction { type_, .. }
+            | ReturnExprKind::UtfCodepointFunction { type_, .. }
             | ReturnExprKind::BoolFunction { type_, .. }
             | ReturnExprKind::NilFunction { type_, .. }
             | ReturnExprKind::TupleFunction { type_, .. }
@@ -1268,6 +1373,9 @@ impl ReturnExpr {
             ReturnExprKind::Float { runtime_id, .. } => RuntimeFunctionId::Float(*runtime_id),
             ReturnExprKind::String { runtime_id, .. } => RuntimeFunctionId::String(*runtime_id),
             ReturnExprKind::BitArray { runtime_id, .. } => RuntimeFunctionId::BitArray(*runtime_id),
+            ReturnExprKind::UtfCodepoint { runtime_id, .. } => {
+                RuntimeFunctionId::UtfCodepoint(*runtime_id)
+            }
             ReturnExprKind::Bool { runtime_id, .. } => RuntimeFunctionId::Bool(*runtime_id),
             ReturnExprKind::Nil { runtime_id, .. } => RuntimeFunctionId::Nil(*runtime_id),
             ReturnExprKind::Tuple {
@@ -1284,6 +1392,9 @@ impl ReturnExpr {
             }
             ReturnExprKind::BitArrayList { runtime_id, .. } => {
                 RuntimeFunctionId::List(ListFunctionId::BitArray(*runtime_id))
+            }
+            ReturnExprKind::UtfCodepointList { runtime_id, .. } => {
+                RuntimeFunctionId::List(ListFunctionId::UtfCodepoint(*runtime_id))
             }
             ReturnExprKind::FloatList { runtime_id, .. } => {
                 RuntimeFunctionId::List(ListFunctionId::Float(*runtime_id))
@@ -1340,6 +1451,12 @@ impl ReturnExpr {
                 runtime_id, type_, ..
             } => RuntimeFunctionId::Function {
                 id: FunctionFunctionId::BitArray(*runtime_id),
+                return_type: type_.clone(),
+            },
+            ReturnExprKind::UtfCodepointFunction {
+                runtime_id, type_, ..
+            } => RuntimeFunctionId::Function {
+                id: FunctionFunctionId::UtfCodepoint(*runtime_id),
                 return_type: type_.clone(),
             },
             ReturnExprKind::BoolFunction {
@@ -1501,6 +1618,10 @@ impl ParamLocal {
         Self::BitArray(local)
     }
 
+    pub(crate) fn utf_codepoint(local: UtfCodepointLocalId) -> Self {
+        Self::UtfCodepoint(local)
+    }
+
     pub(crate) fn bool(local: BoolLocalId) -> Self {
         Self::Bool(local)
     }
@@ -1533,6 +1654,13 @@ impl ParamLocal {
         Self::BitArrayFunction { local, type_ }
     }
 
+    pub(crate) fn utf_codepoint_function(
+        local: UtfCodepointFunctionLocalId,
+        type_: FunctionType,
+    ) -> Self {
+        Self::UtfCodepointFunction { local, type_ }
+    }
+
     pub(crate) fn bool_function(local: BoolFunctionLocalId, type_: FunctionType) -> Self {
         Self::BoolFunction { local, type_ }
     }
@@ -1559,6 +1687,7 @@ impl ParamLocal {
             Self::Float(_) => ValueType::Float,
             Self::String(_) => ValueType::String,
             Self::BitArray(_) => ValueType::BitArray,
+            Self::UtfCodepoint(_) => ValueType::UtfCodepoint,
             Self::Bool(_) => ValueType::Bool,
             Self::Nil(_) => ValueType::Nil,
             Self::Tuple { type_, .. } => ValueType::Tuple(type_.clone()),
@@ -1567,6 +1696,7 @@ impl ParamLocal {
             | Self::FloatFunction { type_, .. }
             | Self::StringFunction { type_, .. }
             | Self::BitArrayFunction { type_, .. }
+            | Self::UtfCodepointFunction { type_, .. }
             | Self::BoolFunction { type_, .. }
             | Self::NilFunction { type_, .. }
             | Self::TupleFunction { type_, .. }
@@ -1599,7 +1729,10 @@ mod tests {
         RuntimeFunctionId, StringExpr, StringFunctionExpr, StringFunctionFunctionId,
         StringFunctionId, StringFunctionLocalId, StringFunctionReference, StringListFunctionId,
         TupleExpr, TupleFunctionExpr, TupleFunctionFunctionId, TupleFunctionId,
-        TupleFunctionLocalId, TupleFunctionReference, TupleListFunctionId, ValueType,
+        TupleFunctionLocalId, TupleFunctionReference, TupleListFunctionId, UtfCodepointExpr,
+        UtfCodepointFunctionExpr, UtfCodepointFunctionFunctionId, UtfCodepointFunctionId,
+        UtfCodepointFunctionReference, UtfCodepointFunctionReturn, UtfCodepointListFunctionId,
+        UtfCodepointListReturn, UtfCodepointLocalId, UtfCodepointReturn, ValueType,
     };
     use num_bigint::BigInt;
 
@@ -1645,6 +1778,17 @@ mod tests {
             ReturnExpr::bit_array(BitArrayFunctionId(0), BitArrayExpr::value(Vec::new()))
                 .value_type(),
             ValueType::BitArray,
+        );
+        assert_eq!(
+            ReturnExpr::utf_codepoint_body(
+                UtfCodepointFunctionId(0),
+                UtfCodepointReturn::expr(UtfCodepointExpr::local_get(
+                    UtfCodepointLocalId(0),
+                    "codepoint".into(),
+                )),
+            )
+            .value_type(),
+            ValueType::UtfCodepoint,
         );
         assert_eq!(
             ReturnExpr::float(FloatFunctionId(0), FloatExpr::value(1.0)).value_type(),
@@ -1715,6 +1859,20 @@ mod tests {
             ValueType::Function(Box::new(
                 FunctionType::new(Vec::new(), ValueType::BitArray,)
             )),
+        );
+        assert_eq!(
+            ReturnExpr::utf_codepoint_function_body(
+                UtfCodepointFunctionFunctionId(0),
+                FunctionType::new(Vec::new(), ValueType::UtfCodepoint),
+                UtfCodepointFunctionReturn::expr(UtfCodepointFunctionExpr::reference(
+                    UtfCodepointFunctionReference::new(UtfCodepointFunctionId(0), Vec::new()),
+                )),
+            )
+            .value_type(),
+            ValueType::Function(Box::new(FunctionType::new(
+                Vec::new(),
+                ValueType::UtfCodepoint,
+            ))),
         );
         assert_eq!(
             ReturnExpr::float_function(
@@ -1844,6 +2002,18 @@ mod tests {
                 ListFunctionId::BitArray(BitArrayListFunctionId(9)),
             ),
             (
+                ReturnExpr::utf_codepoint_list_body(
+                    UtfCodepointListFunctionId(10),
+                    UtfCodepointListReturn::expr(
+                        ListExpr::value(Vec::new(), ValueType::UtfCodepoint)
+                            .into_utf_codepoint()
+                            .expect("expression should be List(UtfCodepoint)"),
+                    ),
+                ),
+                ValueType::UtfCodepoint,
+                ListFunctionId::UtfCodepoint(UtfCodepointListFunctionId(10)),
+            ),
+            (
                 ReturnExpr::float_list_body(
                     FloatListFunctionId(3),
                     FloatListReturn::expr(
@@ -1963,6 +2133,16 @@ mod tests {
                 RuntimeFunctionId::BitArray(BitArrayFunctionId(11)),
             ),
             (
+                ReturnExpr::utf_codepoint_body(
+                    UtfCodepointFunctionId(12),
+                    UtfCodepointReturn::expr(UtfCodepointExpr::local_get(
+                        UtfCodepointLocalId(0),
+                        "codepoint".into(),
+                    )),
+                ),
+                RuntimeFunctionId::UtfCodepoint(UtfCodepointFunctionId(12)),
+            ),
+            (
                 ReturnExpr::bool(BoolFunctionId(3), BoolExpr::value(true)),
                 RuntimeFunctionId::Bool(BoolFunctionId(3)),
             ),
@@ -2033,6 +2213,19 @@ mod tests {
                 RuntimeFunctionId::Function {
                     id: FunctionFunctionId::BitArray(BitArrayFunctionFunctionId(12)),
                     return_type: FunctionType::new(Vec::new(), ValueType::BitArray),
+                },
+            ),
+            (
+                ReturnExpr::utf_codepoint_function_body(
+                    UtfCodepointFunctionFunctionId(13),
+                    FunctionType::new(Vec::new(), ValueType::UtfCodepoint),
+                    UtfCodepointFunctionReturn::expr(UtfCodepointFunctionExpr::reference(
+                        UtfCodepointFunctionReference::new(UtfCodepointFunctionId(0), Vec::new()),
+                    )),
+                ),
+                RuntimeFunctionId::Function {
+                    id: FunctionFunctionId::UtfCodepoint(UtfCodepointFunctionFunctionId(13)),
+                    return_type: FunctionType::new(Vec::new(), ValueType::UtfCodepoint),
                 },
             ),
             (
@@ -2146,6 +2339,10 @@ mod tests {
             ValueType::String,
         );
         assert_eq!(
+            ParamLocal::utf_codepoint(UtfCodepointLocalId(0)).value_type(),
+            ValueType::UtfCodepoint,
+        );
+        assert_eq!(
             ParamLocal::float(FloatLocalId(0)).value_type(),
             ValueType::Float,
         );
@@ -2181,6 +2378,17 @@ mod tests {
             ValueType::Function(Box::new(FunctionType::new(
                 vec![ValueType::String],
                 ValueType::String,
+            ))),
+        );
+        assert_eq!(
+            ParamLocal::utf_codepoint_function(
+                crate::plan::UtfCodepointFunctionLocalId(0),
+                FunctionType::new(vec![ValueType::UtfCodepoint], ValueType::UtfCodepoint,),
+            )
+            .value_type(),
+            ValueType::Function(Box::new(FunctionType::new(
+                vec![ValueType::UtfCodepoint],
+                ValueType::UtfCodepoint,
             ))),
         );
         assert_eq!(
@@ -2307,6 +2515,21 @@ mod tests {
             )),
         );
 
+        let utf_codepoint = ListExpr::value(
+            vec![crate::plan::Expr::utf_codepoint(
+                UtfCodepointExpr::local_get(UtfCodepointLocalId(0), "codepoint".into()),
+            )],
+            ValueType::UtfCodepoint,
+        );
+        assert_eq!(
+            ListReturn::expr(utf_codepoint.clone()),
+            ListReturn::UtfCodepoint(UtfCodepointListReturn::expr(
+                utf_codepoint
+                    .into_utf_codepoint()
+                    .expect("UTF codepoint list"),
+            )),
+        );
+
         let bool_ = ListExpr::value(
             vec![crate::plan::Expr::bool(BoolExpr::value(true))],
             ValueType::Bool,
@@ -2401,6 +2624,16 @@ mod tests {
             ),
             ListReturn::BitArray(BitArrayListReturn::tail_call(
                 BitArrayListFunctionId(0),
+                Vec::new(),
+            )),
+        );
+        assert_eq!(
+            ListReturn::tail_call(
+                ListFunctionId::UtfCodepoint(UtfCodepointListFunctionId(0)),
+                Vec::new(),
+            ),
+            ListReturn::UtfCodepoint(UtfCodepointListReturn::tail_call(
+                UtfCodepointListFunctionId(0),
                 Vec::new(),
             )),
         );
@@ -2710,6 +2943,7 @@ mod tests {
             ValueType::Float,
             ValueType::String,
             ValueType::BitArray,
+            ValueType::UtfCodepoint,
             ValueType::Bool,
             ValueType::Nil,
             ValueType::Tuple(vec![ValueType::Int]),
@@ -2778,6 +3012,7 @@ mod tests {
             ValueType::Float,
             ValueType::String,
             ValueType::BitArray,
+            ValueType::UtfCodepoint,
             ValueType::Bool,
             ValueType::Nil,
             ValueType::Tuple(vec![ValueType::Int]),
@@ -2880,6 +3115,7 @@ mod tests {
             ListReturn::Float(_) => ValueType::Float,
             ListReturn::String(_) => ValueType::String,
             ListReturn::BitArray(_) => ValueType::BitArray,
+            ListReturn::UtfCodepoint(_) => ValueType::UtfCodepoint,
             ListReturn::Bool(_) => ValueType::Bool,
             ListReturn::Nil(_) => ValueType::Nil,
             ListReturn::Tuple { item_type, .. } => ValueType::Tuple(item_type.clone()),

--- a/src/plan/module/id.rs
+++ b/src/plan/module/id.rs
@@ -4,6 +4,7 @@ pub enum LocalId {
     Float(FloatLocalId),
     String(StringLocalId),
     BitArray(BitArrayLocalId),
+    UtfCodepoint(UtfCodepointLocalId),
     Bool(BoolLocalId),
     Nil(NilLocalId),
 }
@@ -19,6 +20,9 @@ pub struct StringLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BitArrayLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoolLocalId(pub(crate) usize);
@@ -37,6 +41,9 @@ pub struct StringListLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BitArrayListLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointListLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FloatListLocalId(pub(crate) usize);
@@ -61,6 +68,7 @@ pub enum ListLocal {
     Int(IntListLocalId),
     String(StringListLocalId),
     BitArray(BitArrayListLocalId),
+    UtfCodepoint(UtfCodepointListLocalId),
     Float(FloatListLocalId),
     Bool(BoolListLocalId),
     Nil(NilListLocalId),
@@ -91,6 +99,9 @@ pub struct StringFunctionLocalId(pub(crate) usize);
 pub struct BitArrayFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UtfCodepointFunctionLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BoolFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -107,6 +118,9 @@ pub struct StringListFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BitArrayListFunctionLocalId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UtfCodepointListFunctionLocalId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FloatListFunctionLocalId(pub(crate) usize);
@@ -138,6 +152,10 @@ pub enum ListFunctionLocal {
     },
     BitArray {
         local: BitArrayListFunctionLocalId,
+        type_: crate::plan::FunctionType,
+    },
+    UtfCodepoint {
+        local: UtfCodepointListFunctionLocalId,
         type_: crate::plan::FunctionType,
     },
     Float {
@@ -181,6 +199,7 @@ pub(crate) enum RuntimeFunctionId {
     Float(FloatFunctionId),
     String(StringFunctionId),
     BitArray(BitArrayFunctionId),
+    UtfCodepoint(UtfCodepointFunctionId),
     Bool(BoolFunctionId),
     Nil(NilFunctionId),
     Tuple {
@@ -207,6 +226,9 @@ pub struct StringFunctionId(pub(crate) usize);
 pub struct BitArrayFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointFunctionId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoolFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -223,6 +245,9 @@ pub struct StringListFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BitArrayListFunctionId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointListFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FloatListFunctionId(pub(crate) usize);
@@ -247,6 +272,7 @@ pub enum ListFunctionId {
     Int(IntListFunctionId),
     String(StringListFunctionId),
     BitArray(BitArrayListFunctionId),
+    UtfCodepoint(UtfCodepointListFunctionId),
     Float(FloatListFunctionId),
     Bool(BoolListFunctionId),
     Nil(NilListFunctionId),
@@ -270,6 +296,7 @@ pub(crate) enum FunctionFunctionId {
     Float(FloatFunctionFunctionId),
     String(StringFunctionFunctionId),
     BitArray(BitArrayFunctionFunctionId),
+    UtfCodepoint(UtfCodepointFunctionFunctionId),
     Bool(BoolFunctionFunctionId),
     Nil(NilFunctionFunctionId),
     Tuple(TupleFunctionFunctionId),
@@ -283,6 +310,7 @@ pub enum FunctionReturnFamily {
     Float,
     String,
     BitArray,
+    UtfCodepoint,
     Bool,
     Nil,
     Tuple,
@@ -303,6 +331,9 @@ pub struct StringFunctionFunctionId(pub(crate) usize);
 pub struct BitArrayFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointFunctionFunctionId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoolFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -319,6 +350,9 @@ pub struct StringListFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BitArrayListFunctionFunctionId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtfCodepointListFunctionFunctionId(pub(crate) usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FloatListFunctionFunctionId(pub(crate) usize);
@@ -350,6 +384,10 @@ pub enum ListFunctionFunctionId {
     },
     BitArray {
         id: BitArrayListFunctionFunctionId,
+        type_: crate::plan::FunctionType,
+    },
+    UtfCodepoint {
+        id: UtfCodepointListFunctionFunctionId,
         type_: crate::plan::FunctionType,
     },
     Float {
@@ -391,6 +429,7 @@ impl LocalId {
             Self::Float(_) => crate::plan::ValueType::Float,
             Self::String(_) => crate::plan::ValueType::String,
             Self::BitArray(_) => crate::plan::ValueType::BitArray,
+            Self::UtfCodepoint(_) => crate::plan::ValueType::UtfCodepoint,
             Self::Bool(_) => crate::plan::ValueType::Bool,
             Self::Nil(_) => crate::plan::ValueType::Nil,
         }
@@ -416,6 +455,7 @@ impl FunctionFunctionId {
             Self::Float(_) => FunctionReturnFamily::Float,
             Self::String(_) => FunctionReturnFamily::String,
             Self::BitArray(_) => FunctionReturnFamily::BitArray,
+            Self::UtfCodepoint(_) => FunctionReturnFamily::UtfCodepoint,
             Self::Bool(_) => FunctionReturnFamily::Bool,
             Self::Nil(_) => FunctionReturnFamily::Nil,
             Self::Tuple(_) => FunctionReturnFamily::Tuple,
@@ -441,6 +481,13 @@ impl FunctionFunctionId {
     pub(crate) fn bit_array(&self) -> Option<BitArrayFunctionFunctionId> {
         match self {
             Self::BitArray(id) => Some(*id),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn utf_codepoint(&self) -> Option<UtfCodepointFunctionFunctionId> {
+        match self {
+            Self::UtfCodepoint(id) => Some(*id),
             _ => None,
         }
     }
@@ -500,6 +547,9 @@ impl ListFunctionLocal {
             crate::plan::ValueType::BitArray => {
                 Self::bit_array(BitArrayListFunctionLocalId(index), type_)
             }
+            crate::plan::ValueType::UtfCodepoint => {
+                Self::utf_codepoint(UtfCodepointListFunctionLocalId(index), type_)
+            }
             crate::plan::ValueType::Float => Self::float(FloatListFunctionLocalId(index), type_),
             crate::plan::ValueType::Bool => Self::bool(BoolListFunctionLocalId(index), type_),
             crate::plan::ValueType::Nil => Self::nil(NilListFunctionLocalId(index), type_),
@@ -531,6 +581,13 @@ impl ListFunctionLocal {
         type_: crate::plan::FunctionType,
     ) -> Self {
         Self::BitArray { local, type_ }
+    }
+
+    pub(crate) fn utf_codepoint(
+        local: UtfCodepointListFunctionLocalId,
+        type_: crate::plan::FunctionType,
+    ) -> Self {
+        Self::UtfCodepoint { local, type_ }
     }
 
     pub(crate) fn float(local: FloatListFunctionLocalId, type_: crate::plan::FunctionType) -> Self {
@@ -586,6 +643,7 @@ impl ListFunctionLocal {
             Self::Int { type_, .. }
             | Self::String { type_, .. }
             | Self::BitArray { type_, .. }
+            | Self::UtfCodepoint { type_, .. }
             | Self::Float { type_, .. }
             | Self::Bool { type_, .. }
             | Self::Nil { type_, .. }
@@ -604,6 +662,7 @@ impl ListFunctionLocal {
             Self::Int { .. } => crate::plan::ValueType::Int,
             Self::String { .. } => crate::plan::ValueType::String,
             Self::BitArray { .. } => crate::plan::ValueType::BitArray,
+            Self::UtfCodepoint { .. } => crate::plan::ValueType::UtfCodepoint,
             Self::Float { .. } => crate::plan::ValueType::Float,
             Self::Bool { .. } => crate::plan::ValueType::Bool,
             Self::Nil { .. } => crate::plan::ValueType::Nil,
@@ -618,6 +677,7 @@ impl ListFunctionLocal {
             Self::Int { local, .. } => local.0,
             Self::String { local, .. } => local.0,
             Self::BitArray { local, .. } => local.0,
+            Self::UtfCodepoint { local, .. } => local.0,
             Self::Float { local, .. } => local.0,
             Self::Bool { local, .. } => local.0,
             Self::Nil { local, .. } => local.0,
@@ -635,6 +695,9 @@ impl ListFunctionId {
             crate::plan::ValueType::Int => Self::Int(IntListFunctionId(index)),
             crate::plan::ValueType::String => Self::String(StringListFunctionId(index)),
             crate::plan::ValueType::BitArray => Self::BitArray(BitArrayListFunctionId(index)),
+            crate::plan::ValueType::UtfCodepoint => {
+                Self::UtfCodepoint(UtfCodepointListFunctionId(index))
+            }
             crate::plan::ValueType::Float => Self::Float(FloatListFunctionId(index)),
             crate::plan::ValueType::Bool => Self::Bool(BoolListFunctionId(index)),
             crate::plan::ValueType::Nil => Self::Nil(NilListFunctionId(index)),
@@ -658,6 +721,7 @@ impl ListFunctionId {
             Self::Int(_) => crate::plan::ValueType::Int,
             Self::String(_) => crate::plan::ValueType::String,
             Self::BitArray(_) => crate::plan::ValueType::BitArray,
+            Self::UtfCodepoint(_) => crate::plan::ValueType::UtfCodepoint,
             Self::Float(_) => crate::plan::ValueType::Float,
             Self::Bool(_) => crate::plan::ValueType::Bool,
             Self::Nil(_) => crate::plan::ValueType::Nil,
@@ -687,6 +751,10 @@ impl ListFunctionFunctionId {
             },
             crate::plan::ValueType::BitArray => Self::BitArray {
                 id: BitArrayListFunctionFunctionId(index),
+                type_,
+            },
+            crate::plan::ValueType::UtfCodepoint => Self::UtfCodepoint {
+                id: UtfCodepointListFunctionFunctionId(index),
                 type_,
             },
             crate::plan::ValueType::Float => Self::Float {
@@ -724,6 +792,7 @@ impl ListFunctionFunctionId {
             Self::Int { type_, .. }
             | Self::String { type_, .. }
             | Self::BitArray { type_, .. }
+            | Self::UtfCodepoint { type_, .. }
             | Self::Float { type_, .. }
             | Self::Bool { type_, .. }
             | Self::Nil { type_, .. }
@@ -738,6 +807,7 @@ impl ListFunctionFunctionId {
             Self::Int { .. } => crate::plan::ValueType::Int,
             Self::String { .. } => crate::plan::ValueType::String,
             Self::BitArray { .. } => crate::plan::ValueType::BitArray,
+            Self::UtfCodepoint { .. } => crate::plan::ValueType::UtfCodepoint,
             Self::Float { .. } => crate::plan::ValueType::Float,
             Self::Bool { .. } => crate::plan::ValueType::Bool,
             Self::Nil { .. } => crate::plan::ValueType::Nil,
@@ -759,6 +829,10 @@ impl ListLocal {
 
     pub(crate) fn bit_array(local: BitArrayListLocalId) -> Self {
         Self::BitArray(local)
+    }
+
+    pub(crate) fn utf_codepoint(local: UtfCodepointListLocalId) -> Self {
+        Self::UtfCodepoint(local)
     }
 
     pub(crate) fn float(local: FloatListLocalId) -> Self {
@@ -796,6 +870,7 @@ impl ListLocal {
             Self::Int(_) => crate::plan::ValueType::Int,
             Self::String(_) => crate::plan::ValueType::String,
             Self::BitArray(_) => crate::plan::ValueType::BitArray,
+            Self::UtfCodepoint(_) => crate::plan::ValueType::UtfCodepoint,
             Self::Float(_) => crate::plan::ValueType::Float,
             Self::Bool(_) => crate::plan::ValueType::Bool,
             Self::Nil(_) => crate::plan::ValueType::Nil,
@@ -816,6 +891,7 @@ impl ListLocal {
             Self::Int(_) => "int",
             Self::String(_) => "string",
             Self::BitArray(_) => "bit array",
+            Self::UtfCodepoint(_) => "utf codepoint",
             Self::Float(_) => "float",
             Self::Bool(_) => "bool",
             Self::Nil(_) => "nil",
@@ -830,6 +906,7 @@ impl ListLocal {
             Self::Int(local) => local.0,
             Self::String(local) => local.0,
             Self::BitArray(local) => local.0,
+            Self::UtfCodepoint(local) => local.0,
             Self::Float(local) => local.0,
             Self::Bool(local) => local.0,
             Self::Nil(local) => local.0,
@@ -847,6 +924,7 @@ impl std::fmt::Display for FunctionReturnFamily {
             Self::Float => f.write_str("Float"),
             Self::String => f.write_str("String"),
             Self::BitArray => f.write_str("BitArray"),
+            Self::UtfCodepoint => f.write_str("UtfCodepoint"),
             Self::Bool => f.write_str("Bool"),
             Self::Nil => f.write_str("Nil"),
             Self::Tuple => f.write_str("Tuple"),
@@ -873,7 +951,9 @@ mod tests {
         StringFunctionFunctionId, StringFunctionLocalId, StringListFunctionFunctionId,
         StringListFunctionLocalId, StringListLocalId, TupleFunctionFunctionId,
         TupleFunctionLocalId, TupleListFunctionFunctionId, TupleListFunctionLocalId,
-        TupleListLocalId,
+        TupleListLocalId, UtfCodepointFunctionFunctionId, UtfCodepointFunctionLocalId,
+        UtfCodepointListFunctionFunctionId, UtfCodepointListFunctionLocalId,
+        UtfCodepointListLocalId,
     };
     use crate::plan::{FunctionType, ValueType};
 
@@ -899,6 +979,10 @@ mod tests {
         assert_eq!(
             format!("{:?}", BitArrayFunctionLocalId(3)),
             "BitArrayFunctionLocalId(3)"
+        );
+        assert_eq!(
+            format!("{:?}", UtfCodepointFunctionLocalId(3)),
+            "UtfCodepointFunctionLocalId(3)"
         );
         assert_eq!(
             format!("{:?}", BoolFunctionLocalId(3)),
@@ -949,6 +1033,10 @@ mod tests {
         assert_eq!(
             FunctionFunctionId::BitArray(BitArrayFunctionFunctionId(7)).bit_array(),
             Some(BitArrayFunctionFunctionId(7)),
+        );
+        assert_eq!(
+            FunctionFunctionId::UtfCodepoint(UtfCodepointFunctionFunctionId(8)).utf_codepoint(),
+            Some(UtfCodepointFunctionFunctionId(8)),
         );
         assert_eq!(
             FunctionFunctionId::Bool(BoolFunctionFunctionId(3)).bool(),
@@ -1002,6 +1090,10 @@ mod tests {
             None,
         );
         assert_eq!(
+            FunctionFunctionId::Int(IntFunctionFunctionId(1)).utf_codepoint(),
+            None,
+        );
+        assert_eq!(
             FunctionFunctionId::Int(IntFunctionFunctionId(1)).float(),
             None,
         );
@@ -1046,6 +1138,10 @@ mod tests {
             super::FunctionReturnFamily::BitArray,
         );
         assert_eq!(
+            FunctionFunctionId::UtfCodepoint(UtfCodepointFunctionFunctionId(1)).family(),
+            super::FunctionReturnFamily::UtfCodepoint,
+        );
+        assert_eq!(
             FunctionFunctionId::Bool(BoolFunctionFunctionId(1)).family(),
             super::FunctionReturnFamily::Bool,
         );
@@ -1084,6 +1180,10 @@ mod tests {
             super::FunctionReturnFamily::BitArray.to_string(),
             "BitArray"
         );
+        assert_eq!(
+            super::FunctionReturnFamily::UtfCodepoint.to_string(),
+            "UtfCodepoint"
+        );
         assert_eq!(super::FunctionReturnFamily::Bool.to_string(), "Bool");
         assert_eq!(super::FunctionReturnFamily::Nil.to_string(), "Nil");
         assert_eq!(super::FunctionReturnFamily::Tuple.to_string(), "Tuple");
@@ -1101,6 +1201,7 @@ mod tests {
             ListLocal::int(IntListLocalId(3)),
             ListLocal::string(StringListLocalId(3)),
             ListLocal::bit_array(BitArrayListLocalId(3)),
+            ListLocal::utf_codepoint(UtfCodepointListLocalId(3)),
             ListLocal::float(super::FloatListLocalId(3)),
             ListLocal::bool(super::BoolListLocalId(3)),
             ListLocal::nil(NilListLocalId(3)),
@@ -1118,7 +1219,7 @@ mod tests {
         );
         assert_eq!(
             locals.iter().map(ListLocal::index).collect::<Vec<_>>(),
-            vec![3; 9],
+            vec![3; 10],
         );
     }
 
@@ -1136,6 +1237,7 @@ mod tests {
             ListFunctionLocal::from_item_type(3, cases[6].clone(), item_types[6].clone()),
             ListFunctionLocal::from_item_type(3, cases[7].clone(), item_types[7].clone()),
             ListFunctionLocal::from_item_type(3, cases[8].clone(), item_types[8].clone()),
+            ListFunctionLocal::from_item_type(3, cases[9].clone(), item_types[9].clone()),
         ];
 
         assert_eq!(
@@ -1144,22 +1246,26 @@ mod tests {
                 ListFunctionLocal::int(IntListFunctionLocalId(3), cases[0].clone()),
                 ListFunctionLocal::string(StringListFunctionLocalId(3), cases[1].clone()),
                 ListFunctionLocal::bit_array(BitArrayListFunctionLocalId(3), cases[2].clone(),),
-                ListFunctionLocal::float(FloatListFunctionLocalId(3), cases[3].clone()),
-                ListFunctionLocal::bool(BoolListFunctionLocalId(3), cases[4].clone()),
-                ListFunctionLocal::nil(NilListFunctionLocalId(3), cases[5].clone()),
+                ListFunctionLocal::utf_codepoint(
+                    UtfCodepointListFunctionLocalId(3),
+                    cases[3].clone(),
+                ),
+                ListFunctionLocal::float(FloatListFunctionLocalId(3), cases[4].clone()),
+                ListFunctionLocal::bool(BoolListFunctionLocalId(3), cases[5].clone()),
+                ListFunctionLocal::nil(NilListFunctionLocalId(3), cases[6].clone()),
                 ListFunctionLocal::tuple(
                     TupleListFunctionLocalId(3),
-                    cases[6].clone(),
+                    cases[7].clone(),
                     vec![ValueType::Int, ValueType::String],
                 ),
                 ListFunctionLocal::list(
                     ListListFunctionLocalId(3),
-                    cases[7].clone(),
+                    cases[8].clone(),
                     ValueType::Int,
                 ),
                 ListFunctionLocal::function(
                     FunctionListFunctionLocalId(3),
-                    cases[8].clone(),
+                    cases[9].clone(),
                     FunctionType::new(vec![ValueType::Int], ValueType::String),
                 ),
             ],
@@ -1187,7 +1293,7 @@ mod tests {
                 .iter()
                 .map(ListFunctionLocal::index)
                 .collect::<Vec<_>>(),
-            vec![3; 9],
+            vec![3; 10],
         );
     }
 
@@ -1205,6 +1311,7 @@ mod tests {
             ListFunctionFunctionId::from_item_type(7, cases[6].clone(), item_types[6].clone()),
             ListFunctionFunctionId::from_item_type(7, cases[7].clone(), item_types[7].clone()),
             ListFunctionFunctionId::from_item_type(7, cases[8].clone(), item_types[8].clone()),
+            ListFunctionFunctionId::from_item_type(7, cases[9].clone(), item_types[9].clone()),
         ];
 
         assert_eq!(
@@ -1222,31 +1329,35 @@ mod tests {
                     id: BitArrayListFunctionFunctionId(7),
                     type_: cases[2].clone(),
                 },
+                ListFunctionFunctionId::UtfCodepoint {
+                    id: UtfCodepointListFunctionFunctionId(7),
+                    type_: cases[3].clone(),
+                },
                 ListFunctionFunctionId::Float {
                     id: FloatListFunctionFunctionId(7),
-                    type_: cases[3].clone(),
+                    type_: cases[4].clone(),
                 },
                 ListFunctionFunctionId::Bool {
                     id: BoolListFunctionFunctionId(7),
-                    type_: cases[4].clone(),
+                    type_: cases[5].clone(),
                 },
                 ListFunctionFunctionId::Nil {
                     id: NilListFunctionFunctionId(7),
-                    type_: cases[5].clone(),
+                    type_: cases[6].clone(),
                 },
                 ListFunctionFunctionId::Tuple {
                     id: TupleListFunctionFunctionId(7),
-                    type_: cases[6].clone(),
+                    type_: cases[7].clone(),
                     item_type: vec![ValueType::Int, ValueType::String],
                 },
                 ListFunctionFunctionId::List {
                     id: ListListFunctionFunctionId(7),
-                    type_: cases[7].clone(),
+                    type_: cases[8].clone(),
                     item_type: Box::new(ValueType::Int),
                 },
                 ListFunctionFunctionId::Function {
                     id: FunctionListFunctionFunctionId(7),
-                    type_: cases[8].clone(),
+                    type_: cases[9].clone(),
                     item_type: Box::new(FunctionType::new(vec![ValueType::Int], ValueType::String)),
                 },
             ],
@@ -1261,15 +1372,16 @@ mod tests {
         );
     }
 
-    fn list_function_type_cases() -> [FunctionType; 9] {
+    fn list_function_type_cases() -> [FunctionType; 10] {
         list_item_types().map(list_function_type)
     }
 
-    fn list_item_types() -> [ValueType; 9] {
+    fn list_item_types() -> [ValueType; 10] {
         [
             ValueType::Int,
             ValueType::String,
             ValueType::BitArray,
+            ValueType::UtfCodepoint,
             ValueType::Float,
             ValueType::Bool,
             ValueType::Nil,

--- a/src/plan/module/pattern/bit_array.rs
+++ b/src/plan/module/pattern/bit_array.rs
@@ -1,4 +1,6 @@
-use crate::plan::{BitArrayLocalId, Endianness, FloatLocalId, IntLocalId, StringEncoding};
+use crate::plan::{
+    BitArrayLocalId, Endianness, FloatLocalId, IntLocalId, StringEncoding, UtfCodepointLocalId,
+};
 use ecow::EcoString;
 use num_bigint::BigInt;
 
@@ -27,6 +29,10 @@ pub(crate) enum BitArrayPatternSegment {
     },
     String {
         pattern: BitArrayStringPattern,
+        encoding: StringEncoding,
+    },
+    UtfCodepoint {
+        pattern: BitArrayBindingPattern<UtfCodepointLocalId>,
         encoding: StringEncoding,
     },
 }

--- a/src/plan/module/reference.rs
+++ b/src/plan/module/reference.rs
@@ -1,7 +1,7 @@
 use super::{
     BitArrayFunctionId, BoolFunctionId, FloatFunctionId, FunctionFunctionId, IntFunctionId,
     ListFunctionId, NilFunctionId, ParamLocal, RuntimeFunctionId, StringFunctionId,
-    TupleFunctionId,
+    TupleFunctionId, UtfCodepointFunctionId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,6 +20,7 @@ pub(crate) type IntFunctionReference = TypedFunctionReference<IntFunctionId>;
 pub(crate) type FloatFunctionReference = TypedFunctionReference<FloatFunctionId>;
 pub(crate) type StringFunctionReference = TypedFunctionReference<StringFunctionId>;
 pub(crate) type BitArrayFunctionReference = TypedFunctionReference<BitArrayFunctionId>;
+pub(crate) type UtfCodepointFunctionReference = TypedFunctionReference<UtfCodepointFunctionId>;
 pub(crate) type BoolFunctionReference = TypedFunctionReference<BoolFunctionId>;
 pub(crate) type NilFunctionReference = TypedFunctionReference<NilFunctionId>;
 pub(crate) type TupleFunctionReference = TypedFunctionReference<TupleFunctionId>;

--- a/src/plan/module/step.rs
+++ b/src/plan/module/step.rs
@@ -2,14 +2,15 @@ use super::expression::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, Expr, FloatExpr,
     FloatFunctionExpr, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListFunctionExpr,
     ListLocalExpr, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr,
-    TupleFunctionExpr,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr,
 };
 use super::function::ParamLocal;
 use super::id::{
     BitArrayFunctionLocalId, BitArrayLocalId, BoolFunctionLocalId, BoolLocalId,
     FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId, IntFunctionLocalId, IntLocalId,
     ListFunctionLocal, ListLocal, NilFunctionLocalId, NilLocalId, StringFunctionLocalId,
-    StringLocalId, TupleFunctionLocalId, TupleLocalId,
+    StringLocalId, TupleFunctionLocalId, TupleLocalId, UtfCodepointFunctionLocalId,
+    UtfCodepointLocalId,
 };
 use crate::plan::BitArrayPattern;
 use crate::plan::{PanicSite, SourceSpan, ValueType};
@@ -80,6 +81,11 @@ pub(crate) enum StepKind {
         name: EcoString,
         value: BitArrayExpr,
     },
+    LetUtfCodepoint {
+        local: UtfCodepointLocalId,
+        name: EcoString,
+        value: UtfCodepointExpr,
+    },
     LetBool {
         local: BoolLocalId,
         name: EcoString,
@@ -118,6 +124,11 @@ pub(crate) enum StepKind {
         local: BitArrayFunctionLocalId,
         name: EcoString,
         value: BitArrayFunctionExpr,
+    },
+    LetUtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
+        name: EcoString,
+        value: UtfCodepointFunctionExpr,
     },
     LetBoolFunction {
         local: BoolFunctionLocalId,
@@ -270,6 +281,16 @@ impl Step {
         }
     }
 
+    pub(crate) fn let_utf_codepoint(
+        local: UtfCodepointLocalId,
+        name: EcoString,
+        value: UtfCodepointExpr,
+    ) -> Self {
+        Self {
+            kind: StepKind::LetUtfCodepoint { local, name, value },
+        }
+    }
+
     pub(crate) fn let_bool(local: BoolLocalId, name: EcoString, value: BoolExpr) -> Self {
         Self {
             kind: StepKind::LetBool { local, name, value },
@@ -331,6 +352,16 @@ impl Step {
     ) -> Self {
         Self {
             kind: StepKind::LetBitArrayFunction { local, name, value },
+        }
+    }
+
+    pub(crate) fn let_utf_codepoint_function(
+        local: UtfCodepointFunctionLocalId,
+        name: EcoString,
+        value: UtfCodepointFunctionExpr,
+    ) -> Self {
+        Self {
+            kind: StepKind::LetUtfCodepointFunction { local, name, value },
         }
     }
 

--- a/src/plan/value_type.rs
+++ b/src/plan/value_type.rs
@@ -4,6 +4,7 @@ pub enum ValueType {
     Float,
     String,
     BitArray,
+    UtfCodepoint,
     Bool,
     Nil,
     Tuple(Vec<ValueType>),

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -16,7 +16,10 @@ use crate::plan::{
     RuntimeFunctionId, StringExpr, StringFunctionExpr, StringFunctionFunctionId, StringFunctionId,
     StringFunctionLocalId, StringListFunctionId, StringListItem, StringListLocalId, StringLocalId,
     TupleExpr, TupleFunctionExpr, TupleFunctionFunctionId, TupleFunctionId, TupleFunctionLocalId,
-    TupleListFunctionId, TupleListItem, TupleListLocalId, TupleLocalId, ValueType,
+    TupleListFunctionId, TupleListItem, TupleListLocalId, TupleLocalId, UtfCodepointExpr,
+    UtfCodepointFunctionExpr, UtfCodepointFunctionFunctionId, UtfCodepointFunctionId,
+    UtfCodepointFunctionLocalId, UtfCodepointListFunctionId, UtfCodepointListItem,
+    UtfCodepointListLocalId, UtfCodepointLocalId, ValueType,
 };
 use crate::planner::error::{InvalidTypedAstReason, PlanError};
 use ecow::EcoString;
@@ -49,12 +52,14 @@ pub(super) struct PlanContext<'a> {
     next_float_local: usize,
     next_string_local: usize,
     next_bit_array_local: usize,
+    next_utf_codepoint_local: usize,
     next_bool_local: usize,
     next_nil_local: usize,
     next_tuple_local: usize,
     next_int_list_local: usize,
     next_string_list_local: usize,
     next_bit_array_list_local: usize,
+    next_utf_codepoint_list_local: usize,
     next_float_list_local: usize,
     next_bool_list_local: usize,
     next_nil_list_local: usize,
@@ -65,6 +70,7 @@ pub(super) struct PlanContext<'a> {
     next_float_function_local: usize,
     next_string_function_local: usize,
     next_bit_array_function_local: usize,
+    next_utf_codepoint_function_local: usize,
     next_bool_function_local: usize,
     next_nil_function_local: usize,
     next_tuple_function_local: usize,
@@ -100,6 +106,10 @@ pub(super) enum FunctionLocalBinding {
     },
     BitArray {
         local: BitArrayFunctionLocalId,
+        type_: FunctionType,
+    },
+    UtfCodepoint {
+        local: UtfCodepointFunctionLocalId,
         type_: FunctionType,
     },
     Float {
@@ -141,12 +151,14 @@ impl<'a> PlanContext<'a> {
             next_float_local: 0,
             next_string_local: 0,
             next_bit_array_local: 0,
+            next_utf_codepoint_local: 0,
             next_bool_local: 0,
             next_nil_local: 0,
             next_tuple_local: 0,
             next_int_list_local: 0,
             next_string_list_local: 0,
             next_bit_array_list_local: 0,
+            next_utf_codepoint_list_local: 0,
             next_float_list_local: 0,
             next_bool_list_local: 0,
             next_nil_list_local: 0,
@@ -157,6 +169,7 @@ impl<'a> PlanContext<'a> {
             next_float_function_local: 0,
             next_string_function_local: 0,
             next_bit_array_function_local: 0,
+            next_utf_codepoint_function_local: 0,
             next_bool_function_local: 0,
             next_nil_function_local: 0,
             next_tuple_function_local: 0,
@@ -191,6 +204,9 @@ impl<'a> PlanContext<'a> {
             LocalId::BitArray(local) => {
                 self.next_bit_array_local = self.next_bit_array_local.max(local.0 + 1);
             }
+            LocalId::UtfCodepoint(local) => {
+                self.next_utf_codepoint_local = self.next_utf_codepoint_local.max(local.0 + 1);
+            }
             LocalId::Bool(local) => {
                 self.next_bool_local = self.next_bool_local.max(local.0 + 1);
             }
@@ -214,6 +230,9 @@ impl<'a> PlanContext<'a> {
             }
             ParamLocal::BitArray(local) => {
                 self.define_existing_local(name, LocalId::BitArray(*local));
+            }
+            ParamLocal::UtfCodepoint(local) => {
+                self.define_existing_local(name, LocalId::UtfCodepoint(*local));
             }
             ParamLocal::Bool(local) => {
                 self.define_existing_local(name, LocalId::Bool(*local));
@@ -272,6 +291,17 @@ impl<'a> PlanContext<'a> {
                 self.bindings.insert(
                     name,
                     LocalBinding::Function(FunctionLocalBinding::BitArray {
+                        local: *local,
+                        type_: type_.clone(),
+                    }),
+                );
+            }
+            ParamLocal::UtfCodepointFunction { local, type_ } => {
+                self.next_utf_codepoint_function_local =
+                    self.next_utf_codepoint_function_local.max(local.0 + 1);
+                self.bindings.insert(
+                    name,
+                    LocalBinding::Function(FunctionLocalBinding::UtfCodepoint {
                         local: *local,
                         type_: type_.clone(),
                     }),
@@ -386,6 +416,28 @@ impl<'a> PlanContext<'a> {
     pub(super) fn define_internal_bit_array_function_local(&mut self) -> BitArrayFunctionLocalId {
         let local = BitArrayFunctionLocalId(self.next_bit_array_function_local);
         self.next_bit_array_function_local += 1;
+        local
+    }
+
+    pub(super) fn define_utf_codepoint_function_local(
+        &mut self,
+        name: EcoString,
+        type_: FunctionType,
+    ) -> UtfCodepointFunctionLocalId {
+        let local = UtfCodepointFunctionLocalId(self.next_utf_codepoint_function_local);
+        self.next_utf_codepoint_function_local += 1;
+        self.bindings.insert(
+            name,
+            LocalBinding::Function(FunctionLocalBinding::UtfCodepoint { local, type_ }),
+        );
+        local
+    }
+
+    pub(super) fn define_internal_utf_codepoint_function_local(
+        &mut self,
+    ) -> UtfCodepointFunctionLocalId {
+        let local = UtfCodepointFunctionLocalId(self.next_utf_codepoint_function_local);
+        self.next_utf_codepoint_function_local += 1;
         local
     }
 
@@ -558,6 +610,20 @@ impl<'a> PlanContext<'a> {
         local
     }
 
+    pub(super) fn define_utf_codepoint_local(&mut self, name: EcoString) -> UtfCodepointLocalId {
+        let local = UtfCodepointLocalId(self.next_utf_codepoint_local);
+        self.next_utf_codepoint_local += 1;
+        self.bindings
+            .insert(name, LocalBinding::Primitive(LocalId::UtfCodepoint(local)));
+        local
+    }
+
+    pub(super) fn define_internal_utf_codepoint_local(&mut self) -> UtfCodepointLocalId {
+        let local = UtfCodepointLocalId(self.next_utf_codepoint_local);
+        self.next_utf_codepoint_local += 1;
+        local
+    }
+
     pub(super) fn define_float_local(&mut self, name: EcoString) -> FloatLocalId {
         let local = FloatLocalId(self.next_float_local);
         self.next_float_local += 1;
@@ -681,6 +747,22 @@ impl<'a> PlanContext<'a> {
                     value: crate::plan::BitArrayListExpr::local_get(BitArrayListItem, source, name),
                 }
             }
+            ListLocal::UtfCodepoint(source) => {
+                let local = UtfCodepointListLocalId(self.next_utf_codepoint_list_local);
+                self.next_utf_codepoint_list_local += 1;
+                self.bindings.insert(
+                    name.clone(),
+                    LocalBinding::List(ListLocal::utf_codepoint(local)),
+                );
+                ListLocalExpr::UtfCodepoint {
+                    local,
+                    value: crate::plan::UtfCodepointListExpr::local_get(
+                        UtfCodepointListItem,
+                        source,
+                        name,
+                    ),
+                }
+            }
             ListLocal::Float(source) => {
                 let local = FloatListLocalId(self.next_float_list_local);
                 self.next_float_list_local += 1;
@@ -782,6 +864,11 @@ impl<'a> PlanContext<'a> {
                 self.next_bit_array_list_local += 1;
                 ListLocal::bit_array(local)
             }
+            ValueType::UtfCodepoint => {
+                let local = UtfCodepointListLocalId(self.next_utf_codepoint_list_local);
+                self.next_utf_codepoint_list_local += 1;
+                ListLocal::utf_codepoint(local)
+            }
             ValueType::Float => {
                 let local = FloatListLocalId(self.next_float_list_local);
                 self.next_float_list_local += 1;
@@ -836,6 +923,14 @@ impl<'a> PlanContext<'a> {
                 (
                     ListLocal::bit_array(local),
                     ListLocalExpr::BitArray { local, value },
+                )
+            }
+            ListExpr::UtfCodepoint(value) => {
+                let local = UtfCodepointListLocalId(self.next_utf_codepoint_list_local);
+                self.next_utf_codepoint_list_local += 1;
+                (
+                    ListLocal::utf_codepoint(local),
+                    ListLocalExpr::UtfCodepoint { local, value },
                 )
             }
             ListExpr::Float(value) => {
@@ -908,6 +1003,10 @@ impl<'a> PlanContext<'a> {
             }
             ListLocal::BitArray(local) => {
                 self.next_bit_array_list_local = self.next_bit_array_list_local.max(local.0 + 1);
+            }
+            ListLocal::UtfCodepoint(local) => {
+                self.next_utf_codepoint_list_local =
+                    self.next_utf_codepoint_list_local.max(local.0 + 1);
             }
             ListLocal::Float(local) => {
                 self.next_float_list_local = self.next_float_list_local.max(local.0 + 1);
@@ -1012,12 +1111,14 @@ impl<'a> PlanContext<'a> {
             next_float_local: 0,
             next_string_local: 0,
             next_bit_array_local: 0,
+            next_utf_codepoint_local: 0,
             next_bool_local: 0,
             next_nil_local: 0,
             next_tuple_local: 0,
             next_int_list_local: 0,
             next_string_list_local: 0,
             next_bit_array_list_local: 0,
+            next_utf_codepoint_list_local: 0,
             next_float_list_local: 0,
             next_bool_list_local: 0,
             next_nil_list_local: 0,
@@ -1028,6 +1129,7 @@ impl<'a> PlanContext<'a> {
             next_float_function_local: 0,
             next_string_function_local: 0,
             next_bit_array_function_local: 0,
+            next_utf_codepoint_function_local: 0,
             next_bool_function_local: 0,
             next_nil_function_local: 0,
             next_tuple_function_local: 0,
@@ -1094,6 +1196,10 @@ impl<'a> PlanContext<'a> {
                 let target = self.define_bit_array_local(capture.name.clone());
                 CaptureArg::bit_array(target, BitArrayExpr::local_get(local, capture.name))
             }
+            LocalBinding::Primitive(LocalId::UtfCodepoint(local)) => {
+                let target = self.define_utf_codepoint_local(capture.name.clone());
+                CaptureArg::utf_codepoint(target, UtfCodepointExpr::local_get(local, capture.name))
+            }
             LocalBinding::Primitive(LocalId::Bool(local)) => {
                 let target = self.define_bool_local(capture.name.clone());
                 CaptureArg::bool(target, BoolExpr::local_get(local, capture.name))
@@ -1136,6 +1242,14 @@ impl<'a> PlanContext<'a> {
                 CaptureArg::bit_array_function(
                     target,
                     BitArrayFunctionExpr::local_get(local, capture.name, type_),
+                )
+            }
+            LocalBinding::Function(FunctionLocalBinding::UtfCodepoint { local, type_ }) => {
+                let target =
+                    self.define_utf_codepoint_function_local(capture.name.clone(), type_.clone());
+                CaptureArg::utf_codepoint_function(
+                    target,
+                    UtfCodepointFunctionExpr::local_get(local, capture.name, type_),
                 )
             }
             LocalBinding::Function(FunctionLocalBinding::Bool { local, type_ }) => {
@@ -1272,12 +1386,14 @@ pub(in crate::planner) struct FunctionRuntimeIds {
     next_float: usize,
     next_string: usize,
     next_bit_array: usize,
+    next_utf_codepoint: usize,
     next_bool: usize,
     next_nil: usize,
     next_tuple: usize,
     next_int_list: usize,
     next_string_list: usize,
     next_bit_array_list: usize,
+    next_utf_codepoint_list: usize,
     next_float_list: usize,
     next_bool_list: usize,
     next_nil_list: usize,
@@ -1288,12 +1404,14 @@ pub(in crate::planner) struct FunctionRuntimeIds {
     next_float_function: usize,
     next_string_function: usize,
     next_bit_array_function: usize,
+    next_utf_codepoint_function: usize,
     next_bool_function: usize,
     next_nil_function: usize,
     next_tuple_function: usize,
     next_int_list_function: usize,
     next_string_list_function: usize,
     next_bit_array_list_function: usize,
+    next_utf_codepoint_list_function: usize,
     next_float_list_function: usize,
     next_bool_list_function: usize,
     next_nil_list_function: usize,
@@ -1310,6 +1428,9 @@ impl FunctionRuntimeIds {
             ValueType::Float => RuntimeFunctionId::Float(self.next_float_id()),
             ValueType::String => RuntimeFunctionId::String(self.next_string_id()),
             ValueType::BitArray => RuntimeFunctionId::BitArray(self.next_bit_array_id()),
+            ValueType::UtfCodepoint => {
+                RuntimeFunctionId::UtfCodepoint(self.next_utf_codepoint_id())
+            }
             ValueType::Bool => RuntimeFunctionId::Bool(self.next_bool_id()),
             ValueType::Nil => RuntimeFunctionId::Nil(self.next_nil_id()),
             ValueType::Tuple(return_type) => RuntimeFunctionId::Tuple {
@@ -1329,6 +1450,9 @@ impl FunctionRuntimeIds {
             ValueType::Float => FunctionFunctionId::Float(self.next_float_function_id()),
             ValueType::String => FunctionFunctionId::String(self.next_string_function_id()),
             ValueType::BitArray => FunctionFunctionId::BitArray(self.next_bit_array_function_id()),
+            ValueType::UtfCodepoint => {
+                FunctionFunctionId::UtfCodepoint(self.next_utf_codepoint_function_id())
+            }
             ValueType::Bool => FunctionFunctionId::Bool(self.next_bool_function_id()),
             ValueType::Nil => FunctionFunctionId::Nil(self.next_nil_function_id()),
             ValueType::Tuple(_) => FunctionFunctionId::Tuple(self.next_tuple_function_id()),
@@ -1361,6 +1485,12 @@ impl FunctionRuntimeIds {
         id
     }
 
+    pub(in crate::planner) fn next_utf_codepoint_id(&mut self) -> UtfCodepointFunctionId {
+        let id = UtfCodepointFunctionId(self.next_utf_codepoint);
+        self.next_utf_codepoint += 1;
+        id
+    }
+
     pub(in crate::planner) fn next_float_id(&mut self) -> FloatFunctionId {
         let id = FloatFunctionId(self.next_float);
         self.next_float += 1;
@@ -1390,6 +1520,9 @@ impl FunctionRuntimeIds {
             ValueType::Int => ListFunctionId::Int(self.next_int_list_id()),
             ValueType::String => ListFunctionId::String(self.next_string_list_id()),
             ValueType::BitArray => ListFunctionId::BitArray(self.next_bit_array_list_id()),
+            ValueType::UtfCodepoint => {
+                ListFunctionId::UtfCodepoint(self.next_utf_codepoint_list_id())
+            }
             ValueType::Float => ListFunctionId::Float(self.next_float_list_id()),
             ValueType::Bool => ListFunctionId::Bool(self.next_bool_list_id()),
             ValueType::Nil => ListFunctionId::Nil(self.next_nil_list_id()),
@@ -1423,6 +1556,12 @@ impl FunctionRuntimeIds {
     pub(in crate::planner) fn next_bit_array_list_id(&mut self) -> BitArrayListFunctionId {
         let id = BitArrayListFunctionId(self.next_bit_array_list);
         self.next_bit_array_list += 1;
+        id
+    }
+
+    pub(in crate::planner) fn next_utf_codepoint_list_id(&mut self) -> UtfCodepointListFunctionId {
+        let id = UtfCodepointListFunctionId(self.next_utf_codepoint_list);
+        self.next_utf_codepoint_list += 1;
         id
     }
 
@@ -1477,6 +1616,14 @@ impl FunctionRuntimeIds {
     pub(in crate::planner) fn next_bit_array_function_id(&mut self) -> BitArrayFunctionFunctionId {
         let id = BitArrayFunctionFunctionId(self.next_bit_array_function);
         self.next_bit_array_function += 1;
+        id
+    }
+
+    pub(in crate::planner) fn next_utf_codepoint_function_id(
+        &mut self,
+    ) -> UtfCodepointFunctionFunctionId {
+        let id = UtfCodepointFunctionFunctionId(self.next_utf_codepoint_function);
+        self.next_utf_codepoint_function += 1;
         id
     }
 
@@ -1535,6 +1682,15 @@ impl FunctionRuntimeIds {
                     ValueType::BitArray,
                 );
                 self.next_bit_array_list_function += 1;
+                id
+            }
+            ValueType::UtfCodepoint => {
+                let id = ListFunctionFunctionId::from_item_type(
+                    self.next_utf_codepoint_list_function,
+                    type_,
+                    ValueType::UtfCodepoint,
+                );
+                self.next_utf_codepoint_list_function += 1;
                 id
             }
             ValueType::Float => {
@@ -1618,6 +1774,8 @@ impl ValueType {
             Some(Self::String)
         } else if type_.is_bit_array() {
             Some(Self::BitArray)
+        } else if type_.is_utf_codepoint() {
+            Some(Self::UtfCodepoint)
         } else if type_.is_bool() {
             Some(Self::Bool)
         } else if type_.is_nil() {
@@ -1663,7 +1821,7 @@ mod tests {
         NilLocalId, ParamLocal, RuntimeFunctionId, StringFunctionExpr, StringFunctionLocalId,
         StringListExpr, StringListItem, StringListLocalId, StringLocalId, TupleFunctionExpr,
         TupleFunctionLocalId, TupleListExpr, TupleListItem, TupleListLocalId, TupleLocalId,
-        ValueType,
+        UtfCodepointListExpr, UtfCodepointListItem, UtfCodepointListLocalId, ValueType,
     };
     use ecow::EcoString;
     use gleam_core::ast::Publicity;
@@ -1956,6 +2114,20 @@ mod tests {
                     BitArrayListItem,
                     BitArrayListLocalId(9),
                     "bit_arrays".into(),
+                ),
+            },
+        );
+        assert_eq!(
+            context.define_list_capture_value(
+                "utf_codepoints".into(),
+                ListLocal::utf_codepoint(UtfCodepointListLocalId(9)),
+            ),
+            ListLocalExpr::UtfCodepoint {
+                local: UtfCodepointListLocalId(0),
+                value: UtfCodepointListExpr::local_get(
+                    UtfCodepointListItem,
+                    UtfCodepointListLocalId(9),
+                    "utf_codepoints".into(),
                 ),
             },
         );
@@ -2523,9 +2695,26 @@ mod tests {
             Some(ValueType::BitArray),
         );
         assert_eq!(
+            ValueType::from_gleam(type_::utf_codepoint().as_ref()),
+            Some(ValueType::UtfCodepoint),
+        );
+        assert_eq!(
             ValueType::from_gleam(
                 type_::named("package", "main", "BitArray", Publicity::Public, Vec::new(),)
                     .as_ref(),
+            ),
+            None,
+        );
+        assert_eq!(
+            ValueType::from_gleam(
+                type_::named(
+                    "package",
+                    "main",
+                    "UtfCodepoint",
+                    Publicity::Public,
+                    Vec::new(),
+                )
+                .as_ref(),
             ),
             None,
         );

--- a/src/planner/dsl.rs
+++ b/src/planner/dsl.rs
@@ -11,10 +11,11 @@ pub(crate) use expression::{
     int_function_call_arg, int_function_closure, int_function_ref, let_bool_function_step,
     let_bool_step, let_float_step, let_int_function_step, let_int_step, let_list_step,
     let_nil_function_step, let_nil_step, let_string_function_step, let_string_step, let_tuple_step,
-    list, list_function_ref, list_spread, local_bool, local_float, local_int, local_int_function,
-    local_list, local_nil, local_string, local_tuple, nil, nil_arg, nil_function_ref, not_equal,
-    string, string_arg, string_function_ref, tuple, tuple_arg, tuple_function_closure,
-    tuple_function_ref,
+    let_utf_codepoint_step, list, list_function_ref, list_spread, local_bool, local_float,
+    local_int, local_int_function, local_list, local_nil, local_string, local_tuple,
+    local_utf_codepoint, nil, nil_arg, nil_function_ref, not_equal, string, string_arg,
+    string_function_ref, tuple, tuple_arg, tuple_function_closure, tuple_function_ref,
+    utf_codepoint_function_ref,
 };
 pub(crate) use function::{
     bool_function_return_block, bool_function_return_bool_case, bool_function_return_expr,
@@ -39,6 +40,7 @@ pub(crate) use function::{
     string_function_return_int_case, string_function_return_string_case,
     string_function_return_tail_call, string_return_block, string_return_bool_case,
     string_return_expr, string_return_float_case, string_return_int_case,
-    string_return_string_case, string_return_tail_call,
+    string_return_string_case, string_return_tail_call, utf_codepoint_return_block,
+    utf_codepoint_return_expr,
 };
 pub(crate) use module::{module, module_with_anonymous};

--- a/src/planner/dsl/expression.rs
+++ b/src/planner/dsl/expression.rs
@@ -23,7 +23,7 @@ use crate::plan::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr,
     FunctionExpr, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr, ListFunctionExpr,
     NilExpr, NilFunctionExpr, ParamLocal, StringExpr, StringFunctionExpr, TupleExpr,
-    TupleFunctionExpr, ValueType,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr, ValueType,
 };
 
 pub(crate) struct Int(IntExpr);
@@ -31,6 +31,8 @@ pub(crate) struct Int(IntExpr);
 pub(crate) struct String(StringExpr);
 
 pub(crate) struct BitArray(BitArrayExpr);
+
+pub(crate) struct UtfCodepoint(UtfCodepointExpr);
 
 pub(crate) struct Float(FloatExpr);
 
@@ -49,6 +51,8 @@ pub(crate) struct IntFunction(IntFunctionExpr);
 pub(crate) struct StringFunction(StringFunctionExpr);
 
 pub(crate) struct BitArrayFunction(BitArrayFunctionExpr);
+
+pub(crate) struct UtfCodepointFunction(UtfCodepointFunctionExpr);
 
 pub(crate) struct FloatFunction(FloatFunctionExpr);
 

--- a/src/planner/dsl/expression/block.rs
+++ b/src/planner/dsl/expression/block.rs
@@ -1,12 +1,12 @@
 use super::{
     BitArray, Bool, Float, Function, FunctionFunction, Int, IntFunction, List, ListFunction, Nil,
-    String, TupleFunction,
+    String, TupleFunction, UtfCodepoint,
 };
 use crate::plan::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, FloatExpr, FloatFunctionExpr,
     FunctionExpr, FunctionExprKind, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr,
     ListFunctionExpr, NilExpr, NilFunctionExpr, Step, StringExpr, StringFunctionExpr,
-    TupleFunctionExpr,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr,
 };
 
 pub(crate) fn block_int(steps: impl IntoIterator<Item = Step>, return_: Int) -> Int {
@@ -25,6 +25,16 @@ pub(crate) fn block_bit_array(
     return_: BitArray,
 ) -> BitArray {
     BitArray(BitArrayExpr::block(
+        steps.into_iter().collect(),
+        return_.into(),
+    ))
+}
+
+pub(crate) fn block_utf_codepoint(
+    steps: impl IntoIterator<Item = Step>,
+    return_: UtfCodepoint,
+) -> UtfCodepoint {
+    UtfCodepoint(UtfCodepointExpr::block(
         steps.into_iter().collect(),
         return_.into(),
     ))
@@ -57,6 +67,9 @@ pub(crate) fn block_function(steps: Vec<Step>, return_: Function) -> Function {
         }
         FunctionExprKind::BitArray(return_) => {
             FunctionExpr::bit_array(BitArrayFunctionExpr::block(steps, return_))
+        }
+        FunctionExprKind::UtfCodepoint(return_) => {
+            FunctionExpr::utf_codepoint(UtfCodepointFunctionExpr::block(steps, return_))
         }
         FunctionExprKind::Float(return_) => {
             FunctionExpr::float(FloatFunctionExpr::block(steps, return_))
@@ -122,7 +135,7 @@ mod tests {
     use super::{
         block_bit_array, block_bool, block_float, block_function, block_function_function,
         block_int, block_int_function, block_list, block_list_function, block_nil, block_string,
-        block_tuple_function,
+        block_tuple_function, block_utf_codepoint,
     };
     use crate::plan::{
         BitArrayExpr, BitArrayFunctionExpr, BitArrayFunctionId, BitArrayFunctionReference,
@@ -132,13 +145,14 @@ mod tests {
         IntFunctionId, IntFunctionReference, ListExpr, ListFunctionExpr, ListFunctionReference,
         NilExpr, NilFunctionId, NilFunctionReference, ParamLocal, RuntimeFunctionId, StringExpr,
         StringFunctionId, StringFunctionReference, TupleFunctionExpr, TupleFunctionReference,
-        ValueType,
+        UtfCodepointExpr, UtfCodepointFunctionExpr, UtfCodepointFunctionId,
+        UtfCodepointFunctionReference, ValueType,
     };
     use crate::planner::dsl::expression::{
         Function, bit_array, bool_, float, function_function_ref, function_ref, int,
         int_function_ref, let_bit_array_step, let_bool_step, let_int_step, let_nil_step,
         let_string_step, list, list_function_ref, local_bit_array, local_bool, local_int,
-        local_nil, local_string, nil, string, tuple_function_ref,
+        local_nil, local_string, local_utf_codepoint, nil, string, tuple_function_ref,
     };
 
     #[test]
@@ -164,6 +178,10 @@ mod tests {
                 vec![let_bit_array_step(0, "x", bit_array([]))],
                 local_bit_array(0, "x").into(),
             ),
+        );
+        assert_eq!(
+            block_utf_codepoint(Vec::new(), local_utf_codepoint(0, "codepoint")).0,
+            UtfCodepointExpr::block(Vec::new(), local_utf_codepoint(0, "codepoint").into(),),
         );
         assert_eq!(
             block_float([], float(1.0)).0,
@@ -219,6 +237,26 @@ mod tests {
                 BitArrayFunctionExpr::reference(BitArrayFunctionReference::new(
                     BitArrayFunctionId(0),
                     vec![ParamLocal::bit_array(crate::plan::BitArrayLocalId(0))],
+                )),
+            )),
+        );
+        assert_eq!(
+            FunctionExpr::from(block_function(
+                vec![],
+                function_ref(
+                    RuntimeFunctionId::UtfCodepoint(UtfCodepointFunctionId(0)),
+                    [crate::plan::LocalId::UtfCodepoint(
+                        crate::plan::UtfCodepointLocalId(0),
+                    )],
+                ),
+            )),
+            FunctionExpr::utf_codepoint(UtfCodepointFunctionExpr::block(
+                Vec::new(),
+                UtfCodepointFunctionExpr::reference(UtfCodepointFunctionReference::new(
+                    UtfCodepointFunctionId(0),
+                    vec![ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(
+                        0
+                    ),)],
                 )),
             )),
         );

--- a/src/planner/dsl/expression/conversion.rs
+++ b/src/planner/dsl/expression/conversion.rs
@@ -1,13 +1,14 @@
 use super::{
     BitArray, BitArrayFunction, Bool, BoolFunction, Float, FloatFunction, Function,
     FunctionFunction, Int, IntFunction, IntoParamLocal, IntoValueType, List, ListFunction, Nil,
-    NilFunction, String, StringFunction, Tuple, TupleFunction,
+    NilFunction, String, StringFunction, Tuple, TupleFunction, UtfCodepoint, UtfCodepointFunction,
 };
 use crate::plan::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, Expr, FloatExpr,
     FloatFunctionExpr, FunctionExpr, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr,
     ListFunctionExpr, LocalId, NilExpr, NilFunctionExpr, ParamLocal, StringExpr,
-    StringFunctionExpr, TupleExpr, TupleFunctionExpr, ValueType,
+    StringFunctionExpr, TupleExpr, TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr,
+    ValueType,
 };
 
 impl From<Int> for Expr {
@@ -25,6 +26,12 @@ impl From<String> for Expr {
 impl From<BitArray> for Expr {
     fn from(value: BitArray) -> Self {
         Self::bit_array(value.into())
+    }
+}
+
+impl From<UtfCodepoint> for Expr {
+    fn from(value: UtfCodepoint) -> Self {
+        Self::utf_codepoint(value.into())
     }
 }
 
@@ -78,6 +85,12 @@ impl From<String> for StringExpr {
 
 impl From<BitArray> for BitArrayExpr {
     fn from(value: BitArray) -> Self {
+        value.0
+    }
+}
+
+impl From<UtfCodepoint> for UtfCodepointExpr {
+    fn from(value: UtfCodepoint) -> Self {
         value.0
     }
 }
@@ -151,6 +164,30 @@ impl From<StringFunction> for StringFunctionExpr {
 impl From<BitArrayFunction> for BitArrayFunctionExpr {
     fn from(value: BitArrayFunction) -> Self {
         value.0
+    }
+}
+
+impl From<UtfCodepointFunction> for UtfCodepointFunctionExpr {
+    fn from(value: UtfCodepointFunction) -> Self {
+        value.0
+    }
+}
+
+impl From<UtfCodepointFunction> for Function {
+    fn from(value: UtfCodepointFunction) -> Self {
+        Function(FunctionExpr::utf_codepoint(value.into()))
+    }
+}
+
+impl From<UtfCodepointFunction> for Expr {
+    fn from(value: UtfCodepointFunction) -> Self {
+        Self::function(FunctionExpr::utf_codepoint(value.into()))
+    }
+}
+
+impl From<UtfCodepointFunction> for FunctionExpr {
+    fn from(value: UtfCodepointFunction) -> Self {
+        FunctionExpr::utf_codepoint(value.into())
     }
 }
 
@@ -310,6 +347,7 @@ impl IntoValueType for LocalId {
             LocalId::Int(_) => ValueType::Int,
             LocalId::String(_) => ValueType::String,
             LocalId::BitArray(_) => ValueType::BitArray,
+            LocalId::UtfCodepoint(_) => ValueType::UtfCodepoint,
             LocalId::Float(_) => ValueType::Float,
             LocalId::Bool(_) => ValueType::Bool,
             LocalId::Nil(_) => ValueType::Nil,
@@ -329,6 +367,7 @@ impl IntoParamLocal for LocalId {
             LocalId::Int(local) => ParamLocal::int(local),
             LocalId::String(local) => ParamLocal::string(local),
             LocalId::BitArray(local) => ParamLocal::bit_array(local),
+            LocalId::UtfCodepoint(local) => ParamLocal::utf_codepoint(local),
             LocalId::Float(local) => ParamLocal::float(local),
             LocalId::Bool(local) => ParamLocal::bool(local),
             LocalId::Nil(local) => ParamLocal::nil(local),
@@ -351,12 +390,13 @@ mod tests {
         FunctionFunctionReference, FunctionType, IntExpr, IntFunctionExpr, IntFunctionFunctionId,
         IntFunctionId, IntFunctionReference, ListExpr, ListFunctionExpr, ListFunctionId,
         ListFunctionReference, NilExpr, ParamLocal, StringExpr, TupleExpr, TupleFunctionExpr,
-        TupleFunctionId, TupleFunctionReference, ValueType,
+        TupleFunctionId, TupleFunctionReference, UtfCodepointExpr, UtfCodepointFunctionExpr,
+        UtfCodepointFunctionId, UtfCodepointFunctionReference, ValueType,
     };
     use crate::planner::dsl::expression::{
         Function, bit_array, bit_array_function_ref, bool_, float, float_function_ref,
-        function_function_ref, int, int_function_ref, list, list_function_ref, nil, string, tuple,
-        tuple_function_ref,
+        function_function_ref, int, int_function_ref, list, list_function_ref, local_utf_codepoint,
+        nil, string, tuple, tuple_function_ref, utf_codepoint_function_ref,
     };
     use num_bigint::BigInt;
 
@@ -379,6 +419,11 @@ mod tests {
         assert_eq!(
             crate::plan::LocalId::BitArray(crate::plan::BitArrayLocalId(5)).into_value_type(),
             ValueType::BitArray,
+        );
+        assert_eq!(
+            crate::plan::LocalId::UtfCodepoint(crate::plan::UtfCodepointLocalId(6))
+                .into_value_type(),
+            ValueType::UtfCodepoint,
         );
         assert_eq!(
             crate::plan::LocalId::Float(crate::plan::FloatLocalId(2)).into_value_type(),
@@ -404,6 +449,11 @@ mod tests {
         assert_eq!(
             crate::plan::LocalId::BitArray(crate::plan::BitArrayLocalId(5)).into_param_local(),
             ParamLocal::bit_array(crate::plan::BitArrayLocalId(5)),
+        );
+        assert_eq!(
+            crate::plan::LocalId::UtfCodepoint(crate::plan::UtfCodepointLocalId(6))
+                .into_param_local(),
+            ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(6)),
         );
         assert_eq!(
             crate::plan::LocalId::Float(crate::plan::FloatLocalId(2)).into_param_local(),
@@ -432,6 +482,13 @@ mod tests {
         assert_eq!(
             Expr::from(bit_array([])),
             Expr::bit_array(BitArrayExpr::value(Vec::new())),
+        );
+        assert_eq!(
+            Expr::from(local_utf_codepoint(0, "codepoint")),
+            Expr::utf_codepoint(UtfCodepointExpr::local_get(
+                crate::plan::UtfCodepointLocalId(0),
+                "codepoint".into(),
+            )),
         );
         assert_eq!(Expr::from(float(1.5)), Expr::float(FloatExpr::value(1.5)));
         assert_eq!(Expr::from(bool_(true)), Expr::bool(BoolExpr::value(true)));
@@ -473,6 +530,30 @@ mod tests {
             ))),
             FunctionExpr::bit_array(BitArrayFunctionExpr::reference(
                 BitArrayFunctionReference::new(BitArrayFunctionId(0), Vec::new()),
+            )),
+        );
+        assert_eq!(
+            Expr::from(utf_codepoint_function_ref(0, Vec::<ParamLocal>::new())),
+            Expr::function(FunctionExpr::utf_codepoint(
+                UtfCodepointFunctionExpr::reference(UtfCodepointFunctionReference::new(
+                    UtfCodepointFunctionId(0),
+                    Vec::new(),
+                )),
+            )),
+        );
+        assert_eq!(
+            FunctionExpr::from(utf_codepoint_function_ref(0, Vec::<ParamLocal>::new(),)),
+            FunctionExpr::utf_codepoint(UtfCodepointFunctionExpr::reference(
+                UtfCodepointFunctionReference::new(UtfCodepointFunctionId(0), Vec::new()),
+            )),
+        );
+        assert_eq!(
+            FunctionExpr::from(Function::from(utf_codepoint_function_ref(
+                0,
+                Vec::<ParamLocal>::new(),
+            ))),
+            FunctionExpr::utf_codepoint(UtfCodepointFunctionExpr::reference(
+                UtfCodepointFunctionReference::new(UtfCodepointFunctionId(0), Vec::new()),
             )),
         );
         assert_eq!(

--- a/src/planner/dsl/expression/function_value.rs
+++ b/src/planner/dsl/expression/function_value.rs
@@ -1,6 +1,7 @@
 use super::{
     BitArrayFunction, BoolFunction, FloatFunction, Function, FunctionFunction, IntFunction,
     IntoParamLocal, IntoValueType, ListFunction, NilFunction, StringFunction, TupleFunction,
+    UtfCodepointFunction,
 };
 use crate::plan::{
     BitArrayFunctionExpr, BitArrayFunctionId, BitArrayFunctionLocalId, BitArrayFunctionReference,
@@ -12,7 +13,8 @@ use crate::plan::{
     ListFunctionReference, NilFunctionExpr, NilFunctionId, NilFunctionLocalId,
     NilFunctionReference, ParamLocal, RuntimeFunctionId, StringFunctionExpr, StringFunctionId,
     StringFunctionLocalId, StringFunctionReference, TupleFunctionExpr, TupleFunctionId,
-    TupleFunctionLocalId, TupleFunctionReference, ValueType,
+    TupleFunctionLocalId, TupleFunctionReference, UtfCodepointFunctionExpr, UtfCodepointFunctionId,
+    UtfCodepointFunctionLocalId, UtfCodepointFunctionReference, ValueType,
 };
 
 use ecow::EcoString;
@@ -107,6 +109,40 @@ pub(crate) fn bit_array_function_closure(
 
     BitArrayFunction(BitArrayFunctionExpr::closure(
         BitArrayFunctionId(runtime_id),
+        params,
+        captures.into_iter().collect(),
+        type_,
+    ))
+}
+
+pub(crate) fn utf_codepoint_function_ref(
+    runtime_id: usize,
+    params: impl IntoIterator<Item = impl IntoParamLocal>,
+) -> UtfCodepointFunction {
+    UtfCodepointFunction(UtfCodepointFunctionExpr::reference(
+        UtfCodepointFunctionReference::new(
+            UtfCodepointFunctionId(runtime_id),
+            params
+                .into_iter()
+                .map(IntoParamLocal::into_param_local)
+                .collect(),
+        ),
+    ))
+}
+
+pub(crate) fn utf_codepoint_function_closure(
+    runtime_id: usize,
+    params: impl IntoIterator<Item = impl IntoParamLocal>,
+    captures: impl IntoIterator<Item = CaptureArg>,
+) -> UtfCodepointFunction {
+    let params = params
+        .into_iter()
+        .map(IntoParamLocal::into_param_local)
+        .collect::<Vec<_>>();
+    let type_ = function_type(&params, ValueType::UtfCodepoint);
+
+    UtfCodepointFunction(UtfCodepointFunctionExpr::closure(
+        UtfCodepointFunctionId(runtime_id),
         params,
         captures.into_iter().collect(),
         type_,
@@ -324,6 +360,18 @@ pub(crate) fn local_bit_array_function(
     ))
 }
 
+pub(crate) fn local_utf_codepoint_function(
+    local: usize,
+    name: impl Into<EcoString>,
+    params: impl IntoIterator<Item = impl IntoValueType>,
+) -> UtfCodepointFunction {
+    UtfCodepointFunction(UtfCodepointFunctionExpr::local_get(
+        UtfCodepointFunctionLocalId(local),
+        name.into(),
+        utf_codepoint_function_type(params),
+    ))
+}
+
 pub(crate) fn local_float_function(
     local: usize,
     name: impl Into<EcoString>,
@@ -423,6 +471,12 @@ fn bit_array_function_type(params: impl IntoIterator<Item = impl IntoValueType>)
     dsl_function_type(params, ValueType::BitArray)
 }
 
+fn utf_codepoint_function_type(
+    params: impl IntoIterator<Item = impl IntoValueType>,
+) -> FunctionType {
+    dsl_function_type(params, ValueType::UtfCodepoint)
+}
+
 fn float_function_type(params: impl IntoIterator<Item = impl IntoValueType>) -> FunctionType {
     dsl_function_type(params, ValueType::Float)
 }
@@ -456,8 +510,10 @@ mod tests {
         function_function_ref, function_ref, int_function_closure, int_function_ref,
         list_function_closure, list_function_ref, local_bit_array_function, local_bool_function,
         local_float_function, local_function_function, local_int_function, local_list_function,
-        local_nil_function, local_string_function, local_tuple_function, nil_function_ref,
-        string_function_ref, tuple_function_closure, tuple_function_ref,
+        local_nil_function, local_string_function, local_tuple_function,
+        local_utf_codepoint_function, nil_function_ref, string_function_ref,
+        tuple_function_closure, tuple_function_ref, utf_codepoint_function_closure,
+        utf_codepoint_function_ref,
     };
     use crate::plan::{
         BitArrayFunctionExpr, BitArrayFunctionId, BitArrayFunctionLocalId,
@@ -470,7 +526,8 @@ mod tests {
         NilFunctionLocalId, NilFunctionReference, ParamLocal, RuntimeFunctionId,
         StringFunctionExpr, StringFunctionId, StringFunctionLocalId, StringFunctionReference,
         TupleFunctionExpr, TupleFunctionId, TupleFunctionLocalId, TupleFunctionReference,
-        ValueType,
+        UtfCodepointFunctionExpr, UtfCodepointFunctionId, UtfCodepointFunctionLocalId,
+        UtfCodepointFunctionReference, ValueType,
     };
     use crate::planner::dsl::expression::{Function, float, int};
 
@@ -508,6 +565,21 @@ mod tests {
             BitArrayFunctionExpr::reference(BitArrayFunctionReference::new(
                 BitArrayFunctionId(8),
                 vec![ParamLocal::bit_array(crate::plan::BitArrayLocalId(0))],
+            )),
+        );
+        assert_eq!(
+            utf_codepoint_function_ref(
+                9,
+                [crate::plan::LocalId::UtfCodepoint(
+                    crate::plan::UtfCodepointLocalId(0),
+                )],
+            )
+            .0,
+            UtfCodepointFunctionExpr::reference(UtfCodepointFunctionReference::new(
+                UtfCodepointFunctionId(9),
+                vec![ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(
+                    0
+                ),)],
             )),
         );
         assert_eq!(
@@ -615,6 +687,21 @@ mod tests {
                 BitArrayFunctionLocalId(1),
                 "bits".into(),
                 FunctionType::new(vec![ValueType::BitArray], ValueType::BitArray),
+            ),
+        );
+        assert_eq!(
+            local_utf_codepoint_function(
+                2,
+                "codepoint",
+                [crate::plan::LocalId::UtfCodepoint(
+                    crate::plan::UtfCodepointLocalId(0),
+                )],
+            )
+            .0,
+            UtfCodepointFunctionExpr::local_get(
+                UtfCodepointFunctionLocalId(2),
+                "codepoint".into(),
+                FunctionType::new(vec![ValueType::UtfCodepoint], ValueType::UtfCodepoint,),
             ),
         );
         assert_eq!(
@@ -737,6 +824,24 @@ mod tests {
                 vec![ParamLocal::bit_array(crate::plan::BitArrayLocalId(0))],
                 Vec::new(),
                 FunctionType::new(vec![ValueType::BitArray], ValueType::BitArray),
+            ),
+        );
+        assert_eq!(
+            utf_codepoint_function_closure(
+                2,
+                [ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(
+                    0
+                ),)],
+                [],
+            )
+            .0,
+            UtfCodepointFunctionExpr::closure(
+                UtfCodepointFunctionId(2),
+                vec![ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(
+                    0
+                ),)],
+                Vec::new(),
+                FunctionType::new(vec![ValueType::UtfCodepoint], ValueType::UtfCodepoint,),
             ),
         );
         assert_eq!(

--- a/src/planner/dsl/expression/local.rs
+++ b/src/planner/dsl/expression/local.rs
@@ -1,9 +1,10 @@
-use super::{BitArray, Bool, Float, Int, List, Nil, String, Tuple};
+use super::{BitArray, Bool, Float, Int, List, Nil, String, Tuple, UtfCodepoint};
 use crate::plan::{
     BitArrayExpr, BitArrayLocalId, BoolExpr, BoolListLocalId, BoolLocalId, FloatExpr,
     FloatListLocalId, FloatLocalId, FunctionListLocalId, IntExpr, IntListLocalId, IntLocalId,
     ListExpr, ListListLocalId, ListLocal, NilExpr, NilListLocalId, NilLocalId, StringExpr,
-    StringListLocalId, StringLocalId, TupleExpr, TupleListLocalId, TupleLocalId, ValueType,
+    StringListLocalId, StringLocalId, TupleExpr, TupleListLocalId, TupleLocalId, UtfCodepointExpr,
+    UtfCodepointLocalId, ValueType,
 };
 use ecow::EcoString;
 
@@ -17,6 +18,13 @@ pub(crate) fn local_string(index: usize, name: impl Into<EcoString>) -> String {
 
 pub(crate) fn local_bit_array(index: usize, name: impl Into<EcoString>) -> BitArray {
     BitArray(BitArrayExpr::local_get(BitArrayLocalId(index), name.into()))
+}
+
+pub(crate) fn local_utf_codepoint(index: usize, name: impl Into<EcoString>) -> UtfCodepoint {
+    UtfCodepoint(UtfCodepointExpr::local_get(
+        UtfCodepointLocalId(index),
+        name.into(),
+    ))
 }
 
 pub(crate) fn local_float(index: usize, name: impl Into<EcoString>) -> Float {
@@ -59,6 +67,9 @@ pub(super) fn list_local(index: usize, element_type: ValueType) -> ListLocal {
         ValueType::Int => ListLocal::int(IntListLocalId(index)),
         ValueType::String => ListLocal::string(StringListLocalId(index)),
         ValueType::BitArray => ListLocal::bit_array(crate::plan::BitArrayListLocalId(index)),
+        ValueType::UtfCodepoint => {
+            ListLocal::utf_codepoint(crate::plan::UtfCodepointListLocalId(index))
+        }
         ValueType::Float => ListLocal::float(FloatListLocalId(index)),
         ValueType::Bool => ListLocal::bool(BoolListLocalId(index)),
         ValueType::Nil => ListLocal::nil(NilListLocalId(index)),
@@ -74,14 +85,14 @@ pub(super) fn list_local(index: usize, element_type: ValueType) -> ListLocal {
 mod tests {
     use super::{
         local_bit_array, local_bool, local_float, local_int, local_list, local_nil, local_string,
-        local_tuple,
+        local_tuple, local_utf_codepoint,
     };
     use crate::plan::{
         BitArrayExpr, BitArrayListLocalId, BitArrayLocalId, BoolExpr, BoolListLocalId, BoolLocalId,
         FloatExpr, FloatListLocalId, FloatLocalId, FunctionListLocalId, FunctionType, IntExpr,
         IntListLocalId, IntLocalId, ListExpr, ListListLocalId, ListLocal, NilExpr, NilListLocalId,
         NilLocalId, StringExpr, StringListLocalId, StringLocalId, TupleExpr, TupleListLocalId,
-        TupleLocalId, ValueType,
+        TupleLocalId, UtfCodepointExpr, UtfCodepointListLocalId, UtfCodepointLocalId, ValueType,
     };
 
     #[test]
@@ -97,6 +108,10 @@ mod tests {
         assert_eq!(
             local_bit_array(14, "bits").0,
             BitArrayExpr::local_get(BitArrayLocalId(14), "bits".into()),
+        );
+        assert_eq!(
+            local_utf_codepoint(15, "codepoint").0,
+            UtfCodepointExpr::local_get(UtfCodepointLocalId(15), "codepoint".into()),
         );
         assert_eq!(
             local_float(2, "ratio").0,
@@ -129,6 +144,13 @@ mod tests {
         assert_eq!(
             local_list(14, "bits", ValueType::BitArray).0,
             ListExpr::local_get(ListLocal::bit_array(BitArrayListLocalId(14)), "bits".into(),),
+        );
+        assert_eq!(
+            local_list(15, "codepoints", ValueType::UtfCodepoint).0,
+            ListExpr::local_get(
+                ListLocal::utf_codepoint(UtfCodepointListLocalId(15)),
+                "codepoints".into(),
+            ),
         );
         assert_eq!(
             local_list(8, "floats", ValueType::Float).0,

--- a/src/planner/dsl/expression/step.rs
+++ b/src/planner/dsl/expression/step.rs
@@ -1,13 +1,14 @@
 use super::{
     BitArray, BitArrayFunction, Bool, BoolFunction, Float, FloatFunction, Int, IntFunction, List,
-    Nil, NilFunction, String, StringFunction, Tuple,
+    Nil, NilFunction, String, StringFunction, Tuple, UtfCodepoint, UtfCodepointFunction,
 };
 use crate::plan::{
     BitArrayFunctionLocalId, BitArrayLocalId, BoolFunctionLocalId, BoolListLocalId, BoolLocalId,
     Expr, FloatFunctionLocalId, FloatListLocalId, FloatLocalId, FunctionListLocalId,
     IntFunctionLocalId, IntListLocalId, IntLocalId, ListExpr, ListListLocalId, ListLocalExpr,
     NilFunctionLocalId, NilListLocalId, NilLocalId, Step, StringFunctionLocalId, StringListLocalId,
-    StringLocalId, TupleListLocalId, TupleLocalId,
+    StringLocalId, TupleListLocalId, TupleLocalId, UtfCodepointFunctionLocalId,
+    UtfCodepointLocalId,
 };
 use ecow::EcoString;
 
@@ -25,6 +26,14 @@ pub(crate) fn let_bit_array_step(
     value: BitArray,
 ) -> Step {
     Step::let_bit_array(BitArrayLocalId(local), name.into(), value.into())
+}
+
+pub(crate) fn let_utf_codepoint_step(
+    local: usize,
+    name: impl Into<EcoString>,
+    value: UtfCodepoint,
+) -> Step {
+    Step::let_utf_codepoint(UtfCodepointLocalId(local), name.into(), value.into())
 }
 
 pub(crate) fn let_float_step(local: usize, name: impl Into<EcoString>, value: Float) -> Step {
@@ -55,6 +64,10 @@ pub(crate) fn let_list_step(local: usize, name: impl Into<EcoString>, value: Lis
         },
         ListExpr::BitArray(value) => ListLocalExpr::BitArray {
             local: crate::plan::BitArrayListLocalId(local),
+            value,
+        },
+        ListExpr::UtfCodepoint(value) => ListLocalExpr::UtfCodepoint {
+            local: crate::plan::UtfCodepointListLocalId(local),
             value,
         },
         ListExpr::Float(value) => ListLocalExpr::Float {
@@ -113,6 +126,18 @@ pub(crate) fn let_bit_array_function_step(
     Step::let_bit_array_function(BitArrayFunctionLocalId(local), name.into(), value.into())
 }
 
+pub(crate) fn let_utf_codepoint_function_step(
+    local: usize,
+    name: impl Into<EcoString>,
+    value: UtfCodepointFunction,
+) -> Step {
+    Step::let_utf_codepoint_function(
+        UtfCodepointFunctionLocalId(local),
+        name.into(),
+        value.into(),
+    )
+}
+
 pub(crate) fn let_float_function_step(
     local: usize,
     name: impl Into<EcoString>,
@@ -147,7 +172,7 @@ mod tests {
         evaluate_step, let_bit_array_function_step, let_bit_array_step, let_bool_function_step,
         let_bool_step, let_float_function_step, let_float_step, let_int_function_step,
         let_int_step, let_list_step, let_nil_function_step, let_nil_step, let_string_function_step,
-        let_string_step, let_tuple_step,
+        let_string_step, let_tuple_step, let_utf_codepoint_function_step, let_utf_codepoint_step,
     };
     use crate::plan::{
         BitArrayExpr, BitArrayFunctionLocalId, BitArrayListLocalId, BitArrayLocalId,
@@ -155,11 +180,13 @@ mod tests {
         FloatListLocalId, FloatLocalId, FunctionListLocalId, FunctionType, IntFunctionLocalId,
         IntListLocalId, IntLocalId, ListExpr, ListListLocalId, ListLocalExpr, NilFunctionLocalId,
         NilListLocalId, NilLocalId, Step, StringFunctionLocalId, StringListLocalId, StringLocalId,
-        TupleListLocalId, TupleLocalId, ValueType,
+        TupleListLocalId, TupleLocalId, UtfCodepointFunctionLocalId, UtfCodepointListLocalId,
+        UtfCodepointLocalId, ValueType,
     };
     use crate::planner::dsl::expression::{
         bit_array, bit_array_function_ref, bool_, bool_function_ref, float, float_function_ref,
-        int, int_function_ref, list, nil, nil_function_ref, string, string_function_ref, tuple,
+        int, int_function_ref, list, local_utf_codepoint, nil, nil_function_ref, string,
+        string_function_ref, tuple, utf_codepoint_function_ref,
     };
 
     #[test]
@@ -178,6 +205,14 @@ mod tests {
                 BitArrayLocalId(14),
                 "bits".into(),
                 BitArrayExpr::value(Vec::new()),
+            ),
+        );
+        assert_eq!(
+            let_utf_codepoint_step(15, "codepoint", local_utf_codepoint(0, "source")),
+            Step::let_utf_codepoint(
+                UtfCodepointLocalId(15),
+                "codepoint".into(),
+                local_utf_codepoint(0, "source").into(),
             ),
         );
         assert_eq!(
@@ -237,6 +272,25 @@ mod tests {
                     value: ListExpr::from(list([bit_array([])], ValueType::BitArray))
                         .into_bit_array()
                         .expect("expected bit array list"),
+                },
+            ),
+        );
+        assert_eq!(
+            let_list_step(
+                15,
+                "codepoints",
+                list([local_utf_codepoint(0, "source")], ValueType::UtfCodepoint,),
+            ),
+            Step::let_list_expr(
+                "codepoints".into(),
+                ListLocalExpr::UtfCodepoint {
+                    local: UtfCodepointListLocalId(15),
+                    value: ListExpr::from(list(
+                        [local_utf_codepoint(0, "source")],
+                        ValueType::UtfCodepoint,
+                    ))
+                    .into_utf_codepoint()
+                    .expect("expected UTF codepoint list"),
                 },
             ),
         );
@@ -401,6 +455,29 @@ mod tests {
                     0,
                     [crate::plan::LocalId::BitArray(
                         crate::plan::BitArrayLocalId(0)
+                    )],
+                )
+                .into(),
+            ),
+        );
+        assert_eq!(
+            let_utf_codepoint_function_step(
+                6,
+                "f",
+                utf_codepoint_function_ref(
+                    0,
+                    [crate::plan::LocalId::UtfCodepoint(
+                        crate::plan::UtfCodepointLocalId(0),
+                    )],
+                ),
+            ),
+            Step::let_utf_codepoint_function(
+                UtfCodepointFunctionLocalId(6),
+                "f".into(),
+                utf_codepoint_function_ref(
+                    0,
+                    [crate::plan::LocalId::UtfCodepoint(
+                        crate::plan::UtfCodepointLocalId(0),
                     )],
                 )
                 .into(),

--- a/src/planner/dsl/function/params.rs
+++ b/src/planner/dsl/function/params.rs
@@ -3,7 +3,7 @@ use crate::plan::{
     BoolFunctionLocalId, BoolLocalId, FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId,
     FunctionType, IntFunctionLocalId, IntLocalId, NilFunctionLocalId, NilLocalId, Param,
     ParamLocal, StringFunctionLocalId, StringLocalId, TupleFunctionLocalId, TupleLocalId,
-    ValueType,
+    UtfCodepointFunctionLocalId, UtfCodepointLocalId, ValueType,
 };
 use ecow::EcoString;
 
@@ -25,6 +25,14 @@ impl FunctionDsl {
     pub(crate) fn param_string(mut self, local: usize, name: impl Into<EcoString>) -> Self {
         self.params.push(Param::named(
             ParamLocal::string(StringLocalId(local)),
+            name.into(),
+        ));
+        self
+    }
+
+    pub(crate) fn param_utf_codepoint(mut self, local: usize, name: impl Into<EcoString>) -> Self {
+        self.params.push(Param::named(
+            ParamLocal::utf_codepoint(UtfCodepointLocalId(local)),
             name.into(),
         ));
         self
@@ -93,6 +101,22 @@ impl FunctionDsl {
             ParamLocal::string_function(
                 StringFunctionLocalId(local),
                 FunctionType::new(arguments.into_iter().collect(), ValueType::String),
+            ),
+            name.into(),
+        ));
+        self
+    }
+
+    pub(crate) fn param_utf_codepoint_function(
+        mut self,
+        local: usize,
+        name: impl Into<EcoString>,
+        arguments: impl IntoIterator<Item = ValueType>,
+    ) -> Self {
+        self.params.push(Param::named(
+            ParamLocal::utf_codepoint_function(
+                UtfCodepointFunctionLocalId(local),
+                FunctionType::new(arguments.into_iter().collect(), ValueType::UtfCodepoint),
             ),
             name.into(),
         ));
@@ -185,7 +209,7 @@ impl FunctionDsl {
 mod tests {
     use crate::plan::{
         FloatFunctionLocalId, FloatLocalId, FunctionType, ParamLocal, TupleFunctionLocalId,
-        TupleLocalId, ValueType,
+        TupleLocalId, UtfCodepointFunctionLocalId, UtfCodepointLocalId, ValueType,
     };
     use crate::planner::dsl::function;
 
@@ -193,8 +217,10 @@ mod tests {
     fn float_param_helpers_build_float_local_shapes() {
         let function = function("main", crate::planner::dsl::int(1))
             .param_float(0, "value")
+            .param_utf_codepoint(0, "codepoint")
             .param_tuple(0, "pair", [ValueType::Int])
             .param_float_function(0, "callback", [ValueType::Float])
+            .param_utf_codepoint_function(0, "codepoint_callback", [ValueType::UtfCodepoint])
             .param_tuple_function(
                 0,
                 "tuple_callback",
@@ -208,17 +234,28 @@ mod tests {
         );
         assert_eq!(
             function.params[1].local(),
-            &ParamLocal::tuple(TupleLocalId(0), vec![ValueType::Int]),
+            &ParamLocal::utf_codepoint(UtfCodepointLocalId(0)),
         );
         assert_eq!(
             function.params[2].local(),
+            &ParamLocal::tuple(TupleLocalId(0), vec![ValueType::Int]),
+        );
+        assert_eq!(
+            function.params[3].local(),
             &ParamLocal::float_function(
                 FloatFunctionLocalId(0),
                 FunctionType::new(vec![ValueType::Float], ValueType::Float),
             ),
         );
         assert_eq!(
-            function.params[3].local(),
+            function.params[4].local(),
+            &ParamLocal::utf_codepoint_function(
+                UtfCodepointFunctionLocalId(0),
+                FunctionType::new(vec![ValueType::UtfCodepoint], ValueType::UtfCodepoint,),
+            ),
+        );
+        assert_eq!(
+            function.params[5].local(),
             &ParamLocal::tuple_function(
                 TupleFunctionLocalId(0),
                 FunctionType::new(

--- a/src/planner/dsl/function/return_body.rs
+++ b/src/planner/dsl/function/return_body.rs
@@ -6,7 +6,8 @@ use crate::plan::{
     BitArrayFunctionReturn, BitArrayReturn, BoolFunctionReturn, BoolReturn, FloatFunctionReturn,
     FloatReturn, FunctionFunctionReturn, FunctionType, IntFunctionReturn, IntReturn,
     ListFunctionReturn, ListReturn, NilFunctionReturn, NilReturn, ReturnExpr, StringFunctionReturn,
-    StringReturn, TupleFunctionReturn, TupleReturn, ValueType,
+    StringReturn, TupleFunctionReturn, TupleReturn, UtfCodepointFunctionReturn, UtfCodepointReturn,
+    ValueType,
 };
 use crate::planner::context::FunctionRuntimeIds;
 
@@ -18,6 +19,7 @@ pub(crate) enum FunctionReturn {
     Int(IntReturn),
     String(StringReturn),
     BitArray(BitArrayReturn),
+    UtfCodepoint(UtfCodepointReturn),
     Float(FloatReturn),
     Bool(BoolReturn),
     Nil(NilReturn),
@@ -37,6 +39,10 @@ pub(crate) enum FunctionReturn {
     BitArrayFunction {
         type_: FunctionType,
         body: BitArrayFunctionReturn,
+    },
+    UtfCodepointFunction {
+        type_: FunctionType,
+        body: UtfCodepointFunctionReturn,
     },
     FloatFunction {
         type_: FunctionType,
@@ -73,6 +79,9 @@ impl FunctionReturn {
             Self::BitArray(body) => {
                 ReturnExpr::bit_array_body(runtime_ids.next_bit_array_id(), body)
             }
+            Self::UtfCodepoint(body) => {
+                ReturnExpr::utf_codepoint_body(runtime_ids.next_utf_codepoint_id(), body)
+            }
             Self::Float(body) => ReturnExpr::float_body(runtime_ids.next_float_id(), body),
             Self::Bool(body) => ReturnExpr::bool_body(runtime_ids.next_bool_id(), body),
             Self::Nil(body) => ReturnExpr::nil_body(runtime_ids.next_nil_id(), body),
@@ -87,6 +96,9 @@ impl FunctionReturn {
             }
             Self::List(ListReturn::BitArray(body)) => {
                 ReturnExpr::bit_array_list_body(runtime_ids.next_bit_array_list_id(), body)
+            }
+            Self::List(ListReturn::UtfCodepoint(body)) => {
+                ReturnExpr::utf_codepoint_list_body(runtime_ids.next_utf_codepoint_list_id(), body)
             }
             Self::List(ListReturn::Float(body)) => {
                 ReturnExpr::float_list_body(runtime_ids.next_float_list_id(), body)
@@ -114,6 +126,11 @@ impl FunctionReturn {
             }
             Self::BitArrayFunction { type_, body } => ReturnExpr::bit_array_function_body(
                 runtime_ids.next_bit_array_function_id(),
+                type_,
+                body,
+            ),
+            Self::UtfCodepointFunction { type_, body } => ReturnExpr::utf_codepoint_function_body(
+                runtime_ids.next_utf_codepoint_function_id(),
                 type_,
                 body,
             ),
@@ -155,13 +172,14 @@ mod tests {
         FunctionFunctionId, FunctionType, IntFunctionFunctionId, IntFunctionId,
         ListFunctionFunctionId, NilFunctionFunctionId, NilFunctionId, ParamLocal, ReturnBody,
         ReturnExpr, StringFunctionFunctionId, StringFunctionId, TupleFunctionFunctionId,
-        TupleFunctionId, ValueType,
+        TupleFunctionId, UtfCodepointFunctionFunctionId, UtfCodepointFunctionId, ValueType,
     };
     use crate::planner::context::FunctionRuntimeIds;
     use crate::planner::dsl::expression::{
         bit_array, bit_array_function_ref, bool_, bool_function_ref, float, float_function_ref,
-        function_function_ref, int, int_function_ref, list, list_function_ref, nil,
-        nil_function_ref, string, string_function_ref, tuple, tuple_function_ref,
+        function_function_ref, int, int_function_ref, list, list_function_ref, local_utf_codepoint,
+        nil, nil_function_ref, string, string_function_ref, tuple, tuple_function_ref,
+        utf_codepoint_function_ref,
     };
 
     #[test]
@@ -184,6 +202,13 @@ mod tests {
             ReturnExpr::bit_array_body(
                 BitArrayFunctionId(0),
                 ReturnBody::expr(bit_array([]).into()),
+            ),
+        );
+        assert_eq!(
+            FunctionReturn::from(local_utf_codepoint(0, "codepoint")).build(&mut runtime_ids),
+            ReturnExpr::utf_codepoint_body(
+                UtfCodepointFunctionId(0),
+                ReturnBody::expr(local_utf_codepoint(0, "codepoint").into()),
             ),
         );
         assert_eq!(
@@ -238,6 +263,18 @@ mod tests {
                     crate::plan::ListExpr::from(list(Vec::<Expr>::new(), ValueType::BitArray))
                         .into_bit_array()
                         .expect("expression should be List(BitArray)"),
+                ),
+            ),
+        );
+        assert_eq!(
+            FunctionReturn::from(list(Vec::<Expr>::new(), ValueType::UtfCodepoint))
+                .build(&mut runtime_ids),
+            ReturnExpr::utf_codepoint_list_body(
+                crate::plan::UtfCodepointListFunctionId(0),
+                crate::plan::UtfCodepointListReturn::expr(
+                    crate::plan::ListExpr::from(list(Vec::<Expr>::new(), ValueType::UtfCodepoint,))
+                        .into_utf_codepoint()
+                        .expect("expression should be List(UtfCodepoint)"),
                 ),
             ),
         );
@@ -361,6 +398,15 @@ mod tests {
                 BitArrayFunctionFunctionId(0),
                 FunctionType::new(Vec::new(), ValueType::BitArray),
                 ReturnBody::expr(bit_array_function_ref(0, Vec::<ParamLocal>::new()).into()),
+            ),
+        );
+        assert_eq!(
+            FunctionReturn::from(utf_codepoint_function_ref(0, Vec::<ParamLocal>::new(),))
+                .build(&mut runtime_ids),
+            ReturnExpr::utf_codepoint_function_body(
+                UtfCodepointFunctionFunctionId(0),
+                FunctionType::new(Vec::new(), ValueType::UtfCodepoint),
+                ReturnBody::expr(utf_codepoint_function_ref(0, Vec::<ParamLocal>::new()).into(),),
             ),
         );
         assert_eq!(

--- a/src/planner/dsl/function/return_body/conversion.rs
+++ b/src/planner/dsl/function/return_body/conversion.rs
@@ -3,12 +3,12 @@ use crate::plan::{
     BitArrayFunctionExpr, BitArrayReturn, BoolFunctionExpr, BoolReturn, FloatFunctionExpr,
     FloatReturn, FunctionExpr, FunctionExprKind, FunctionFunctionExpr, IntFunctionExpr, IntReturn,
     ListFunctionExpr, ListReturn, NilFunctionExpr, NilReturn, ReturnBody, StringFunctionExpr,
-    StringReturn, TupleFunctionExpr, TupleReturn,
+    StringReturn, TupleFunctionExpr, TupleReturn, UtfCodepointFunctionExpr, UtfCodepointReturn,
 };
 use crate::planner::dsl::expression::{
     BitArray, BitArrayFunction, Bool, BoolFunction, Float, FloatFunction, Function,
     FunctionFunction, Int, IntFunction, List, ListFunction, Nil, NilFunction, String,
-    StringFunction, Tuple, TupleFunction,
+    StringFunction, Tuple, TupleFunction, UtfCodepoint, UtfCodepointFunction,
 };
 
 impl From<Int> for FunctionReturn {
@@ -26,6 +26,12 @@ impl From<String> for FunctionReturn {
 impl From<BitArray> for FunctionReturn {
     fn from(value: BitArray) -> Self {
         Self::BitArray(ReturnBody::expr(value.into()))
+    }
+}
+
+impl From<UtfCodepoint> for FunctionReturn {
+    fn from(value: UtfCodepoint) -> Self {
+        Self::UtfCodepoint(ReturnBody::expr(value.into()))
     }
 }
 
@@ -88,6 +94,16 @@ impl From<BitArrayFunction> for FunctionReturn {
     fn from(value: BitArrayFunction) -> Self {
         let expression = BitArrayFunctionExpr::from(value);
         Self::BitArrayFunction {
+            type_: expression.type_().clone(),
+            body: ReturnBody::expr(expression),
+        }
+    }
+}
+
+impl From<UtfCodepointFunction> for FunctionReturn {
+    fn from(value: UtfCodepointFunction) -> Self {
+        let expression = UtfCodepointFunctionExpr::from(value);
+        Self::UtfCodepointFunction {
             type_: expression.type_().clone(),
             body: ReturnBody::expr(expression),
         }
@@ -170,6 +186,10 @@ impl From<Function> for FunctionReturn {
                 type_: expression.type_().clone(),
                 body: ReturnBody::expr(expression),
             },
+            FunctionExprKind::UtfCodepoint(expression) => Self::UtfCodepointFunction {
+                type_: expression.type_().clone(),
+                body: ReturnBody::expr(expression),
+            },
             FunctionExprKind::Float(expression) => Self::FloatFunction {
                 type_: expression.type_().clone(),
                 body: ReturnBody::expr(expression),
@@ -211,6 +231,12 @@ impl From<BitArrayReturn> for FunctionReturn {
     }
 }
 
+impl From<UtfCodepointReturn> for FunctionReturn {
+    fn from(value: UtfCodepointReturn) -> Self {
+        Self::UtfCodepoint(value)
+    }
+}
+
 impl From<StringReturn> for FunctionReturn {
     fn from(value: StringReturn) -> Self {
         Self::String(value)
@@ -242,12 +268,14 @@ mod tests {
         BitArrayFunctionId, BitArrayReturn, BoolFunctionId, BoolReturn, Expr, FloatFunctionId,
         FloatReturn, FunctionFunctionId, FunctionType, IntFunctionFunctionId, IntFunctionId,
         IntReturn, ListFunctionId, ListReturn, NilFunctionId, NilReturn, ParamLocal, ReturnBody,
-        RuntimeFunctionId, StringFunctionId, StringReturn, TupleFunctionId, ValueType,
+        RuntimeFunctionId, StringFunctionId, StringReturn, TupleFunctionId, UtfCodepointFunctionId,
+        UtfCodepointReturn, ValueType,
     };
     use crate::planner::dsl::expression::{
         bit_array, bit_array_function_ref, bool_, bool_function_ref, float, float_function_ref,
-        function_function_ref, function_ref, int, int_function_ref, list, list_function_ref, nil,
-        nil_function_ref, string, string_function_ref, tuple, tuple_function_ref,
+        function_function_ref, function_ref, int, int_function_ref, list, list_function_ref,
+        local_utf_codepoint, nil, nil_function_ref, string, string_function_ref, tuple,
+        tuple_function_ref, utf_codepoint_function_ref,
     };
 
     #[test]
@@ -267,6 +295,20 @@ mod tests {
         assert_eq!(
             FunctionReturn::from(BitArrayReturn::expr(bit_array([]).into())),
             FunctionReturn::BitArray(BitArrayReturn::expr(bit_array([]).into())),
+        );
+        assert_eq!(
+            FunctionReturn::from(local_utf_codepoint(0, "codepoint")),
+            FunctionReturn::UtfCodepoint(ReturnBody::expr(
+                local_utf_codepoint(0, "codepoint").into(),
+            )),
+        );
+        assert_eq!(
+            FunctionReturn::from(UtfCodepointReturn::expr(
+                local_utf_codepoint(0, "codepoint").into(),
+            )),
+            FunctionReturn::UtfCodepoint(UtfCodepointReturn::expr(
+                local_utf_codepoint(0, "codepoint").into(),
+            )),
         );
         assert_eq!(
             FunctionReturn::from(float(1.5)),
@@ -314,6 +356,15 @@ mod tests {
             FunctionReturn::BitArrayFunction {
                 type_: FunctionType::new(Vec::new(), ValueType::BitArray),
                 body: ReturnBody::expr(bit_array_function_ref(0, Vec::<ParamLocal>::new()).into(),),
+            },
+        );
+        assert_eq!(
+            FunctionReturn::from(utf_codepoint_function_ref(0, Vec::<ParamLocal>::new(),)),
+            FunctionReturn::UtfCodepointFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::UtfCodepoint),
+                body: ReturnBody::expr(
+                    utf_codepoint_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                ),
             },
         );
         assert_eq!(
@@ -420,6 +471,18 @@ mod tests {
             FunctionReturn::BitArrayFunction {
                 type_: FunctionType::new(Vec::new(), ValueType::BitArray),
                 body: ReturnBody::expr(bit_array_function_ref(0, Vec::<ParamLocal>::new()).into(),),
+            },
+        );
+        assert_eq!(
+            FunctionReturn::from(function_ref(
+                RuntimeFunctionId::UtfCodepoint(UtfCodepointFunctionId(0)),
+                Vec::<ParamLocal>::new(),
+            )),
+            FunctionReturn::UtfCodepointFunction {
+                type_: FunctionType::new(Vec::new(), ValueType::UtfCodepoint),
+                body: ReturnBody::expr(
+                    utf_codepoint_function_ref(0, Vec::<ParamLocal>::new()).into(),
+                ),
             },
         );
         assert_eq!(

--- a/src/planner/dsl/function/return_body/primitive.rs
+++ b/src/planner/dsl/function/return_body/primitive.rs
@@ -2,13 +2,77 @@ use super::FunctionReturn;
 use crate::plan::{
     BoolFunctionId, BoolReturn, CallArg, FloatFunctionId, FloatReturn, IntFunctionId, IntReturn,
     ListFunctionId, ListReturn, NilFunctionId, NilReturn, ReturnBody, Step, StringFunctionId,
-    StringReturn, ValueType,
+    StringReturn, UtfCodepointFunctionId, UtfCodepointReturn, ValueType,
 };
-use crate::planner::dsl::expression::{Bool, Float, Int, List, Nil, String};
+use crate::planner::dsl::expression::{Bool, Float, Int, List, Nil, String, UtfCodepoint};
 use num_bigint::BigInt;
 
 pub(crate) fn int_return_expr(expression: Int) -> IntReturn {
     ReturnBody::expr(expression.into())
+}
+
+pub(crate) fn utf_codepoint_return_expr(expression: UtfCodepoint) -> UtfCodepointReturn {
+    ReturnBody::expr(expression.into())
+}
+
+pub(crate) fn utf_codepoint_return_tail_call(
+    function: usize,
+    args: impl IntoIterator<Item = CallArg>,
+) -> UtfCodepointReturn {
+    ReturnBody::tail_call(UtfCodepointFunctionId(function), args.into_iter().collect())
+}
+
+pub(crate) fn utf_codepoint_return_bool_case(
+    subject: Bool,
+    true_: UtfCodepointReturn,
+    false_: UtfCodepointReturn,
+) -> UtfCodepointReturn {
+    ReturnBody::bool_case(subject.into(), true_, false_)
+}
+
+pub(crate) fn utf_codepoint_return_int_case(
+    subject: Int,
+    clauses: impl IntoIterator<Item = (i64, UtfCodepointReturn)>,
+    fallback: UtfCodepointReturn,
+) -> UtfCodepointReturn {
+    ReturnBody::int_case(
+        subject.into(),
+        clauses
+            .into_iter()
+            .map(|(value, branch)| (BigInt::from(value), branch))
+            .collect(),
+        fallback,
+    )
+}
+
+pub(crate) fn utf_codepoint_return_string_case(
+    subject: String,
+    clauses: impl IntoIterator<Item = (&'static str, UtfCodepointReturn)>,
+    fallback: UtfCodepointReturn,
+) -> UtfCodepointReturn {
+    ReturnBody::string_case(
+        subject.into(),
+        clauses
+            .into_iter()
+            .map(|(value, branch)| (value.into(), branch))
+            .collect(),
+        fallback,
+    )
+}
+
+pub(crate) fn utf_codepoint_return_float_case(
+    subject: Float,
+    clauses: impl IntoIterator<Item = (f64, UtfCodepointReturn)>,
+    fallback: UtfCodepointReturn,
+) -> UtfCodepointReturn {
+    ReturnBody::float_case(subject.into(), clauses.into_iter().collect(), fallback)
+}
+
+pub(crate) fn utf_codepoint_return_block(
+    steps: impl IntoIterator<Item = Step>,
+    return_: UtfCodepointReturn,
+) -> UtfCodepointReturn {
+    ReturnBody::block(steps.into_iter().collect(), return_)
 }
 
 pub(crate) fn int_return_tail_call(
@@ -417,12 +481,17 @@ mod tests {
         nil_return_float_case, nil_return_int_case, nil_return_string_case, nil_return_tail_call,
         string_return_block, string_return_bool_case, string_return_expr, string_return_float_case,
         string_return_int_case, string_return_string_case, string_return_tail_call,
+        utf_codepoint_return_block, utf_codepoint_return_bool_case, utf_codepoint_return_expr,
+        utf_codepoint_return_float_case, utf_codepoint_return_int_case,
+        utf_codepoint_return_string_case, utf_codepoint_return_tail_call,
     };
     use crate::plan::{
         BoolFunctionId, CallArg, FloatFunctionId, IntFunctionId, ListFunctionId, ListReturn,
-        NilFunctionId, ReturnBody, Step, StringFunctionId,
+        NilFunctionId, ReturnBody, Step, StringFunctionId, UtfCodepointFunctionId,
     };
-    use crate::planner::dsl::expression::{bool_, float, int, list, nil, string};
+    use crate::planner::dsl::expression::{
+        bool_, float, int, list, local_utf_codepoint, nil, string,
+    };
     use num_bigint::BigInt;
 
     #[test]
@@ -444,6 +513,57 @@ mod tests {
         assert_eq!(
             list_return_expr(list([int(1)], crate::plan::ValueType::Int)),
             ListReturn::expr(list([int(1)], crate::plan::ValueType::Int).into()),
+        );
+    }
+
+    #[test]
+    fn utf_codepoint_return_helpers_build_exact_shapes() {
+        let first = utf_codepoint_return_expr(local_utf_codepoint(0, "first"));
+        let second = utf_codepoint_return_expr(local_utf_codepoint(1, "second"));
+
+        assert_eq!(
+            first,
+            ReturnBody::expr(local_utf_codepoint(0, "first").into()),
+        );
+        assert_eq!(
+            utf_codepoint_return_tail_call(2, Vec::<CallArg>::new()),
+            ReturnBody::tail_call(UtfCodepointFunctionId(2), Vec::new()),
+        );
+        assert_eq!(
+            utf_codepoint_return_bool_case(bool_(true), first.clone(), second.clone()),
+            ReturnBody::bool_case(bool_(true).into(), first.clone(), second.clone()),
+        );
+        assert_eq!(
+            utf_codepoint_return_int_case(int(1), [(1, first.clone())], second.clone()),
+            ReturnBody::int_case(
+                int(1).into(),
+                vec![(BigInt::from(1), first.clone())],
+                second.clone(),
+            ),
+        );
+        assert_eq!(
+            utf_codepoint_return_string_case(
+                string("key"),
+                [("one", first.clone())],
+                second.clone(),
+            ),
+            ReturnBody::string_case(
+                string("key").into(),
+                vec![("one".into(), first.clone())],
+                second.clone(),
+            ),
+        );
+        assert_eq!(
+            utf_codepoint_return_float_case(float(1.0), [(1.0, first.clone())], second.clone(),),
+            ReturnBody::float_case(
+                float(1.0).into(),
+                vec![(1.0, first.clone())],
+                second.clone(),
+            ),
+        );
+        assert_eq!(
+            utf_codepoint_return_block([Step::evaluate(int(1).into())], first.clone()),
+            ReturnBody::block(vec![Step::evaluate(int(1).into())], first),
         );
     }
 

--- a/src/planner/error/invalid.rs
+++ b/src/planner/error/invalid.rs
@@ -79,6 +79,8 @@ pub enum InvalidExpressionType {
     String,
     #[error("BitArray")]
     BitArray,
+    #[error("UtfCodepoint")]
+    UtfCodepoint,
     #[error("Float")]
     Float,
     #[error("Bool")]

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -52,8 +52,6 @@ pub enum UnsupportedExpressionKind {
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedBitArraySegmentReason {
-    #[error("UtfCodepoint segments are not supported")]
-    UtfCodepoint,
     #[error("native-endian segments are not supported")]
     NativeEndianness,
     #[error("dynamic segment sizes are not supported")]

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -268,6 +268,7 @@ fn panic_expr(panic: PanicExpr, return_type: ValueType) -> Expr {
         ValueType::Int => Expr::int(IntExpr::panic(panic)),
         ValueType::String => Expr::string(StringExpr::panic(panic)),
         ValueType::BitArray => Expr::bit_array(BitArrayExpr::panic(panic)),
+        ValueType::UtfCodepoint => Expr::utf_codepoint(crate::plan::UtfCodepointExpr::panic(panic)),
         ValueType::Float => Expr::float(FloatExpr::panic(panic)),
         ValueType::Bool => Expr::bool(BoolExpr::panic(panic)),
         ValueType::Nil => Expr::nil(crate::plan::NilExpr::panic(panic)),
@@ -287,6 +288,9 @@ fn panic_function_expr(panic: PanicExpr, type_: FunctionType) -> Expr {
         )),
         ValueType::BitArray => Expr::function(FunctionExpr::bit_array(
             crate::plan::BitArrayFunctionExpr::panic(panic, type_),
+        )),
+        ValueType::UtfCodepoint => Expr::function(FunctionExpr::utf_codepoint(
+            crate::plan::UtfCodepointFunctionExpr::panic(panic, type_),
         )),
         ValueType::Float => Expr::function(FunctionExpr::float(
             crate::plan::FloatFunctionExpr::panic(panic, type_),
@@ -475,6 +479,9 @@ pub(super) fn tuple_index_expr(tuple: TupleExpr, index: usize, return_type: Valu
         ValueType::Int => Expr::int(IntExpr::tuple_index(tuple, index)),
         ValueType::String => Expr::string(StringExpr::tuple_index(tuple, index)),
         ValueType::BitArray => Expr::bit_array(BitArrayExpr::tuple_index(tuple, index)),
+        ValueType::UtfCodepoint => {
+            Expr::utf_codepoint(crate::plan::UtfCodepointExpr::tuple_index(tuple, index))
+        }
         ValueType::Float => Expr::float(FloatExpr::tuple_index(tuple, index)),
         ValueType::Bool => Expr::bool(BoolExpr::tuple_index(tuple, index)),
         ValueType::Nil => Expr::nil(crate::plan::NilExpr::tuple_index(tuple, index)),
@@ -498,6 +505,9 @@ pub(super) fn list_index_expr(
         }
         (ValueType::BitArray, ListExpr::BitArray(list)) => {
             Expr::bit_array(BitArrayExpr::list_index(list, index))
+        }
+        (ValueType::UtfCodepoint, ListExpr::UtfCodepoint(list)) => {
+            Expr::utf_codepoint(crate::plan::UtfCodepointExpr::list_index(list, index))
         }
         (ValueType::Float, ListExpr::Float(list)) => {
             Expr::float(FloatExpr::list_index(list, index))
@@ -531,6 +541,9 @@ fn tuple_index_function_expr(tuple: TupleExpr, index: usize, type_: FunctionType
         )),
         ValueType::BitArray => Expr::function(FunctionExpr::bit_array(
             crate::plan::BitArrayFunctionExpr::tuple_index(tuple, index, type_),
+        )),
+        ValueType::UtfCodepoint => Expr::function(FunctionExpr::utf_codepoint(
+            crate::plan::UtfCodepointFunctionExpr::tuple_index(tuple, index, type_),
         )),
         ValueType::Float => Expr::function(FunctionExpr::float(
             crate::plan::FloatFunctionExpr::tuple_index(tuple, index, type_),
@@ -567,6 +580,9 @@ fn list_index_function_expr(
         )),
         ValueType::BitArray => Expr::function(FunctionExpr::bit_array(
             crate::plan::BitArrayFunctionExpr::list_index(list.clone(), index, type_),
+        )),
+        ValueType::UtfCodepoint => Expr::function(FunctionExpr::utf_codepoint(
+            crate::plan::UtfCodepointFunctionExpr::list_index(list.clone(), index, type_),
         )),
         ValueType::Float => Expr::function(FunctionExpr::float(
             crate::plan::FloatFunctionExpr::list_index(list.clone(), index, type_),
@@ -665,6 +681,7 @@ fn expression_type(expression: &Expr) -> InvalidExpressionType {
         ValueType::Int => InvalidExpressionType::Int,
         ValueType::String => InvalidExpressionType::String,
         ValueType::BitArray => InvalidExpressionType::BitArray,
+        ValueType::UtfCodepoint => InvalidExpressionType::UtfCodepoint,
         ValueType::Float => InvalidExpressionType::Float,
         ValueType::Bool => InvalidExpressionType::Bool,
         ValueType::Nil => InvalidExpressionType::Nil,
@@ -679,6 +696,7 @@ fn value_type_expression_type(type_: ValueType) -> InvalidExpressionType {
         ValueType::Int => InvalidExpressionType::Int,
         ValueType::String => InvalidExpressionType::String,
         ValueType::BitArray => InvalidExpressionType::BitArray,
+        ValueType::UtfCodepoint => InvalidExpressionType::UtfCodepoint,
         ValueType::Float => InvalidExpressionType::Float,
         ValueType::Bool => InvalidExpressionType::Bool,
         ValueType::Nil => InvalidExpressionType::Nil,
@@ -773,7 +791,8 @@ mod tests {
         FunctionExpr, FunctionFunctionExpr, FunctionFunctionId, FunctionReference, FunctionType,
         IntExpr, IntFunctionExpr, IntFunctionFunctionId, IntFunctionId, IntLocalId, ListExpr,
         NilExpr, NilFunctionId, NilLocalId, PanicExpr, PanicSite, ParamLocal, ReturnBody,
-        RuntimeFunctionId, SourceSpan, StringExpr, StringLocalId, TupleExpr, ValueType,
+        RuntimeFunctionId, SourceSpan, StringExpr, StringLocalId, TupleExpr, UtfCodepointExpr,
+        UtfCodepointLocalId, ValueType,
     };
     use crate::planner::context::{AnonymousFunctions, PlanContext};
     use crate::planner::dsl::{
@@ -1295,6 +1314,10 @@ pub fn main() {
         let list_expression = Expr::from(list([int(1)], ValueType::Int));
         let nil_expression = Expr::from(nil());
         let bit_array_expression = Expr::bit_array(BitArrayExpr::value(Vec::new()));
+        let utf_codepoint_expression = Expr::utf_codepoint(UtfCodepointExpr::local_get(
+            UtfCodepointLocalId(0),
+            "codepoint".into(),
+        ));
 
         assert_eq!(
             invalid_expression_type(InvalidExpressionType::Int, expression_type(&expression)),
@@ -1352,6 +1375,27 @@ pub fn main() {
             PlanError::InvalidTypedAst {
                 reason: InvalidTypedAstReason::ExpressionType {
                     expected: InvalidExpressionType::BitArray,
+                    actual: InvalidExpressionType::Int,
+                },
+            },
+        );
+        assert_eq!(
+            invalid_expression_type(
+                InvalidExpressionType::Int,
+                expression_type(&utf_codepoint_expression),
+            ),
+            PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Int,
+                    actual: InvalidExpressionType::UtfCodepoint,
+                },
+            },
+        );
+        assert_eq!(
+            invalid_expression_type_for_value(ValueType::UtfCodepoint, ValueType::Int),
+            PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::UtfCodepoint,
                     actual: InvalidExpressionType::Int,
                 },
             },
@@ -2262,6 +2306,19 @@ pub fn main() {
         assert_eq!(
             super::list_index_expr(string_list, 0, ValueType::String),
             Ok(Expr::string(StringExpr::list_index(typed_string_list, 0))),
+        );
+
+        let utf_codepoint_list = ListExpr::value(Vec::new(), ValueType::UtfCodepoint);
+        let typed_utf_codepoint_list = utf_codepoint_list
+            .clone()
+            .into_utf_codepoint()
+            .expect("utf codepoint item list should build utf codepoint list expression");
+        assert_eq!(
+            super::list_index_expr(utf_codepoint_list, 0, ValueType::UtfCodepoint),
+            Ok(Expr::utf_codepoint(UtfCodepointExpr::list_index(
+                typed_utf_codepoint_list,
+                0,
+            ))),
         );
 
         let float_list = ListExpr::value(Vec::new(), ValueType::Float);

--- a/src/planner/expression/bit_array.rs
+++ b/src/planner/expression/bit_array.rs
@@ -46,6 +46,7 @@ enum SegmentKind {
     Float,
     Bits,
     String(StringEncoding),
+    UtfCodepoint(StringEncoding),
 }
 
 fn plan_segment<Value>(
@@ -56,8 +57,10 @@ fn plan_segment<Value>(
     let value_type = value.value_type();
     let mut kind = None;
     let mut endianness = Endianness::Big;
+    let mut explicit_endianness = false;
     let mut size = None;
     let mut unit = 1usize;
+    let mut explicit_unit = false;
 
     for option in options {
         match option {
@@ -75,9 +78,29 @@ fn plan_segment<Value>(
                 &mut kind,
                 SegmentKind::String(StringEncoding::Utf32(Endianness::Big)),
             )?,
-            BitArrayOption::Big { .. } => endianness = Endianness::Big,
-            BitArrayOption::Little { .. } => endianness = Endianness::Little,
-            BitArrayOption::Unit { value, .. } => unit = usize::from(value),
+            BitArrayOption::Utf8Codepoint { .. } => {
+                set_kind(&mut kind, SegmentKind::UtfCodepoint(StringEncoding::Utf8))?
+            }
+            BitArrayOption::Utf16Codepoint { .. } => set_kind(
+                &mut kind,
+                SegmentKind::UtfCodepoint(StringEncoding::Utf16(Endianness::Big)),
+            )?,
+            BitArrayOption::Utf32Codepoint { .. } => set_kind(
+                &mut kind,
+                SegmentKind::UtfCodepoint(StringEncoding::Utf32(Endianness::Big)),
+            )?,
+            BitArrayOption::Big { .. } => {
+                endianness = Endianness::Big;
+                explicit_endianness = true;
+            }
+            BitArrayOption::Little { .. } => {
+                endianness = Endianness::Little;
+                explicit_endianness = true;
+            }
+            BitArrayOption::Unit { value, .. } => {
+                unit = usize::from(value);
+                explicit_unit = true;
+            }
             BitArrayOption::Size { value, .. } => {
                 let Some(value) = int_literal(value.as_ref()) else {
                     return unsupported(UnsupportedBitArraySegmentReason::DynamicSize);
@@ -85,11 +108,6 @@ fn plan_segment<Value>(
                 size = Some(usize::try_from(value).map_err(|_| {
                     unsupported_error(UnsupportedBitArraySegmentReason::SizeOutOfRange)
                 })?);
-            }
-            BitArrayOption::Utf8Codepoint { .. }
-            | BitArrayOption::Utf16Codepoint { .. }
-            | BitArrayOption::Utf32Codepoint { .. } => {
-                return unsupported(UnsupportedBitArraySegmentReason::UtfCodepoint);
             }
             BitArrayOption::Native { .. } => {
                 return unsupported(UnsupportedBitArraySegmentReason::NativeEndianness);
@@ -100,17 +118,21 @@ fn plan_segment<Value>(
         }
     }
 
-    let kind = kind.unwrap_or(match value_type {
-        ValueType::Int => SegmentKind::Int,
-        ValueType::Float => SegmentKind::Float,
-        ValueType::String => SegmentKind::String(StringEncoding::Utf8),
-        ValueType::BitArray => SegmentKind::Bits,
-        ValueType::Bool
-        | ValueType::Nil
-        | ValueType::Tuple(_)
-        | ValueType::List(_)
-        | ValueType::Function(_) => SegmentKind::Bits,
-    });
+    let kind = match kind {
+        Some(kind) => kind,
+        None => match value_type {
+            ValueType::Int => SegmentKind::Int,
+            ValueType::Float => SegmentKind::Float,
+            ValueType::String
+            | ValueType::BitArray
+            | ValueType::UtfCodepoint
+            | ValueType::Bool
+            | ValueType::Nil
+            | ValueType::Tuple(_)
+            | ValueType::List(_)
+            | ValueType::Function(_) => return invalid_segment_option(),
+        },
+    };
 
     match kind {
         SegmentKind::Int => {
@@ -168,6 +190,23 @@ fn plan_segment<Value>(
             };
             Ok(BitArraySegment::String { value, encoding })
         }
+        SegmentKind::UtfCodepoint(encoding) => {
+            if size.is_some()
+                || explicit_unit
+                || matches!(encoding, StringEncoding::Utf8) && explicit_endianness
+            {
+                return invalid_segment_option();
+            }
+            let Some(value) = value.into_utf_codepoint() else {
+                return invalid_segment_option();
+            };
+            let encoding = match encoding {
+                StringEncoding::Utf8 => StringEncoding::Utf8,
+                StringEncoding::Utf16(_) => StringEncoding::Utf16(endianness),
+                StringEncoding::Utf32(_) => StringEncoding::Utf32(endianness),
+            };
+            Ok(BitArraySegment::UtfCodepoint { value, encoding })
+        }
     }
 }
 
@@ -214,7 +253,7 @@ mod tests {
     use crate::plan::{
         BitArrayExpr, BitArraySegment, Endianness, Expr, FloatBitSize, FloatExpr, FunctionExpr,
         FunctionReference, IntExpr, IntFunctionId, ParamLocal, RuntimeFunctionId, StringEncoding,
-        StringExpr,
+        StringExpr, UtfCodepointExpr, UtfCodepointLocalId,
     };
     use crate::planner::error::{
         InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError,
@@ -353,6 +392,98 @@ mod tests {
                 }),
             );
         }
+
+        let codepoint = UtfCodepointExpr::local_get(UtfCodepointLocalId(0), "codepoint".into());
+        let static_size = |_: &()| Some(BigInt::from(1));
+        for (options, expected) in [
+            (
+                vec![BitArrayOption::Utf8Codepoint { location }],
+                StringEncoding::Utf8,
+            ),
+            (
+                vec![
+                    BitArrayOption::Utf16Codepoint { location },
+                    BitArrayOption::Little { location },
+                ],
+                StringEncoding::Utf16(Endianness::Little),
+            ),
+            (
+                vec![
+                    BitArrayOption::Utf32Codepoint { location },
+                    BitArrayOption::Big { location },
+                ],
+                StringEncoding::Utf32(Endianness::Big),
+            ),
+        ] {
+            assert_eq!(
+                plan_segment(Expr::utf_codepoint(codepoint.clone()), options, static_size,),
+                Ok(BitArraySegment::UtfCodepoint {
+                    value: codepoint.clone(),
+                    encoding: expected,
+                }),
+            );
+        }
+        assert_eq!(
+            plan_segment(
+                Expr::utf_codepoint(codepoint.clone()),
+                Vec::new(),
+                static_size,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::BitArraySegmentOption,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_segment(
+                Expr::utf_codepoint(codepoint.clone()),
+                vec![
+                    BitArrayOption::Utf8Codepoint { location },
+                    BitArrayOption::Size {
+                        location,
+                        value: Box::new(()),
+                        short_form: false,
+                    },
+                ],
+                static_size,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::BitArraySegmentOption,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_segment(
+                Expr::utf_codepoint(codepoint.clone()),
+                vec![
+                    BitArrayOption::Utf8Codepoint { location },
+                    BitArrayOption::Little { location },
+                ],
+                static_size,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::BitArraySegmentOption,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_segment(
+                Expr::utf_codepoint(codepoint),
+                vec![
+                    BitArrayOption::Utf16Codepoint { location },
+                    BitArrayOption::Unit { location, value: 1 },
+                ],
+                static_size,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::BitArraySegmentOption,
+                },
+            }),
+        );
     }
 
     #[test]
@@ -396,6 +527,18 @@ mod tests {
                 BitArrayOption::Utf16 { location },
                 BitArrayOption::Utf32 { location },
             ],
+            vec![
+                BitArrayOption::Utf8Codepoint { location },
+                BitArrayOption::Utf8Codepoint { location },
+            ],
+            vec![
+                BitArrayOption::Utf16Codepoint { location },
+                BitArrayOption::Utf16Codepoint { location },
+            ],
+            vec![
+                BitArrayOption::Utf32Codepoint { location },
+                BitArrayOption::Utf32Codepoint { location },
+            ],
         ] {
             assert_eq!(
                 plan_segment(Expr::int(IntExpr::value(1.into())), options, |_: &()| None,),
@@ -418,6 +561,28 @@ mod tests {
             plan_segment(
                 Expr::string(StringExpr::value("wrong".into())),
                 vec![BitArrayOption::Int { location }],
+                |_: &()| None,
+            ),
+            invalid,
+        );
+        assert_eq!(
+            plan_segment(
+                Expr::utf_codepoint(UtfCodepointExpr::local_get(
+                    UtfCodepointLocalId(0),
+                    "codepoint".into(),
+                )),
+                vec![
+                    BitArrayOption::Utf8Codepoint { location },
+                    BitArrayOption::Unit { location, value: 2 },
+                ],
+                |_: &()| None,
+            ),
+            invalid,
+        );
+        assert_eq!(
+            plan_segment(
+                Expr::int(IntExpr::value(1.into())),
+                vec![BitArrayOption::Utf8Codepoint { location }],
                 |_: &()| None,
             ),
             invalid,
@@ -541,20 +706,12 @@ mod tests {
 
     #[test]
     fn unsupported_segment_options_keep_distinct_profile_reasons() {
-        let cases = [
-            (
-                BitArrayOption::Utf8Codepoint {
-                    location: SrcSpan::new(0, 0),
-                },
-                UnsupportedBitArraySegmentReason::UtfCodepoint,
-            ),
-            (
-                BitArrayOption::Native {
-                    location: SrcSpan::new(0, 0),
-                },
-                UnsupportedBitArraySegmentReason::NativeEndianness,
-            ),
-        ];
+        let cases = [(
+            BitArrayOption::Native {
+                location: SrcSpan::new(0, 0),
+            },
+            UnsupportedBitArraySegmentReason::NativeEndianness,
+        )];
 
         for (option, reason) in cases {
             assert_eq!(

--- a/src/planner/expression/block.rs
+++ b/src/planner/expression/block.rs
@@ -2,7 +2,8 @@ use crate::plan::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, Expr, ExprKind, FloatExpr,
     FloatFunctionExpr, FunctionExpr, FunctionExprKind, FunctionFunctionExpr, IntExpr,
     IntFunctionExpr, ListExpr, ListFunctionExpr, NilExpr, NilFunctionExpr, Step, StringExpr,
-    StringFunctionExpr, TupleExpr, TupleFunctionExpr, ValueType,
+    StringFunctionExpr, TupleExpr, TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr,
+    ValueType,
 };
 use crate::planner::context::PlanContext;
 use crate::planner::error::PlanError;
@@ -36,6 +37,9 @@ pub(super) fn block_expr(steps: Vec<Step>, return_: Expr) -> Expr {
         ExprKind::Int(return_) => Expr::int(IntExpr::block(steps, return_)),
         ExprKind::String(return_) => Expr::string(StringExpr::block(steps, return_)),
         ExprKind::BitArray(return_) => Expr::bit_array(BitArrayExpr::block(steps, return_)),
+        ExprKind::UtfCodepoint(return_) => {
+            Expr::utf_codepoint(UtfCodepointExpr::block(steps, return_))
+        }
         ExprKind::Float(return_) => Expr::float(FloatExpr::block(steps, return_)),
         ExprKind::Bool(return_) => Expr::bool(BoolExpr::block(steps, return_)),
         ExprKind::Nil(return_) => Expr::nil(NilExpr::block(steps, return_)),
@@ -50,6 +54,9 @@ pub(super) fn block_expr(steps: Vec<Step>, return_: Expr) -> Expr {
             )),
             FunctionExprKind::BitArray(return_) => Expr::function(FunctionExpr::bit_array(
                 BitArrayFunctionExpr::block(steps, return_),
+            )),
+            FunctionExprKind::UtfCodepoint(return_) => Expr::function(FunctionExpr::utf_codepoint(
+                UtfCodepointFunctionExpr::block(steps, return_),
             )),
             FunctionExprKind::Float(return_) => Expr::function(FunctionExpr::float(
                 FloatFunctionExpr::block(steps, return_),

--- a/src/planner/expression/call/argument.rs
+++ b/src/planner/expression/call/argument.rs
@@ -2,7 +2,8 @@ use super::CaptureSubstitution;
 use crate::plan::{
     BitArrayListLocalId, BoolListLocalId, CallArg, Expr, FloatListLocalId, FunctionListLocalId,
     IntListLocalId, ListFunctionLocal, ListListLocalId, ListLocal, NilListLocalId, ParamLocal,
-    StringListLocalId, TupleFunctionLocalId, TupleListLocalId, TupleLocalId, ValueType,
+    StringListLocalId, TupleFunctionLocalId, TupleListLocalId, TupleLocalId,
+    UtfCodepointListLocalId, ValueType,
 };
 use crate::planner::context::{FunctionParam, PlanContext};
 use crate::planner::error::{InvalidCallShapeReason, InvalidTypedAstReason, PlanError};
@@ -51,6 +52,7 @@ fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
     let mut next_int = 0;
     let mut next_string = 0;
     let mut next_bit_array = 0;
+    let mut next_utf_codepoint = 0;
     let mut next_float = 0;
     let mut next_bool = 0;
     let mut next_nil = 0;
@@ -58,6 +60,7 @@ fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
     let mut next_int_list = 0;
     let mut next_string_list = 0;
     let mut next_bit_array_list = 0;
+    let mut next_utf_codepoint_list = 0;
     let mut next_float_list = 0;
     let mut next_bool_list = 0;
     let mut next_nil_list = 0;
@@ -67,6 +70,7 @@ fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
     let mut next_int_function = 0;
     let mut next_string_function = 0;
     let mut next_bit_array_function = 0;
+    let mut next_utf_codepoint_function = 0;
     let mut next_float_function = 0;
     let mut next_bool_function = 0;
     let mut next_nil_function = 0;
@@ -90,6 +94,12 @@ fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
             ValueType::BitArray => {
                 let local = ParamLocal::bit_array(crate::plan::BitArrayLocalId(next_bit_array));
                 next_bit_array += 1;
+                local
+            }
+            ValueType::UtfCodepoint => {
+                let local =
+                    ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(next_utf_codepoint));
+                next_utf_codepoint += 1;
                 local
             }
             ValueType::Float => {
@@ -127,6 +137,13 @@ fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
                     ValueType::BitArray => {
                         let local = ListLocal::bit_array(BitArrayListLocalId(next_bit_array_list));
                         next_bit_array_list += 1;
+                        local
+                    }
+                    ValueType::UtfCodepoint => {
+                        let local = ListLocal::utf_codepoint(UtfCodepointListLocalId(
+                            next_utf_codepoint_list,
+                        ));
+                        next_utf_codepoint_list += 1;
                         local
                     }
                     ValueType::Float => {
@@ -190,6 +207,14 @@ fn function_call_param_locals(params: &[ValueType]) -> Vec<ParamLocal> {
                         type_.as_ref().clone(),
                     );
                     next_bit_array_function += 1;
+                    local
+                }
+                ValueType::UtfCodepoint => {
+                    let local = ParamLocal::utf_codepoint_function(
+                        crate::plan::UtfCodepointFunctionLocalId(next_utf_codepoint_function),
+                        type_.as_ref().clone(),
+                    );
+                    next_utf_codepoint_function += 1;
                     local
                 }
                 ValueType::Float => {
@@ -279,7 +304,7 @@ mod tests {
     use crate::plan::{
         BitArrayListLocalId, BoolListLocalId, FloatListLocalId, FunctionListLocalId, FunctionType,
         IntListLocalId, ListListLocalId, ListLocal, NilListLocalId, ParamLocal, StringListLocalId,
-        TupleListLocalId, ValueType,
+        TupleListLocalId, UtfCodepointListLocalId, ValueType,
     };
 
     #[test]
@@ -290,12 +315,14 @@ mod tests {
                 ValueType::Float,
                 ValueType::String,
                 ValueType::BitArray,
+                ValueType::UtfCodepoint,
                 ValueType::Bool,
                 ValueType::Nil,
                 ValueType::Int,
                 ValueType::List(Box::new(ValueType::Int)),
                 ValueType::List(Box::new(ValueType::String)),
                 ValueType::List(Box::new(ValueType::BitArray)),
+                ValueType::List(Box::new(ValueType::UtfCodepoint)),
                 ValueType::List(Box::new(ValueType::Float)),
                 ValueType::List(Box::new(ValueType::Bool)),
                 ValueType::List(Box::new(ValueType::Nil)),
@@ -316,6 +343,10 @@ mod tests {
                 ValueType::Function(Box::new(FunctionType::new(
                     vec![ValueType::BitArray],
                     ValueType::BitArray,
+                ))),
+                ValueType::Function(Box::new(FunctionType::new(
+                    vec![ValueType::UtfCodepoint],
+                    ValueType::UtfCodepoint,
                 ))),
                 ValueType::Function(Box::new(FunctionType::new(
                     vec![ValueType::Float],
@@ -347,12 +378,14 @@ mod tests {
                 ParamLocal::float(crate::plan::FloatLocalId(0)),
                 ParamLocal::string(crate::plan::StringLocalId(0)),
                 ParamLocal::bit_array(crate::plan::BitArrayLocalId(0)),
+                ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(0)),
                 ParamLocal::bool(crate::plan::BoolLocalId(0)),
                 ParamLocal::nil(crate::plan::NilLocalId(0)),
                 ParamLocal::int(crate::plan::IntLocalId(1)),
                 ParamLocal::list(ListLocal::int(IntListLocalId(0))),
                 ParamLocal::list(ListLocal::string(StringListLocalId(0))),
                 ParamLocal::list(ListLocal::bit_array(BitArrayListLocalId(0))),
+                ParamLocal::list(ListLocal::utf_codepoint(UtfCodepointListLocalId(0))),
                 ParamLocal::list(ListLocal::float(FloatListLocalId(0))),
                 ParamLocal::list(ListLocal::bool(BoolListLocalId(0))),
                 ParamLocal::list(ListLocal::nil(NilListLocalId(0))),
@@ -373,6 +406,10 @@ mod tests {
                 ParamLocal::bit_array_function(
                     crate::plan::BitArrayFunctionLocalId(0),
                     FunctionType::new(vec![ValueType::BitArray], ValueType::BitArray),
+                ),
+                ParamLocal::utf_codepoint_function(
+                    crate::plan::UtfCodepointFunctionLocalId(0),
+                    FunctionType::new(vec![ValueType::UtfCodepoint], ValueType::UtfCodepoint,),
                 ),
                 ParamLocal::float_function(
                     crate::plan::FloatFunctionLocalId(0),

--- a/src/planner/expression/call/direct.rs
+++ b/src/planner/expression/call/direct.rs
@@ -2,7 +2,7 @@ use super::CaptureSubstitution;
 use crate::plan::{
     BitArrayExpr, BoolExpr, CallArg, Expr, FloatExpr, FunctionExpr, FunctionFunctionExpr, IntExpr,
     ListExpr, ListFunctionExpr, NilExpr, RuntimeFunctionId, StringExpr, TupleExpr,
-    TupleFunctionExpr, ValueType,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr, ValueType,
 };
 use crate::planner::context::{FunctionInfo, FunctionParam, PlanContext};
 use crate::planner::error::{InvalidCallShapeReason, InvalidTypedAstReason, PlanError};
@@ -70,6 +70,9 @@ fn call_expr(function: RuntimeFunctionId, args: Vec<CallArg>) -> Expr {
         RuntimeFunctionId::BitArray(function) => {
             Expr::bit_array(BitArrayExpr::call(function, args))
         }
+        RuntimeFunctionId::UtfCodepoint(function) => {
+            Expr::utf_codepoint(UtfCodepointExpr::call(function, args))
+        }
         RuntimeFunctionId::Float(function) => Expr::float(FloatExpr::call(function, args)),
         RuntimeFunctionId::Bool(function) => Expr::bool(BoolExpr::call(function, args)),
         RuntimeFunctionId::Nil(function) => Expr::nil(NilExpr::call(function, args)),
@@ -99,6 +102,13 @@ fn function_returning_function_call_expr(
             Expr::function(FunctionExpr::bit_array(
                 crate::plan::BitArrayFunctionExpr::call(function, args, return_type),
             ))
+        }
+        crate::plan::FunctionFunctionId::UtfCodepoint(function) => {
+            Expr::function(FunctionExpr::utf_codepoint(UtfCodepointFunctionExpr::call(
+                function,
+                args,
+                return_type,
+            )))
         }
         crate::plan::FunctionFunctionId::Float(function) => Expr::function(FunctionExpr::float(
             crate::plan::FloatFunctionExpr::call(function, args, return_type),

--- a/src/planner/expression/call/function_value.rs
+++ b/src/planner/expression/call/function_value.rs
@@ -91,6 +91,12 @@ fn function_call_expr(
             ))),
             None => Err(function_call_return_type_mismatch()),
         },
+        ValueType::UtfCodepoint => match function.into_utf_codepoint() {
+            Some(function) => Ok(Expr::utf_codepoint(
+                crate::plan::UtfCodepointExpr::function_call(function, args),
+            )),
+            None => Err(function_call_return_type_mismatch()),
+        },
         ValueType::Float => match function.into_float() {
             Some(function) => Ok(Expr::float(crate::plan::FloatExpr::function_call(
                 function, args,
@@ -157,6 +163,9 @@ fn function_returning_function_value_call_expr(
         ValueType::BitArray => Expr::function(FunctionExpr::bit_array(
             crate::plan::BitArrayFunctionExpr::function_call(function, args, return_type),
         )),
+        ValueType::UtfCodepoint => Expr::function(FunctionExpr::utf_codepoint(
+            crate::plan::UtfCodepointFunctionExpr::function_call(function, args, return_type),
+        )),
         ValueType::Float => Expr::function(FunctionExpr::float(
             crate::plan::FloatFunctionExpr::function_call(function, args, return_type),
         )),
@@ -190,7 +199,7 @@ mod tests {
         FunctionFunctionFunctionId, FunctionFunctionId, FunctionType, IntFunctionFunctionId,
         IntLocalId, LocalId, NilFunctionFunctionId, NilFunctionId, ParamLocal, RuntimeFunctionId,
         StringFunctionFunctionId, StringFunctionId, TupleFunctionFunctionId, TupleFunctionId,
-        TupleLocalId, ValueType,
+        TupleLocalId, UtfCodepointFunctionFunctionId, UtfCodepointFunctionId, ValueType,
     };
     use crate::planner::dsl::{
         block_int_function, bool_, bool_case_int_function, call_int_function, function,
@@ -811,6 +820,19 @@ pub fn main() {
         assert_eq!(
             function_call_expr(
                 FunctionExpr::from(function_ref(
+                    RuntimeFunctionId::UtfCodepoint(UtfCodepointFunctionId(0)),
+                    Vec::<ParamLocal>::new(),
+                )),
+                Vec::new(),
+                ValueType::UtfCodepoint,
+            )
+            .expect("utf codepoint function call")
+            .value_type(),
+            ValueType::UtfCodepoint,
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(function_ref(
                     RuntimeFunctionId::Float(FloatFunctionId(0)),
                     Vec::<ParamLocal>::new(),
                 )),
@@ -913,6 +935,10 @@ pub fn main() {
                 FunctionType::new(vec![ValueType::BitArray], ValueType::BitArray),
             ),
             (
+                FunctionFunctionId::UtfCodepoint(UtfCodepointFunctionFunctionId(0)),
+                FunctionType::new(vec![ValueType::UtfCodepoint], ValueType::UtfCodepoint),
+            ),
+            (
                 FunctionFunctionId::Float(FloatFunctionFunctionId(0)),
                 FunctionType::new(vec![ValueType::Float], ValueType::Float),
             ),
@@ -1002,6 +1028,14 @@ pub fn main() {
                 FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
                 Vec::new(),
                 ValueType::BitArray,
+            ),
+            Err(function_call_return_type_mismatch()),
+        );
+        assert_eq!(
+            function_call_expr(
+                FunctionExpr::from(int_function_ref(0, Vec::<ParamLocal>::new())),
+                Vec::new(),
+                ValueType::UtfCodepoint,
             ),
             Err(function_call_return_type_mismatch()),
         );

--- a/src/planner/expression/case/guard.rs
+++ b/src/planner/expression/case/guard.rs
@@ -2,7 +2,7 @@ use crate::plan::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, Expr, FloatExpr,
     FloatFunctionExpr, FunctionExpr, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr,
     ListFunctionExpr, LocalId, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr,
-    TupleFunctionExpr, ValueType,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr, ValueType,
 };
 use crate::planner::context::{FunctionLocalBinding, PlanContext};
 use crate::planner::error::{
@@ -300,6 +300,9 @@ fn local_get(local: LocalId, name: EcoString, type_: ValueType) -> Result<Expr, 
         (LocalId::BitArray(local), ValueType::BitArray) => {
             Ok(Expr::bit_array(BitArrayExpr::local_get(local, name)))
         }
+        (LocalId::UtfCodepoint(local), ValueType::UtfCodepoint) => Ok(Expr::utf_codepoint(
+            UtfCodepointExpr::local_get(local, name),
+        )),
         (LocalId::Bool(local), ValueType::Bool) => Ok(Expr::bool(BoolExpr::local_get(local, name))),
         (LocalId::Nil(local), ValueType::Nil) => Ok(Expr::nil(NilExpr::local_get(local, name))),
         _ => invalid_expression_shape(InvalidExpressionShapeKind::Invalid),
@@ -317,6 +320,9 @@ fn function_local_get(binding: FunctionLocalBinding, name: EcoString) -> Expr {
         FunctionLocalBinding::BitArray { local, type_ } => Expr::function(FunctionExpr::bit_array(
             BitArrayFunctionExpr::local_get(local, name, type_),
         )),
+        FunctionLocalBinding::UtfCodepoint { local, type_ } => Expr::function(
+            FunctionExpr::utf_codepoint(UtfCodepointFunctionExpr::local_get(local, name, type_)),
+        ),
         FunctionLocalBinding::Float { local, type_ } => Expr::function(FunctionExpr::float(
             FloatFunctionExpr::local_get(local, name, type_),
         )),
@@ -347,6 +353,7 @@ fn contains_function_value(type_: &ValueType) -> bool {
         | ValueType::Float
         | ValueType::String
         | ValueType::BitArray
+        | ValueType::UtfCodepoint
         | ValueType::Bool
         | ValueType::Nil => false,
     }
@@ -367,6 +374,7 @@ fn invalid_expression_type(type_: ValueType) -> InvalidExpressionType {
         ValueType::Float => InvalidExpressionType::Float,
         ValueType::String => InvalidExpressionType::String,
         ValueType::BitArray => InvalidExpressionType::BitArray,
+        ValueType::UtfCodepoint => InvalidExpressionType::UtfCodepoint,
         ValueType::Bool => InvalidExpressionType::Bool,
         ValueType::Nil => InvalidExpressionType::Nil,
         ValueType::Tuple(_) => InvalidExpressionType::Tuple,
@@ -391,7 +399,8 @@ mod tests {
         FunctionType, IntExpr, IntFunctionExpr, IntFunctionLocalId, IntLocalId, ListExpr,
         ListFunctionExpr, ListLocal, LocalId, NilExpr, NilFunctionExpr, NilFunctionLocalId,
         NilLocalId, StringExpr, StringFunctionExpr, StringFunctionLocalId, StringListLocalId,
-        TupleExpr, TupleFunctionExpr, TupleFunctionLocalId, TupleLocalId, ValueType,
+        TupleExpr, TupleFunctionExpr, TupleFunctionLocalId, TupleLocalId, UtfCodepointExpr,
+        UtfCodepointFunctionExpr, UtfCodepointFunctionLocalId, UtfCodepointLocalId, ValueType,
     };
     use crate::planner::context::{AnonymousFunctions, FunctionLocalBinding, PlanContext};
     use crate::planner::support::dummy_span;
@@ -1041,6 +1050,7 @@ mod tests {
         let mut anonymous = AnonymousFunctions::default();
         let mut context = PlanContext::new(&module, &functions, &mut anonymous);
         context.define_bit_array_local("bits".into());
+        context.define_utf_codepoint_local("codepoint".into());
         context.define_nil_local("none".into());
         context.define_tuple_local("pair".into(), vec![ValueType::Int]);
         context.define_list_local("values".into(), ValueType::String);
@@ -1054,6 +1064,13 @@ mod tests {
             Ok(Expr::bit_array(BitArrayExpr::local_get(
                 BitArrayLocalId(0),
                 "bits".into(),
+            ))),
+        );
+        assert_eq!(
+            super::plan_local("codepoint".into(), &context),
+            Ok(Expr::utf_codepoint(UtfCodepointExpr::local_get(
+                UtfCodepointLocalId(0),
+                "codepoint".into(),
             ))),
         );
         assert_eq!(
@@ -1106,6 +1123,8 @@ mod tests {
         let unary_int = FunctionType::new(vec![ValueType::Int], ValueType::Int);
         let unary_string = FunctionType::new(vec![ValueType::String], ValueType::String);
         let unary_bit_array = FunctionType::new(vec![ValueType::BitArray], ValueType::BitArray);
+        let unary_utf_codepoint =
+            FunctionType::new(vec![ValueType::UtfCodepoint], ValueType::UtfCodepoint);
         let unary_float = FunctionType::new(vec![ValueType::Float], ValueType::Float);
         let unary_bool = FunctionType::new(vec![ValueType::Bool], ValueType::Bool);
         let unary_nil = FunctionType::new(vec![ValueType::Nil], ValueType::Nil);
@@ -1157,6 +1176,22 @@ mod tests {
                 "f".into(),
                 unary_bit_array,
             ))),
+        );
+        assert_eq!(
+            function_local_get(
+                FunctionLocalBinding::UtfCodepoint {
+                    local: UtfCodepointFunctionLocalId(0),
+                    type_: unary_utf_codepoint.clone(),
+                },
+                "f".into(),
+            ),
+            Expr::function(FunctionExpr::utf_codepoint(
+                UtfCodepointFunctionExpr::local_get(
+                    UtfCodepointFunctionLocalId(0),
+                    "f".into(),
+                    unary_utf_codepoint,
+                ),
+            )),
         );
         assert_eq!(
             function_local_get(
@@ -1268,6 +1303,7 @@ mod tests {
             ValueType::Float,
             ValueType::String,
             ValueType::BitArray,
+            ValueType::UtfCodepoint,
             ValueType::Bool,
             ValueType::Nil,
             ValueType::List(Box::new(ValueType::Int)),
@@ -1279,6 +1315,7 @@ mod tests {
                 ValueType::Float,
                 ValueType::String,
                 ValueType::BitArray,
+                ValueType::UtfCodepoint,
                 ValueType::Bool,
                 ValueType::Nil,
                 ValueType::Tuple(Vec::new()),
@@ -1291,6 +1328,7 @@ mod tests {
                 InvalidExpressionType::Float,
                 InvalidExpressionType::String,
                 InvalidExpressionType::BitArray,
+                InvalidExpressionType::UtfCodepoint,
                 InvalidExpressionType::Bool,
                 InvalidExpressionType::Nil,
                 InvalidExpressionType::Tuple,

--- a/src/planner/expression/case/subject.rs
+++ b/src/planner/expression/case/subject.rs
@@ -7,6 +7,7 @@ mod list;
 mod nil;
 mod string;
 mod tuple;
+mod utf_codepoint;
 
 use crate::plan::{
     BoolCaseBranches, BoolExpr, BoolListCaseBranches, BoolLocalId, Expr, ExprKind, FloatExpr,
@@ -33,6 +34,7 @@ pub(super) fn plan(
         Some(ValueType::Int) => int::plan(type_, subject, clauses, context),
         Some(ValueType::String) => string::plan(type_, subject, clauses, context),
         Some(ValueType::BitArray) => bit_array::plan(type_, subject, clauses, context),
+        Some(ValueType::UtfCodepoint) => utf_codepoint::plan(type_, subject, clauses, context),
         Some(ValueType::Float) => float::plan(type_, subject, clauses, context),
         Some(ValueType::Nil) => nil::plan(type_, subject, clauses, context),
         Some(ValueType::Tuple(subject_type)) => {
@@ -229,6 +231,9 @@ fn bool_case_expr(subject: BoolExpr, true_: Expr, false_: Expr) -> Result<Expr, 
         (ExprKind::BitArray(true_), ExprKind::BitArray(false_)) => {
             BoolCaseBranches::BitArray { true_, false_ }
         }
+        (ExprKind::UtfCodepoint(true_), ExprKind::UtfCodepoint(false_)) => {
+            BoolCaseBranches::UtfCodepoint { true_, false_ }
+        }
         (ExprKind::Float(true_), ExprKind::Float(false_)) => {
             BoolCaseBranches::Float { true_, false_ }
         }
@@ -266,6 +271,9 @@ fn bool_list_case_branches(
         }
         (ListExpr::BitArray(true_), ListExpr::BitArray(false_)) => {
             BoolListCaseBranches::BitArray { true_, false_ }
+        }
+        (ListExpr::UtfCodepoint(true_), ListExpr::UtfCodepoint(false_)) => {
+            BoolListCaseBranches::UtfCodepoint { true_, false_ }
         }
         (ListExpr::Float(true_), ListExpr::Float(false_)) => {
             BoolListCaseBranches::Float { true_, false_ }
@@ -308,6 +316,9 @@ fn bool_function_case_branches(
         }
         (FunctionExprKind::BitArray(true_), FunctionExprKind::BitArray(false_)) => {
             BoolCaseBranches::BitArrayFunction { true_, false_ }
+        }
+        (FunctionExprKind::UtfCodepoint(true_), FunctionExprKind::UtfCodepoint(false_)) => {
+            BoolCaseBranches::UtfCodepointFunction { true_, false_ }
         }
         (FunctionExprKind::Float(true_), FunctionExprKind::Float(false_)) => {
             BoolCaseBranches::FloatFunction { true_, false_ }

--- a/src/planner/expression/case/subject/float.rs
+++ b/src/planner/expression/case/subject/float.rs
@@ -204,6 +204,10 @@ fn float_case_expr(
             clauses: bit_array_case_clauses(clauses)?,
             fallback,
         },
+        ExprKind::UtfCodepoint(fallback) => FloatCaseBranches::UtfCodepoint {
+            clauses: utf_codepoint_case_clauses(clauses)?,
+            fallback,
+        },
         ExprKind::Float(fallback) => FloatCaseBranches::Float {
             clauses: float_case_clauses(clauses)?,
             fallback,
@@ -263,6 +267,21 @@ fn bit_array_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::BitArray(clause) = clause.into_kind() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn utf_codepoint_case_clauses(
+    clauses: Vec<(f64, Expr)>,
+) -> Result<Vec<(f64, crate::plan::UtfCodepointExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::UtfCodepoint(clause) = clause.into_kind() else {
             return Err(invalid_case_shape(
                 InvalidCaseShapeReason::BranchReturnTypeMismatch,
             ));
@@ -374,6 +393,12 @@ fn function_case_branches(
                 fallback,
             })
         }
+        crate::plan::FunctionExprKind::UtfCodepoint(fallback) => {
+            Ok(FloatCaseBranches::UtfCodepointFunction {
+                clauses: utf_codepoint_function_case_clauses(clauses)?,
+                fallback,
+            })
+        }
         crate::plan::FunctionExprKind::Float(fallback) => Ok(FloatCaseBranches::FloatFunction {
             clauses: float_function_case_clauses(clauses)?,
             fallback,
@@ -454,6 +479,26 @@ fn bit_array_function_case_clauses(
             ));
         };
         let crate::plan::FunctionExprKind::BitArray(clause) = function.into_kind() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn utf_codepoint_function_case_clauses(
+    clauses: Vec<(f64, Expr)>,
+) -> Result<Vec<(f64, crate::plan::UtfCodepointFunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(function) = clause.into_kind() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        };
+        let crate::plan::FunctionExprKind::UtfCodepoint(clause) = function.into_kind() else {
             return Err(invalid_case_shape(
                 InvalidCaseShapeReason::BranchReturnTypeMismatch,
             ));
@@ -589,7 +634,8 @@ mod tests {
         BoolExpr, BoolFunctionId, Expr, FloatCaseBranches, FloatFunctionFunctionId,
         FloatFunctionId, FloatReturn, FunctionExpr, FunctionFunctionId, FunctionType,
         IntFunctionExpr, IntFunctionId, IntLocalId, ListFunctionId, LocalId, NilFunctionId,
-        RuntimeFunctionId, StringFunctionId, TupleFunctionId, ValueType,
+        RuntimeFunctionId, StringFunctionId, TupleFunctionId, UtfCodepointExpr,
+        UtfCodepointFunctionId, UtfCodepointLocalId, ValueType,
     };
     use crate::planner::dsl::{
         bit_array, bit_array_function_ref, bool_, bool_return_expr, bool_return_float_case, float,
@@ -1015,6 +1061,56 @@ fn duplicate_literal(value: Float) {
 
     #[test]
     fn plan_float_case_function_branch_return_families_direct() {
+        let codepoint = |local| {
+            Expr::utf_codepoint(UtfCodepointExpr::local_get(
+                UtfCodepointLocalId(local),
+                "codepoint".into(),
+            ))
+        };
+        assert_eq!(
+            super::float_case_expr(float(1.0).into(), vec![(1.0, codepoint(0))], codepoint(1),),
+            Ok(Expr::float_case(
+                float(1.0).into(),
+                FloatCaseBranches::UtfCodepoint {
+                    clauses: vec![(
+                        1.0,
+                        UtfCodepointExpr::local_get(UtfCodepointLocalId(0), "codepoint".into(),),
+                    )],
+                    fallback: UtfCodepointExpr::local_get(
+                        UtfCodepointLocalId(1),
+                        "codepoint".into(),
+                    ),
+                },
+            )),
+        );
+        assert_eq!(
+            super::float_case_expr(float(1.0).into(), vec![(1.0, int(1).into())], codepoint(1),),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::function_case_branches(
+                vec![(1.0, utf_codepoint_function_ref_expr(0))],
+                utf_codepoint_function_ref_expr(1)
+                    .into_function()
+                    .expect("function expression"),
+            ),
+            Ok(FloatCaseBranches::UtfCodepointFunction {
+                clauses: vec![(
+                    1.0,
+                    utf_codepoint_function_ref_expr(0)
+                        .into_function()
+                        .expect("function expression")
+                        .into_utf_codepoint()
+                        .expect("utf codepoint function expression"),
+                )],
+                fallback: utf_codepoint_function_ref_expr(1)
+                    .into_function()
+                    .expect("function expression")
+                    .into_utf_codepoint()
+                    .expect("utf codepoint function expression"),
+            }),
+        );
+
         assert_eq!(
             super::function_case_branches(
                 vec![(1.0, string_function_ref_expr(0))],
@@ -1591,6 +1687,18 @@ fn add_one(value: Float) {
     #[test]
     fn reject_margin_float_case_function_clause_family_mismatch_direct() {
         assert_eq!(
+            super::utf_codepoint_case_clauses(vec![(1.0, Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::utf_codepoint_function_case_clauses(vec![(1.0, Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::utf_codepoint_function_case_clauses(vec![(1.0, int_function_ref_expr(0))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
             super::bit_array_case_clauses(vec![(1.0, Expr::from(int(1)))]),
             Err(case_branch_return_type_mismatch()),
         );
@@ -1669,6 +1777,7 @@ fn add_one(value: Float) {
 
         assert_float_function_case_branch_mismatch(int_function_ref_expr(1));
         assert_float_function_case_branch_mismatch(string_function_ref_expr(1));
+        assert_float_function_case_branch_mismatch(utf_codepoint_function_ref_expr(1));
         assert_float_function_case_branch_mismatch(float_function_ref_expr(1));
         assert_float_function_case_branch_mismatch(bool_function_ref_expr(1));
         assert_float_function_case_branch_mismatch(nil_function_ref_expr(1));
@@ -1732,6 +1841,14 @@ fn add_one(value: Float) {
                 return_type: vec![ValueType::Int],
             },
             [LocalId::Int(IntLocalId(0))],
+        )
+        .into()
+    }
+
+    fn utf_codepoint_function_ref_expr(id: usize) -> Expr {
+        function_ref(
+            RuntimeFunctionId::UtfCodepoint(UtfCodepointFunctionId(id)),
+            [LocalId::UtfCodepoint(UtfCodepointLocalId(0))],
         )
         .into()
     }

--- a/src/planner/expression/case/subject/function.rs
+++ b/src/planner/expression/case/subject/function.rs
@@ -154,6 +154,17 @@ fn bind_function_case_subject(
                 ))),
             )
         }
+        FunctionExprKind::UtfCodepoint(subject) => {
+            let local = context.define_internal_utf_codepoint_function_local();
+            let name = internal_utf_codepoint_function_case_subject_name(local);
+            let type_ = subject.type_().clone();
+            (
+                Step::let_utf_codepoint_function(local, name.clone(), subject),
+                Expr::function(FunctionExpr::utf_codepoint(
+                    crate::plan::UtfCodepointFunctionExpr::local_get(local, name, type_),
+                )),
+            )
+        }
         FunctionExprKind::Float(subject) => {
             let local = context.define_internal_float_function_local();
             let name = internal_float_function_case_subject_name(local);
@@ -240,6 +251,12 @@ fn internal_bit_array_function_case_subject_name(
     format!("<case:bit_array_function:{}>", local.0).into()
 }
 
+fn internal_utf_codepoint_function_case_subject_name(
+    local: crate::plan::UtfCodepointFunctionLocalId,
+) -> EcoString {
+    format!("<case:utf_codepoint_function:{}>", local.0).into()
+}
+
 fn internal_float_function_case_subject_name(
     local: crate::plan::FloatFunctionLocalId,
 ) -> EcoString {
@@ -282,7 +299,7 @@ mod tests {
         function_function_ref, int, int_function_call_arg, int_function_ref, int_return_block,
         int_return_expr, let_bool_function_step, let_int_function_step, let_nil_function_step,
         let_string_function_step, list_function_ref, local_int, local_int_function, module,
-        nil_function_ref, string_function_ref, tuple_function_ref,
+        nil_function_ref, string_function_ref, tuple_function_ref, utf_codepoint_function_ref,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{dummy_span, expect_plan_error};
@@ -446,6 +463,26 @@ pub fn main() {
                     "<case:bit_array_function:0>".into(),
                     FunctionType::new(Vec::new(), ValueType::BitArray),
                 ))),
+            ),
+        );
+        assert_eq!(
+            bind_function_case_subject(
+                utf_codepoint_function_ref(0, Vec::<LocalId>::new()).into(),
+                &mut context,
+            ),
+            (
+                Step::let_utf_codepoint_function(
+                    crate::plan::UtfCodepointFunctionLocalId(0),
+                    "<case:utf_codepoint_function:0>".into(),
+                    utf_codepoint_function_ref(0, Vec::<LocalId>::new()).into(),
+                ),
+                Expr::function(FunctionExpr::utf_codepoint(
+                    crate::plan::UtfCodepointFunctionExpr::local_get(
+                        crate::plan::UtfCodepointFunctionLocalId(0),
+                        "<case:utf_codepoint_function:0>".into(),
+                        FunctionType::new(Vec::new(), ValueType::UtfCodepoint),
+                    ),
+                )),
             ),
         );
         assert_eq!(

--- a/src/planner/expression/case/subject/int.rs
+++ b/src/planner/expression/case/subject/int.rs
@@ -203,6 +203,10 @@ fn int_case_expr(
             clauses: bit_array_case_clauses(clauses)?,
             fallback,
         },
+        ExprKind::UtfCodepoint(fallback) => IntCaseBranches::UtfCodepoint {
+            clauses: utf_codepoint_case_clauses(clauses)?,
+            fallback,
+        },
         ExprKind::Float(fallback) => IntCaseBranches::Float {
             clauses: float_case_clauses(clauses)?,
             fallback,
@@ -262,6 +266,21 @@ fn bit_array_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::BitArray(clause) = clause.into_kind() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn utf_codepoint_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::UtfCodepointExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::UtfCodepoint(clause) = clause.into_kind() else {
             return Err(invalid_case_shape(
                 InvalidCaseShapeReason::BranchReturnTypeMismatch,
             ));
@@ -373,6 +392,12 @@ fn function_case_branches(
                 fallback,
             })
         }
+        crate::plan::FunctionExprKind::UtfCodepoint(fallback) => {
+            Ok(IntCaseBranches::UtfCodepointFunction {
+                clauses: utf_codepoint_function_case_clauses(clauses)?,
+                fallback,
+            })
+        }
         crate::plan::FunctionExprKind::Float(fallback) => Ok(IntCaseBranches::FloatFunction {
             clauses: float_function_case_clauses(clauses)?,
             fallback,
@@ -453,6 +478,26 @@ fn bit_array_function_case_clauses(
             ));
         };
         let crate::plan::FunctionExprKind::BitArray(clause) = function.into_kind() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn utf_codepoint_function_case_clauses(
+    clauses: Vec<(BigInt, Expr)>,
+) -> Result<Vec<(BigInt, crate::plan::UtfCodepointFunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(function) = clause.into_kind() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        };
+        let crate::plan::FunctionExprKind::UtfCodepoint(clause) = function.into_kind() else {
             return Err(invalid_case_shape(
                 InvalidCaseShapeReason::BranchReturnTypeMismatch,
             ));
@@ -588,7 +633,8 @@ mod tests {
         BoolExpr, BoolFunctionId, Expr, FloatExpr, FloatFunctionId, FunctionExpr,
         FunctionFunctionId, FunctionType, IntCaseBranches, IntFunctionExpr, IntFunctionFunctionId,
         IntFunctionId, IntLocalId, IntReturn, ListFunctionId, LocalId, NilFunctionId,
-        RuntimeFunctionId, StringFunctionId, TupleFunctionId, ValueType,
+        RuntimeFunctionId, StringFunctionId, TupleFunctionId, UtfCodepointExpr,
+        UtfCodepointFunctionId, UtfCodepointLocalId, ValueType,
     };
     use crate::planner::dsl::{
         bit_array, bit_array_function_ref, bool_, bool_return_expr, bool_return_int_case, float,
@@ -1033,6 +1079,23 @@ pub fn main() {
     #[test]
     fn reject_margin_int_case_function_clause_family_mismatch_direct() {
         assert_eq!(
+            super::utf_codepoint_case_clauses(vec![(BigInt::from(1), Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::utf_codepoint_function_case_clauses(vec![
+                (BigInt::from(1), Expr::from(int(1)),)
+            ]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::utf_codepoint_function_case_clauses(vec![(
+                BigInt::from(1),
+                int_function_ref_expr(0),
+            )]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
             super::bit_array_case_clauses(vec![(BigInt::from(1), Expr::from(int(1)))]),
             Err(case_branch_return_type_mismatch()),
         );
@@ -1117,6 +1180,7 @@ pub fn main() {
 
         assert_int_function_case_branch_mismatch(int_function_ref_expr(1));
         assert_int_function_case_branch_mismatch(string_function_ref_expr(1));
+        assert_int_function_case_branch_mismatch(utf_codepoint_function_ref_expr(1));
         assert_int_function_case_branch_mismatch(float_function_ref_expr(1));
         assert_int_function_case_branch_mismatch(bool_function_ref_expr(1));
         assert_int_function_case_branch_mismatch(nil_function_ref_expr(1));
@@ -1127,6 +1191,65 @@ pub fn main() {
 
     #[test]
     fn plan_int_case_function_branch_return_families_direct() {
+        let codepoint = |local| {
+            Expr::utf_codepoint(UtfCodepointExpr::local_get(
+                UtfCodepointLocalId(local),
+                "codepoint".into(),
+            ))
+        };
+        assert_eq!(
+            super::int_case_expr(
+                int(1).into(),
+                vec![(BigInt::from(1), codepoint(0))],
+                codepoint(1),
+            ),
+            Ok(Expr::int_case(
+                int(1).into(),
+                IntCaseBranches::UtfCodepoint {
+                    clauses: vec![(
+                        BigInt::from(1),
+                        UtfCodepointExpr::local_get(UtfCodepointLocalId(0), "codepoint".into(),),
+                    )],
+                    fallback: UtfCodepointExpr::local_get(
+                        UtfCodepointLocalId(1),
+                        "codepoint".into(),
+                    ),
+                },
+            )),
+        );
+        assert_eq!(
+            super::int_case_expr(
+                int(1).into(),
+                vec![(BigInt::from(1), int(1).into())],
+                codepoint(1),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+
+        assert_eq!(
+            super::function_case_branches(
+                vec![(BigInt::from(1), utf_codepoint_function_ref_expr(0))],
+                utf_codepoint_function_ref_expr(1)
+                    .into_function()
+                    .expect("function expression"),
+            ),
+            Ok(IntCaseBranches::UtfCodepointFunction {
+                clauses: vec![(
+                    BigInt::from(1),
+                    utf_codepoint_function_ref_expr(0)
+                        .into_function()
+                        .expect("function expression")
+                        .into_utf_codepoint()
+                        .expect("utf codepoint function expression"),
+                )],
+                fallback: utf_codepoint_function_ref_expr(1)
+                    .into_function()
+                    .expect("function expression")
+                    .into_utf_codepoint()
+                    .expect("utf codepoint function expression"),
+            }),
+        );
+
         assert_eq!(
             super::int_case_expr(
                 int(1).into(),
@@ -1784,6 +1907,14 @@ fn add_one(value: Int) {
                 return_type: vec![ValueType::Int],
             },
             [LocalId::Int(IntLocalId(0))],
+        )
+        .into()
+    }
+
+    fn utf_codepoint_function_ref_expr(id: usize) -> crate::plan::Expr {
+        function_ref(
+            RuntimeFunctionId::UtfCodepoint(UtfCodepointFunctionId(id)),
+            [LocalId::UtfCodepoint(UtfCodepointLocalId(0))],
         )
         .into()
     }

--- a/src/planner/expression/case/subject/string.rs
+++ b/src/planner/expression/case/subject/string.rs
@@ -376,6 +376,10 @@ fn string_case_expr(
             clauses: bit_array_case_clauses(clauses)?,
             fallback,
         },
+        ExprKind::UtfCodepoint(fallback) => StringCaseBranches::UtfCodepoint {
+            clauses: utf_codepoint_case_clauses(clauses)?,
+            fallback,
+        },
         ExprKind::Float(fallback) => StringCaseBranches::Float {
             clauses: float_case_clauses(clauses)?,
             fallback,
@@ -437,6 +441,21 @@ fn bit_array_case_clauses(
     let mut typed_clauses = Vec::with_capacity(clauses.len());
     for (value, clause) in clauses {
         let ExprKind::BitArray(clause) = clause.into_kind() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn utf_codepoint_case_clauses(
+    clauses: Vec<(EcoString, Expr)>,
+) -> Result<Vec<(EcoString, crate::plan::UtfCodepointExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::UtfCodepoint(clause) = clause.into_kind() else {
             return Err(invalid_case_shape(
                 InvalidCaseShapeReason::BranchReturnTypeMismatch,
             ));
@@ -548,6 +567,12 @@ fn function_case_branches(
                 fallback,
             })
         }
+        crate::plan::FunctionExprKind::UtfCodepoint(fallback) => {
+            Ok(StringCaseBranches::UtfCodepointFunction {
+                clauses: utf_codepoint_function_case_clauses(clauses)?,
+                fallback,
+            })
+        }
         crate::plan::FunctionExprKind::Float(fallback) => Ok(StringCaseBranches::FloatFunction {
             clauses: float_function_case_clauses(clauses)?,
             fallback,
@@ -628,6 +653,26 @@ fn bit_array_function_case_clauses(
             ));
         };
         let crate::plan::FunctionExprKind::BitArray(clause) = function.into_kind() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        };
+        typed_clauses.push((value, clause));
+    }
+    Ok(typed_clauses)
+}
+
+fn utf_codepoint_function_case_clauses(
+    clauses: Vec<(EcoString, Expr)>,
+) -> Result<Vec<(EcoString, crate::plan::UtfCodepointFunctionExpr)>, PlanError> {
+    let mut typed_clauses = Vec::with_capacity(clauses.len());
+    for (value, clause) in clauses {
+        let ExprKind::Function(function) = clause.into_kind() else {
+            return Err(invalid_case_shape(
+                InvalidCaseShapeReason::BranchReturnTypeMismatch,
+            ));
+        };
+        let crate::plan::FunctionExprKind::UtfCodepoint(clause) = function.into_kind() else {
             return Err(invalid_case_shape(
                 InvalidCaseShapeReason::BranchReturnTypeMismatch,
             ));
@@ -764,7 +809,7 @@ mod tests {
         FunctionFunctionId, FunctionType, IntFunctionExpr, IntFunctionFunctionId, IntFunctionId,
         IntLocalId, ListFunctionId, LocalId, NilFunctionId, RuntimeFunctionId, Step,
         StringCaseBranches, StringExpr, StringFunctionId, StringLocalId, StringReturn,
-        TupleFunctionId, ValueType,
+        TupleFunctionId, UtfCodepointExpr, UtfCodepointFunctionId, UtfCodepointLocalId, ValueType,
     };
     use crate::planner::dsl::{
         bit_array, bit_array_function_ref, bool_, bool_return_expr, bool_return_string_case, float,
@@ -1872,6 +1917,64 @@ fn return_value(value: String) {
 
     #[test]
     fn plan_string_case_function_branch_return_families_direct() {
+        let codepoint = |local| {
+            Expr::utf_codepoint(UtfCodepointExpr::local_get(
+                UtfCodepointLocalId(local),
+                "codepoint".into(),
+            ))
+        };
+        assert_eq!(
+            super::string_case_expr(
+                string("one").into(),
+                vec![("one".into(), codepoint(0))],
+                codepoint(1),
+            ),
+            Ok(Expr::string_case(
+                string("one").into(),
+                StringCaseBranches::UtfCodepoint {
+                    clauses: vec![(
+                        "one".into(),
+                        UtfCodepointExpr::local_get(UtfCodepointLocalId(0), "codepoint".into(),),
+                    )],
+                    fallback: UtfCodepointExpr::local_get(
+                        UtfCodepointLocalId(1),
+                        "codepoint".into(),
+                    ),
+                },
+            )),
+        );
+        assert_eq!(
+            super::string_case_expr(
+                string("one").into(),
+                vec![("one".into(), int(1).into())],
+                codepoint(1),
+            ),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::function_case_branches(
+                vec![("one".into(), utf_codepoint_function_ref_expr(0))],
+                utf_codepoint_function_ref_expr(1)
+                    .into_function()
+                    .expect("function expression"),
+            ),
+            Ok(StringCaseBranches::UtfCodepointFunction {
+                clauses: vec![(
+                    "one".into(),
+                    utf_codepoint_function_ref_expr(0)
+                        .into_function()
+                        .expect("function expression")
+                        .into_utf_codepoint()
+                        .expect("utf codepoint function expression"),
+                )],
+                fallback: utf_codepoint_function_ref_expr(1)
+                    .into_function()
+                    .expect("function expression")
+                    .into_utf_codepoint()
+                    .expect("utf codepoint function expression"),
+            }),
+        );
+
         assert_eq!(
             super::string_case_expr(
                 string("one").into(),
@@ -2046,6 +2149,21 @@ fn return_value(value: String) {
     #[test]
     fn reject_margin_string_case_function_clause_family_mismatch_direct() {
         assert_eq!(
+            super::utf_codepoint_case_clauses(vec![("one".into(), Expr::from(int(1)))]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::utf_codepoint_function_case_clauses(vec![("one".into(), Expr::from(int(1)),)]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
+            super::utf_codepoint_function_case_clauses(vec![(
+                "one".into(),
+                int_function_ref_expr(0),
+            )]),
+            Err(case_branch_return_type_mismatch()),
+        );
+        assert_eq!(
             super::bit_array_case_clauses(vec![("one".into(), Expr::from(int(1)))]),
             Err(case_branch_return_type_mismatch()),
         );
@@ -2124,6 +2242,7 @@ fn return_value(value: String) {
 
         assert_string_function_case_branch_mismatch(int_function_ref_expr(1));
         assert_string_function_case_branch_mismatch(string_function_ref_expr(1));
+        assert_string_function_case_branch_mismatch(utf_codepoint_function_ref_expr(1));
         assert_string_function_case_branch_mismatch(float_function_ref_expr(1));
         assert_string_function_case_branch_mismatch(bool_function_ref_expr(1));
         assert_string_function_case_branch_mismatch(nil_function_ref_expr(1));
@@ -2187,6 +2306,14 @@ fn return_value(value: String) {
                 return_type: vec![ValueType::Int],
             },
             [LocalId::Int(IntLocalId(0))],
+        )
+        .into()
+    }
+
+    fn utf_codepoint_function_ref_expr(id: usize) -> crate::plan::Expr {
+        function_ref(
+            RuntimeFunctionId::UtfCodepoint(UtfCodepointFunctionId(id)),
+            [LocalId::UtfCodepoint(UtfCodepointLocalId(0))],
         )
         .into()
     }

--- a/src/planner/expression/case/subject/utf_codepoint.rs
+++ b/src/planner/expression/case/subject/utf_codepoint.rs
@@ -1,0 +1,379 @@
+use super::super::super::plan_expr_with_expected_source_stop_type;
+use super::super::invalid_case_shape;
+use super::{CaseClause, OrderedCaseClauseInput, case_return_type};
+use crate::plan::{
+    BoolExpr, Expr, ExprKind, Step, UtfCodepointExpr, UtfCodepointLocalId, ValueType,
+};
+use crate::planner::context::PlanContext;
+use crate::planner::error::{InvalidCaseShapeReason, PlanError};
+use ecow::EcoString;
+use gleam_core::ast::{Pattern, TypedExpr};
+use gleam_core::type_::Type;
+use std::sync::Arc;
+
+pub(super) fn plan(
+    type_: Arc<Type>,
+    subject: TypedExpr,
+    clauses: Vec<CaseClause>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let subject =
+        plan_expr_with_expected_source_stop_type(subject, ValueType::UtfCodepoint, context)?;
+    let return_type = case_return_type(type_.as_ref())?;
+    let ExprKind::UtfCodepoint(subject) = subject.into_kind() else {
+        return Err(invalid_case_shape(
+            InvalidCaseShapeReason::PatternTypeMismatch,
+        ));
+    };
+    let (subject_step, subject) = bind_case_subject(subject, context);
+    let mut ordered_clauses = Vec::new();
+    for clause in clauses {
+        for pattern in clause.patterns() {
+            let pattern = plan_case_pattern(pattern)?;
+            let bindings = super::branch_bindings(pattern.bound_names(), subject.clone());
+            let is_total = clause.guard.is_none();
+            ordered_clauses.push(super::plan_ordered_case_clause(
+                OrderedCaseClauseInput {
+                    case_type: type_.as_ref(),
+                    return_type: &return_type,
+                    then: clause.then.clone(),
+                    branch_bindings: bindings,
+                    guard: clause.guard.clone(),
+                    match_condition: BoolExpr::value(true),
+                    is_total,
+                },
+                context,
+            )?);
+        }
+    }
+
+    super::ordered_case_expr(ordered_clauses)
+        .map(|case| super::case_subject_block(subject_step, case))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UtfCodepointCasePattern {
+    bound_names: Vec<EcoString>,
+}
+
+impl UtfCodepointCasePattern {
+    fn bound_names(&self) -> &[EcoString] {
+        &self.bound_names
+    }
+
+    fn add_bound_name(&mut self, name: EcoString) {
+        self.bound_names.push(name);
+    }
+}
+
+fn plan_case_pattern(pattern: Pattern<Arc<Type>>) -> Result<UtfCodepointCasePattern, PlanError> {
+    match pattern {
+        Pattern::Variable { name, type_, .. }
+            if ValueType::from_gleam(type_.as_ref()) == Some(ValueType::UtfCodepoint) =>
+        {
+            Ok(UtfCodepointCasePattern {
+                bound_names: vec![name],
+            })
+        }
+        Pattern::Discard { type_, .. }
+            if ValueType::from_gleam(type_.as_ref()) == Some(ValueType::UtfCodepoint) =>
+        {
+            Ok(UtfCodepointCasePattern {
+                bound_names: Vec::new(),
+            })
+        }
+        Pattern::Assign { name, pattern, .. } => {
+            let mut pattern = plan_case_pattern(*pattern)?;
+            pattern.add_bound_name(name);
+            Ok(pattern)
+        }
+        Pattern::Invalid { .. } => Err(invalid_case_shape(InvalidCaseShapeReason::InvalidPattern)),
+        Pattern::Variable { .. }
+        | Pattern::Discard { .. }
+        | Pattern::Int { .. }
+        | Pattern::Float { .. }
+        | Pattern::String { .. }
+        | Pattern::BitArraySize(_)
+        | Pattern::List { .. }
+        | Pattern::Constructor { .. }
+        | Pattern::Tuple { .. }
+        | Pattern::BitArray { .. }
+        | Pattern::StringPrefix { .. } => Err(invalid_case_shape(
+            InvalidCaseShapeReason::PatternTypeMismatch,
+        )),
+    }
+}
+
+fn bind_case_subject(subject: UtfCodepointExpr, context: &mut PlanContext<'_>) -> (Step, Expr) {
+    let local = context.define_internal_utf_codepoint_local();
+    let name = internal_case_subject_name(local);
+    (
+        Step::let_utf_codepoint(local, name.clone(), subject),
+        Expr::utf_codepoint(UtfCodepointExpr::local_get(local, name)),
+    )
+}
+
+fn internal_case_subject_name(local: UtfCodepointLocalId) -> EcoString {
+    format!("<case:utf_codepoint:{}>", local.0).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::planner::dsl::{
+        function, int, let_utf_codepoint_step, local_utf_codepoint, module,
+        utf_codepoint_return_block, utf_codepoint_return_expr,
+    };
+    use crate::planner::plan_module;
+    use crate::planner::support::dummy_span;
+    use crate::planner::{
+        InvalidCaseShapeReason, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
+    };
+    use gleam_core::type_::error::VariableOrigin;
+
+    #[test]
+    fn plan_utf_codepoint_subject_binds_internal_subject_once() {
+        let actual = plan_module(crate::planner::support::compile(
+            r#"
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  case value {
+    bound -> bound
+  }
+}
+
+pub fn main() {
+  0
+}
+"#,
+        ))
+        .expect("source should plan");
+        let expected = module(
+            "main",
+            function("main", int(0)),
+            [function(
+                "identity",
+                utf_codepoint_return_block(
+                    [let_utf_codepoint_step(
+                        1,
+                        "<case:utf_codepoint:1>",
+                        local_utf_codepoint(0, "value"),
+                    )],
+                    utf_codepoint_return_block(
+                        [let_utf_codepoint_step(
+                            2,
+                            "bound",
+                            local_utf_codepoint(1, "<case:utf_codepoint:1>"),
+                        )],
+                        utf_codepoint_return_expr(local_utf_codepoint(2, "bound")),
+                    ),
+                ),
+            )
+            .param_utf_codepoint(0, "value")],
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn plan_utf_codepoint_case_pattern_preserves_binding_order() {
+        let type_ = utf_codepoint_type();
+        let pattern = gleam_core::ast::Pattern::Assign {
+            location: dummy_span(),
+            name: "alias".into(),
+            pattern: Box::new(gleam_core::ast::Pattern::Variable {
+                location: dummy_span(),
+                name: "value".into(),
+                type_,
+                origin: VariableOrigin::generated(),
+            }),
+        };
+
+        let planned = super::plan_case_pattern(pattern).expect("pattern should plan");
+        assert_eq!(planned.bound_names(), &["value", "alias"]);
+    }
+
+    #[test]
+    fn reject_margin_utf_codepoint_case_pattern_shapes() {
+        let type_ = utf_codepoint_type();
+        assert_eq!(
+            super::plan_case_pattern(gleam_core::ast::Pattern::Discard {
+                location: dummy_span(),
+                name: "_".into(),
+                type_: type_.clone(),
+            })
+            .expect("discard should plan")
+            .bound_names(),
+            Vec::<ecow::EcoString>::new().as_slice(),
+        );
+        assert_eq!(
+            super::plan_case_pattern(gleam_core::ast::Pattern::Variable {
+                location: dummy_span(),
+                name: "value".into(),
+                type_: gleam_core::type_::int(),
+                origin: VariableOrigin::generated(),
+            }),
+            Err(pattern_type_mismatch()),
+        );
+        assert_eq!(
+            super::plan_case_pattern(gleam_core::ast::Pattern::Discard {
+                location: dummy_span(),
+                name: "_".into(),
+                type_: gleam_core::type_::int(),
+            }),
+            Err(pattern_type_mismatch()),
+        );
+        assert_eq!(
+            super::plan_case_pattern(gleam_core::ast::Pattern::Assign {
+                location: dummy_span(),
+                name: "alias".into(),
+                pattern: Box::new(gleam_core::ast::Pattern::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: 1.into(),
+                }),
+            }),
+            Err(pattern_type_mismatch()),
+        );
+        assert_eq!(
+            super::plan_case_pattern(gleam_core::ast::Pattern::Invalid {
+                location: dummy_span(),
+                type_,
+            }),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::InvalidPattern,
+                },
+            }),
+        );
+        assert_eq!(
+            super::plan_case_pattern(gleam_core::ast::Pattern::Tuple {
+                location: dummy_span(),
+                elements: Vec::new(),
+            }),
+            Err(pattern_type_mismatch()),
+        );
+    }
+
+    #[test]
+    fn reject_margin_utf_codepoint_subject_expression_family_mismatch() {
+        let mut module = crate::planner::support::compile(
+            r#"
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  case value {
+    bound -> bound
+  }
+}
+
+pub fn main() {
+  0
+}
+"#,
+        );
+        let (_, subjects, _) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
+        subjects[0] = gleam_core::ast::TypedExpr::Int {
+            location: dummy_span(),
+            type_: utf_codepoint_type(),
+            value: "1".into(),
+            int_value: 1.into(),
+        };
+
+        assert_eq!(plan_module(module), Err(pattern_type_mismatch()));
+    }
+
+    #[test]
+    fn reject_profile_utf_codepoint_case_subject_and_branch_errors_propagate() {
+        for source in [
+            r#"
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  case echo value { bound -> bound }
+}
+pub fn main() { 0 }
+"#,
+            r#"
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  case value { bound -> echo bound }
+}
+pub fn main() { 0 }
+"#,
+        ] {
+            assert_eq!(
+                plan_module(crate::planner::support::compile(source)),
+                Err(PlanError::UnsupportedExpression {
+                    kind: UnsupportedExpressionKind::Echo,
+                }),
+            );
+        }
+    }
+
+    #[test]
+    fn reject_margin_utf_codepoint_case_return_type_and_nested_pattern_errors_propagate() {
+        let mut invalid_return_type = crate::planner::support::compile(
+            r#"
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  case value { bound -> bound }
+}
+pub fn main() { 0 }
+"#,
+        );
+        let (type_, _, _) = super::super::super::expect_case_statement_mut(
+            &mut invalid_return_type.definitions.functions[0].body[0],
+        );
+        *type_ = super::super::unsupported_case_return_type();
+        assert_eq!(
+            plan_module(invalid_return_type),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::BranchReturnTypeMismatch,
+                },
+            }),
+        );
+
+        let mut module = crate::planner::support::compile(
+            r#"
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  case value { bound -> bound }
+}
+pub fn main() { 0 }
+"#,
+        );
+        let (_, _, clauses) = super::super::super::expect_case_statement_mut(
+            &mut module.definitions.functions[0].body[0],
+        );
+        clauses[0].pattern[0] = gleam_core::ast::Pattern::Invalid {
+            location: dummy_span(),
+            type_: utf_codepoint_type(),
+        };
+        assert_eq!(
+            plan_module(module),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::CaseShape {
+                    reason: InvalidCaseShapeReason::InvalidPattern,
+                },
+            }),
+        );
+    }
+
+    fn utf_codepoint_type() -> std::sync::Arc<gleam_core::type_::Type> {
+        let module = crate::planner::support::compile(
+            r#"
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  value
+}
+
+pub fn main() {
+  0
+}
+"#,
+        );
+        module.definitions.functions[0].arguments[0].type_.clone()
+    }
+
+    fn pattern_type_mismatch() -> PlanError {
+        PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::CaseShape {
+                reason: InvalidCaseShapeReason::PatternTypeMismatch,
+            },
+        }
+    }
+}

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -172,6 +172,9 @@ fn closure_expr(
         RuntimeFunctionId::BitArray(runtime_id) => FunctionExpr::bit_array(
             crate::plan::BitArrayFunctionExpr::closure(*runtime_id, params, captures, type_),
         ),
+        RuntimeFunctionId::UtfCodepoint(runtime_id) => FunctionExpr::utf_codepoint(
+            crate::plan::UtfCodepointFunctionExpr::closure(*runtime_id, params, captures, type_),
+        ),
         RuntimeFunctionId::Float(runtime_id) => FunctionExpr::float(
             crate::plan::FloatFunctionExpr::closure(*runtime_id, params, captures, type_),
         ),
@@ -226,6 +229,12 @@ fn anonymous_function_type(type_: &Type) -> Result<FunctionType, PlanError> {
             reason: InvalidTypedAstReason::ExpressionType {
                 expected: InvalidExpressionType::Function,
                 actual: InvalidExpressionType::BitArray,
+            },
+        }),
+        Some(ValueType::UtfCodepoint) => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionType {
+                expected: InvalidExpressionType::Function,
+                actual: InvalidExpressionType::UtfCodepoint,
             },
         }),
         Some(ValueType::Float) => Err(PlanError::InvalidTypedAst {
@@ -814,6 +823,7 @@ pub fn main() {
                 gleam_core::type_::bit_array(),
                 InvalidExpressionType::BitArray,
             ),
+            (utf_codepoint_type(), InvalidExpressionType::UtfCodepoint),
             (gleam_core::type_::float(), InvalidExpressionType::Float),
             (gleam_core::type_::bool(), InvalidExpressionType::Bool),
             (gleam_core::type_::nil(), InvalidExpressionType::Nil),
@@ -836,6 +846,16 @@ pub fn main() {
                 }),
             );
         }
+    }
+
+    fn utf_codepoint_type() -> std::sync::Arc<gleam_core::type_::Type> {
+        let module = compile(
+            r#"
+fn identity(value: UtfCodepoint) -> UtfCodepoint { value }
+pub fn main() { 0 }
+"#,
+        );
+        module.definitions.functions[0].arguments[0].type_.clone()
     }
 
     #[test]

--- a/src/planner/expression/operator/equality.rs
+++ b/src/planner/expression/operator/equality.rs
@@ -48,6 +48,7 @@ fn contains_function_value(type_: &ValueType) -> bool {
         | ValueType::Float
         | ValueType::String
         | ValueType::BitArray
+        | ValueType::UtfCodepoint
         | ValueType::Bool
         | ValueType::Nil => false,
     }

--- a/src/planner/expression/var.rs
+++ b/src/planner/expression/var.rs
@@ -2,7 +2,7 @@ use crate::plan::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, Expr, FloatExpr,
     FloatFunctionExpr, FunctionExpr, FunctionFunctionExpr, IntExpr, IntFunctionExpr, ListExpr,
     ListFunctionExpr, LocalId, NilExpr, NilFunctionExpr, StringExpr, StringFunctionExpr, TupleExpr,
-    TupleFunctionExpr, ValueType,
+    TupleFunctionExpr, UtfCodepointExpr, UtfCodepointFunctionExpr, ValueType,
 };
 use crate::planner::context::{FunctionLocalBinding, PlanContext};
 use crate::planner::error::{
@@ -113,6 +113,9 @@ fn function_local_get(binding: FunctionLocalBinding, name: EcoString) -> Expr {
         FunctionLocalBinding::BitArray { local, type_ } => Expr::function(FunctionExpr::bit_array(
             BitArrayFunctionExpr::local_get(local, name, type_),
         )),
+        FunctionLocalBinding::UtfCodepoint { local, type_ } => Expr::function(
+            FunctionExpr::utf_codepoint(UtfCodepointFunctionExpr::local_get(local, name, type_)),
+        ),
         FunctionLocalBinding::Float { local, type_ } => Expr::function(FunctionExpr::float(
             FloatFunctionExpr::local_get(local, name, type_),
         )),
@@ -146,6 +149,9 @@ fn local_get(local: LocalId, name: EcoString, type_: ValueType) -> Result<Expr, 
         (LocalId::BitArray(local), ValueType::BitArray) => {
             Ok(Expr::bit_array(BitArrayExpr::local_get(local, name)))
         }
+        (LocalId::UtfCodepoint(local), ValueType::UtfCodepoint) => Ok(Expr::utf_codepoint(
+            UtfCodepointExpr::local_get(local, name),
+        )),
         (LocalId::Bool(local), ValueType::Bool) => Ok(Expr::bool(BoolExpr::local_get(local, name))),
         (LocalId::Nil(local), ValueType::Nil) => Ok(Expr::nil(NilExpr::local_get(local, name))),
         _ => Err(PlanError::InvalidTypedAst {

--- a/src/planner/function/return_body.rs
+++ b/src/planner/function/return_body.rs
@@ -28,6 +28,14 @@ pub(super) fn function_return_expr(
             *runtime_id,
             primitive::bit_array_return(actual),
         )),
+        (
+            ValueType::UtfCodepoint,
+            RuntimeFunctionId::UtfCodepoint(runtime_id),
+            ExprKind::UtfCodepoint(actual),
+        ) => Ok(ReturnExpr::utf_codepoint_body(
+            *runtime_id,
+            primitive::utf_codepoint_return(actual),
+        )),
         (ValueType::Float, RuntimeFunctionId::Float(runtime_id), ExprKind::Float(actual)) => Ok(
             ReturnExpr::float_body(*runtime_id, primitive::float_return(actual)),
         ),
@@ -70,6 +78,16 @@ pub(super) fn function_return_expr(
             *runtime_id,
             primitive::typed_list_return_body(actual),
         )),
+        (
+            ValueType::List(expected),
+            RuntimeFunctionId::List(ListFunctionId::UtfCodepoint(runtime_id)),
+            ExprKind::List(ListExpr::UtfCodepoint(actual)),
+        ) if expected.as_ref() == &ValueType::UtfCodepoint => {
+            Ok(ReturnExpr::utf_codepoint_list_body(
+                *runtime_id,
+                primitive::typed_list_return_body(actual),
+            ))
+        }
         (
             ValueType::List(expected),
             RuntimeFunctionId::List(ListFunctionId::Float(runtime_id)),
@@ -162,12 +180,12 @@ pub(super) fn function_return_expr(
 mod tests {
     use super::function_return_expr;
     use crate::plan::{
-        BoolListFunctionId, Expr, FloatExpr, FloatListFunctionId, FunctionExpr, FunctionFunctionId,
-        FunctionListFunctionId, FunctionType, IntFunctionExpr, IntFunctionFunctionId,
-        IntFunctionId, IntFunctionReference, IntListFunctionId, IntLocalId, ListExpr,
-        ListFunctionId, ListListFunctionId, NilListFunctionId, ParamLocal, ReturnBody, ReturnExpr,
-        RuntimeFunctionId, StringFunctionFunctionId, StringListFunctionId, TupleListFunctionId,
-        ValueType,
+        BitArrayListFunctionId, BoolListFunctionId, Expr, FloatExpr, FloatListFunctionId,
+        FunctionExpr, FunctionFunctionId, FunctionListFunctionId, FunctionType, IntFunctionExpr,
+        IntFunctionFunctionId, IntFunctionId, IntFunctionReference, IntListFunctionId, IntLocalId,
+        ListExpr, ListFunctionId, ListListFunctionId, NilListFunctionId, ParamLocal, ReturnBody,
+        ReturnExpr, RuntimeFunctionId, StringFunctionFunctionId, StringListFunctionId,
+        TupleListFunctionId, UtfCodepointListFunctionId, ValueType,
     };
     use crate::planner::{InvalidFunctionShapeReason, InvalidTypedAstReason, PlanError};
 
@@ -273,6 +291,44 @@ mod tests {
                     string
                         .into_string()
                         .expect("expression should be List(String)"),
+                ),
+            )),
+        );
+
+        let bit_array = ListExpr::value(Vec::new(), ValueType::BitArray);
+        assert_eq!(
+            function_return_expr(
+                &"bit_arrays".into(),
+                &ValueType::List(Box::new(ValueType::BitArray)),
+                &RuntimeFunctionId::List(ListFunctionId::BitArray(BitArrayListFunctionId(0))),
+                Expr::list(bit_array.clone()),
+            ),
+            Ok(ReturnExpr::bit_array_list_body(
+                BitArrayListFunctionId(0),
+                ReturnBody::expr(
+                    bit_array
+                        .into_bit_array()
+                        .expect("expression should be List(BitArray)"),
+                ),
+            )),
+        );
+
+        let utf_codepoint = ListExpr::value(Vec::new(), ValueType::UtfCodepoint);
+        assert_eq!(
+            function_return_expr(
+                &"utf_codepoints".into(),
+                &ValueType::List(Box::new(ValueType::UtfCodepoint)),
+                &RuntimeFunctionId::List(ListFunctionId::UtfCodepoint(UtfCodepointListFunctionId(
+                    0
+                ),)),
+                Expr::list(utf_codepoint.clone()),
+            ),
+            Ok(ReturnExpr::utf_codepoint_list_body(
+                UtfCodepointListFunctionId(0),
+                ReturnBody::expr(
+                    utf_codepoint
+                        .into_utf_codepoint()
+                        .expect("expression should be List(UtfCodepoint)"),
                 ),
             )),
         );

--- a/src/planner/function/return_body/function_value.rs
+++ b/src/planner/function/return_body/function_value.rs
@@ -6,7 +6,8 @@ use crate::plan::{
     IntFunctionExprKind, IntFunctionReturn, ListFunctionExpr, ListFunctionExprKind,
     ListFunctionReturn, NilFunctionExpr, NilFunctionExprKind, NilFunctionReturn, ReturnBody,
     ReturnExpr, StringFunctionExpr, StringFunctionExprKind, StringFunctionReturn,
-    TupleFunctionExpr, TupleFunctionExprKind, TupleFunctionReturn,
+    TupleFunctionExpr, TupleFunctionExprKind, TupleFunctionReturn, UtfCodepointFunctionExpr,
+    UtfCodepointFunctionExprKind, UtfCodepointFunctionReturn,
 };
 use crate::planner::error::{InvalidFunctionShapeReason, InvalidTypedAstReason, PlanError};
 use ecow::EcoString;
@@ -39,6 +40,14 @@ pub(super) fn function_returning_function_expr(
                 runtime_id,
                 type_,
                 bit_array_function_return(actual),
+            ))
+        }
+        (FunctionFunctionId::UtfCodepoint(runtime_id), FunctionExprKind::UtfCodepoint(actual)) => {
+            let type_ = actual.type_().clone();
+            Ok(ReturnExpr::utf_codepoint_function_body(
+                runtime_id,
+                type_,
+                utf_codepoint_function_return(actual),
             ))
         }
         (FunctionFunctionId::Float(runtime_id), FunctionExprKind::Float(actual)) => {
@@ -260,6 +269,70 @@ fn bit_array_function_return(expression: BitArrayFunctionExpr) -> BitArrayFuncti
         BitArrayFunctionExprKind::Block { steps, return_ } => ReturnBody::block(
             steps.clone(),
             bit_array_function_return((**return_).clone()),
+        ),
+        _ => ReturnBody::expr(expression),
+    }
+}
+
+fn utf_codepoint_function_return(
+    expression: UtfCodepointFunctionExpr,
+) -> UtfCodepointFunctionReturn {
+    match expression.kind() {
+        UtfCodepointFunctionExprKind::Call { function, args, .. } => {
+            ReturnBody::tail_call(*function, args.clone())
+        }
+        UtfCodepointFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => ReturnBody::bool_case(
+            (**subject).clone(),
+            utf_codepoint_function_return((**true_).clone()),
+            utf_codepoint_function_return((**false_).clone()),
+        ),
+        UtfCodepointFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::int_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| {
+                    (value.clone(), utf_codepoint_function_return(branch.clone()))
+                })
+                .collect(),
+            utf_codepoint_function_return((**fallback).clone()),
+        ),
+        UtfCodepointFunctionExprKind::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::string_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| {
+                    (value.clone(), utf_codepoint_function_return(branch.clone()))
+                })
+                .collect(),
+            utf_codepoint_function_return((**fallback).clone()),
+        ),
+        UtfCodepointFunctionExprKind::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::float_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (*value, utf_codepoint_function_return(branch.clone())))
+                .collect(),
+            utf_codepoint_function_return((**fallback).clone()),
+        ),
+        UtfCodepointFunctionExprKind::Block { steps, return_ } => ReturnBody::block(
+            steps.clone(),
+            utf_codepoint_function_return((**return_).clone()),
         ),
         _ => ReturnBody::expr(expression),
     }

--- a/src/planner/function/return_body/primitive.rs
+++ b/src/planner/function/return_body/primitive.rs
@@ -2,7 +2,8 @@ use crate::plan::{
     BitArrayExpr, BitArrayExprKind, BitArrayReturn, BoolExpr, BoolExprKind, BoolReturn, FloatExpr,
     FloatExprKind, FloatReturn, IntExpr, IntExprKind, IntReturn, ListItem, NilExpr, NilExprKind,
     NilReturn, ReturnBody, StringExpr, StringExprKind, StringReturn, TupleExpr, TupleExprKind,
-    TupleReturn, TypedListExpr, TypedListReturnKind,
+    TupleReturn, TypedListExpr, TypedListReturnKind, UtfCodepointExpr, UtfCodepointExprKind,
+    UtfCodepointReturn,
 };
 
 #[cfg(test)]
@@ -168,6 +169,63 @@ pub(super) fn bit_array_return(expression: BitArrayExpr) -> BitArrayReturn {
         ),
         BitArrayExprKind::Block { steps, return_ } => {
             ReturnBody::block(steps.clone(), bit_array_return((**return_).clone()))
+        }
+        _ => ReturnBody::expr(expression),
+    }
+}
+
+pub(super) fn utf_codepoint_return(expression: UtfCodepointExpr) -> UtfCodepointReturn {
+    match expression.kind() {
+        UtfCodepointExprKind::Call { function, args } => {
+            ReturnBody::tail_call(*function, args.clone())
+        }
+        UtfCodepointExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => ReturnBody::bool_case(
+            (**subject).clone(),
+            utf_codepoint_return((**true_).clone()),
+            utf_codepoint_return((**false_).clone()),
+        ),
+        UtfCodepointExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::int_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (value.clone(), utf_codepoint_return(branch.clone())))
+                .collect(),
+            utf_codepoint_return((**fallback).clone()),
+        ),
+        UtfCodepointExprKind::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::string_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (value.clone(), utf_codepoint_return(branch.clone())))
+                .collect(),
+            utf_codepoint_return((**fallback).clone()),
+        ),
+        UtfCodepointExprKind::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::float_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (*value, utf_codepoint_return(branch.clone())))
+                .collect(),
+            utf_codepoint_return((**fallback).clone()),
+        ),
+        UtfCodepointExprKind::Block { steps, return_ } => {
+            ReturnBody::block(steps.clone(), utf_codepoint_return((**return_).clone()))
         }
         _ => ReturnBody::expr(expression),
     }
@@ -399,6 +457,9 @@ pub(super) fn list_return(expression: ListExpr) -> ListReturn {
         ListExpr::Int(expression) => ListReturn::Int(typed_list_return_body(expression)),
         ListExpr::String(expression) => ListReturn::String(typed_list_return_body(expression)),
         ListExpr::BitArray(expression) => ListReturn::BitArray(typed_list_return_body(expression)),
+        ListExpr::UtfCodepoint(expression) => {
+            ListReturn::UtfCodepoint(typed_list_return_body(expression))
+        }
         ListExpr::Float(expression) => ListReturn::Float(typed_list_return_body(expression)),
         ListExpr::Bool(expression) => ListReturn::Bool(typed_list_return_body(expression)),
         ListExpr::Nil(expression) => ListReturn::Nil(typed_list_return_body(expression)),
@@ -570,6 +631,10 @@ mod tests {
         assert_eq!(
             list_return(ListExpr::value(Vec::new(), ValueType::BitArray)),
             ListReturn::expr(ListExpr::value(Vec::new(), ValueType::BitArray)),
+        );
+        assert_eq!(
+            list_return(ListExpr::value(Vec::new(), ValueType::UtfCodepoint)),
+            ListReturn::expr(ListExpr::value(Vec::new(), ValueType::UtfCodepoint)),
         );
         assert_eq!(
             list_return(ListExpr::value(Vec::new(), ValueType::Bool)),

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -259,12 +259,14 @@ pub(super) fn function_params(
     let mut next_float = 0;
     let mut next_string = 0;
     let mut next_bit_array = 0;
+    let mut next_utf_codepoint = 0;
     let mut next_bool = 0;
     let mut next_nil = 0;
     let mut next_tuple = 0;
     let mut next_int_list = 0;
     let mut next_string_list = 0;
     let mut next_bit_array_list = 0;
+    let mut next_utf_codepoint_list = 0;
     let mut next_float_list = 0;
     let mut next_bool_list = 0;
     let mut next_nil_list = 0;
@@ -326,6 +328,13 @@ pub(super) fn function_params(
                     next_bit_array += 1;
                     local
                 }
+                ValueType::UtfCodepoint => {
+                    let local = ParamLocal::utf_codepoint(crate::plan::UtfCodepointLocalId(
+                        next_utf_codepoint,
+                    ));
+                    next_utf_codepoint += 1;
+                    local
+                }
                 ValueType::Bool => {
                     let local = ParamLocal::bool(crate::plan::BoolLocalId(next_bool));
                     next_bool += 1;
@@ -363,6 +372,13 @@ pub(super) fn function_params(
                                 crate::plan::BitArrayListLocalId(next_bit_array_list),
                             );
                             next_bit_array_list += 1;
+                            local
+                        }
+                        ValueType::UtfCodepoint => {
+                            let local = crate::plan::ListLocal::utf_codepoint(
+                                crate::plan::UtfCodepointListLocalId(next_utf_codepoint_list),
+                            );
+                            next_utf_codepoint_list += 1;
                             local
                         }
                         ValueType::Float => {
@@ -436,6 +452,7 @@ struct FunctionParamLocalCounters {
     next_float: usize,
     next_string: usize,
     next_bit_array: usize,
+    next_utf_codepoint: usize,
     next_bool: usize,
     next_nil: usize,
     next_tuple: usize,
@@ -474,6 +491,14 @@ impl FunctionParamLocalCounters {
                     type_.clone(),
                 );
                 self.next_bit_array += 1;
+                local
+            }
+            ValueType::UtfCodepoint => {
+                let local = ParamLocal::utf_codepoint_function(
+                    crate::plan::UtfCodepointFunctionLocalId(self.next_utf_codepoint),
+                    type_.clone(),
+                );
+                self.next_utf_codepoint += 1;
                 local
             }
             ValueType::Bool => {

--- a/src/planner/pattern/bit_array.rs
+++ b/src/planner/pattern/bit_array.rs
@@ -2,7 +2,7 @@ use crate::plan::{
     BitArrayBindingPattern, BitArrayLocalId, BitArrayPattern, BitArrayPatternSegment,
     BitArrayPatternSize, BitArrayPatternSizeExpr, BitArrayPatternValue, BitArrayStringPattern,
     Endianness, FloatLocalId, IntLocalId, LocalId, PatternBinding, Signedness, StringEncoding,
-    ValueType,
+    UtfCodepointLocalId, ValueType,
 };
 use crate::planner::context::PlanContext;
 use crate::planner::error::{InvalidTypedAstReason, PlanError, UnsupportedBitArraySegmentReason};
@@ -42,17 +42,6 @@ fn plan_segment(
     {
         return unsupported_segment(UnsupportedBitArraySegmentReason::NativeEndianness);
     }
-    if segment.options.iter().any(|option| {
-        matches!(
-            option,
-            BitArrayOption::Utf8Codepoint { .. }
-                | BitArrayOption::Utf16Codepoint { .. }
-                | BitArrayOption::Utf32Codepoint { .. }
-        )
-    }) {
-        return unsupported_segment(UnsupportedBitArraySegmentReason::UtfCodepoint);
-    }
-
     let kind = segment_kind(&segment)?;
     validate_segment_options(&segment, kind)?;
     let endianness = segment_endianness(&segment);
@@ -90,6 +79,10 @@ fn plan_segment(
             pattern: plan_string_pattern(*segment.value)?,
             encoding,
         }),
+        SegmentKind::UtfCodepoint(encoding) => Ok(BitArrayPatternSegment::UtfCodepoint {
+            pattern: plan_utf_codepoint_pattern(*segment.value, context)?,
+            encoding,
+        }),
     }
 }
 
@@ -99,6 +92,7 @@ enum SegmentKind {
     Float,
     Bits,
     String(StringEncoding),
+    UtfCodepoint(StringEncoding),
 }
 
 fn validate_segment_options(
@@ -155,6 +149,12 @@ fn validate_segment_options(
         SegmentKind::String(StringEncoding::Utf16(_) | StringEncoding::Utf32(_)) => {
             signedness_count + size_count + unit_count != 0
         }
+        SegmentKind::UtfCodepoint(StringEncoding::Utf8) => {
+            signedness_count + endianness_count + size_count + unit_count != 0
+        }
+        SegmentKind::UtfCodepoint(StringEncoding::Utf16(_) | StringEncoding::Utf32(_)) => {
+            signedness_count + size_count + unit_count != 0
+        }
     };
 
     if [duplicate_option, invalid_unit, incompatible_modifier].contains(&true) {
@@ -180,10 +180,16 @@ fn segment_kind(
             BitArrayOption::Utf32 { .. } => Some(SegmentKind::String(StringEncoding::Utf32(
                 segment_endianness(segment),
             ))),
-            BitArrayOption::Utf8Codepoint { .. }
-            | BitArrayOption::Utf16Codepoint { .. }
-            | BitArrayOption::Utf32Codepoint { .. }
-            | BitArrayOption::Signed { .. }
+            BitArrayOption::Utf8Codepoint { .. } => {
+                Some(SegmentKind::UtfCodepoint(StringEncoding::Utf8))
+            }
+            BitArrayOption::Utf16Codepoint { .. } => Some(SegmentKind::UtfCodepoint(
+                StringEncoding::Utf16(segment_endianness(segment)),
+            )),
+            BitArrayOption::Utf32Codepoint { .. } => Some(SegmentKind::UtfCodepoint(
+                StringEncoding::Utf32(segment_endianness(segment)),
+            )),
+            BitArrayOption::Signed { .. }
             | BitArrayOption::Unsigned { .. }
             | BitArrayOption::Big { .. }
             | BitArrayOption::Little { .. }
@@ -395,6 +401,32 @@ fn plan_string_pattern(pattern: Pattern<Arc<Type>>) -> Result<BitArrayStringPatt
     }
 }
 
+fn plan_utf_codepoint_pattern(
+    pattern: Pattern<Arc<Type>>,
+    context: &mut PlanContext<'_>,
+) -> Result<BitArrayBindingPattern<UtfCodepointLocalId>, PlanError> {
+    match pattern {
+        Pattern::Variable { name, type_, .. } if type_.is_utf_codepoint() => {
+            let local = context.define_utf_codepoint_local(name.clone());
+            Ok(BitArrayBindingPattern::Bind(PatternBinding::new(
+                local, name,
+            )))
+        }
+        Pattern::Discard { type_, .. } if type_.is_utf_codepoint() => {
+            Ok(BitArrayBindingPattern::Discard)
+        }
+        Pattern::Assign { name, pattern, .. } => {
+            let pattern = plan_utf_codepoint_pattern(*pattern, context)?;
+            let local = context.define_utf_codepoint_local(name.clone());
+            Ok(BitArrayBindingPattern::Alias {
+                pattern: Box::new(pattern),
+                binding: PatternBinding::new(local, name),
+            })
+        }
+        _ => Err(invalid_pattern()),
+    }
+}
+
 fn is_total_pattern(segments: &[BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>]) -> bool {
     segments.len() == 1
         && segments[0].size().is_none()
@@ -419,7 +451,7 @@ mod tests {
     use crate::plan::{
         BitArrayBindingPattern, BitArrayLocalId, BitArrayPattern, BitArrayPatternSegment,
         BitArrayPatternSizeExpr, BitArrayStringPattern, Endianness, FloatLocalId, IntLocalId,
-        PatternBinding, Signedness, StringEncoding,
+        PatternBinding, Signedness, StringEncoding, UtfCodepointLocalId,
     };
     use crate::planner::context::{AnonymousFunctions, PlanContext};
     use crate::planner::error::{
@@ -447,25 +479,6 @@ pub fn main() {
             ),
             PlanError::UnsupportedBitArraySegment {
                 reason: UnsupportedBitArraySegmentReason::NativeEndianness,
-            },
-        );
-    }
-
-    #[test]
-    fn reject_profile_bit_array_pattern_utf_codepoint() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  case <<"A":utf8>> {
-    <<_:utf8_codepoint>> -> 1
-    _ -> 0
-  }
-}
-"#,
-            ),
-            PlanError::UnsupportedBitArraySegment {
-                reason: UnsupportedBitArraySegmentReason::UtfCodepoint,
             },
         );
     }
@@ -521,6 +534,60 @@ pub fn main() {
             })
         };
         let mut cases = Vec::new();
+
+        cases.push((
+            vec![segment(
+                discard(type_::int()),
+                vec![BitArrayOption::Utf8Codepoint {
+                    location: dummy_span(),
+                }],
+                type_::int(),
+            )],
+            invalid(),
+        ));
+        cases.push((
+            vec![segment(
+                alias("codepoint_alias", discard(type_::int())),
+                vec![BitArrayOption::Utf8Codepoint {
+                    location: dummy_span(),
+                }],
+                type_::utf_codepoint(),
+            )],
+            invalid(),
+        ));
+        for options in [
+            vec![
+                BitArrayOption::Utf8Codepoint {
+                    location: dummy_span(),
+                },
+                BitArrayOption::Big {
+                    location: dummy_span(),
+                },
+            ],
+            vec![
+                BitArrayOption::Utf16Codepoint {
+                    location: dummy_span(),
+                },
+                BitArrayOption::Signed {
+                    location: dummy_span(),
+                },
+            ],
+            vec![
+                BitArrayOption::Utf32Codepoint {
+                    location: dummy_span(),
+                },
+                size(int_size()),
+            ],
+        ] {
+            cases.push((
+                vec![segment(
+                    discard(type_::utf_codepoint()),
+                    options,
+                    type_::utf_codepoint(),
+                )],
+                invalid(),
+            ));
+        }
 
         for options in [
             vec![
@@ -823,6 +890,67 @@ pub fn main() {
                     unit: 1,
                 }]),
                 true,
+            )),
+        ));
+        cases.push((
+            vec![
+                segment(
+                    Pattern::Variable {
+                        location: dummy_span(),
+                        name: "codepoint".into(),
+                        type_: type_::utf_codepoint(),
+                        origin: VariableOrigin::generated(),
+                    },
+                    vec![BitArrayOption::Utf8Codepoint {
+                        location: dummy_span(),
+                    }],
+                    type_::utf_codepoint(),
+                ),
+                segment(
+                    discard(type_::utf_codepoint()),
+                    vec![
+                        BitArrayOption::Utf16Codepoint {
+                            location: dummy_span(),
+                        },
+                        BitArrayOption::Little {
+                            location: dummy_span(),
+                        },
+                    ],
+                    type_::utf_codepoint(),
+                ),
+                segment(
+                    alias("codepoint_alias", discard(type_::utf_codepoint())),
+                    vec![BitArrayOption::Utf32Codepoint {
+                        location: dummy_span(),
+                    }],
+                    type_::utf_codepoint(),
+                ),
+            ],
+            Ok((
+                BitArrayPattern::new(vec![
+                    BitArrayPatternSegment::UtfCodepoint {
+                        pattern: BitArrayBindingPattern::Bind(PatternBinding::new(
+                            UtfCodepointLocalId(0),
+                            "codepoint".into(),
+                        )),
+                        encoding: StringEncoding::Utf8,
+                    },
+                    BitArrayPatternSegment::UtfCodepoint {
+                        pattern: BitArrayBindingPattern::Discard,
+                        encoding: StringEncoding::Utf16(Endianness::Little),
+                    },
+                    BitArrayPatternSegment::UtfCodepoint {
+                        pattern: BitArrayBindingPattern::Alias {
+                            pattern: Box::new(BitArrayBindingPattern::Discard),
+                            binding: PatternBinding::new(
+                                UtfCodepointLocalId(1),
+                                "codepoint_alias".into(),
+                            ),
+                        },
+                        encoding: StringEncoding::Utf32(Endianness::Big),
+                    },
+                ]),
+                false,
             )),
         ));
         cases.push((

--- a/src/planner/statement/assignment.rs
+++ b/src/planner/statement/assignment.rs
@@ -4,7 +4,8 @@ use crate::plan::{
     BitArrayExpr, BitArrayFunctionExpr, BoolExpr, BoolFunctionExpr, Expr, ExprKind, FloatExpr,
     FloatFunctionExpr, FunctionExpr, FunctionExprKind, FunctionFunctionExpr, IntExpr,
     IntFunctionExpr, ListExpr, ListFunctionExpr, NilExpr, NilFunctionExpr, Step, StringExpr,
-    StringFunctionExpr, TupleExpr, TupleFunctionExpr, TupleLocalId, ValueType,
+    StringFunctionExpr, TupleExpr, TupleFunctionExpr, TupleLocalId, UtfCodepointExpr,
+    UtfCodepointFunctionExpr, ValueType,
 };
 use crate::planner::context::PlanContext;
 use crate::planner::error::{
@@ -297,6 +298,7 @@ fn value_type_expression_type(type_: ValueType) -> InvalidExpressionType {
         ValueType::Int => InvalidExpressionType::Int,
         ValueType::String => InvalidExpressionType::String,
         ValueType::BitArray => InvalidExpressionType::BitArray,
+        ValueType::UtfCodepoint => InvalidExpressionType::UtfCodepoint,
         ValueType::Float => InvalidExpressionType::Float,
         ValueType::Bool => InvalidExpressionType::Bool,
         ValueType::Nil => InvalidExpressionType::Nil,
@@ -339,6 +341,13 @@ fn plan_variable_runtime_step_and_return(
             (
                 Step::let_bit_array(local, name.clone(), value),
                 Expr::bit_array(BitArrayExpr::local_get(local, name)),
+            )
+        }
+        ExprKind::UtfCodepoint(value) => {
+            let local = context.define_utf_codepoint_local(name.clone());
+            (
+                Step::let_utf_codepoint(local, name.clone(), value),
+                Expr::utf_codepoint(UtfCodepointExpr::local_get(local, name)),
             )
         }
         ExprKind::Float(value) => {
@@ -408,6 +417,17 @@ fn plan_variable_runtime_step_and_return(
                     Expr::function(FunctionExpr::bit_array(BitArrayFunctionExpr::local_get(
                         local, name, type_,
                     ))),
+                )
+            }
+            FunctionExprKind::UtfCodepoint(value) => {
+                let local = context
+                    .define_utf_codepoint_function_local(name.clone(), value.type_().clone());
+                let type_ = value.type_().clone();
+                (
+                    Step::let_utf_codepoint_function(local, name.clone(), value),
+                    Expr::function(FunctionExpr::utf_codepoint(
+                        UtfCodepointFunctionExpr::local_get(local, name, type_),
+                    )),
                 )
             }
             FunctionExprKind::Float(value) => {
@@ -1237,6 +1257,7 @@ pub fn main() {
             (ValueType::Int, InvalidExpressionType::Int),
             (ValueType::String, InvalidExpressionType::String),
             (ValueType::BitArray, InvalidExpressionType::BitArray),
+            (ValueType::UtfCodepoint, InvalidExpressionType::UtfCodepoint),
             (ValueType::Float, InvalidExpressionType::Float),
             (ValueType::Bool, InvalidExpressionType::Bool),
             (ValueType::Nil, InvalidExpressionType::Nil),

--- a/src/planner/statement/assignment/assert.rs
+++ b/src/planner/statement/assignment/assert.rs
@@ -258,6 +258,9 @@ fn define_assert_local(
         ValueType::Float => ParamLocal::float(context.define_float_local(name)),
         ValueType::String => ParamLocal::string(context.define_string_local(name)),
         ValueType::BitArray => ParamLocal::bit_array(context.define_bit_array_local(name)),
+        ValueType::UtfCodepoint => {
+            ParamLocal::utf_codepoint(context.define_utf_codepoint_local(name))
+        }
         ValueType::Bool => ParamLocal::bool(context.define_bool_local(name)),
         ValueType::Nil => ParamLocal::nil(context.define_nil_local(name)),
         ValueType::Tuple(type_) => {
@@ -284,6 +287,10 @@ fn define_assert_local(
                 ),
                 ValueType::BitArray => ParamLocal::bit_array_function(
                     context.define_bit_array_function_local(name, type_.clone()),
+                    type_,
+                ),
+                ValueType::UtfCodepoint => ParamLocal::utf_codepoint_function(
+                    context.define_utf_codepoint_function_local(name, type_.clone()),
                     type_,
                 ),
                 ValueType::Bool => ParamLocal::bool_function(
@@ -441,7 +448,8 @@ mod tests {
         FunctionType, IntExpr, IntFunctionLocalId, IntListLocalId, IntLocalId, ListAssertPattern,
         ListAssertTail, ListLocal, NilFunctionLocalId, NilLocalId, PanicSite, ParamLocal,
         Signedness, SourceSpan, Step, StringExpr, StringFunctionLocalId, StringLocalId,
-        TupleFunctionLocalId, TupleLocalId, ValueType,
+        TupleFunctionLocalId, TupleLocalId, UtfCodepointFunctionLocalId, UtfCodepointLocalId,
+        ValueType,
     };
     use crate::planner::context::{AnonymousFunctions, PlanContext};
     use crate::planner::dsl::{
@@ -1515,6 +1523,7 @@ pub fn main() {
         let float_function_type = FunctionType::new(Vec::new(), ValueType::Float);
         let string_function_type = FunctionType::new(Vec::new(), ValueType::String);
         let bit_array_function_type = FunctionType::new(Vec::new(), ValueType::BitArray);
+        let utf_codepoint_function_type = FunctionType::new(Vec::new(), ValueType::UtfCodepoint);
         let bool_function_type = FunctionType::new(Vec::new(), ValueType::Bool);
         let nil_function_type = FunctionType::new(Vec::new(), ValueType::Nil);
         let tuple_function_type =
@@ -1541,6 +1550,14 @@ pub fn main() {
         assert_eq!(
             super::define_assert_local("bit_array".into(), ValueType::BitArray, &mut context),
             ParamLocal::bit_array(BitArrayLocalId(0)),
+        );
+        assert_eq!(
+            super::define_assert_local(
+                "utf_codepoint".into(),
+                ValueType::UtfCodepoint,
+                &mut context,
+            ),
+            ParamLocal::utf_codepoint(UtfCodepointLocalId(0)),
         );
         assert_eq!(
             super::define_assert_local("bool".into(), ValueType::Bool, &mut context),
@@ -1597,6 +1614,17 @@ pub fn main() {
                 &mut context,
             ),
             ParamLocal::bit_array_function(BitArrayFunctionLocalId(0), bit_array_function_type,),
+        );
+        assert_eq!(
+            super::define_assert_local(
+                "utf_codepoint_function".into(),
+                ValueType::Function(Box::new(utf_codepoint_function_type.clone())),
+                &mut context,
+            ),
+            ParamLocal::utf_codepoint_function(
+                UtfCodepointFunctionLocalId(0),
+                utf_codepoint_function_type,
+            ),
         );
         assert_eq!(
             super::define_assert_local(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,14 +14,14 @@ pub(in crate::runtime) use evaluated::{
     EvaluatedCaptureKind, EvaluatedFloatFunction, EvaluatedFunctionFunction,
     EvaluatedFunctionValue, EvaluatedFunctionValueKind, EvaluatedIntFunction, EvaluatedListCapture,
     EvaluatedListFunction, EvaluatedNilFunction, EvaluatedStringFunction, EvaluatedTupleFunction,
-    EvaluatedValue,
+    EvaluatedUtfCodepointFunction, EvaluatedValue,
 };
 #[cfg(test)]
 pub(in crate::runtime) use state::RuntimeState;
 pub(crate) use value::{
     BitArrayFunctionValue, BoolFunctionValue, CaptureListValue, CaptureValue, FloatFunctionValue,
     FunctionFunctionValue, FunctionValueKind, IntFunctionValue, ListFunctionValue,
-    NilFunctionValue, StringFunctionValue, TupleFunctionValue,
+    NilFunctionValue, StringFunctionValue, TupleFunctionValue, UtfCodepointFunctionValue,
 };
 pub use value::{
     BitArrayValue, BitArrayValueLengthError, FunctionValue, ListValue, ListValueItemTypeMismatch,

--- a/src/runtime/error/diagnostic.rs
+++ b/src/runtime/error/diagnostic.rs
@@ -87,6 +87,7 @@ fn render_value(value: &Value) -> String {
             value.bytes(),
             value.bit_len(),
         ),
+        Value::UtfCodepoint(value) => format!("UtfCodepoint({value:?})"),
         Value::Bool(value) => format!("Bool({value})"),
         Value::Nil => "Nil".into(),
         Value::Tuple(values) => format!(
@@ -131,6 +132,7 @@ fn render_value_type(type_: &ValueType) -> String {
         ValueType::Float => "Float".into(),
         ValueType::String => "String".into(),
         ValueType::BitArray => "BitArray".into(),
+        ValueType::UtfCodepoint => "UtfCodepoint".into(),
         ValueType::Bool => "Bool".into(),
         ValueType::Nil => "Nil".into(),
         ValueType::Tuple(types) => format!(
@@ -286,6 +288,10 @@ mod tests {
                 Value::BitArray(BitArrayValue::from_bytes(vec![0xa5])),
                 "BitArray(bytes=[165], bit_len=8)",
             ),
+            (
+                Value::UtfCodepoint('\u{10ffff}'),
+                "UtfCodepoint('\\u{10ffff}')",
+            ),
             (Value::Bool(true), "Bool(true)"),
             (Value::Nil, "Nil"),
             (
@@ -305,6 +311,7 @@ mod tests {
     #[test]
     fn render_value_type_preserves_compound_shapes() {
         assert_eq!(render_value_type(&ValueType::BitArray), "BitArray");
+        assert_eq!(render_value_type(&ValueType::UtfCodepoint), "UtfCodepoint");
         assert_eq!(
             render_value_type(&ValueType::Tuple(vec![ValueType::Int, ValueType::String])),
             "#(Int, String)",

--- a/src/runtime/evaluated.rs
+++ b/src/runtime/evaluated.rs
@@ -12,7 +12,8 @@ use crate::plan::execution::{
     FunctionFunctionId, FunctionFunctionLocalId, FunctionReturnFamily, FunctionType, IntFunctionId,
     IntFunctionLocalId, IntLocalId, ListFunctionId, ListFunctionLocal, NilFunctionId,
     NilFunctionLocalId, NilLocalId, ParamLocal, StringFunctionId, StringFunctionLocalId,
-    StringLocalId, TupleFunctionId, TupleFunctionLocalId, TupleLocalId,
+    StringLocalId, TupleFunctionId, TupleFunctionLocalId, TupleLocalId, UtfCodepointFunctionId,
+    UtfCodepointFunctionLocalId, UtfCodepointLocalId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,6 +41,7 @@ pub(in crate::runtime) enum EvaluatedValue {
     Float(f64),
     String(EcoString),
     BitArray(EvaluatedBitArray),
+    UtfCodepoint(char),
     Bool(bool),
     Nil,
     Tuple(Vec<EvaluatedValue>),
@@ -59,6 +61,8 @@ pub(in crate::runtime) type EvaluatedIntFunction = EvaluatedFunction<IntFunction
 pub(in crate::runtime) type EvaluatedFloatFunction = EvaluatedFunction<FloatFunctionId>;
 pub(in crate::runtime) type EvaluatedStringFunction = EvaluatedFunction<StringFunctionId>;
 pub(in crate::runtime) type EvaluatedBitArrayFunction = EvaluatedFunction<BitArrayFunctionId>;
+pub(in crate::runtime) type EvaluatedUtfCodepointFunction =
+    EvaluatedFunction<UtfCodepointFunctionId>;
 pub(in crate::runtime) type EvaluatedBoolFunction = EvaluatedFunction<BoolFunctionId>;
 pub(in crate::runtime) type EvaluatedNilFunction = EvaluatedFunction<NilFunctionId>;
 pub(in crate::runtime) type EvaluatedTupleFunction = EvaluatedFunction<TupleFunctionId>;
@@ -83,6 +87,7 @@ pub(in crate::runtime) enum EvaluatedFunctionValueKind {
     Float(EvaluatedFloatFunction),
     String(EvaluatedStringFunction),
     BitArray(EvaluatedBitArrayFunction),
+    UtfCodepoint(EvaluatedUtfCodepointFunction),
     Bool(EvaluatedBoolFunction),
     Nil(EvaluatedNilFunction),
     Tuple(EvaluatedTupleFunction),
@@ -113,6 +118,10 @@ pub(in crate::runtime) enum EvaluatedCaptureKind {
         local: BitArrayLocalId,
         value: EvaluatedBitArray,
     },
+    UtfCodepoint {
+        local: UtfCodepointLocalId,
+        value: char,
+    },
     Bool {
         local: BoolLocalId,
         value: bool,
@@ -140,6 +149,10 @@ pub(in crate::runtime) enum EvaluatedCaptureKind {
     BitArrayFunction {
         local: BitArrayFunctionLocalId,
         value: EvaluatedBitArrayFunction,
+    },
+    UtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
+        value: EvaluatedUtfCodepointFunction,
     },
     BoolFunction {
         local: BoolFunctionLocalId,
@@ -177,6 +190,10 @@ pub(in crate::runtime) enum EvaluatedListCapture {
         local: crate::plan::execution::BitArrayListLocalId,
         value: super::state::BitArrayListValueId,
     },
+    UtfCodepoint {
+        local: crate::plan::execution::UtfCodepointListLocalId,
+        value: super::state::UtfCodepointListValueId,
+    },
     Float {
         local: crate::plan::execution::FloatListLocalId,
         value: super::state::FloatListValueId,
@@ -210,6 +227,7 @@ impl EvaluatedValue {
             Self::Float(_) => ValueType::Float,
             Self::String(_) => ValueType::String,
             Self::BitArray(_) => ValueType::BitArray,
+            Self::UtfCodepoint(_) => ValueType::UtfCodepoint,
             Self::Bool(_) => ValueType::Bool,
             Self::Nil => ValueType::Nil,
             Self::Tuple(values) => {
@@ -269,6 +287,7 @@ evaluated_function_value_from!(EvaluatedIntFunction, Int);
 evaluated_function_value_from!(EvaluatedFloatFunction, Float);
 evaluated_function_value_from!(EvaluatedStringFunction, String);
 evaluated_function_value_from!(EvaluatedBitArrayFunction, BitArray);
+evaluated_function_value_from!(EvaluatedUtfCodepointFunction, UtfCodepoint);
 evaluated_function_value_from!(EvaluatedBoolFunction, Bool);
 evaluated_function_value_from!(EvaluatedNilFunction, Nil);
 evaluated_function_value_from!(EvaluatedTupleFunction, Tuple);
@@ -290,6 +309,7 @@ impl EvaluatedFunctionValue {
             EvaluatedFunctionValueKind::Float(value) => value.type_(),
             EvaluatedFunctionValueKind::String(value) => value.type_(),
             EvaluatedFunctionValueKind::BitArray(value) => value.type_(),
+            EvaluatedFunctionValueKind::UtfCodepoint(value) => value.type_(),
             EvaluatedFunctionValueKind::Bool(value) => value.type_(),
             EvaluatedFunctionValueKind::Nil(value) => value.type_(),
             EvaluatedFunctionValueKind::Tuple(value) => value.type_(),
@@ -306,6 +326,7 @@ impl EvaluatedFunctionValueKind {
             Self::Float(_) => FunctionReturnFamily::Float,
             Self::String(_) => FunctionReturnFamily::String,
             Self::BitArray(_) => FunctionReturnFamily::BitArray,
+            Self::UtfCodepoint(_) => FunctionReturnFamily::UtfCodepoint,
             Self::Bool(_) => FunctionReturnFamily::Bool,
             Self::Nil(_) => FunctionReturnFamily::Nil,
             Self::Tuple(_) => FunctionReturnFamily::Tuple,
@@ -338,6 +359,10 @@ impl EvaluatedCapture {
 
     pub(in crate::runtime) fn bit_array(local: BitArrayLocalId, value: EvaluatedBitArray) -> Self {
         Self::from_kind(EvaluatedCaptureKind::BitArray { local, value })
+    }
+
+    pub(in crate::runtime) fn utf_codepoint(local: UtfCodepointLocalId, value: char) -> Self {
+        Self::from_kind(EvaluatedCaptureKind::UtfCodepoint { local, value })
     }
 
     pub(in crate::runtime) fn bool(local: BoolLocalId, value: bool) -> Self {
@@ -382,6 +407,13 @@ impl EvaluatedCapture {
         value: EvaluatedBitArrayFunction,
     ) -> Self {
         Self::from_kind(EvaluatedCaptureKind::BitArrayFunction { local, value })
+    }
+
+    pub(in crate::runtime) fn utf_codepoint_function(
+        local: UtfCodepointFunctionLocalId,
+        value: EvaluatedUtfCodepointFunction,
+    ) -> Self {
+        Self::from_kind(EvaluatedCaptureKind::UtfCodepointFunction { local, value })
     }
 
     pub(in crate::runtime) fn bool_function(
@@ -431,6 +463,7 @@ pub(in crate::runtime) fn values_equal(
         (EvaluatedValue::Float(left), EvaluatedValue::Float(right)) => left == right,
         (EvaluatedValue::String(left), EvaluatedValue::String(right)) => left == right,
         (EvaluatedValue::BitArray(left), EvaluatedValue::BitArray(right)) => left == right,
+        (EvaluatedValue::UtfCodepoint(left), EvaluatedValue::UtfCodepoint(right)) => left == right,
         (EvaluatedValue::Bool(left), EvaluatedValue::Bool(right)) => left == right,
         (EvaluatedValue::Nil, EvaluatedValue::Nil) => true,
         (EvaluatedValue::Tuple(left), EvaluatedValue::Tuple(right)) => {
@@ -488,6 +521,10 @@ fn functions_equal(
         (
             EvaluatedFunctionValueKind::BitArray(left),
             EvaluatedFunctionValueKind::BitArray(right),
+        ) => function_values_equal(plan, state, left, right),
+        (
+            EvaluatedFunctionValueKind::UtfCodepoint(left),
+            EvaluatedFunctionValueKind::UtfCodepoint(right),
         ) => function_values_equal(plan, state, left, right),
         (EvaluatedFunctionValueKind::Bool(left), EvaluatedFunctionValueKind::Bool(right)) => {
             function_values_equal(plan, state, left, right)
@@ -564,6 +601,16 @@ fn captures_equal(
             },
         ) => left_local == right_local && left == right,
         (
+            EvaluatedCaptureKind::UtfCodepoint {
+                local: left_local,
+                value: left,
+            },
+            EvaluatedCaptureKind::UtfCodepoint {
+                local: right_local,
+                value: right,
+            },
+        ) => left_local == right_local && left == right,
+        (
             EvaluatedCaptureKind::Bool {
                 local: left_local,
                 value: left,
@@ -623,6 +670,16 @@ fn captures_equal(
                 value: left,
             },
             EvaluatedCaptureKind::StringFunction {
+                local: right_local,
+                value: right,
+            },
+        ) => left_local == right_local && function_values_equal(plan, state, left, right),
+        (
+            EvaluatedCaptureKind::UtfCodepointFunction {
+                local: left_local,
+                value: left,
+            },
+            EvaluatedCaptureKind::UtfCodepointFunction {
                 local: right_local,
                 value: right,
             },
@@ -707,6 +764,19 @@ fn list_captures_equal(
                 value: left,
             },
             EvaluatedListCapture::String {
+                local: right_local,
+                value: right,
+            },
+        ) => {
+            left_local == right_local
+                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
+        }
+        (
+            EvaluatedListCapture::UtfCodepoint {
+                local: left_local,
+                value: left,
+            },
+            EvaluatedListCapture::UtfCodepoint {
                 local: right_local,
                 value: right,
             },
@@ -802,7 +872,8 @@ mod tests {
         EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedCapture,
         EvaluatedFloatFunction, EvaluatedFunctionFunction, EvaluatedFunctionValue,
         EvaluatedIntFunction, EvaluatedListCapture, EvaluatedListFunction, EvaluatedNilFunction,
-        EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedValue, values_equal,
+        EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedUtfCodepointFunction,
+        EvaluatedValue, values_equal,
     };
     use crate::plan::ValueType;
     use crate::plan::execution::{
@@ -813,6 +884,8 @@ mod tests {
         ListFunctionLocal, ListListLocalId, NilFunctionId, NilFunctionLocalId, NilListLocalId,
         NilLocalId, ParamLocal, StringFunctionId, StringFunctionLocalId, StringListLocalId,
         StringLocalId, TupleFunctionId, TupleFunctionLocalId, TupleListLocalId, TupleLocalId,
+        UtfCodepointFunctionId, UtfCodepointFunctionLocalId, UtfCodepointListLocalId,
+        UtfCodepointLocalId,
     };
     use crate::runtime::state::{ListValueId, RuntimeState};
     use bitvec::order::Msb0;
@@ -822,6 +895,7 @@ mod tests {
 fn ints() -> List(Int) { [] }
 fn strings() -> List(String) { [] }
 fn bit_arrays() -> List(BitArray) { [] }
+fn utf_codepoints() -> List(UtfCodepoint) { [] }
 fn floats() -> List(Float) { [] }
 fn bools() -> List(Bool) { [] }
 fn nils() -> List(Nil) { [] }
@@ -859,6 +933,7 @@ pub fn main() { 0 }
             EvaluatedValue::Float(1.5),
             EvaluatedValue::String("one".into()),
             EvaluatedValue::BitArray(EvaluatedBitArray::new(bitvec::vec::BitVec::new())),
+            EvaluatedValue::UtfCodepoint('\u{10ffff}'),
             EvaluatedValue::Bool(true),
             EvaluatedValue::Nil,
             EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
@@ -870,6 +945,7 @@ pub fn main() { 0 }
             ValueType::Float,
             ValueType::String,
             ValueType::BitArray,
+            ValueType::UtfCodepoint,
             ValueType::Bool,
             ValueType::Nil,
             ValueType::Tuple(vec![ValueType::Int]),
@@ -961,6 +1037,26 @@ pub fn main() { 0 }
                     crate::plan::execution::FunctionType::new(
                         Vec::new(),
                         crate::plan::execution::ValueType::BitArray,
+                    ),
+                )),
+            ),
+            (
+                EvaluatedFunctionValue::from(EvaluatedUtfCodepointFunction::new(
+                    UtfCodepointFunctionId(0),
+                    Vec::new(),
+                    Vec::new(),
+                    crate::plan::execution::FunctionType::new(
+                        Vec::new(),
+                        crate::plan::execution::ValueType::UtfCodepoint,
+                    ),
+                )),
+                EvaluatedFunctionValue::from(EvaluatedUtfCodepointFunction::new(
+                    UtfCodepointFunctionId(0),
+                    Vec::new(),
+                    Vec::new(),
+                    crate::plan::execution::FunctionType::new(
+                        Vec::new(),
+                        crate::plan::execution::ValueType::UtfCodepoint,
                     ),
                 )),
             ),
@@ -1129,6 +1225,10 @@ pub fn main() { 0 }
             state.float(plan.float_list_function_id(0).type_id(), vec![1.5]),
             state.float(plan.float_list_function_id(0).type_id(), vec![1.5]),
         );
+        let utf_codepoint_lists = (
+            state.utf_codepoint(plan.utf_codepoint_list_function_id(0).type_id(), vec!['a']),
+            state.utf_codepoint(plan.utf_codepoint_list_function_id(0).type_id(), vec!['a']),
+        );
         let bool_lists = (
             state.bool(plan.bool_list_function_id(0).type_id(), vec![true]),
             state.bool(plan.bool_list_function_id(0).type_id(), vec![true]),
@@ -1177,6 +1277,10 @@ pub fn main() { 0 }
             (
                 ListValueId::String(string_lists.0.clone()),
                 ListValueId::String(string_lists.1.clone()),
+            ),
+            (
+                ListValueId::UtfCodepoint(utf_codepoint_lists.0.clone()),
+                ListValueId::UtfCodepoint(utf_codepoint_lists.1.clone()),
             ),
             (
                 ListValueId::Float(float_lists.0.clone()),
@@ -1285,6 +1389,15 @@ pub fn main() { 0 }
                 crate::plan::execution::ValueType::String,
             ),
         );
+        let captured_utf_codepoint_function = EvaluatedUtfCodepointFunction::new(
+            UtfCodepointFunctionId(0),
+            Vec::new(),
+            Vec::new(),
+            crate::plan::execution::FunctionType::new(
+                Vec::new(),
+                crate::plan::execution::ValueType::UtfCodepoint,
+            ),
+        );
         let captured_bool_function = EvaluatedBoolFunction::new(
             BoolFunctionId(0),
             Vec::new(),
@@ -1345,6 +1458,10 @@ pub fn main() { 0 }
             plan.string_list_function_id(0).type_id(),
             vec!["one".into()],
         );
+        let left_utf_codepoint_list =
+            state.utf_codepoint(plan.utf_codepoint_list_function_id(0).type_id(), vec!['a']);
+        let right_utf_codepoint_list =
+            state.utf_codepoint(plan.utf_codepoint_list_function_id(0).type_id(), vec!['a']);
         let left_float_list = state.float(plan.float_list_function_id(0).type_id(), vec![1.5]);
         let right_float_list = state.float(plan.float_list_function_id(0).type_id(), vec![1.5]);
         let left_bool_list = state.bool(plan.bool_list_function_id(0).type_id(), vec![true]);
@@ -1396,6 +1513,10 @@ pub fn main() { 0 }
                 EvaluatedCapture::string(StringLocalId(0), "one".into()),
             ),
             (
+                EvaluatedCapture::utf_codepoint(UtfCodepointLocalId(0), 'a'),
+                EvaluatedCapture::utf_codepoint(UtfCodepointLocalId(0), 'a'),
+            ),
+            (
                 EvaluatedCapture::bool(BoolLocalId(0), true),
                 EvaluatedCapture::bool(BoolLocalId(0), true),
             ),
@@ -1425,6 +1546,16 @@ pub fn main() { 0 }
                 EvaluatedCapture::list(EvaluatedListCapture::String {
                     local: StringListLocalId(0),
                     value: right_string_list,
+                }),
+            ),
+            (
+                EvaluatedCapture::list(EvaluatedListCapture::UtfCodepoint {
+                    local: UtfCodepointListLocalId(0),
+                    value: left_utf_codepoint_list,
+                }),
+                EvaluatedCapture::list(EvaluatedListCapture::UtfCodepoint {
+                    local: UtfCodepointListLocalId(0),
+                    value: right_utf_codepoint_list,
                 }),
             ),
             (
@@ -1515,6 +1646,16 @@ pub fn main() { 0 }
                 EvaluatedCapture::string_function(
                     StringFunctionLocalId(0),
                     captured_string_function.clone(),
+                ),
+            ),
+            (
+                EvaluatedCapture::utf_codepoint_function(
+                    UtfCodepointFunctionLocalId(0),
+                    captured_utf_codepoint_function.clone(),
+                ),
+                EvaluatedCapture::utf_codepoint_function(
+                    UtfCodepointFunctionLocalId(0),
+                    captured_utf_codepoint_function,
                 ),
             ),
             (

--- a/src/runtime/expression.rs
+++ b/src/runtime/expression.rs
@@ -7,6 +7,7 @@ mod list;
 mod nil;
 mod string;
 mod tuple;
+mod utf_codepoint;
 
 use crate::plan::execution::ExecutionPlan;
 use crate::plan::execution::{Expr, ExprKind, PanicExpr, PanicExprKind};
@@ -24,20 +25,22 @@ pub(super) use self::{
         eval_bit_array_function_expr, eval_bool_function_expr, eval_float_function_expr,
         eval_function_expr, eval_function_function_expr, eval_int_function_expr,
         eval_list_function_expr, eval_nil_function_expr, eval_string_function_expr,
-        eval_tuple_function_expr,
+        eval_tuple_function_expr, eval_utf_codepoint_function_expr,
     },
     int::eval_int_expr,
     list::{
         eval_bit_array_list_expr, eval_bool_list_expr, eval_float_list_expr,
         eval_function_list_expr, eval_int_list_expr, eval_list_expr, eval_list_list_expr,
-        eval_nil_list_expr, eval_string_list_expr, eval_tuple_list_expr, get_list_value,
-        project_bit_array_list_expr, project_bool_list_expr, project_float_list_expr,
-        project_function_list_expr, project_int_list_expr, project_nil_list_expr,
-        project_string_list_expr, project_tuple_list_expr,
+        eval_nil_list_expr, eval_string_list_expr, eval_tuple_list_expr,
+        eval_utf_codepoint_list_expr, get_list_value, project_bit_array_list_expr,
+        project_bool_list_expr, project_float_list_expr, project_function_list_expr,
+        project_int_list_expr, project_nil_list_expr, project_string_list_expr,
+        project_tuple_list_expr, project_utf_codepoint_list_expr,
     },
     nil::eval_nil_expr,
     string::eval_string_expr,
     tuple::{eval_tuple_expr, project_tuple_expr},
+    utf_codepoint::eval_utf_codepoint_expr,
 };
 
 pub(super) fn eval_expr(
@@ -56,6 +59,9 @@ pub(super) fn eval_expr(
         ExprKind::BitArray(expression) => Ok(EvaluatedValue::BitArray(eval_bit_array_expr(
             plan, state, frame, expression,
         )?)),
+        ExprKind::UtfCodepoint(expression) => Ok(EvaluatedValue::UtfCodepoint(
+            eval_utf_codepoint_expr(plan, state, frame, expression)?,
+        )),
         ExprKind::Float(expression) => Ok(EvaluatedValue::Float(eval_float_expr(
             plan, state, frame, expression,
         )?)),
@@ -127,19 +133,21 @@ mod tests {
         eval_function_list_expr, eval_int_expr, eval_int_function_expr, eval_int_list_expr,
         eval_list_function_expr, eval_list_list_expr, eval_nil_expr, eval_nil_function_expr,
         eval_nil_list_expr, eval_string_expr, eval_string_function_expr, eval_string_list_expr,
-        eval_tuple_expr, eval_tuple_function_expr, eval_tuple_list_expr,
+        eval_tuple_expr, eval_tuple_function_expr, eval_tuple_list_expr, eval_utf_codepoint_expr,
+        eval_utf_codepoint_function_expr, eval_utf_codepoint_list_expr,
     };
     use crate::plan::execution::{
         BoolFunctionFunctionId, BoolFunctionId, FloatFunctionFunctionId, FloatFunctionId,
         FunctionFunctionFunctionId, IntFunctionFunctionId, IntFunctionId, NilFunctionFunctionId,
         NilFunctionId, ReturnBody, ReturnBodyKind, StringFunctionFunctionId, StringFunctionId,
-        TupleFunctionFunctionId, TupleFunctionId, TupleLocalId,
+        TupleFunctionFunctionId, TupleFunctionId, TupleLocalId, UtfCodepointFunctionFunctionId,
+        UtfCodepointFunctionId,
     };
     use crate::plan::{FunctionType, ValueType};
     use crate::runtime::frame::Frame;
     use crate::runtime::{
-        EvaluatedFunctionValue, EvaluatedIntFunction, EvaluatedStringFunction, EvaluatedValue,
-        ExecutionError,
+        EvaluatedFunctionValue, EvaluatedIntFunction, EvaluatedStringFunction,
+        EvaluatedUtfCodepointFunction, EvaluatedValue, ExecutionError,
     };
 
     #[test]
@@ -716,6 +724,115 @@ pub fn main() { Nil }
     }
 
     #[test]
+    fn utf_codepoint_tuple_projections_preserve_scalar_list_and_function_families() {
+        let plan = crate::runtime::plan_src(
+            r#"
+fn codepoint(value: #(UtfCodepoint)) { value.0 }
+fn codepoints(value: #(List(UtfCodepoint))) { value.0 }
+fn codepoint_function(value: #(fn() -> UtfCodepoint)) { value.0 }
+pub fn main() { Nil }
+"#,
+        );
+
+        let function = plan.utf_codepoint_function(UtfCodepointFunctionId(0));
+        let expression = expression_return(function.return_())
+            .expect("source function should have an expression return body");
+        let mut state = crate::runtime::RuntimeState::new();
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        frame.set_tuple(
+            TupleLocalId(0),
+            vec![EvaluatedValue::UtfCodepoint('\u{10ffff}')],
+        );
+        assert_eq!(
+            eval_utf_codepoint_expr(&plan, &mut state, &mut frame, expression),
+            Ok('\u{10ffff}'),
+        );
+        frame.set_tuple(TupleLocalId(0), vec![EvaluatedValue::Int(1.into())]);
+        assert_eq!(
+            eval_utf_codepoint_expr(&plan, &mut state, &mut frame, expression),
+            Err(ExecutionError::TupleIndexFamilyMismatch {
+                expected: ValueType::UtfCodepoint,
+                actual: ValueType::Int,
+            }),
+        );
+
+        let function_id = plan.utf_codepoint_list_function_id(0);
+        let function = plan.utf_codepoint_list_function(function_id);
+        let expression = expression_return(function.return_())
+            .expect("source function should have an expression return body");
+        let mut state = crate::runtime::RuntimeState::new();
+        let list = state.utf_codepoint(function_id.type_id(), vec!['a']);
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        frame.set_tuple(
+            TupleLocalId(0),
+            vec![EvaluatedValue::List(list.clone().into())],
+        );
+        assert_eq!(
+            eval_utf_codepoint_list_expr(&plan, &mut state, &mut frame, expression),
+            Ok(list),
+        );
+
+        let function = plan.utf_codepoint_function_function(UtfCodepointFunctionFunctionId(0));
+        let expression = expression_return(function.return_())
+            .expect("source function should have an expression return body");
+        let expected = EvaluatedUtfCodepointFunction::new(
+            UtfCodepointFunctionId(0),
+            Vec::new(),
+            Vec::new(),
+            crate::runtime::evaluated::function_type(
+                &[],
+                crate::plan::execution::ValueType::UtfCodepoint,
+            ),
+        );
+        let mut state = crate::runtime::RuntimeState::new();
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        frame.set_tuple(
+            TupleLocalId(0),
+            vec![EvaluatedValue::Function(expected.clone().into())],
+        );
+        assert_eq!(
+            eval_utf_codepoint_function_expr(&plan, &mut state, &mut frame, expression),
+            Ok(expected),
+        );
+
+        let wrong_function = EvaluatedIntFunction::new(
+            IntFunctionId(0),
+            Vec::new(),
+            Vec::new(),
+            crate::runtime::evaluated::function_type(&[], crate::plan::execution::ValueType::Int),
+        );
+        frame.set_tuple(
+            TupleLocalId(0),
+            vec![EvaluatedValue::Function(wrong_function.into())],
+        );
+        assert_eq!(
+            eval_utf_codepoint_function_expr(&plan, &mut state, &mut frame, expression),
+            Err(ExecutionError::TupleIndexFamilyMismatch {
+                expected: ValueType::Function(Box::new(FunctionType::new(
+                    Vec::new(),
+                    ValueType::UtfCodepoint,
+                ))),
+                actual: ValueType::Function(Box::new(FunctionType::new(
+                    Vec::new(),
+                    ValueType::Int,
+                ))),
+            }),
+        );
+
+        frame.set_tuple(TupleLocalId(0), vec![EvaluatedValue::Int(1.into())]);
+        assert_eq!(
+            eval_utf_codepoint_function_expr(&plan, &mut state, &mut frame, expression),
+            Err(ExecutionError::TupleIndexFamilyMismatch {
+                expected: ValueType::Function(Box::new(FunctionType::new(
+                    Vec::new(),
+                    ValueType::UtfCodepoint,
+                ))),
+                actual: ValueType::Int,
+            }),
+        );
+    }
+
+    #[test]
     fn expression_return_shape_guard_rejects_tail_calls_for_every_return_family() {
         let plan = crate::runtime::plan_src(
             r#"
@@ -899,6 +1016,43 @@ pub fn main() { Nil }
         assert_eq!(
             expression_return(
                 plan.function_function_function(FunctionFunctionFunctionId(0))
+                    .return_(),
+            )
+            .map(|_| ()),
+            None,
+        );
+    }
+
+    #[test]
+    fn expression_return_shape_guard_rejects_utf_codepoint_tail_calls() {
+        let plan = crate::runtime::plan_src(
+            r#"
+fn codepoint() -> UtfCodepoint { codepoint() }
+fn codepoints() -> List(UtfCodepoint) { codepoints() }
+fn codepoint_function() -> fn() -> UtfCodepoint { codepoint_function() }
+pub fn main() { Nil }
+"#,
+        );
+
+        assert_eq!(
+            expression_return(
+                plan.utf_codepoint_function(UtfCodepointFunctionId(0))
+                    .return_()
+            )
+            .map(|_| ()),
+            None,
+        );
+        assert_eq!(
+            expression_return(
+                plan.utf_codepoint_list_function(plan.utf_codepoint_list_function_id(0))
+                    .return_(),
+            )
+            .map(|_| ()),
+            None,
+        );
+        assert_eq!(
+            expression_return(
+                plan.utf_codepoint_function_function(UtfCodepointFunctionFunctionId(0))
                     .return_(),
             )
             .map(|_| ()),

--- a/src/runtime/expression/bit_array.rs
+++ b/src/runtime/expression/bit_array.rs
@@ -4,7 +4,7 @@ use num_bigint::BigInt;
 
 use super::{
     eval_bool_expr, eval_float_expr, eval_int_expr, eval_panic_expr, eval_string_expr,
-    project_bit_array_list_expr, project_tuple_expr,
+    eval_utf_codepoint_expr, project_bit_array_list_expr, project_tuple_expr,
 };
 use crate::plan::ValueType;
 use crate::plan::execution::{
@@ -137,6 +137,10 @@ fn append_segment(
             let value = eval_string_expr(plan, state, frame, value)?;
             append_string(output, value.as_str(), *encoding);
         }
+        BitArraySegment::UtfCodepoint { value, encoding } => {
+            let value = eval_utf_codepoint_expr(plan, state, frame, value)?;
+            append_utf_codepoint(output, value, *encoding);
+        }
         BitArraySegment::Bits(value) => {
             let value = eval_bit_array_expr(plan, state, frame, value)?;
             output.extend_from_bitslice(value.bits());
@@ -233,6 +237,34 @@ fn append_string(output: &mut BitVec<u8, Msb0>, value: &str, encoding: StringEnc
     }
 }
 
+fn append_utf_codepoint(output: &mut BitVec<u8, Msb0>, value: char, encoding: StringEncoding) {
+    match encoding {
+        StringEncoding::Utf8 => {
+            let mut buffer = [0; 4];
+            let encoded = value.encode_utf8(&mut buffer);
+            output.extend_from_bitslice(encoded.as_bytes().view_bits::<Msb0>());
+        }
+        StringEncoding::Utf16(endianness) => {
+            let mut buffer = [0; 2];
+            for code in value.encode_utf16(&mut buffer) {
+                let bytes = match endianness {
+                    Endianness::Big => code.to_be_bytes(),
+                    Endianness::Little => code.to_le_bytes(),
+                };
+                output.extend_from_bitslice(bytes.view_bits::<Msb0>());
+            }
+        }
+        StringEncoding::Utf32(endianness) => {
+            let code = u32::from(value);
+            let bytes = match endianness {
+                Endianness::Big => code.to_be_bytes(),
+                Endianness::Little => code.to_le_bytes(),
+            };
+            output.extend_from_bitslice(bytes.view_bits::<Msb0>());
+        }
+    }
+}
+
 use bitvec::view::BitView;
 
 #[cfg(test)]
@@ -243,7 +275,8 @@ mod tests {
     use crate::plan::{
         BitArrayExpr, BitArrayFunctionId, BitArraySegment, BoolExpr, Endianness, Expr,
         FloatBitSize, FloatExpr, FunctionId, FunctionPlan, IntExpr, ListExpr, ModulePlan,
-        PanicExpr, PanicSite, ReturnExpr, Step, StringEncoding, StringExpr, TupleExpr, ValueType,
+        PanicExpr, PanicSite, ReturnExpr, Step, StringEncoding, StringExpr, TupleExpr,
+        UtfCodepointExpr, ValueType,
     };
     use crate::runtime::{BitArrayValue, ExecutionError, ListValue, Value, run_main};
 
@@ -264,6 +297,10 @@ mod tests {
             }]),
             BitArrayExpr::value(vec![BitArraySegment::String {
                 value: StringExpr::panic(panic()),
+                encoding: StringEncoding::Utf8,
+            }]),
+            BitArrayExpr::value(vec![BitArraySegment::UtfCodepoint {
+                value: UtfCodepointExpr::panic(panic()),
                 encoding: StringEncoding::Utf8,
             }]),
             BitArrayExpr::value(vec![BitArraySegment::Bits(BitArrayExpr::panic(panic()))]),

--- a/src/runtime/expression/function.rs
+++ b/src/runtime/expression/function.rs
@@ -7,6 +7,7 @@ mod nil;
 mod returning_function;
 mod string;
 mod tuple;
+mod utf_codepoint;
 
 use crate::plan::execution::ExecutionPlan;
 use crate::plan::execution::{FunctionExpr, FunctionExprKind};
@@ -19,6 +20,7 @@ pub(in crate::runtime) use self::{
     float::eval_float_function_expr, int::eval_int_function_expr, list::eval_list_function_expr,
     nil::eval_nil_function_expr, returning_function::eval_function_function_expr,
     string::eval_string_function_expr, tuple::eval_tuple_function_expr,
+    utf_codepoint::eval_utf_codepoint_function_expr,
 };
 
 pub(in crate::runtime) fn eval_function_expr(
@@ -36,6 +38,9 @@ pub(in crate::runtime) fn eval_function_expr(
         }
         FunctionExprKind::BitArray(expression) => {
             Ok(eval_bit_array_function_expr(plan, state, frame, expression)?.into())
+        }
+        FunctionExprKind::UtfCodepoint(expression) => {
+            Ok(eval_utf_codepoint_function_expr(plan, state, frame, expression)?.into())
         }
         FunctionExprKind::Float(expression) => {
             Ok(eval_float_function_expr(plan, state, frame, expression)?.into())

--- a/src/runtime/expression/function/utf_codepoint.rs
+++ b/src/runtime/expression/function/utf_codepoint.rs
@@ -1,0 +1,293 @@
+use crate::plan::ValueType;
+use crate::plan::execution::{
+    ExecutionPlan, FunctionReturnFamily, UtfCodepointFunctionExpr, UtfCodepointFunctionExprKind,
+};
+use crate::runtime::expression::{
+    eval_bool_expr, eval_float_expr, eval_int_expr, eval_panic_expr, eval_string_expr,
+    project_function_list_expr, project_tuple_expr,
+};
+use crate::runtime::frame::Frame;
+use crate::runtime::function;
+use crate::runtime::state::RuntimeState;
+use crate::runtime::{
+    EvaluatedFunctionValueKind, EvaluatedUtfCodepointFunction, EvaluatedValue, ExecutionError,
+};
+
+pub(in crate::runtime) fn eval_utf_codepoint_function_expr(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    frame: &mut Frame,
+    expression: &UtfCodepointFunctionExpr,
+) -> Result<EvaluatedUtfCodepointFunction, ExecutionError> {
+    match expression.kind() {
+        UtfCodepointFunctionExprKind::Reference(reference) => {
+            Ok(EvaluatedUtfCodepointFunction::new(
+                *reference.function(),
+                reference.params().to_vec(),
+                Vec::new(),
+                crate::runtime::evaluated::function_type(
+                    reference.params(),
+                    crate::plan::execution::ValueType::UtfCodepoint,
+                ),
+            ))
+        }
+        UtfCodepointFunctionExprKind::Closure(template) => Ok(EvaluatedUtfCodepointFunction::new(
+            *template.function(),
+            template.params().to_vec(),
+            function::eval_capture_args(plan, state, frame, template.captures())?,
+            crate::runtime::evaluated::function_type(
+                template.params(),
+                crate::plan::execution::ValueType::UtfCodepoint,
+            ),
+        )),
+        UtfCodepointFunctionExprKind::LocalGet { local, .. } => {
+            Ok(frame.get_utf_codepoint_function(*local))
+        }
+        UtfCodepointFunctionExprKind::Call { function, args, .. } => {
+            function::run_utf_codepoint_function_returning_function_call(
+                plan, state, *function, args, frame,
+            )
+        }
+        UtfCodepointFunctionExprKind::FunctionCall {
+            function: callee,
+            args,
+            ..
+        } => function::run_utf_codepoint_function_function_call(
+            plan,
+            state,
+            callee.as_ref(),
+            args,
+            frame,
+        ),
+        UtfCodepointFunctionExprKind::TupleIndex {
+            tuple,
+            index,
+            type_,
+        } => {
+            let expected = ValueType::Function(Box::new(plan.function_type(type_)));
+            let value = project_tuple_expr(plan, state, frame, tuple, *index, expected.clone())?;
+            let actual = value.value_type(plan);
+            match value {
+                EvaluatedValue::Function(function) => match function.kind() {
+                    EvaluatedFunctionValueKind::UtfCodepoint(value) => Ok(value.clone()),
+                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                },
+                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+            }
+        }
+        UtfCodepointFunctionExprKind::ListIndex { list, index, type_ } => {
+            let type_ = plan.function_type(type_);
+            let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
+            match function.kind() {
+                EvaluatedFunctionValueKind::UtfCodepoint(value) => Ok(value.clone()),
+                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::UtfCodepoint,
+                    actual: function.kind().family(),
+                }),
+            }
+        }
+        UtfCodepointFunctionExprKind::Panic(panic) => {
+            eval_panic_expr(plan, state, frame, panic).map(|never| match never {})
+        }
+        UtfCodepointFunctionExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, state, frame, subject)? {
+                eval_utf_codepoint_function_expr(plan, state, frame, true_)
+            } else {
+                eval_utf_codepoint_function_expr(plan, state, frame, false_)
+            }
+        }
+        UtfCodepointFunctionExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, state, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_utf_codepoint_function_expr(plan, state, frame, branch);
+                }
+            }
+            eval_utf_codepoint_function_expr(plan, state, frame, fallback)
+        }
+        UtfCodepointFunctionExprKind::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_string_expr(plan, state, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_utf_codepoint_function_expr(plan, state, frame, branch);
+                }
+            }
+            eval_utf_codepoint_function_expr(plan, state, frame, fallback)
+        }
+        UtfCodepointFunctionExprKind::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_float_expr(plan, state, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_utf_codepoint_function_expr(plan, state, frame, branch);
+                }
+            }
+            eval_utf_codepoint_function_expr(plan, state, frame, fallback)
+        }
+        UtfCodepointFunctionExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, state, steps, frame)?;
+            eval_utf_codepoint_function_expr(plan, state, frame, return_)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::plan::{
+        BoolExpr, CaptureArg, Expr, FloatExpr, FunctionId, FunctionPlan, FunctionType, IntExpr,
+        IntLocalId, ListExpr, ModulePlan, PanicExpr, PanicSite, ReturnBody, ReturnExpr, Step,
+        StringExpr, TupleExpr, UtfCodepointFunctionExpr, UtfCodepointFunctionFunctionId,
+        UtfCodepointFunctionId, ValueType,
+    };
+    use crate::runtime::{BitArrayValue, ExecutionError, Value, run_main};
+
+    #[test]
+    fn source_utf_codepoint_function_expression_paths_evaluate_exact_values() {
+        let bytes = [
+            1, 2, 3, 4, 24, 5, 6, 23, 25, 7, 99, 9, 99, 11, 99, 13, 99, 16, 99, 17, 99, 18, 99, 19,
+            99, 15, 20, 21, 22,
+        ];
+
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../../tests/fixtures/execution/values/utf_codepoint_function_value_paths.gleam"
+            )),
+            Value::Tuple(
+                bytes
+                    .into_iter()
+                    .map(|byte| Value::BitArray(BitArrayValue::from_bytes(vec![byte])))
+                    .collect(),
+            ),
+        );
+    }
+
+    #[test]
+    fn module_expression_errors_propagate_through_utf_codepoint_function_wrappers() {
+        let type_ = FunctionType::new(Vec::new(), ValueType::UtfCodepoint);
+        let panic = |message: &str| {
+            PanicExpr::panic_at(
+                Some(StringExpr::value(message.into())),
+                PanicSite::unknown(),
+            )
+        };
+        let fallback = || UtfCodepointFunctionExpr::panic(panic("fallback"), type_.clone());
+        let expressions = [
+            (
+                UtfCodepointFunctionExpr::closure(
+                    UtfCodepointFunctionId(1),
+                    Vec::new(),
+                    vec![CaptureArg::int(
+                        IntLocalId(0),
+                        IntExpr::panic(panic("capture")),
+                    )],
+                    type_.clone(),
+                ),
+                "capture",
+            ),
+            (
+                UtfCodepointFunctionExpr::tuple_index(
+                    TupleExpr::panic(
+                        panic("tuple"),
+                        vec![ValueType::Function(Box::new(type_.clone()))],
+                    ),
+                    0,
+                    type_.clone(),
+                ),
+                "tuple",
+            ),
+            (
+                UtfCodepointFunctionExpr::list_index(
+                    super::super::expect_function_list(ListExpr::panic(
+                        panic("list"),
+                        ValueType::Function(Box::new(type_.clone())),
+                    )),
+                    0,
+                    type_.clone(),
+                ),
+                "list",
+            ),
+            (
+                UtfCodepointFunctionExpr::bool_case(
+                    BoolExpr::panic(panic("bool subject")),
+                    fallback(),
+                    fallback(),
+                ),
+                "bool subject",
+            ),
+            (
+                UtfCodepointFunctionExpr::int_case(
+                    IntExpr::panic(panic("int subject")),
+                    Vec::new(),
+                    fallback(),
+                ),
+                "int subject",
+            ),
+            (
+                UtfCodepointFunctionExpr::string_case(
+                    StringExpr::panic(panic("string subject")),
+                    Vec::new(),
+                    fallback(),
+                ),
+                "string subject",
+            ),
+            (
+                UtfCodepointFunctionExpr::float_case(
+                    FloatExpr::panic(panic("float subject")),
+                    Vec::new(),
+                    fallback(),
+                ),
+                "float subject",
+            ),
+            (
+                UtfCodepointFunctionExpr::block(
+                    vec![Step::evaluate(Expr::int(IntExpr::panic(panic("step"))))],
+                    fallback(),
+                ),
+                "step",
+            ),
+        ];
+
+        for (expression, message) in expressions {
+            assert_eq!(
+                run_module_utf_codepoint_function_expression(expression).to_string(),
+                format!("panic: {message}"),
+            );
+        }
+    }
+
+    fn run_module_utf_codepoint_function_expression(
+        expression: UtfCodepointFunctionExpr,
+    ) -> ExecutionError {
+        let type_ = FunctionType::new(Vec::new(), ValueType::UtfCodepoint);
+        let main = FunctionPlan::new(
+            FunctionId::new(0),
+            "main".into(),
+            Vec::new(),
+            Vec::new(),
+            ReturnExpr::utf_codepoint_function_body(
+                UtfCodepointFunctionFunctionId(0),
+                type_,
+                ReturnBody::expr(expression),
+            ),
+        );
+        let module = ModulePlan::new("main".into(), main, Vec::new());
+        let plan = crate::ExecutionPlan::from_module_plan(module);
+
+        run_main(&plan).expect_err("module expression should fail at runtime")
+    }
+}

--- a/src/runtime/expression/list.rs
+++ b/src/runtime/expression/list.rs
@@ -3,13 +3,15 @@ use num_bigint::BigInt;
 
 use super::{
     eval_bit_array_expr, eval_bool_expr, eval_float_expr, eval_function_expr, eval_int_expr,
-    eval_nil_expr, eval_panic_expr, eval_string_expr, eval_tuple_expr, project_tuple_expr,
+    eval_nil_expr, eval_panic_expr, eval_string_expr, eval_tuple_expr, eval_utf_codepoint_expr,
+    project_tuple_expr,
 };
 use crate::plan::execution::{
     BitArrayListExpr, BitArrayListItem, BoolListExpr, BoolListItem, ExecutionPlan, FloatListExpr,
     FloatListItem, FunctionListExpr, FunctionListItem, IntListExpr, IntListItem, ListExpr,
     ListItem, ListListExpr, ListListItem, NilListExpr, NilListItem, StringListExpr, StringListItem,
-    TupleListExpr, TupleListItem, TypedListExpr, TypedListExprKind,
+    TupleListExpr, TupleListItem, TypedListExpr, TypedListExprKind, UtfCodepointListExpr,
+    UtfCodepointListItem,
 };
 use crate::plan::{FunctionType, ValueType};
 use crate::runtime::ExecutionError;
@@ -19,7 +21,7 @@ use crate::runtime::function;
 use crate::runtime::state::{
     BitArrayListValueId, BoolListValueId, FloatListValueId, FunctionListValueId, IntListValueId,
     ListHandleCore, ListListValueId, ListValueId, NilListValueId, RuntimeState, StringListValueId,
-    TupleListValueId,
+    TupleListValueId, UtfCodepointListValueId,
 };
 
 pub(in crate::runtime) fn eval_list_expr(
@@ -37,6 +39,9 @@ pub(in crate::runtime) fn eval_list_expr(
         }
         ListExpr::BitArray(expression) => {
             eval_bit_array_list_expr(plan, state, frame, expression).map(Into::into)
+        }
+        ListExpr::UtfCodepoint(expression) => {
+            eval_utf_codepoint_list_expr(plan, state, frame, expression).map(Into::into)
         }
         ListExpr::Float(expression) => {
             eval_float_list_expr(plan, state, frame, expression).map(Into::into)
@@ -83,6 +88,15 @@ pub(in crate::runtime) fn eval_bit_array_list_expr(
     frame: &mut Frame,
     expression: &BitArrayListExpr,
 ) -> Result<BitArrayListValueId, ExecutionError> {
+    eval_typed_list_expr(plan, state, frame, expression)
+}
+
+pub(in crate::runtime) fn eval_utf_codepoint_list_expr(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    frame: &mut Frame,
+    expression: &UtfCodepointListExpr,
+) -> Result<UtfCodepointListValueId, ExecutionError> {
     eval_typed_list_expr(plan, state, frame, expression)
 }
 
@@ -431,6 +445,18 @@ primitive_runtime_list_item!(
     run_bit_array_list_function_call
 );
 primitive_runtime_list_item!(
+    UtfCodepointListItem,
+    char,
+    UtfCodepointListValueId,
+    UtfCodepoint,
+    eval_utf_codepoint_expr,
+    utf_codepoint_values,
+    utf_codepoint,
+    get_utf_codepoint_list,
+    run_utf_codepoint_list_call,
+    run_utf_codepoint_list_function_call
+);
+primitive_runtime_list_item!(
     FloatListItem,
     f64,
     FloatListValueId,
@@ -726,6 +752,9 @@ pub(in crate::runtime) fn get_list_value(
         crate::plan::execution::ListLocal::BitArray { local, .. } => {
             frame.get_bit_array_list(*local).into()
         }
+        crate::plan::execution::ListLocal::UtfCodepoint { local, .. } => {
+            frame.get_utf_codepoint_list(*local).into()
+        }
         crate::plan::execution::ListLocal::Float { local, .. } => {
             frame.get_float_list(*local).into()
         }
@@ -790,6 +819,15 @@ project_primitive_list!(
     bit_array_values,
     ValueType::BitArray,
     cloned
+);
+project_primitive_list!(
+    project_utf_codepoint_list_expr,
+    UtfCodepointListExpr,
+    char,
+    eval_utf_codepoint_list_expr,
+    utf_codepoint_values,
+    ValueType::UtfCodepoint,
+    copied
 );
 project_primitive_list!(
     project_float_list_expr,
@@ -873,13 +911,13 @@ pub(in crate::runtime) fn project_function_list_expr(
 #[cfg(test)]
 mod tests {
     use super::{
-        project_bool_list_expr, project_float_list_expr, project_function_list_expr,
-        project_int_list_expr, project_nil_list_expr, project_string_list_expr,
-        project_tuple_list_expr,
+        project_bit_array_list_expr, project_bool_list_expr, project_float_list_expr,
+        project_function_list_expr, project_int_list_expr, project_nil_list_expr,
+        project_string_list_expr, project_tuple_list_expr, project_utf_codepoint_list_expr,
     };
     use crate::plan::execution::{
-        BoolListItem, FloatListItem, FunctionListItem, IntListItem, ListListItem, NilListItem,
-        StringListItem, TupleListItem,
+        BitArrayListItem, BoolListItem, FloatListItem, FunctionListItem, IntListItem, ListListItem,
+        NilListItem, StringListItem, TupleListItem, UtfCodepointListItem,
     };
     use crate::plan::execution::{ReturnBody, ReturnBodyKind};
     use crate::plan::{
@@ -898,6 +936,8 @@ mod tests {
             r#"
 fn int_values(values: List(Int)) { values }
 fn string_values(values: List(String)) { values }
+fn bit_array_values(values: List(BitArray)) { values }
+fn utf_codepoint_values(values: List(UtfCodepoint)) { values }
 fn float_values(values: List(Float)) { values }
 fn bool_values(values: List(Bool)) { values }
 fn nil_values(values: List(Nil)) { values }
@@ -928,6 +968,30 @@ pub fn main() { Nil }
             project_string_list_expr(&plan, &mut state, &mut frame, expression, 0),
             Err(ExecutionError::ListIndexOutOfBounds {
                 item_type: ValueType::String,
+                index: 0,
+                length: 0,
+            }),
+        );
+
+        let function = plan.bit_array_list_function(plan.bit_array_list_function_id(0));
+        let expression = expect_expression_return(function.return_());
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        assert_eq!(
+            project_bit_array_list_expr(&plan, &mut state, &mut frame, expression, 0),
+            Err(ExecutionError::ListIndexOutOfBounds {
+                item_type: ValueType::BitArray,
+                index: 0,
+                length: 0,
+            }),
+        );
+
+        let function = plan.utf_codepoint_list_function(plan.utf_codepoint_list_function_id(0));
+        let expression = expect_expression_return(function.return_());
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        assert_eq!(
+            project_utf_codepoint_list_expr(&plan, &mut state, &mut frame, expression, 0),
+            Err(ExecutionError::ListIndexOutOfBounds {
+                item_type: ValueType::UtfCodepoint,
                 index: 0,
                 length: 0,
             }),
@@ -1016,6 +1080,7 @@ pub fn main() { Nil }
 fn first_int(values: List(List(Int))) -> List(Int) { case values { [first, ..] -> first _ -> [] } }
 fn first_string(values: List(List(String))) -> List(String) { case values { [first, ..] -> first _ -> [] } }
 fn first_bit_array(values: List(List(BitArray))) -> List(BitArray) { case values { [first, ..] -> first _ -> [] } }
+fn first_utf_codepoint(values: List(List(UtfCodepoint))) -> List(UtfCodepoint) { case values { [first, ..] -> first _ -> [] } }
 fn first_float(values: List(List(Float))) -> List(Float) { case values { [first, ..] -> first _ -> [] } }
 fn first_bool(values: List(List(Bool))) -> List(Bool) { case values { [first, ..] -> first _ -> [] } }
 fn first_nil(values: List(List(Nil))) -> List(Nil) { case values { [first, ..] -> first _ -> [] } }
@@ -1037,6 +1102,15 @@ pub fn main() { Nil }
         );
 
         let function = plan.bit_array_list_function(plan.bit_array_list_function_id(0));
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        assert_nested_list_out_of_bounds(
+            &plan,
+            &mut state,
+            &mut frame,
+            expect_nested_list_binding(function.return_()),
+        );
+
+        let function = plan.utf_codepoint_list_function(plan.utf_codepoint_list_function_id(0));
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_nested_list_out_of_bounds(
             &plan,
@@ -1143,6 +1217,8 @@ pub fn main() { Nil }
             r#"
 fn ints() -> List(Int) { [] }
 fn strings() -> List(String) { [] }
+fn bit_arrays() -> List(BitArray) { [] }
+fn utf_codepoints() -> List(UtfCodepoint) { [] }
 fn floats() -> List(Float) { [] }
 fn bools() -> List(Bool) { [] }
 fn nils() -> List(Nil) { [] }
@@ -1162,6 +1238,14 @@ pub fn main() { Nil }
         );
         assert_eq!(
             <StringListItem as super::RuntimeListItem>::from_tuple_value(int.clone().into()),
+            None,
+        );
+        assert_eq!(
+            <BitArrayListItem as super::RuntimeListItem>::from_tuple_value(int.clone().into()),
+            None,
+        );
+        assert_eq!(
+            <UtfCodepointListItem as super::RuntimeListItem>::from_tuple_value(int.clone().into()),
             None,
         );
         assert_eq!(
@@ -1450,6 +1534,14 @@ pub fn main() { Nil }
                 super::eval_bit_array_list_expr(plan, state, frame, value),
                 Err(ExecutionError::ListIndexOutOfBounds {
                     item_type: ValueType::List(Box::new(ValueType::BitArray)),
+                    index: 0,
+                    length: 0,
+                }),
+            ),
+            crate::plan::execution::ListLocalExpr::UtfCodepoint { value, .. } => assert_eq!(
+                super::eval_utf_codepoint_list_expr(plan, state, frame, value),
+                Err(ExecutionError::ListIndexOutOfBounds {
+                    item_type: ValueType::List(Box::new(ValueType::UtfCodepoint)),
                     index: 0,
                     length: 0,
                 }),

--- a/src/runtime/expression/utf_codepoint.rs
+++ b/src/runtime/expression/utf_codepoint.rs
@@ -1,0 +1,166 @@
+use super::{
+    eval_bool_expr, eval_float_expr, eval_int_expr, eval_panic_expr, eval_string_expr,
+    project_tuple_expr, project_utf_codepoint_list_expr,
+};
+use crate::plan::ValueType;
+use crate::plan::execution::{ExecutionPlan, UtfCodepointExpr, UtfCodepointExprKind};
+use crate::runtime::evaluated::EvaluatedValue;
+use crate::runtime::frame::Frame;
+use crate::runtime::state::RuntimeState;
+use crate::runtime::{ExecutionError, function};
+
+pub(in crate::runtime) fn eval_utf_codepoint_expr(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    frame: &mut Frame,
+    expression: &UtfCodepointExpr,
+) -> Result<char, ExecutionError> {
+    match expression.kind() {
+        UtfCodepointExprKind::LocalGet { local } => Ok(frame.get_utf_codepoint(*local)),
+        UtfCodepointExprKind::Call { function, args } => {
+            function::run_utf_codepoint_call(plan, state, *function, args, frame)
+        }
+        UtfCodepointExprKind::FunctionCall { function, args } => {
+            function::run_utf_codepoint_function_call(plan, state, function, args, frame)
+        }
+        UtfCodepointExprKind::TupleIndex { tuple, index } => {
+            match project_tuple_expr(plan, state, frame, tuple, *index, ValueType::UtfCodepoint)? {
+                EvaluatedValue::UtfCodepoint(value) => Ok(value),
+                other => Err(ExecutionError::TupleIndexFamilyMismatch {
+                    expected: ValueType::UtfCodepoint,
+                    actual: other.value_type(plan),
+                }),
+            }
+        }
+        UtfCodepointExprKind::ListIndex { list, index } => {
+            project_utf_codepoint_list_expr(plan, state, frame, list, *index)
+        }
+        UtfCodepointExprKind::Panic(panic) => {
+            eval_panic_expr(plan, state, frame, panic).map(|never| match never {})
+        }
+        UtfCodepointExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => {
+            if eval_bool_expr(plan, state, frame, subject)? {
+                eval_utf_codepoint_expr(plan, state, frame, true_)
+            } else {
+                eval_utf_codepoint_expr(plan, state, frame, false_)
+            }
+        }
+        UtfCodepointExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_int_expr(plan, state, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_utf_codepoint_expr(plan, state, frame, branch);
+                }
+            }
+            eval_utf_codepoint_expr(plan, state, frame, fallback)
+        }
+        UtfCodepointExprKind::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_string_expr(plan, state, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_utf_codepoint_expr(plan, state, frame, branch);
+                }
+            }
+            eval_utf_codepoint_expr(plan, state, frame, fallback)
+        }
+        UtfCodepointExprKind::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => {
+            let subject = eval_float_expr(plan, state, frame, subject)?;
+            for (pattern, branch) in clauses {
+                if pattern == &subject {
+                    return eval_utf_codepoint_expr(plan, state, frame, branch);
+                }
+            }
+            eval_utf_codepoint_expr(plan, state, frame, fallback)
+        }
+        UtfCodepointExprKind::Block { steps, return_ } => {
+            function::execute_steps(plan, state, steps, frame)?;
+            eval_utf_codepoint_expr(plan, state, frame, return_)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::plan::{
+        BoolExpr, Expr, FloatExpr, FunctionId, FunctionPlan, IntExpr, ModulePlan, PanicExpr,
+        PanicSite, ReturnBody, ReturnExpr, Step, StringExpr, TupleExpr, UtfCodepointExpr,
+        UtfCodepointFunctionId, ValueType,
+    };
+    use crate::runtime::{BitArrayValue, ExecutionError, Value, run_main};
+
+    #[test]
+    fn source_utf_codepoint_expression_paths_evaluate_exact_values() {
+        let bytes = [
+            1, 2, 3, 11, 12, 3, 4, 5, 6, 7, 8, 9, 10, 14, 15, 16, 17, 18, 19, 20, 21, 22, 13,
+        ];
+
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../../tests/fixtures/execution/values/utf_codepoint_expression_paths.gleam"
+            )),
+            Value::Tuple(
+                bytes
+                    .into_iter()
+                    .map(|byte| Value::BitArray(BitArrayValue::from_bytes(vec![byte])))
+                    .collect(),
+            ),
+        );
+    }
+
+    #[test]
+    fn module_expression_errors_propagate_through_utf_codepoint_wrappers() {
+        let panic = || PanicExpr::panic_at(None, PanicSite::unknown());
+        let fallback = || UtfCodepointExpr::panic(panic());
+        let expressions = [
+            UtfCodepointExpr::tuple_index(
+                TupleExpr::panic(panic(), vec![ValueType::UtfCodepoint]),
+                0,
+            ),
+            UtfCodepointExpr::bool_case(BoolExpr::panic(panic()), fallback(), fallback()),
+            UtfCodepointExpr::int_case(IntExpr::panic(panic()), Vec::new(), fallback()),
+            UtfCodepointExpr::string_case(StringExpr::panic(panic()), Vec::new(), fallback()),
+            UtfCodepointExpr::float_case(FloatExpr::panic(panic()), Vec::new(), fallback()),
+            UtfCodepointExpr::block(
+                vec![Step::evaluate(Expr::bool(BoolExpr::panic(panic())))],
+                fallback(),
+            ),
+        ];
+
+        for expression in expressions {
+            assert_eq!(
+                run_module_utf_codepoint_expression(expression).to_string(),
+                "panic: `panic` expression evaluated.",
+            );
+        }
+    }
+
+    fn run_module_utf_codepoint_expression(expression: UtfCodepointExpr) -> ExecutionError {
+        let main = FunctionPlan::new(
+            FunctionId::new(0),
+            "main".into(),
+            Vec::new(),
+            Vec::new(),
+            ReturnExpr::utf_codepoint_body(UtfCodepointFunctionId(0), ReturnBody::expr(expression)),
+        );
+        let module = ModulePlan::new("main".into(), main, Vec::new());
+        let plan = crate::ExecutionPlan::from_module_plan(module);
+
+        run_main(&plan).expect_err("module expression should fail at runtime")
+    }
+}

--- a/src/runtime/frame.rs
+++ b/src/runtime/frame.rs
@@ -4,16 +4,18 @@ use crate::plan::execution::{
     FrameLayout, FunctionFunctionLocalId, FunctionListLocalId, IntFunctionLocalId, IntListLocalId,
     IntLocalId, ListFunctionLocal, ListListLocalId, NilFunctionLocalId, NilListLocalId, NilLocalId,
     StringFunctionLocalId, StringListLocalId, StringLocalId, TupleFunctionLocalId,
-    TupleListLocalId, TupleLocalId,
+    TupleListLocalId, TupleLocalId, UtfCodepointFunctionLocalId, UtfCodepointListLocalId,
+    UtfCodepointLocalId,
 };
 use crate::runtime::evaluated::{
     EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedFloatFunction,
     EvaluatedFunctionFunction, EvaluatedIntFunction, EvaluatedListFunction, EvaluatedNilFunction,
-    EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedValue,
+    EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedUtfCodepointFunction, EvaluatedValue,
 };
 use crate::runtime::state::{
     BitArrayListValueId, BoolListValueId, FloatListValueId, FunctionListValueId, IntListValueId,
     ListListValueId, NilListValueId, RuntimeState, StringListValueId, TupleListValueId,
+    UtfCodepointListValueId,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -24,11 +26,13 @@ pub(super) struct Frame {
     floats: Vec<f64>,
     strings: Vec<EcoString>,
     bit_arrays: Vec<EvaluatedBitArray>,
+    utf_codepoints: Vec<char>,
     bools: Vec<bool>,
     tuples: Vec<Vec<EvaluatedValue>>,
     int_lists: Vec<IntListValueId>,
     string_lists: Vec<StringListValueId>,
     bit_array_lists: Vec<BitArrayListValueId>,
+    utf_codepoint_lists: Vec<UtfCodepointListValueId>,
     float_lists: Vec<FloatListValueId>,
     bool_lists: Vec<BoolListValueId>,
     nil_lists: Vec<NilListValueId>,
@@ -39,6 +43,7 @@ pub(super) struct Frame {
     float_functions: HashMap<FloatFunctionLocalId, EvaluatedFloatFunction>,
     string_functions: HashMap<StringFunctionLocalId, EvaluatedStringFunction>,
     bit_array_functions: HashMap<BitArrayFunctionLocalId, EvaluatedBitArrayFunction>,
+    utf_codepoint_functions: HashMap<UtfCodepointFunctionLocalId, EvaluatedUtfCodepointFunction>,
     bool_functions: HashMap<BoolFunctionLocalId, EvaluatedBoolFunction>,
     nil_functions: HashMap<NilFunctionLocalId, EvaluatedNilFunction>,
     tuple_functions: HashMap<TupleFunctionLocalId, EvaluatedTupleFunction>,
@@ -53,6 +58,7 @@ impl Frame {
             floats: vec![0.0; layout.floats()],
             strings: vec![EcoString::default(); layout.strings()],
             bit_arrays: vec![EvaluatedBitArray::new(Default::default()); layout.bit_arrays()],
+            utf_codepoints: vec!['\0'; layout.utf_codepoints()],
             bools: vec![false; layout.bools()],
             tuples: vec![Vec::new(); layout.tuples()],
             int_lists: layout
@@ -69,6 +75,11 @@ impl Frame {
                 .bit_array_lists()
                 .iter()
                 .map(|type_id| state.bit_array(*type_id, Vec::new()))
+                .collect(),
+            utf_codepoint_lists: layout
+                .utf_codepoint_lists()
+                .iter()
+                .map(|type_id| state.utf_codepoint(*type_id, Vec::new()))
                 .collect(),
             float_lists: layout
                 .float_lists()
@@ -104,6 +115,7 @@ impl Frame {
             float_functions: HashMap::with_capacity(layout.float_functions()),
             string_functions: HashMap::with_capacity(layout.string_functions()),
             bit_array_functions: HashMap::with_capacity(layout.bit_array_functions()),
+            utf_codepoint_functions: HashMap::with_capacity(layout.utf_codepoint_functions()),
             bool_functions: HashMap::with_capacity(layout.bool_functions()),
             nil_functions: HashMap::with_capacity(layout.nil_functions()),
             tuple_functions: HashMap::with_capacity(layout.tuple_functions()),
@@ -142,6 +154,14 @@ impl Frame {
 
     pub(super) fn get_bit_array(&self, local: BitArrayLocalId) -> EvaluatedBitArray {
         self.bit_arrays[local.0].clone()
+    }
+
+    pub(super) fn set_utf_codepoint(&mut self, local: UtfCodepointLocalId, value: char) {
+        set_slot(&mut self.utf_codepoints, local.0, value);
+    }
+
+    pub(super) fn get_utf_codepoint(&self, local: UtfCodepointLocalId) -> char {
+        self.utf_codepoints[local.0]
     }
 
     pub(super) fn set_bool(&mut self, local: BoolLocalId, value: bool) {
@@ -190,6 +210,21 @@ impl Frame {
 
     pub(super) fn get_bit_array_list(&self, local: BitArrayListLocalId) -> BitArrayListValueId {
         self.bit_array_lists[local.0].clone()
+    }
+
+    pub(super) fn set_utf_codepoint_list(
+        &mut self,
+        local: UtfCodepointListLocalId,
+        value: UtfCodepointListValueId,
+    ) {
+        set_slot(&mut self.utf_codepoint_lists, local.0, value);
+    }
+
+    pub(super) fn get_utf_codepoint_list(
+        &self,
+        local: UtfCodepointListLocalId,
+    ) -> UtfCodepointListValueId {
+        self.utf_codepoint_lists[local.0].clone()
     }
 
     pub(super) fn set_float_list(&mut self, local: FloatListLocalId, value: FloatListValueId) {
@@ -296,6 +331,21 @@ impl Frame {
         local: BitArrayFunctionLocalId,
     ) -> EvaluatedBitArrayFunction {
         self.bit_array_functions[&local].clone()
+    }
+
+    pub(super) fn set_utf_codepoint_function(
+        &mut self,
+        local: UtfCodepointFunctionLocalId,
+        value: EvaluatedUtfCodepointFunction,
+    ) {
+        self.utf_codepoint_functions.insert(local, value);
+    }
+
+    pub(super) fn get_utf_codepoint_function(
+        &self,
+        local: UtfCodepointFunctionLocalId,
+    ) -> EvaluatedUtfCodepointFunction {
+        self.utf_codepoint_functions[&local].clone()
     }
 
     pub(super) fn set_bool_function(

--- a/src/runtime/function.rs
+++ b/src/runtime/function.rs
@@ -12,24 +12,26 @@ use crate::plan::execution::{
     FunctionReturnFamily, IntFunctionFunctionId, IntFunctionId, ListFunctionFunctionId,
     ListFunctionId, NilFunctionFunctionId, NilFunctionId, RuntimeFunctionId,
     StringFunctionFunctionId, StringFunctionId, TupleFunctionFunctionId, TupleFunctionId,
+    UtfCodepointFunctionFunctionId, UtfCodepointFunctionId,
 };
 use crate::runtime::error::ExecutionResult;
 use crate::runtime::expression::{
     eval_bit_array_function_expr, eval_bool_function_expr, eval_float_function_expr,
     eval_function_function_expr, eval_int_function_expr, eval_list_function_expr,
     eval_nil_function_expr, eval_string_function_expr, eval_tuple_function_expr,
+    eval_utf_codepoint_function_expr,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::state::{
     BitArrayListValueId, BoolListValueId, FloatListValueId, FunctionListValueId, IntListValueId,
     ListListValueId, ListValueId, NilListValueId, RuntimeState, StringListValueId,
-    TupleListValueId,
+    TupleListValueId, UtfCodepointListValueId,
 };
 use crate::runtime::{
     EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedFloatFunction,
     EvaluatedFunctionFunction, EvaluatedFunctionValue, EvaluatedIntFunction, EvaluatedListFunction,
-    EvaluatedNilFunction, EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedValue,
-    ExecutionError, Value,
+    EvaluatedNilFunction, EvaluatedStringFunction, EvaluatedTupleFunction,
+    EvaluatedUtfCodepointFunction, EvaluatedValue, ExecutionError, Value,
 };
 use bind::{bind_arguments, bind_function_value_arguments};
 use ecow::EcoString;
@@ -41,7 +43,8 @@ use return_body::{
     run_int_function_loop, run_int_list_loop, run_int_loop, run_list_function_loop,
     run_list_list_loop, run_list_loop, run_nil_function_loop, run_nil_list_loop, run_nil_loop,
     run_string_function_loop, run_string_list_loop, run_string_loop, run_tuple_function_loop,
-    run_tuple_list_loop, run_tuple_loop,
+    run_tuple_list_loop, run_tuple_loop, run_utf_codepoint_function_loop,
+    run_utf_codepoint_list_loop, run_utf_codepoint_loop,
 };
 
 pub(super) fn run_main(plan: &ExecutionPlan) -> ExecutionResult<Value> {
@@ -64,6 +67,10 @@ pub(super) fn run_main(plan: &ExecutionPlan) -> ExecutionResult<Value> {
         RuntimeFunctionId::BitArray(function) => {
             run_bit_array_call(plan, &mut state, function, &[], &mut caller_frame)
                 .map(EvaluatedValue::BitArray)
+        }
+        RuntimeFunctionId::UtfCodepoint(function) => {
+            run_utf_codepoint_call(plan, &mut state, function, &[], &mut caller_frame)
+                .map(EvaluatedValue::UtfCodepoint)
         }
         RuntimeFunctionId::Bool(function) => {
             run_bool_call(plan, &mut state, function, &[], &mut caller_frame)
@@ -154,6 +161,23 @@ pub(super) fn run_bit_array_call(
         plan.bit_array_function(function).frame_layout(),
     )?;
     run_bit_array_loop(plan, state, function, frame)
+}
+
+pub(super) fn run_utf_codepoint_call(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    function: UtfCodepointFunctionId,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<char> {
+    let frame = bind_arguments(
+        plan,
+        state,
+        args,
+        caller_frame,
+        plan.utf_codepoint_function(function).frame_layout(),
+    )?;
+    run_utf_codepoint_loop(plan, state, function, frame)
 }
 
 pub(super) fn run_bool_call(
@@ -273,6 +297,23 @@ pub(in crate::runtime) fn run_bit_array_list_call(
         plan.bit_array_list_function(function).frame_layout(),
     )?;
     run_bit_array_list_loop(plan, state, function, frame)
+}
+
+pub(in crate::runtime) fn run_utf_codepoint_list_call(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    function: crate::plan::execution::UtfCodepointListFunctionId,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<UtfCodepointListValueId> {
+    let frame = bind_arguments(
+        plan,
+        state,
+        args,
+        caller_frame,
+        plan.utf_codepoint_list_function(function).frame_layout(),
+    )?;
+    run_utf_codepoint_list_loop(plan, state, function, frame)
 }
 
 pub(in crate::runtime) fn run_float_list_call(
@@ -439,6 +480,26 @@ pub(in crate::runtime) fn run_bit_array_function_call(
     run_bit_array_loop(plan, state, function.runtime_id(), frame)
 }
 
+pub(in crate::runtime) fn run_utf_codepoint_function_call(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    function: &crate::plan::execution::UtfCodepointFunctionExpr,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<char> {
+    let function = eval_utf_codepoint_function_expr(plan, state, caller_frame, function)?;
+    let runtime_function = plan.utf_codepoint_function(function.runtime_id());
+    let frame = bind_function_value_arguments(
+        plan,
+        state,
+        args,
+        caller_frame,
+        runtime_function.frame_layout(),
+        function.captures(),
+    )?;
+    run_utf_codepoint_loop(plan, state, function.runtime_id(), frame)
+}
+
 pub(in crate::runtime) fn run_float_function_call(
     plan: &ExecutionPlan,
     state: &mut RuntimeState,
@@ -596,6 +657,31 @@ pub(in crate::runtime) fn run_bit_array_list_function_call(
         function.captures(),
     )?;
     run_bit_array_list_loop(plan, state, runtime_id, frame)
+}
+
+pub(in crate::runtime) fn run_utf_codepoint_list_function_call(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    function: &crate::plan::execution::ListFunctionExpr,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<UtfCodepointListValueId> {
+    let function = eval_list_function_expr(plan, state, caller_frame, function)?;
+    let ListFunctionId::UtfCodepoint(runtime_id) = function.runtime_id() else {
+        return Err(ExecutionError::FunctionReturnFamilyMismatch {
+            expected: FunctionReturnFamily::List,
+            actual: FunctionReturnFamily::List,
+        });
+    };
+    let frame = bind_function_value_arguments(
+        plan,
+        state,
+        args,
+        caller_frame,
+        plan.utf_codepoint_list_function(runtime_id).frame_layout(),
+        function.captures(),
+    )?;
+    run_utf_codepoint_list_loop(plan, state, runtime_id, frame)
 }
 
 pub(in crate::runtime) fn run_float_list_function_call(
@@ -756,6 +842,7 @@ fn list_function_frame_layout<'a>(
         ListFunctionId::Int(id) => plan.int_list_function(*id).frame_layout(),
         ListFunctionId::String(id) => plan.string_list_function(*id).frame_layout(),
         ListFunctionId::BitArray(id) => plan.bit_array_list_function(*id).frame_layout(),
+        ListFunctionId::UtfCodepoint(id) => plan.utf_codepoint_list_function(*id).frame_layout(),
         ListFunctionId::Float(id) => plan.float_list_function(*id).frame_layout(),
         ListFunctionId::Bool(id) => plan.bool_list_function(*id).frame_layout(),
         ListFunctionId::Nil(id) => plan.nil_list_function(*id).frame_layout(),
@@ -831,6 +918,24 @@ pub(in crate::runtime) fn run_bit_array_function_returning_function_call(
         plan.bit_array_function_function(function).frame_layout(),
     )?;
     run_bit_array_function_loop(plan, state, function, frame)
+}
+
+pub(in crate::runtime) fn run_utf_codepoint_function_returning_function_call(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    function: UtfCodepointFunctionFunctionId,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<EvaluatedUtfCodepointFunction> {
+    let frame = bind_arguments(
+        plan,
+        state,
+        args,
+        caller_frame,
+        plan.utf_codepoint_function_function(function)
+            .frame_layout(),
+    )?;
+    run_utf_codepoint_function_loop(plan, state, function, frame)
 }
 
 pub(in crate::runtime) fn run_bool_function_returning_function_call(
@@ -1030,6 +1135,34 @@ pub(in crate::runtime) fn run_bit_array_function_function_call(
     run_bit_array_function_loop(plan, state, function_id, frame)
 }
 
+pub(in crate::runtime) fn run_utf_codepoint_function_function_call(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    function: &crate::plan::execution::FunctionFunctionExpr,
+    args: &[CallArg],
+    caller_frame: &mut Frame,
+) -> ExecutionResult<EvaluatedUtfCodepointFunction> {
+    let function = eval_function_function_expr(plan, state, caller_frame, function)?;
+    let runtime_id = function.runtime_id();
+    let function_id =
+        runtime_id
+            .utf_codepoint()
+            .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::UtfCodepoint,
+                actual: runtime_id.family(),
+            })?;
+    let runtime_function = plan.utf_codepoint_function_function(function_id);
+    let frame = bind_function_value_arguments(
+        plan,
+        state,
+        args,
+        caller_frame,
+        runtime_function.frame_layout(),
+        function.captures(),
+    )?;
+    run_utf_codepoint_function_loop(plan, state, function_id, frame)
+}
+
 pub(in crate::runtime) fn run_bool_function_function_call(
     plan: &ExecutionPlan,
     state: &mut RuntimeState,
@@ -1200,6 +1333,16 @@ fn run_function_returning_function_call(
             )
             .map(Into::into)
         }
+        crate::plan::execution::FunctionFunctionId::UtfCodepoint(function) => {
+            run_utf_codepoint_function_returning_function_call(
+                plan,
+                state,
+                function,
+                args,
+                caller_frame,
+            )
+            .map(Into::into)
+        }
         crate::plan::execution::FunctionFunctionId::Bool(function) => {
             run_bool_function_returning_function_call(plan, state, function, args, caller_frame)
                 .map(Into::into)
@@ -1231,18 +1374,35 @@ mod tests {
         run_function_function_loop, run_function_list_loop, run_int_function_loop,
         run_int_list_loop, run_list_function_loop, run_list_list_loop, run_nil_function_loop,
         run_nil_list_loop, run_string_function_loop, run_string_list_loop, run_tuple_function_loop,
-        run_tuple_list_loop,
+        run_tuple_list_loop, run_utf_codepoint_function_loop, run_utf_codepoint_list_loop,
     };
     use crate::plan::execution::{
         BoolFunctionFunctionId, CallArg, FloatFunctionFunctionId, FunctionFunctionFunctionId,
         FunctionFunctionId, FunctionFunctionLocalId, FunctionListLocalId, FunctionReturnFamily,
         IntFunctionFunctionId, IntFunctionId, ListFunctionFunctionId, ListFunctionId,
         NilFunctionFunctionId, ReturnBody, ReturnBodyKind, StringFunctionFunctionId,
-        StringFunctionId, TupleFunctionFunctionId,
+        StringFunctionId, TupleFunctionFunctionId, UtfCodepointFunctionFunctionId,
     };
     use crate::runtime::FunctionValueKind;
     use crate::runtime::frame::Frame;
     use crate::runtime::{ExecutionError, Value, run_main};
+
+    #[test]
+    fn source_utf_codepoint_list_function_calls_return_values_and_argument_errors() {
+        assert_eq!(
+            crate::runtime::run_src(include_str!(
+                "../../tests/fixtures/execution/values/utf_codepoint_list_function_paths.gleam"
+            )),
+            Value::Tuple(vec![Value::UtfCodepoint('A'); 6]),
+        );
+        assert_eq!(
+            crate::runtime::run_src_error(include_str!(
+                "../../tests/fixtures/execution_errors/functions/utf_codepoint_list_call_argument.gleam"
+            ))
+            .to_string(),
+            "panic: argument",
+        );
+    }
 
     #[test]
     fn primitive_function_value_calls_propagate_callee_and_argument_panics() {
@@ -1250,6 +1410,7 @@ mod tests {
             "pub fn main() -> Int { case True { True -> panic as \"callee\" False -> fn() { 0 } }() }",
             "pub fn main() -> String { case True { True -> panic as \"callee\" False -> fn() { \"\" } }() }",
             "pub fn main() -> BitArray { case True { True -> panic as \"callee\" False -> fn() { <<>> } }() }",
+            "pub fn main() -> UtfCodepoint { case True { True -> panic as \"callee\" False -> fn() { panic } }() }",
             "pub fn main() -> Float { case True { True -> panic as \"callee\" False -> fn() { 0.0 } }() }",
             "pub fn main() -> Bool { case True { True -> panic as \"callee\" False -> fn() { False } }() }",
             "pub fn main() -> Nil { case True { True -> panic as \"callee\" False -> fn() { Nil } }() }",
@@ -1259,6 +1420,7 @@ mod tests {
             "fn callee(value: Int) -> Int { value } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> String { \"value\" } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> BitArray { <<value>> } pub fn main() { let function = callee function(panic as \"argument\") }",
+            "fn callee(value: Int) -> UtfCodepoint { panic } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> Float { 1.0 } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> Bool { True } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> Nil { Nil } pub fn main() { let function = callee function(panic as \"argument\") }",
@@ -1285,6 +1447,7 @@ mod tests {
             "pub fn main() -> List(Int) { case True { True -> panic as \"callee\" False -> fn() { [] } }() }",
             "pub fn main() -> List(String) { case True { True -> panic as \"callee\" False -> fn() { [] } }() }",
             "pub fn main() -> List(BitArray) { case True { True -> panic as \"callee\" False -> fn() { [] } }() }",
+            "pub fn main() -> List(UtfCodepoint) { case True { True -> panic as \"callee\" False -> fn() { [] } }() }",
             "pub fn main() -> List(Float) { case True { True -> panic as \"callee\" False -> fn() { [] } }() }",
             "pub fn main() -> List(Bool) { case True { True -> panic as \"callee\" False -> fn() { [] } }() }",
             "pub fn main() -> List(Nil) { case True { True -> panic as \"callee\" False -> fn() { [] } }() }",
@@ -1307,6 +1470,7 @@ mod tests {
             "pub fn main() -> fn() -> Int { case True { True -> panic as \"callee\" False -> fn() { fn() { 0 } } }() }",
             "pub fn main() -> fn() -> String { case True { True -> panic as \"callee\" False -> fn() { fn() { \"\" } } }() }",
             "pub fn main() -> fn() -> BitArray { case True { True -> panic as \"callee\" False -> fn() { fn() { <<>> } } }() }",
+            "pub fn main() -> fn() -> UtfCodepoint { case True { True -> panic as \"callee\" False -> fn() { fn() { panic } } }() }",
             "pub fn main() -> fn() -> Float { case True { True -> panic as \"callee\" False -> fn() { fn() { 0.0 } } }() }",
             "pub fn main() -> fn() -> Bool { case True { True -> panic as \"callee\" False -> fn() { fn() { False } } }() }",
             "pub fn main() -> fn() -> Nil { case True { True -> panic as \"callee\" False -> fn() { fn() { Nil } } }() }",
@@ -1318,6 +1482,7 @@ mod tests {
             "fn callee(value: Int) -> fn() -> Int { fn() { value } } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> fn() -> String { fn() { \"value\" } } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> fn() -> BitArray { fn() { <<value>> } } pub fn main() { let function = callee function(panic as \"argument\") }",
+            "fn callee(value: Int) -> fn() -> UtfCodepoint { fn() { panic } } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> fn() -> Float { fn() { 1.0 } } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> fn() -> Bool { fn() { True } } pub fn main() { let function = callee function(panic as \"argument\") }",
             "fn callee(value: Int) -> fn() -> Nil { fn() { Nil } } pub fn main() { let function = callee function(panic as \"argument\") }",
@@ -1346,6 +1511,7 @@ mod tests {
             "fn callee(value: Int) -> Int { value } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> String { \"value\" } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> BitArray { <<value>> } pub fn main() { let _ = callee(panic) 0 }",
+            "fn callee(value: Int) -> UtfCodepoint { panic } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> Float { 1.0 } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> Bool { True } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> Nil { Nil } pub fn main() { let _ = callee(panic) 0 }",
@@ -1353,6 +1519,7 @@ mod tests {
             "fn callee(value: Int) -> List(Int) { [] } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> List(String) { [] } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> List(BitArray) { [] } pub fn main() { let _ = callee(panic) 0 }",
+            "fn callee(value: Int) -> List(UtfCodepoint) { [] } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> List(Float) { [] } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> List(Bool) { [] } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> List(Nil) { [] } pub fn main() { let _ = callee(panic) 0 }",
@@ -1407,6 +1574,7 @@ mod tests {
             "fn callee(value: Int) -> List(Int) { [] } pub fn main() { let function = callee function(panic) }",
             "fn callee(value: Int) -> List(String) { [] } pub fn main() { let function = callee function(panic) }",
             "fn callee(value: Int) -> List(BitArray) { [] } pub fn main() { let function = callee function(panic) }",
+            "fn callee(value: Int) -> List(UtfCodepoint) { [] } pub fn main() { let function = callee function(panic) }",
             "fn callee(value: Int) -> List(Float) { [] } pub fn main() { let function = callee function(panic) }",
             "fn callee(value: Int) -> List(Bool) { [] } pub fn main() { let function = callee function(panic) }",
             "fn callee(value: Int) -> List(Nil) { [] } pub fn main() { let function = callee function(panic) }",
@@ -1430,6 +1598,7 @@ mod tests {
 fn ints(function: fn() -> List(Int)) { function() }
 fn strings(function: fn() -> List(String)) { function() }
 fn bit_arrays(function: fn() -> List(BitArray)) { function() }
+fn utf_codepoints(function: fn() -> List(UtfCodepoint)) { function() }
 fn floats(function: fn() -> List(Float)) { function() }
 fn bools(function: fn() -> List(Bool)) { function() }
 fn nils(function: fn() -> List(Nil)) { function() }
@@ -1502,6 +1671,24 @@ pub fn main() { Nil }
         assert_eq!(
             run_bit_array_list_loop(&plan, &mut state, plan.bit_array_list_function_id(0), frame,)
                 .expect_err("direct-mutated list function family must fail"),
+            expected,
+        );
+
+        let function = plan.utf_codepoint_list_function(plan.utf_codepoint_list_function_id(0));
+        let mut state = crate::runtime::RuntimeState::new();
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        frame.set_list_function(
+            function.frame_layout().list_functions()[0].clone(),
+            wrong_int.clone(),
+        );
+        assert_eq!(
+            run_utf_codepoint_list_loop(
+                &plan,
+                &mut state,
+                plan.utf_codepoint_list_function_id(0),
+                frame,
+            )
+            .expect_err("direct-mutated list function family must fail"),
             expected,
         );
 
@@ -1590,6 +1777,7 @@ pub fn main() { Nil }
             "fn callee(value: Int) -> fn() -> Int { panic } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> fn() -> String { panic } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> fn() -> BitArray { panic } pub fn main() { let _ = callee(panic) 0 }",
+            "fn callee(value: Int) -> fn() -> UtfCodepoint { panic } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> fn() -> Float { panic } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> fn() -> Bool { panic } pub fn main() { let _ = callee(panic) 0 }",
             "fn callee(value: Int) -> fn() -> Nil { panic } pub fn main() { let _ = callee(panic) 0 }",
@@ -1613,6 +1801,7 @@ pub fn main() { Nil }
 fn int_function(provider: fn() -> fn() -> Int) { provider() }
 fn string_function(provider: fn() -> fn() -> String) { provider() }
 fn bit_array_function(provider: fn() -> fn() -> BitArray) { provider() }
+fn utf_codepoint_function(provider: fn() -> fn() -> UtfCodepoint) { provider() }
 fn float_function(provider: fn() -> fn() -> Float) { provider() }
 fn bool_function(provider: fn() -> fn() -> Bool) { provider() }
 fn nil_function(provider: fn() -> fn() -> Nil) { provider() }
@@ -1683,6 +1872,23 @@ pub fn main() { list_function }
             ),
             Err(ExecutionError::FunctionReturnFamilyMismatch {
                 expected: FunctionReturnFamily::BitArray,
+                actual: FunctionReturnFamily::Int,
+            }),
+        );
+
+        let function = plan.utf_codepoint_function_function(UtfCodepointFunctionFunctionId(0));
+        let mut state = crate::runtime::RuntimeState::new();
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        frame.set_function_function(FunctionFunctionLocalId(0), wrong_int.clone());
+        assert_eq!(
+            run_utf_codepoint_function_loop(
+                &plan,
+                &mut state,
+                UtfCodepointFunctionFunctionId(0),
+                frame,
+            ),
+            Err(ExecutionError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::UtfCodepoint,
                 actual: FunctionReturnFamily::Int,
             }),
         );
@@ -1771,6 +1977,9 @@ fn string_function(values: List(fn() -> String)) {
   case values { [value, ..] -> value _ -> panic }
 }
 fn bit_array_function(values: List(fn() -> BitArray)) {
+  case values { [value, ..] -> value _ -> panic }
+}
+fn utf_codepoint_function(values: List(fn() -> UtfCodepoint)) {
   case values { [value, ..] -> value _ -> panic }
 }
 fn float_function(values: List(fn() -> Float)) {
@@ -1867,6 +2076,27 @@ pub fn main() { list_function }
             ),
             Err(ExecutionError::FunctionReturnFamilyMismatch {
                 expected: FunctionReturnFamily::BitArray,
+                actual: FunctionReturnFamily::Int,
+            }),
+        );
+
+        let function = plan.utf_codepoint_function_function(UtfCodepointFunctionFunctionId(0));
+        let mut state = crate::runtime::RuntimeState::new();
+        let mut frame = Frame::new(function.frame_layout(), &mut state);
+        let value = state.function(
+            function.frame_layout().function_lists()[0],
+            vec![wrong_int.clone().into()],
+        );
+        frame.set_function_list(FunctionListLocalId(0), value);
+        assert_eq!(
+            run_utf_codepoint_function_loop(
+                &plan,
+                &mut state,
+                UtfCodepointFunctionFunctionId(0),
+                frame,
+            ),
+            Err(ExecutionError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::UtfCodepoint,
                 actual: FunctionReturnFamily::Int,
             }),
         );

--- a/src/runtime/function/bind.rs
+++ b/src/runtime/function/bind.rs
@@ -8,7 +8,8 @@ use crate::runtime::expression::{
     eval_int_function_expr, eval_int_list_expr, eval_list_function_expr, eval_list_list_expr,
     eval_nil_expr, eval_nil_function_expr, eval_nil_list_expr, eval_string_expr,
     eval_string_function_expr, eval_string_list_expr, eval_tuple_expr, eval_tuple_function_expr,
-    eval_tuple_list_expr,
+    eval_tuple_list_expr, eval_utf_codepoint_expr, eval_utf_codepoint_function_expr,
+    eval_utf_codepoint_list_expr,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::state::RuntimeState;
@@ -61,6 +62,10 @@ fn bind_arguments_into(
                 let value = eval_bit_array_expr(plan, state, caller_frame, value)?;
                 frame.set_bit_array(*local, value);
             }
+            CallArgKind::UtfCodepoint { local, value } => {
+                let value = eval_utf_codepoint_expr(plan, state, caller_frame, value)?;
+                frame.set_utf_codepoint(*local, value);
+            }
             CallArgKind::Float { local, value } => {
                 let value = eval_float_expr(plan, state, caller_frame, value)?;
                 frame.set_float(*local, value);
@@ -91,6 +96,10 @@ fn bind_arguments_into(
             CallArgKind::BitArrayFunction { local, value } => {
                 let value = eval_bit_array_function_expr(plan, state, caller_frame, value)?;
                 frame.set_bit_array_function(*local, value);
+            }
+            CallArgKind::UtfCodepointFunction { local, value } => {
+                let value = eval_utf_codepoint_function_expr(plan, state, caller_frame, value)?;
+                frame.set_utf_codepoint_function(*local, value);
             }
             CallArgKind::FloatFunction { local, value } => {
                 let value = eval_float_function_expr(plan, state, caller_frame, value)?;
@@ -140,6 +149,10 @@ pub(in crate::runtime) fn eval_capture_args(
             CaptureArgKind::BitArray { local, value } => {
                 EvaluatedCapture::bit_array(*local, eval_bit_array_expr(plan, state, frame, value)?)
             }
+            CaptureArgKind::UtfCodepoint { local, value } => EvaluatedCapture::utf_codepoint(
+                *local,
+                eval_utf_codepoint_expr(plan, state, frame, value)?,
+            ),
             CaptureArgKind::Float { local, value } => {
                 EvaluatedCapture::float(*local, eval_float_expr(plan, state, frame, value)?)
             }
@@ -166,6 +179,12 @@ pub(in crate::runtime) fn eval_capture_args(
                 EvaluatedCapture::bit_array_function(
                     *local,
                     eval_bit_array_function_expr(plan, state, frame, value)?,
+                )
+            }
+            CaptureArgKind::UtfCodepointFunction { local, value } => {
+                EvaluatedCapture::utf_codepoint_function(
+                    *local,
+                    eval_utf_codepoint_function_expr(plan, state, frame, value)?,
                 )
             }
             CaptureArgKind::FloatFunction { local, value } => EvaluatedCapture::float_function(
@@ -210,6 +229,9 @@ fn bind_captures(frame: &mut Frame, captures: &[EvaluatedCapture]) {
             EvaluatedCaptureKind::BitArray { local, value } => {
                 frame.set_bit_array(*local, value.clone())
             }
+            EvaluatedCaptureKind::UtfCodepoint { local, value } => {
+                frame.set_utf_codepoint(*local, *value)
+            }
             EvaluatedCaptureKind::Float { local, value } => frame.set_float(*local, *value),
             EvaluatedCaptureKind::Bool { local, value } => frame.set_bool(*local, *value),
             EvaluatedCaptureKind::Nil { local } => frame.set_nil(*local),
@@ -223,6 +245,9 @@ fn bind_captures(frame: &mut Frame, captures: &[EvaluatedCapture]) {
             }
             EvaluatedCaptureKind::BitArrayFunction { local, value } => {
                 frame.set_bit_array_function(*local, value.clone());
+            }
+            EvaluatedCaptureKind::UtfCodepointFunction { local, value } => {
+                frame.set_utf_codepoint_function(*local, value.clone());
             }
             EvaluatedCaptureKind::FloatFunction { local, value } => {
                 frame.set_float_function(*local, value.clone());
@@ -265,6 +290,10 @@ fn bind_list_argument(
         crate::plan::execution::ListLocalExpr::BitArray { local, value } => {
             let value = eval_bit_array_list_expr(plan, state, caller_frame, value)?;
             frame.set_bit_array_list(*local, value);
+        }
+        crate::plan::execution::ListLocalExpr::UtfCodepoint { local, value } => {
+            let value = eval_utf_codepoint_list_expr(plan, state, caller_frame, value)?;
+            frame.set_utf_codepoint_list(*local, value);
         }
         crate::plan::execution::ListLocalExpr::Float { local, value } => {
             let value = eval_float_list_expr(plan, state, caller_frame, value)?;
@@ -319,6 +348,12 @@ fn eval_list_capture(
                 value: eval_bit_array_list_expr(plan, state, frame, value)?,
             })
         }
+        crate::plan::execution::ListLocalExpr::UtfCodepoint { local, value } => {
+            EvaluatedCapture::list(EvaluatedListCapture::UtfCodepoint {
+                local: *local,
+                value: eval_utf_codepoint_list_expr(plan, state, frame, value)?,
+            })
+        }
         crate::plan::execution::ListLocalExpr::Float { local, value } => {
             EvaluatedCapture::list(EvaluatedListCapture::Float {
                 local: *local,
@@ -369,6 +404,9 @@ fn bind_list_capture(frame: &mut Frame, value: &EvaluatedListCapture) {
         EvaluatedListCapture::BitArray { local, value } => {
             frame.set_bit_array_list(*local, value.clone());
         }
+        EvaluatedListCapture::UtfCodepoint { local, value } => {
+            frame.set_utf_codepoint_list(*local, value.clone());
+        }
         EvaluatedListCapture::Float { local, value } => {
             frame.set_float_list(*local, value.clone());
         }
@@ -404,7 +442,9 @@ mod tests {
         NilFunctionLocalId, NilListExpr, NilListLocalId, NilLocalId, PanicExpr, PanicSite,
         ReturnExpr, StringExpr, StringFunctionExpr, StringFunctionLocalId, StringListExpr,
         StringListLocalId, StringLocalId, TupleExpr, TupleFunctionExpr, TupleFunctionLocalId,
-        TupleListExpr, TupleListLocalId, TupleLocalId, ValueType,
+        TupleListExpr, TupleListLocalId, TupleLocalId, UtfCodepointExpr, UtfCodepointFunctionExpr,
+        UtfCodepointFunctionLocalId, UtfCodepointListExpr, UtfCodepointListLocalId,
+        UtfCodepointLocalId, ValueType,
     };
     use crate::runtime::{ExecutionError, run_main};
 
@@ -565,6 +605,7 @@ pub fn main() {
             "Int",
             "String",
             "BitArray",
+            "UtfCodepoint",
             "Float",
             "Bool",
             "Nil",
@@ -572,6 +613,7 @@ pub fn main() {
             "List(Int)",
             "List(String)",
             "List(BitArray)",
+            "List(UtfCodepoint)",
             "List(Float)",
             "List(Bool)",
             "List(Nil)",
@@ -581,12 +623,14 @@ pub fn main() {
             "fn() -> Int",
             "fn() -> String",
             "fn() -> BitArray",
+            "fn() -> UtfCodepoint",
             "fn() -> Float",
             "fn() -> Bool",
             "fn() -> Nil",
             "fn() -> #(Int)",
             "fn() -> List(Int)",
             "fn() -> List(BitArray)",
+            "fn() -> List(UtfCodepoint)",
             "fn() -> fn() -> Int",
         ];
 
@@ -600,6 +644,37 @@ pub fn main() {
                 "panic: argument",
             );
         }
+    }
+
+    #[test]
+    fn source_utf_codepoint_scalar_list_and_function_captures_bind_exact_values() {
+        assert_eq!(
+            crate::runtime::run_src(
+                r#"
+fn codepoint() -> UtfCodepoint {
+  let assert <<value:utf8_codepoint>> = <<65>>
+  value
+}
+
+fn identity(value: UtfCodepoint) { value }
+
+pub fn main() {
+  let scalar = codepoint()
+  let values = [scalar]
+  let function = identity
+  let closure = fn() {
+    let assert [value] = values
+    case scalar == value {
+      True -> function(value)
+      False -> panic
+    }
+  }
+  closure()
+}
+"#,
+            ),
+            crate::runtime::Value::UtfCodepoint('A'),
+        );
     }
 
     #[test]
@@ -619,6 +694,7 @@ pub fn main() {
             CaptureArg::int(IntLocalId(0), IntExpr::panic(panic())),
             CaptureArg::string(StringLocalId(0), StringExpr::panic(panic())),
             CaptureArg::bit_array(BitArrayLocalId(0), BitArrayExpr::panic(panic())),
+            CaptureArg::utf_codepoint(UtfCodepointLocalId(0), UtfCodepointExpr::panic(panic())),
             CaptureArg::float(crate::plan::FloatLocalId(0), FloatExpr::panic(panic())),
             CaptureArg::bool(crate::plan::BoolLocalId(0), BoolExpr::panic(panic())),
             CaptureArg::nil(NilLocalId(0), NilExpr::panic(panic())),
@@ -637,6 +713,13 @@ pub fn main() {
             CaptureArg::list(ListLocalExpr::BitArray {
                 local: BitArrayListLocalId(0),
                 value: BitArrayListExpr::from(ListExpr::panic(panic(), ValueType::BitArray)),
+            }),
+            CaptureArg::list(ListLocalExpr::UtfCodepoint {
+                local: UtfCodepointListLocalId(0),
+                value: UtfCodepointListExpr::from(ListExpr::panic(
+                    panic(),
+                    ValueType::UtfCodepoint,
+                )),
             }),
             CaptureArg::list(ListLocalExpr::Float {
                 local: FloatListLocalId(0),
@@ -685,6 +768,10 @@ pub fn main() {
             CaptureArg::bit_array_function(
                 BitArrayFunctionLocalId(0),
                 BitArrayFunctionExpr::panic(panic(), function_type(ValueType::BitArray)),
+            ),
+            CaptureArg::utf_codepoint_function(
+                UtfCodepointFunctionLocalId(0),
+                UtfCodepointFunctionExpr::panic(panic(), function_type(ValueType::UtfCodepoint)),
             ),
             CaptureArg::float_function(
                 FloatFunctionLocalId(0),

--- a/src/runtime/function/return_body.rs
+++ b/src/runtime/function/return_body.rs
@@ -8,7 +8,8 @@ use crate::plan::execution::{
     IntFunctionId, IntListFunctionId, ListFunctionFunctionId, ListFunctionId, ListListFunctionId,
     NilFunctionFunctionId, NilFunctionId, NilListFunctionId, ReturnBody, ReturnBodyKind,
     StringFunctionFunctionId, StringFunctionId, StringListFunctionId, TupleFunctionFunctionId,
-    TupleFunctionId, TupleListFunctionId,
+    TupleFunctionId, TupleListFunctionId, UtfCodepointFunctionFunctionId, UtfCodepointFunctionId,
+    UtfCodepointListFunctionId,
 };
 use crate::runtime::error::ExecutionResult;
 use crate::runtime::expression::{
@@ -18,18 +19,19 @@ use crate::runtime::expression::{
     eval_int_function_expr, eval_int_list_expr, eval_list_function_expr, eval_list_list_expr,
     eval_nil_expr, eval_nil_function_expr, eval_nil_list_expr, eval_string_expr,
     eval_string_function_expr, eval_string_list_expr, eval_tuple_expr, eval_tuple_function_expr,
-    eval_tuple_list_expr,
+    eval_tuple_list_expr, eval_utf_codepoint_expr, eval_utf_codepoint_function_expr,
+    eval_utf_codepoint_list_expr,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::state::{
     BitArrayListValueId, BoolListValueId, FloatListValueId, FunctionListValueId, IntListValueId,
     ListListValueId, ListValueId, NilListValueId, RuntimeState, StringListValueId,
-    TupleListValueId,
+    TupleListValueId, UtfCodepointListValueId,
 };
 use crate::runtime::{
     EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedFloatFunction,
     EvaluatedFunctionFunction, EvaluatedIntFunction, EvaluatedListFunction, EvaluatedNilFunction,
-    EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedValue,
+    EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedUtfCodepointFunction, EvaluatedValue,
 };
 use ecow::EcoString;
 use num_bigint::BigInt;
@@ -250,6 +252,36 @@ pub(super) fn run_bit_array_loop(
     }
 }
 
+pub(super) fn run_utf_codepoint_loop(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    mut function: UtfCodepointFunctionId,
+    mut frame: Frame,
+) -> ExecutionResult<char> {
+    loop {
+        let runtime_function = plan.utf_codepoint_function(function);
+        execute_steps(plan, state, runtime_function.steps(), &mut frame)?;
+        let outcome = eval_return_body(
+            plan,
+            state,
+            &mut frame,
+            runtime_function.return_(),
+            eval_utf_codepoint_expr,
+        )?;
+        match outcome {
+            ReturnOutcome::Value(value) => return finish_return(state, frame, value),
+            ReturnOutcome::TailCall {
+                function: next,
+                args,
+            } => {
+                let frame_layout = plan.utf_codepoint_function(next).frame_layout();
+                frame = bind_tail_arguments(plan, state, args, frame, frame_layout)?;
+                function = next;
+            }
+        }
+    }
+}
+
 pub(super) fn run_bool_loop(
     plan: &ExecutionPlan,
     state: &mut RuntimeState,
@@ -340,6 +372,9 @@ pub(super) fn run_list_loop(
         }
         ListFunctionId::BitArray(function) => {
             run_bit_array_list_loop(plan, state, function, frame).map(Into::into)
+        }
+        ListFunctionId::UtfCodepoint(function) => {
+            run_utf_codepoint_list_loop(plan, state, function, frame).map(Into::into)
         }
         ListFunctionId::Float(function) => {
             run_float_list_loop(plan, state, function, frame).map(Into::into)
@@ -445,6 +480,36 @@ pub(super) fn run_bit_array_list_loop(
                 args,
             } => {
                 let frame_layout = plan.bit_array_list_function(next).frame_layout();
+                frame = bind_tail_arguments(plan, state, args, frame, frame_layout)?;
+                function = next;
+            }
+        }
+    }
+}
+
+pub(super) fn run_utf_codepoint_list_loop(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    mut function: UtfCodepointListFunctionId,
+    mut frame: Frame,
+) -> ExecutionResult<UtfCodepointListValueId> {
+    loop {
+        let runtime_function = plan.utf_codepoint_list_function(function);
+        execute_steps(plan, state, runtime_function.steps(), &mut frame)?;
+        let outcome = eval_return_body(
+            plan,
+            state,
+            &mut frame,
+            runtime_function.return_(),
+            eval_utf_codepoint_list_expr,
+        )?;
+        match outcome {
+            ReturnOutcome::Value(value) => return finish_return(state, frame, value),
+            ReturnOutcome::TailCall {
+                function: next,
+                args,
+            } => {
+                let frame_layout = plan.utf_codepoint_list_function(next).frame_layout();
                 frame = bind_tail_arguments(plan, state, args, frame, frame_layout)?;
                 function = next;
             }
@@ -737,6 +802,36 @@ pub(super) fn run_bit_array_function_loop(
     }
 }
 
+pub(super) fn run_utf_codepoint_function_loop(
+    plan: &ExecutionPlan,
+    state: &mut RuntimeState,
+    mut function: UtfCodepointFunctionFunctionId,
+    mut frame: Frame,
+) -> ExecutionResult<EvaluatedUtfCodepointFunction> {
+    loop {
+        let runtime_function = plan.utf_codepoint_function_function(function);
+        execute_steps(plan, state, runtime_function.steps(), &mut frame)?;
+        let outcome = eval_return_body(
+            plan,
+            state,
+            &mut frame,
+            runtime_function.return_(),
+            eval_utf_codepoint_function_expr,
+        )?;
+        match outcome {
+            ReturnOutcome::Value(value) => return finish_return(state, frame, value),
+            ReturnOutcome::TailCall {
+                function: next,
+                args,
+            } => {
+                let frame_layout = plan.utf_codepoint_function_function(next).frame_layout();
+                frame = bind_tail_arguments(plan, state, args, frame, frame_layout)?;
+                function = next;
+            }
+        }
+    }
+}
+
 pub(super) fn run_bool_function_loop(
     plan: &ExecutionPlan,
     state: &mut RuntimeState,
@@ -1002,6 +1097,30 @@ mod tests {
                 ),
                 Value::Int(20_000.into()),
             ),
+            (
+                r#"
+fn codepoint() -> UtfCodepoint { let assert <<value:utf8_codepoint>> = <<65>> value }
+fn recurse(count: Int) -> UtfCodepoint { case count { 0 -> codepoint() _ -> recurse(count - 1) } }
+pub fn main() { recurse(3) }
+"#,
+                Value::UtfCodepoint('A'),
+            ),
+            (
+                r#"
+fn codepoint() -> UtfCodepoint { let assert <<value:utf8_codepoint>> = <<65>> value }
+fn recurse(count: Int) -> List(UtfCodepoint) { case count { 0 -> [codepoint()] _ -> recurse(count - 1) } }
+pub fn main() { recurse(3) }
+"#,
+                Value::List(ListValue::utf_codepoint(vec!['A'])),
+            ),
+            (
+                r#"
+fn codepoint() -> UtfCodepoint { let assert <<value:utf8_codepoint>> = <<65>> value }
+fn recurse(count: Int) -> fn() -> UtfCodepoint { case count { 0 -> fn() { codepoint() } _ -> recurse(count - 1) } }
+pub fn main() { recurse(3)() }
+"#,
+                Value::UtfCodepoint('A'),
+            ),
         ];
 
         for (source, expected) in cases {
@@ -1015,6 +1134,7 @@ mod tests {
             ("Int", "0"),
             ("String", "\"\""),
             ("BitArray", "<<>>"),
+            ("UtfCodepoint", "panic"),
             ("Float", "0.0"),
             ("Bool", "False"),
             ("Nil", "Nil"),
@@ -1022,6 +1142,7 @@ mod tests {
             ("List(Int)", "[]"),
             ("List(String)", "[]"),
             ("List(BitArray)", "[]"),
+            ("List(UtfCodepoint)", "[]"),
             ("List(Float)", "[]"),
             ("List(Bool)", "[]"),
             ("List(Nil)", "[]"),
@@ -1031,6 +1152,7 @@ mod tests {
             ("fn() -> Int", "fn() { 0 }"),
             ("fn() -> String", "fn() { \"\" }"),
             ("fn() -> BitArray", "fn() { <<>> }"),
+            ("fn() -> UtfCodepoint", "fn() { panic }"),
             ("fn() -> Float", "fn() { 0.0 }"),
             ("fn() -> Bool", "fn() { False }"),
             ("fn() -> Nil", "fn() { Nil }"),
@@ -1057,6 +1179,7 @@ mod tests {
             "Int",
             "String",
             "BitArray",
+            "UtfCodepoint",
             "Float",
             "Bool",
             "Nil",
@@ -1064,6 +1187,7 @@ mod tests {
             "List(Int)",
             "List(String)",
             "List(BitArray)",
+            "List(UtfCodepoint)",
             "List(Float)",
             "List(Bool)",
             "List(Nil)",
@@ -1073,6 +1197,7 @@ mod tests {
             "fn() -> Int",
             "fn() -> String",
             "fn() -> BitArray",
+            "fn() -> UtfCodepoint",
             "fn() -> Float",
             "fn() -> Bool",
             "fn() -> Nil",
@@ -1129,6 +1254,8 @@ mod tests {
         let sources = [
             "pub fn main() -> List(Int) { panic }",
             "pub fn main() -> List(String) { panic }",
+            "pub fn main() -> List(BitArray) { panic }",
+            "pub fn main() -> List(UtfCodepoint) { panic }",
             "pub fn main() -> List(Float) { panic }",
             "pub fn main() -> List(Bool) { panic }",
             "pub fn main() -> List(Nil) { panic }",

--- a/src/runtime/function/steps.rs
+++ b/src/runtime/function/steps.rs
@@ -5,7 +5,7 @@ use crate::plan::execution::{
     BoolLocalId, FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocalId, IntFunctionLocalId,
     IntLocalId, ListAssertPattern, ListAssertTail, ListFunctionLocal, NilFunctionLocalId,
     NilLocalId, ParamLocal, StepKind, StringFunctionLocalId, StringLocalId, TupleFunctionLocalId,
-    TupleLocalId,
+    TupleLocalId, UtfCodepointFunctionLocalId, UtfCodepointLocalId,
 };
 use crate::runtime::error::ExecutionResult;
 use crate::runtime::expression::{
@@ -15,7 +15,8 @@ use crate::runtime::expression::{
     eval_function_list_expr, eval_int_expr, eval_int_function_expr, eval_int_list_expr,
     eval_list_function_expr, eval_list_list_expr, eval_nil_expr, eval_nil_function_expr,
     eval_nil_list_expr, eval_string_expr, eval_string_function_expr, eval_string_list_expr,
-    eval_tuple_expr, eval_tuple_function_expr, eval_tuple_list_expr, get_list_value,
+    eval_tuple_expr, eval_tuple_function_expr, eval_tuple_list_expr, eval_utf_codepoint_expr,
+    eval_utf_codepoint_function_expr, eval_utf_codepoint_list_expr, get_list_value,
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::state::{ListValueId, RuntimeState};
@@ -23,7 +24,7 @@ use crate::runtime::{
     EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedFloatFunction,
     EvaluatedFunctionFunction, EvaluatedFunctionValue, EvaluatedFunctionValueKind,
     EvaluatedIntFunction, EvaluatedListCapture, EvaluatedListFunction, EvaluatedNilFunction,
-    EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedValue,
+    EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedUtfCodepointFunction, EvaluatedValue,
 };
 use crate::runtime::{ExecutionError, PanicKind};
 use ecow::EcoString;
@@ -48,6 +49,10 @@ pub(in crate::runtime) fn execute_steps(
             StepKind::LetBitArray { local, value, .. } => {
                 let value = eval_bit_array_expr(plan, state, frame, value)?;
                 frame.set_bit_array(*local, value);
+            }
+            StepKind::LetUtfCodepoint { local, value, .. } => {
+                let value = eval_utf_codepoint_expr(plan, state, frame, value)?;
+                frame.set_utf_codepoint(*local, value);
             }
             StepKind::LetFloat { local, value, .. } => {
                 let value = eval_float_expr(plan, state, frame, value)?;
@@ -77,6 +82,10 @@ pub(in crate::runtime) fn execute_steps(
             StepKind::LetBitArrayFunction { local, value, .. } => {
                 let value = eval_bit_array_function_expr(plan, state, frame, value)?;
                 frame.set_bit_array_function(*local, value);
+            }
+            StepKind::LetUtfCodepointFunction { local, value, .. } => {
+                let value = eval_utf_codepoint_function_expr(plan, state, frame, value)?;
+                frame.set_utf_codepoint_function(*local, value);
             }
             StepKind::LetFloatFunction { local, value, .. } => {
                 let value = eval_float_function_expr(plan, state, frame, value)?;
@@ -214,6 +223,7 @@ enum PendingBinding {
     Float(FloatLocalId, f64),
     String(StringLocalId, EcoString),
     BitArray(BitArrayLocalId, EvaluatedBitArray),
+    UtfCodepoint(UtfCodepointLocalId, char),
     Bool(BoolLocalId, bool),
     Nil(NilLocalId),
     Tuple(TupleLocalId, Vec<EvaluatedValue>),
@@ -222,6 +232,7 @@ enum PendingBinding {
     FloatFunction(FloatFunctionLocalId, EvaluatedFloatFunction),
     StringFunction(StringFunctionLocalId, EvaluatedStringFunction),
     BitArrayFunction(BitArrayFunctionLocalId, EvaluatedBitArrayFunction),
+    UtfCodepointFunction(UtfCodepointFunctionLocalId, EvaluatedUtfCodepointFunction),
     BoolFunction(BoolFunctionLocalId, EvaluatedBoolFunction),
     NilFunction(NilFunctionLocalId, EvaluatedNilFunction),
     TupleFunction(TupleFunctionLocalId, EvaluatedTupleFunction),
@@ -345,6 +356,9 @@ fn pending_binding(
         (ParamLocal::BitArray(local), EvaluatedValue::BitArray(value)) => {
             Some(PendingBinding::BitArray(*local, value.clone()))
         }
+        (ParamLocal::UtfCodepoint(local), EvaluatedValue::UtfCodepoint(value)) => {
+            Some(PendingBinding::UtfCodepoint(*local, *value))
+        }
         (ParamLocal::Bool(local), EvaluatedValue::Bool(value)) => {
             Some(PendingBinding::Bool(*local, *value))
         }
@@ -390,6 +404,10 @@ fn pending_function_binding(
             ParamLocal::BitArrayFunction { local, .. },
             EvaluatedFunctionValueKind::BitArray(value),
         ) => Some(PendingBinding::BitArrayFunction(*local, value.clone())),
+        (
+            ParamLocal::UtfCodepointFunction { local, .. },
+            EvaluatedFunctionValueKind::UtfCodepoint(value),
+        ) => Some(PendingBinding::UtfCodepointFunction(*local, value.clone())),
         (ParamLocal::BoolFunction { local, .. }, EvaluatedFunctionValueKind::Bool(value)) => {
             Some(PendingBinding::BoolFunction(*local, value.clone()))
         }
@@ -425,6 +443,10 @@ fn pending_list_binding(
             crate::plan::execution::ListLocal::BitArray { local, .. },
             ListValueId::BitArray(value),
         ) => Some(EvaluatedListCapture::BitArray { local, value }),
+        (
+            crate::plan::execution::ListLocal::UtfCodepoint { local, .. },
+            ListValueId::UtfCodepoint(value),
+        ) => Some(EvaluatedListCapture::UtfCodepoint { local, value }),
         (crate::plan::execution::ListLocal::Float { local, .. }, ListValueId::Float(value)) => {
             Some(EvaluatedListCapture::Float { local, value })
         }
@@ -454,6 +476,7 @@ fn frame_set_binding(frame: &mut Frame, binding: PendingBinding) {
         PendingBinding::Float(local, value) => frame.set_float(local, value),
         PendingBinding::String(local, value) => frame.set_string(local, value),
         PendingBinding::BitArray(local, value) => frame.set_bit_array(local, value),
+        PendingBinding::UtfCodepoint(local, value) => frame.set_utf_codepoint(local, value),
         PendingBinding::Bool(local, value) => frame.set_bool(local, value),
         PendingBinding::Nil(local) => frame.set_nil(local),
         PendingBinding::Tuple(local, value) => frame.set_tuple(local, value),
@@ -463,6 +486,9 @@ fn frame_set_binding(frame: &mut Frame, binding: PendingBinding) {
         PendingBinding::StringFunction(local, value) => frame.set_string_function(local, value),
         PendingBinding::BitArrayFunction(local, value) => {
             frame.set_bit_array_function(local, value)
+        }
+        PendingBinding::UtfCodepointFunction(local, value) => {
+            frame.set_utf_codepoint_function(local, value)
         }
         PendingBinding::BoolFunction(local, value) => frame.set_bool_function(local, value),
         PendingBinding::NilFunction(local, value) => frame.set_nil_function(local, value),
@@ -492,6 +518,10 @@ fn execute_let_list(
         crate::plan::execution::ListLocalExpr::BitArray { local, value } => {
             let value = eval_bit_array_list_expr(plan, state, frame, value)?;
             frame.set_bit_array_list(*local, value);
+        }
+        crate::plan::execution::ListLocalExpr::UtfCodepoint { local, value } => {
+            let value = eval_utf_codepoint_list_expr(plan, state, frame, value)?;
+            frame.set_utf_codepoint_list(*local, value);
         }
         crate::plan::execution::ListLocalExpr::Float { local, value } => {
             let value = eval_float_list_expr(plan, state, frame, value)?;
@@ -526,6 +556,9 @@ fn frame_set_list_binding(frame: &mut Frame, value: EvaluatedListCapture) {
         EvaluatedListCapture::Int { local, value } => frame.set_int_list(local, value),
         EvaluatedListCapture::String { local, value } => frame.set_string_list(local, value),
         EvaluatedListCapture::BitArray { local, value } => frame.set_bit_array_list(local, value),
+        EvaluatedListCapture::UtfCodepoint { local, value } => {
+            frame.set_utf_codepoint_list(local, value)
+        }
         EvaluatedListCapture::Float { local, value } => frame.set_float_list(local, value),
         EvaluatedListCapture::Bool { local, value } => frame.set_bool_list(local, value),
         EvaluatedListCapture::Nil { local, value } => frame.set_nil_list(local, value),
@@ -631,6 +664,10 @@ mod tests {
             ("Int", "1"),
             ("String", "\"one\""),
             ("BitArray", "<<1>>"),
+            (
+                "UtfCodepoint",
+                "{ let assert <<value:utf8_codepoint>> = <<65>> value }",
+            ),
             ("Float", "1.0"),
             ("Bool", "True"),
             ("Nil", "Nil"),
@@ -656,6 +693,29 @@ pub fn main() {{
                 crate::runtime::Value::Int(42.into()),
             );
         }
+    }
+
+    #[test]
+    fn let_assert_binds_utf_codepoint_list_elements_and_tails() {
+        assert_eq!(
+            crate::runtime::run_src(
+                r#"
+fn codepoint() -> UtfCodepoint {
+  let assert <<value:utf8_codepoint>> = <<65>>
+  value
+}
+
+pub fn main() {
+  let assert [value, ..rest] = [codepoint(), codepoint()]
+  #(value, rest)
+}
+"#,
+            ),
+            crate::runtime::Value::Tuple(vec![
+                crate::runtime::Value::UtfCodepoint('A'),
+                crate::runtime::Value::List(crate::runtime::ListValue::utf_codepoint(vec!['A'])),
+            ]),
+        );
     }
 
     #[test]
@@ -702,6 +762,7 @@ pub fn main() {{
             "Int",
             "String",
             "BitArray",
+            "UtfCodepoint",
             "Float",
             "Bool",
             "Nil",
@@ -709,6 +770,7 @@ pub fn main() {{
             "List(Int)",
             "List(String)",
             "List(BitArray)",
+            "List(UtfCodepoint)",
             "List(Float)",
             "List(Bool)",
             "List(Nil)",
@@ -718,12 +780,14 @@ pub fn main() {{
             "fn() -> Int",
             "fn() -> String",
             "fn() -> BitArray",
+            "fn() -> UtfCodepoint",
             "fn() -> Float",
             "fn() -> Bool",
             "fn() -> Nil",
             "fn() -> #(Int)",
             "fn() -> List(Int)",
             "fn() -> List(BitArray)",
+            "fn() -> List(UtfCodepoint)",
             "fn() -> fn() -> Int",
         ];
 

--- a/src/runtime/materialize.rs
+++ b/src/runtime/materialize.rs
@@ -2,13 +2,15 @@ use super::evaluated::{
     EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedCapture, EvaluatedCaptureKind,
     EvaluatedFloatFunction, EvaluatedFunctionFunction, EvaluatedFunctionValue,
     EvaluatedFunctionValueKind, EvaluatedIntFunction, EvaluatedListCapture, EvaluatedListFunction,
-    EvaluatedNilFunction, EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedValue,
+    EvaluatedNilFunction, EvaluatedStringFunction, EvaluatedTupleFunction,
+    EvaluatedUtfCodepointFunction, EvaluatedValue,
 };
 use super::state::{ListValueId, RuntimeState};
 use super::{
     BitArrayFunctionValue, BitArrayValue, BoolFunctionValue, CaptureListValue, CaptureValue,
     FloatFunctionValue, FunctionFunctionValue, FunctionValue, FunctionValueKind, IntFunctionValue,
-    ListFunctionValue, ListValue, NilFunctionValue, StringFunctionValue, TupleFunctionValue, Value,
+    ListFunctionValue, ListValue, NilFunctionValue, StringFunctionValue, TupleFunctionValue,
+    UtfCodepointFunctionValue, Value,
 };
 use crate::plan::execution::ExecutionPlan;
 
@@ -20,6 +22,7 @@ pub(super) fn value(plan: &ExecutionPlan, state: &RuntimeState, value: Evaluated
         EvaluatedValue::BitArray(value) => {
             Value::BitArray(BitArrayValue::from_evaluated(value.bits()))
         }
+        EvaluatedValue::UtfCodepoint(value) => Value::UtfCodepoint(value),
         EvaluatedValue::Bool(value) => Value::Bool(value),
         EvaluatedValue::Nil => Value::Nil,
         EvaluatedValue::Tuple(values) => Value::Tuple(
@@ -44,6 +47,9 @@ fn list(plan: &ExecutionPlan, state: &RuntimeState, value: &ListValueId) -> List
                 .map(|value| BitArrayValue::from_evaluated(value.bits()))
                 .collect(),
         ),
+        ListValueId::UtfCodepoint(value) => {
+            ListValue::utf_codepoint(state.utf_codepoint_values(value).to_vec())
+        }
         ListValueId::Float(value) => ListValue::float(state.float_values(value).to_vec()),
         ListValueId::Bool(value) => ListValue::bool(state.bool_values(value).to_vec()),
         ListValueId::Nil(value) => ListValue::nil(state.nil_len(value)),
@@ -105,6 +111,9 @@ fn function(
         }
         EvaluatedFunctionValueKind::BitArray(value) => {
             FunctionValueKind::BitArray(bit_array_function(plan, state, value))
+        }
+        EvaluatedFunctionValueKind::UtfCodepoint(value) => {
+            FunctionValueKind::UtfCodepoint(utf_codepoint_function(plan, state, value))
         }
         EvaluatedFunctionValueKind::Bool(value) => {
             FunctionValueKind::Bool(bool_function(plan, state, value))
@@ -170,6 +179,19 @@ fn bit_array_function(
     value: &EvaluatedBitArrayFunction,
 ) -> BitArrayFunctionValue {
     BitArrayFunctionValue::new_with_captures(
+        value.runtime_id(),
+        value.params().to_vec(),
+        captures(plan, state, value.captures()),
+        plan.function_type(value.type_()),
+    )
+}
+
+fn utf_codepoint_function(
+    plan: &ExecutionPlan,
+    state: &RuntimeState,
+    value: &EvaluatedUtfCodepointFunction,
+) -> UtfCodepointFunctionValue {
+    UtfCodepointFunctionValue::new_with_captures(
         value.runtime_id(),
         value.params().to_vec(),
         captures(plan, state, value.captures()),
@@ -282,6 +304,9 @@ fn capture(plan: &ExecutionPlan, state: &RuntimeState, value: &EvaluatedCapture)
         EvaluatedCaptureKind::BitArray { local, value } => {
             CaptureValue::bit_array(*local, BitArrayValue::from_evaluated(value.bits()))
         }
+        EvaluatedCaptureKind::UtfCodepoint { local, value } => {
+            CaptureValue::utf_codepoint(*local, *value)
+        }
         EvaluatedCaptureKind::Bool { local, value } => CaptureValue::bool(*local, *value),
         EvaluatedCaptureKind::Nil { local } => CaptureValue::nil(*local),
         EvaluatedCaptureKind::Tuple { local, value } => CaptureValue::tuple(
@@ -304,6 +329,9 @@ fn capture(plan: &ExecutionPlan, state: &RuntimeState, value: &EvaluatedCapture)
         }
         EvaluatedCaptureKind::BitArrayFunction { local, value } => {
             CaptureValue::bit_array_function(*local, bit_array_function(plan, state, value))
+        }
+        EvaluatedCaptureKind::UtfCodepointFunction { local, value } => {
+            CaptureValue::utf_codepoint_function(*local, utf_codepoint_function(plan, state, value))
         }
         EvaluatedCaptureKind::BoolFunction { local, value } => {
             CaptureValue::bool_function(*local, bool_function(plan, state, value))
@@ -344,6 +372,10 @@ fn list_capture(
                 .iter()
                 .map(|value| BitArrayValue::from_evaluated(value.bits()))
                 .collect(),
+        },
+        EvaluatedListCapture::UtfCodepoint { local, value } => CaptureListValue::UtfCodepoint {
+            local: *local,
+            value: state.utf_codepoint_values(value).to_vec(),
         },
         EvaluatedListCapture::Float { local, value } => CaptureListValue::Float {
             local: *local,
@@ -402,13 +434,16 @@ mod tests {
         ListFunctionLocal, ListListLocalId, NilFunctionId, NilFunctionLocalId, NilListLocalId,
         NilLocalId, StringFunctionId, StringFunctionLocalId, StringListLocalId, StringLocalId,
         TupleFunctionId, TupleFunctionLocalId, TupleListLocalId, TupleLocalId,
+        UtfCodepointFunctionId, UtfCodepointFunctionLocalId, UtfCodepointListLocalId,
+        UtfCodepointLocalId,
     };
     use crate::plan::{FunctionType, ValueType};
     use crate::runtime::evaluated::{
         EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedCapture,
         EvaluatedFloatFunction, EvaluatedFunctionFunction, EvaluatedFunctionValue,
         EvaluatedIntFunction, EvaluatedListCapture, EvaluatedListFunction, EvaluatedNilFunction,
-        EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedValue,
+        EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedUtfCodepointFunction,
+        EvaluatedValue,
     };
     use crate::runtime::state::{ListValueId, RuntimeState};
     use crate::runtime::{BitArrayValue, CaptureListValue, CaptureValue, ListValue, Value};
@@ -418,6 +453,7 @@ mod tests {
 fn ints() -> List(Int) { [] }
 fn strings() -> List(String) { [] }
 fn bit_arrays() -> List(BitArray) { [] }
+fn utf_codepoints() -> List(UtfCodepoint) { [] }
 fn floats() -> List(Float) { [] }
 fn bools() -> List(Bool) { [] }
 fn nils() -> List(Nil) { [] }
@@ -450,6 +486,10 @@ pub fn main() { 0 }
             plan.bit_array_list_function_id(0).type_id(),
             vec![bit_array.clone()],
         );
+        let utf_codepoint_list = state.utf_codepoint(
+            plan.utf_codepoint_list_function_id(0).type_id(),
+            vec!['\u{10ffff}'],
+        );
         let float_list = state.float(plan.float_list_function_id(0).type_id(), vec![1.5]);
         let bool_list = state.bool(plan.bool_list_function_id(0).type_id(), vec![true]);
         let nil_list = state.nil(plan.nil_list_function_id(0).type_id(), 1);
@@ -475,12 +515,14 @@ pub fn main() { 0 }
                 EvaluatedValue::Float(1.5),
                 EvaluatedValue::String("one".into()),
                 EvaluatedValue::BitArray(bit_array),
+                EvaluatedValue::UtfCodepoint('\u{10ffff}'),
                 EvaluatedValue::Bool(true),
                 EvaluatedValue::Nil,
                 EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
                 EvaluatedValue::List(ListValueId::Int(int_list)),
                 EvaluatedValue::List(ListValueId::String(string_list)),
                 EvaluatedValue::List(ListValueId::BitArray(bit_array_list)),
+                EvaluatedValue::List(ListValueId::UtfCodepoint(utf_codepoint_list)),
                 EvaluatedValue::List(ListValueId::Float(float_list)),
                 EvaluatedValue::List(ListValueId::Bool(bool_list)),
                 EvaluatedValue::List(ListValueId::Nil(nil_list)),
@@ -497,6 +539,7 @@ pub fn main() { 0 }
                 Value::Float(1.5),
                 Value::String("one".into()),
                 Value::BitArray(BitArrayValue::from_bytes(vec![1])),
+                Value::UtfCodepoint('\u{10ffff}'),
                 Value::Bool(true),
                 Value::Nil,
                 Value::Tuple(vec![Value::Int(1.into())]),
@@ -505,6 +548,7 @@ pub fn main() { 0 }
                 Value::List(ListValue::bit_array(vec![BitArrayValue::from_bytes(vec![
                     1
                 ])])),
+                Value::List(ListValue::utf_codepoint(vec!['\u{10ffff}'])),
                 Value::List(ListValue::float(vec![1.5])),
                 Value::List(ListValue::bool(vec![true])),
                 Value::List(ListValue::nil(1)),
@@ -570,6 +614,15 @@ pub fn main() { 0 }
                 crate::plan::execution::ValueType::BitArray,
             ),
         );
+        let utf_codepoint_function = EvaluatedUtfCodepointFunction::new(
+            UtfCodepointFunctionId(0),
+            Vec::new(),
+            Vec::new(),
+            crate::plan::execution::FunctionType::new(
+                Vec::new(),
+                crate::plan::execution::ValueType::UtfCodepoint,
+            ),
+        );
         let bool_function = EvaluatedBoolFunction::new(
             BoolFunctionId(0),
             Vec::new(),
@@ -630,6 +683,10 @@ pub fn main() { 0 }
             plan.bit_array_list_function_id(0).type_id(),
             vec![bit_array.clone()],
         );
+        let utf_codepoint_list = state.utf_codepoint(
+            plan.utf_codepoint_list_function_id(0).type_id(),
+            vec!['\u{10ffff}'],
+        );
         let float_list = state.float(plan.float_list_function_id(0).type_id(), vec![1.5]);
         let bool_list = state.bool(plan.bool_list_function_id(0).type_id(), vec![true]);
         let nil_list = state.nil(plan.nil_list_function_id(0).type_id(), 1);
@@ -657,6 +714,7 @@ pub fn main() { 0 }
             EvaluatedCapture::float(FloatLocalId(0), 1.5),
             EvaluatedCapture::string(StringLocalId(0), "one".into()),
             EvaluatedCapture::bit_array(BitArrayLocalId(0), bit_array),
+            EvaluatedCapture::utf_codepoint(UtfCodepointLocalId(0), '\u{10ffff}'),
             EvaluatedCapture::bool(BoolLocalId(0), true),
             EvaluatedCapture::nil(NilLocalId(0)),
             EvaluatedCapture::tuple(TupleLocalId(0), vec![EvaluatedValue::Int(1.into())]),
@@ -671,6 +729,10 @@ pub fn main() { 0 }
             EvaluatedCapture::list(EvaluatedListCapture::BitArray {
                 local: BitArrayListLocalId(0),
                 value: bit_array_list,
+            }),
+            EvaluatedCapture::list(EvaluatedListCapture::UtfCodepoint {
+                local: UtfCodepointListLocalId(0),
+                value: utf_codepoint_list,
             }),
             EvaluatedCapture::list(EvaluatedListCapture::Float {
                 local: FloatListLocalId(0),
@@ -703,6 +765,10 @@ pub fn main() { 0 }
                 BitArrayFunctionLocalId(0),
                 bit_array_function.clone(),
             ),
+            EvaluatedCapture::utf_codepoint_function(
+                UtfCodepointFunctionLocalId(0),
+                utf_codepoint_function.clone(),
+            ),
             EvaluatedCapture::bool_function(BoolFunctionLocalId(0), bool_function.clone()),
             EvaluatedCapture::nil_function(NilFunctionLocalId(0), nil_function.clone()),
             EvaluatedCapture::tuple_function(TupleFunctionLocalId(0), tuple_function.clone()),
@@ -717,6 +783,7 @@ pub fn main() { 0 }
             CaptureValue::float(FloatLocalId(0), 1.5),
             CaptureValue::string(StringLocalId(0), "one".into()),
             CaptureValue::bit_array(BitArrayLocalId(0), BitArrayValue::from_bytes(vec![1])),
+            CaptureValue::utf_codepoint(UtfCodepointLocalId(0), '\u{10ffff}'),
             CaptureValue::bool(BoolLocalId(0), true),
             CaptureValue::nil(NilLocalId(0)),
             CaptureValue::tuple(TupleLocalId(0), vec![Value::Int(1.into())]),
@@ -731,6 +798,10 @@ pub fn main() { 0 }
             CaptureValue::list(CaptureListValue::BitArray {
                 local: BitArrayListLocalId(0),
                 value: vec![BitArrayValue::from_bytes(vec![1])],
+            }),
+            CaptureValue::list(CaptureListValue::UtfCodepoint {
+                local: UtfCodepointListLocalId(0),
+                value: vec!['\u{10ffff}'],
             }),
             CaptureValue::list(CaptureListValue::Float {
                 local: FloatListLocalId(0),
@@ -798,6 +869,15 @@ pub fn main() { 0 }
                     FunctionType::new(Vec::new(), ValueType::BitArray),
                 ),
             ),
+            CaptureValue::utf_codepoint_function(
+                UtfCodepointFunctionLocalId(0),
+                crate::runtime::UtfCodepointFunctionValue::new_with_captures(
+                    UtfCodepointFunctionId(0),
+                    Vec::new(),
+                    Vec::new(),
+                    FunctionType::new(Vec::new(), ValueType::UtfCodepoint),
+                ),
+            ),
             CaptureValue::bool_function(
                 BoolFunctionLocalId(0),
                 crate::runtime::BoolFunctionValue::new_with_captures(
@@ -854,6 +934,7 @@ pub fn main() { 0 }
             EvaluatedFunctionValue::from(float_function),
             EvaluatedFunctionValue::from(string_function),
             EvaluatedFunctionValue::from(bit_array_function),
+            EvaluatedFunctionValue::from(utf_codepoint_function),
             EvaluatedFunctionValue::from(bool_function),
             EvaluatedFunctionValue::from(nil_function),
             EvaluatedFunctionValue::from(tuple_function),

--- a/src/runtime/pattern/bit_array.rs
+++ b/src/runtime/pattern/bit_array.rs
@@ -2,7 +2,6 @@ use bitvec::order::Msb0;
 use bitvec::slice::BitSlice;
 use bitvec::vec::BitVec;
 use bitvec::view::BitView;
-use ecow::EcoString;
 use num_bigint::BigInt;
 
 use crate::plan::execution::{
@@ -61,6 +60,9 @@ pub(in crate::runtime) fn match_bit_array_pattern(
             ),
             BitArrayPatternSegment::String { pattern, encoding } => {
                 match_string_segment(subject.bits(), &mut cursor, pattern, *encoding)
+            }
+            BitArrayPatternSegment::UtfCodepoint { pattern, encoding } => {
+                match_utf_codepoint_segment(frame, subject.bits(), &mut cursor, pattern, *encoding)
             }
         };
         if !matched {
@@ -165,13 +167,28 @@ fn match_string_segment(
             true
         }
         BitArrayStringPattern::Discard => {
-            let Some((_, bit_size)) = decode_one_string(&subject[*cursor..], encoding) else {
+            let Some((_, bit_size)) = decode_codepoint(&subject[*cursor..], encoding) else {
                 return false;
             };
             *cursor += bit_size;
             true
         }
     }
+}
+
+fn match_utf_codepoint_segment(
+    frame: &mut Frame,
+    subject: &BitSlice<u8, Msb0>,
+    cursor: &mut usize,
+    pattern: &BitArrayBindingPattern<crate::plan::execution::UtfCodepointLocalId>,
+    encoding: StringEncoding,
+) -> bool {
+    let Some((value, bit_size)) = decode_codepoint(&subject[*cursor..], encoding) else {
+        return false;
+    };
+    *cursor += bit_size;
+    bind_utf_codepoint_pattern(frame, pattern, value);
+    true
 }
 
 fn eval_size(frame: &Frame, size: &BitArrayPatternSize) -> Option<usize> {
@@ -328,10 +345,7 @@ fn encode_string(value: &str, encoding: StringEncoding) -> BitVec<u8, Msb0> {
     bits
 }
 
-fn decode_one_string(
-    bits: &BitSlice<u8, Msb0>,
-    encoding: StringEncoding,
-) -> Option<(EcoString, usize)> {
+fn decode_codepoint(bits: &BitSlice<u8, Msb0>, encoding: StringEncoding) -> Option<(char, usize)> {
     match encoding {
         StringEncoding::Utf8 => decode_utf8(bits),
         StringEncoding::Utf16(endianness) => decode_utf16(bits, endianness),
@@ -339,7 +353,7 @@ fn decode_one_string(
     }
 }
 
-fn decode_utf8(bits: &BitSlice<u8, Msb0>) -> Option<(EcoString, usize)> {
+fn decode_utf8(bits: &BitSlice<u8, Msb0>) -> Option<(char, usize)> {
     let first = read_byte(bits, 0)?;
     let bytes = match first {
         0x00..=0x7f => 1,
@@ -355,10 +369,10 @@ fn decode_utf8(bits: &BitSlice<u8, Msb0>) -> Option<(EcoString, usize)> {
     let Ok(value) = std::str::from_utf8(&encoded) else {
         return None;
     };
-    Some((value.into(), bytes * 8))
+    value.chars().next().map(|character| (character, bytes * 8))
 }
 
-fn decode_utf16(bits: &BitSlice<u8, Msb0>, endianness: Endianness) -> Option<(EcoString, usize)> {
+fn decode_utf16(bits: &BitSlice<u8, Msb0>, endianness: Endianness) -> Option<(char, usize)> {
     let first = read_u16(bits, 0, endianness)?;
     let (codepoint, bit_size) = if (0xd800..=0xdbff).contains(&first) {
         let second = read_u16(bits, 16, endianness)?;
@@ -372,10 +386,10 @@ fn decode_utf16(bits: &BitSlice<u8, Msb0>, endianness: Endianness) -> Option<(Ec
         (u32::from(first), 16)
     };
     let character = char::from_u32(codepoint)?;
-    Some((character.to_string().into(), bit_size))
+    Some((character, bit_size))
 }
 
-fn decode_utf32(bits: &BitSlice<u8, Msb0>, endianness: Endianness) -> Option<(EcoString, usize)> {
+fn decode_utf32(bits: &BitSlice<u8, Msb0>, endianness: Endianness) -> Option<(char, usize)> {
     let bytes = [
         read_byte(bits, 0)?,
         read_byte(bits, 8)?,
@@ -386,7 +400,7 @@ fn decode_utf32(bits: &BitSlice<u8, Msb0>, endianness: Endianness) -> Option<(Ec
         Endianness::Big => u32::from_be_bytes(bytes),
         Endianness::Little => u32::from_le_bytes(bytes),
     };
-    Some((char::from_u32(value)?.to_string().into(), 32))
+    Some((char::from_u32(value)?, 32))
 }
 
 fn read_u16(bits: &BitSlice<u8, Msb0>, offset: usize, endianness: Endianness) -> Option<u16> {
@@ -468,6 +482,23 @@ fn bind_bits_pattern(
     }
 }
 
+fn bind_utf_codepoint_pattern(
+    frame: &mut Frame,
+    pattern: &BitArrayBindingPattern<crate::plan::execution::UtfCodepointLocalId>,
+    value: char,
+) {
+    match pattern {
+        BitArrayBindingPattern::Bind(binding) => {
+            frame.set_utf_codepoint(*binding.local(), value);
+        }
+        BitArrayBindingPattern::Discard => {}
+        BitArrayBindingPattern::Alias { pattern, binding } => {
+            bind_utf_codepoint_pattern(frame, pattern, value);
+            frame.set_utf_codepoint(*binding.local(), value);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -524,6 +555,22 @@ pub fn main() {
       <<_:utf8>> -> True
       _ -> False
     },
+    case <<65>> {
+      <<value:utf8_codepoint>> -> value
+      _ -> panic
+    },
+    case <<65>> {
+      <<_ as alias:utf8_codepoint>> -> alias
+      _ -> panic
+    },
+    case <<65>> {
+      <<_:utf8_codepoint>> -> True
+      _ -> False
+    },
+    case <<255>> {
+      <<_:utf8_codepoint>> -> True
+      _ -> False
+    },
   )
 }
 "#;
@@ -542,6 +589,10 @@ pub fn main() {
                     Value::BitArray(crate::BitArrayValue::from_bytes(vec![2])),
                 ]),
                 Value::Bool(true),
+                Value::Bool(true),
+                Value::Bool(false),
+                Value::UtfCodepoint('A'),
+                Value::UtfCodepoint('A'),
                 Value::Bool(true),
                 Value::Bool(false),
             ]),
@@ -681,23 +732,20 @@ pub fn main() {
     }
 
     #[test]
-    fn string_decoders_accept_one_scalar_and_reject_invalid_encoding() {
+    fn codepoint_decoders_accept_one_scalar_and_reject_invalid_encoding() {
         assert_eq!(decode_utf8([].view_bits::<Msb0>()), None);
-        assert_eq!(
-            decode_utf8([b'A'].view_bits::<Msb0>()),
-            Some(("A".into(), 8)),
-        );
+        assert_eq!(decode_utf8([b'A'].view_bits::<Msb0>()), Some(('A', 8)),);
         assert_eq!(
             decode_utf8([0xc2, 0xa2].view_bits::<Msb0>()),
-            Some(("¢".into(), 16)),
+            Some(('¢', 16)),
         );
         assert_eq!(
             decode_utf8("안".as_bytes().view_bits::<Msb0>()),
-            Some(("안".into(), 24)),
+            Some(('안', 24)),
         );
         assert_eq!(
             decode_utf8([0xf0, 0x9f, 0x98, 0x80].view_bits::<Msb0>()),
-            Some(("😀".into(), 32)),
+            Some(('😀', 32)),
         );
         assert_eq!(decode_utf8([0xc2].view_bits::<Msb0>()), None);
         assert_eq!(decode_utf8([0xc2, 0x20].view_bits::<Msb0>()), None);
@@ -705,18 +753,18 @@ pub fn main() {
         assert_eq!(decode_utf16([].view_bits::<Msb0>(), Endianness::Big), None);
         assert_eq!(
             decode_utf16([0, 0x41].view_bits::<Msb0>(), Endianness::Big),
-            Some(("A".into(), 16)),
+            Some(('A', 16)),
         );
         assert_eq!(
             decode_utf16([0x41, 0].view_bits::<Msb0>(), Endianness::Little),
-            Some(("A".into(), 16)),
+            Some(('A', 16)),
         );
         assert_eq!(
             decode_utf16(
                 [0xd8, 0x3d, 0xde, 0x00].view_bits::<Msb0>(),
                 Endianness::Big
             ),
-            Some(("😀".into(), 32)),
+            Some(('😀', 32)),
         );
         assert_eq!(
             decode_utf16([0xd8, 0x00].view_bits::<Msb0>(), Endianness::Big),
@@ -745,11 +793,11 @@ pub fn main() {
         );
         assert_eq!(
             decode_utf32([0, 0, 0, 0x41].view_bits::<Msb0>(), Endianness::Big),
-            Some(("A".into(), 32)),
+            Some(('A', 32)),
         );
         assert_eq!(
             decode_utf32([0x41, 0, 0, 0].view_bits::<Msb0>(), Endianness::Little),
-            Some(("A".into(), 32)),
+            Some(('A', 32)),
         );
         assert_eq!(
             decode_utf32([0, 0x11, 0, 0].view_bits::<Msb0>(), Endianness::Big),

--- a/src/runtime/state.rs
+++ b/src/runtime/state.rs
@@ -9,7 +9,7 @@ use super::evaluated::{EvaluatedBitArray, EvaluatedFunctionValue, EvaluatedValue
 use crate::plan::execution::{
     BitArrayListTypeId, BoolListTypeId, ExecutionPlan, FloatListTypeId, FunctionListTypeId,
     IntListTypeId, ListListTypeId, ListStorageTypeId, ListTypeId, NilListTypeId, StringListTypeId,
-    TupleListTypeId,
+    TupleListTypeId, UtfCodepointListTypeId,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,6 +17,7 @@ enum ListStorageKey {
     Int { slot: usize },
     String { slot: usize },
     BitArray { slot: usize },
+    UtfCodepoint { slot: usize },
     Float { slot: usize },
     Bool { slot: usize },
     Nil { slot: usize },
@@ -53,6 +54,7 @@ impl ListStorageKey {
             Self::Int { slot }
             | Self::String { slot }
             | Self::BitArray { slot }
+            | Self::UtfCodepoint { slot }
             | Self::Float { slot }
             | Self::Bool { slot }
             | Self::Nil { slot }
@@ -113,6 +115,11 @@ macro_rules! typed_list_value_id {
 typed_list_value_id!(IntListValueId, IntListTypeId, Int);
 typed_list_value_id!(StringListValueId, StringListTypeId, String);
 typed_list_value_id!(BitArrayListValueId, BitArrayListTypeId, BitArray);
+typed_list_value_id!(
+    UtfCodepointListValueId,
+    UtfCodepointListTypeId,
+    UtfCodepoint
+);
 typed_list_value_id!(FloatListValueId, FloatListTypeId, Float);
 typed_list_value_id!(BoolListValueId, BoolListTypeId, Bool);
 typed_list_value_id!(NilListValueId, NilListTypeId, Nil);
@@ -125,6 +132,7 @@ pub(super) enum ListValueId {
     Int(IntListValueId),
     String(StringListValueId),
     BitArray(BitArrayListValueId),
+    UtfCodepoint(UtfCodepointListValueId),
     Float(FloatListValueId),
     Bool(BoolListValueId),
     Nil(NilListValueId),
@@ -139,6 +147,7 @@ impl ListValueId {
             Self::Int(value) => value.type_id().list_type(),
             Self::String(value) => value.type_id().list_type(),
             Self::BitArray(value) => value.type_id().list_type(),
+            Self::UtfCodepoint(value) => value.type_id().list_type(),
             Self::Float(value) => value.type_id().list_type(),
             Self::Bool(value) => value.type_id().list_type(),
             Self::Nil(value) => value.type_id().list_type(),
@@ -153,6 +162,7 @@ impl ListValueId {
             Self::Int(value) => value.into_core(),
             Self::String(value) => value.into_core(),
             Self::BitArray(value) => value.into_core(),
+            Self::UtfCodepoint(value) => value.into_core(),
             Self::Float(value) => value.into_core(),
             Self::Bool(value) => value.into_core(),
             Self::Nil(value) => value.into_core(),
@@ -174,6 +184,9 @@ impl ListValueId {
             }
             ListStorageTypeId::BitArray(type_id) => {
                 Self::BitArray(BitArrayListValueId::new(type_id, core))
+            }
+            ListStorageTypeId::UtfCodepoint(type_id) => {
+                Self::UtfCodepoint(UtfCodepointListValueId::new(type_id, core))
             }
             ListStorageTypeId::Float(type_id) => Self::Float(FloatListValueId::new(type_id, core)),
             ListStorageTypeId::Bool(type_id) => Self::Bool(BoolListValueId::new(type_id, core)),
@@ -221,6 +234,7 @@ pub(in crate::runtime) struct RuntimeState {
     ints: ListPool<Vec<BigInt>>,
     strings: ListPool<Vec<EcoString>>,
     bit_arrays: ListPool<Vec<EvaluatedBitArray>>,
+    utf_codepoints: ListPool<Vec<char>>,
     floats: ListPool<Vec<f64>>,
     bools: ListPool<Vec<bool>>,
     nils: ListPool<usize>,
@@ -236,6 +250,7 @@ impl RuntimeState {
             ints: ListPool::default(),
             strings: ListPool::default(),
             bit_arrays: ListPool::default(),
+            utf_codepoints: ListPool::default(),
             floats: ListPool::default(),
             bools: ListPool::default(),
             nils: ListPool::default(),
@@ -256,6 +271,7 @@ impl RuntimeState {
                 ListStorageKey::Int { slot } => drop(self.ints.release(slot)),
                 ListStorageKey::String { slot } => drop(self.strings.release(slot)),
                 ListStorageKey::BitArray { slot } => drop(self.bit_arrays.release(slot)),
+                ListStorageKey::UtfCodepoint { slot } => drop(self.utf_codepoints.release(slot)),
                 ListStorageKey::Float { slot } => drop(self.floats.release(slot)),
                 ListStorageKey::Bool { slot } => drop(self.bools.release(slot)),
                 ListStorageKey::Nil { slot } => {
@@ -305,6 +321,16 @@ impl RuntimeState {
         self.prepare_allocation();
         let slot = self.bit_arrays.allocate(values);
         BitArrayListValueId::new(type_id, self.core(ListStorageKey::BitArray { slot }))
+    }
+
+    pub(super) fn utf_codepoint(
+        &mut self,
+        type_id: UtfCodepointListTypeId,
+        values: Vec<char>,
+    ) -> UtfCodepointListValueId {
+        self.prepare_allocation();
+        let slot = self.utf_codepoints.allocate(values);
+        UtfCodepointListValueId::new(type_id, self.core(ListStorageKey::UtfCodepoint { slot }))
     }
 
     pub(super) fn float(&mut self, type_id: FloatListTypeId, values: Vec<f64>) -> FloatListValueId {
@@ -367,6 +393,10 @@ impl RuntimeState {
         self.bit_arrays.get(value.core.slot())
     }
 
+    pub(super) fn utf_codepoint_values(&self, value: &UtfCodepointListValueId) -> &[char] {
+        self.utf_codepoints.get(value.core.slot())
+    }
+
     pub(super) fn float_values(&self, value: &FloatListValueId) -> &[f64] {
         self.floats.get(value.core.slot())
     }
@@ -396,6 +426,7 @@ impl RuntimeState {
             ListValueId::Int(value) => self.int_values(value).len(),
             ListValueId::String(value) => self.string_values(value).len(),
             ListValueId::BitArray(value) => self.bit_array_values(value).len(),
+            ListValueId::UtfCodepoint(value) => self.utf_codepoint_values(value).len(),
             ListValueId::Float(value) => self.float_values(value).len(),
             ListValueId::Bool(value) => self.bool_values(value).len(),
             ListValueId::Nil(value) => self.nil_len(value),
@@ -428,6 +459,12 @@ impl RuntimeState {
                 .iter()
                 .cloned()
                 .map(EvaluatedValue::BitArray)
+                .collect(),
+            ListValueId::UtfCodepoint(value) => self
+                .utf_codepoint_values(value)
+                .iter()
+                .copied()
+                .map(EvaluatedValue::UtfCodepoint)
                 .collect(),
             ListValueId::Float(value) => self
                 .float_values(value)
@@ -486,6 +523,11 @@ impl RuntimeState {
                 let values = values[count.min(values.len())..].to_vec();
                 self.bit_array(value.type_id(), values).into()
             }
+            ListValueId::UtfCodepoint(value) => {
+                let values = self.utf_codepoint_values(value);
+                let values = values[count.min(values.len())..].to_vec();
+                self.utf_codepoint(value.type_id(), values).into()
+            }
             ListValueId::Float(value) => {
                 let values = self.float_values(value);
                 let values = values[count.min(values.len())..].to_vec();
@@ -526,13 +568,15 @@ mod tests {
     use crate::runtime::frame::Frame;
     use crate::runtime::function::return_body::run_int_list_loop;
     use crate::runtime::{
-        EvaluatedCapture, EvaluatedFunctionValue, EvaluatedIntFunction, EvaluatedValue,
+        EvaluatedBitArray, EvaluatedCapture, EvaluatedFunctionValue, EvaluatedIntFunction,
+        EvaluatedValue,
     };
 
     const EVERY_LIST_FAMILY_SOURCE: &str = r#"
 fn ints() -> List(Int) { [] }
 fn strings() -> List(String) { [] }
 fn bit_arrays() -> List(BitArray) { [] }
+fn utf_codepoints() -> List(UtfCodepoint) { [] }
 fn floats() -> List(Float) { [] }
 fn bools() -> List(Bool) { [] }
 fn nils() -> List(Nil) { [] }
@@ -678,6 +722,16 @@ pub fn main() { 0 }
             plan.string_list_function_id(0).type_id(),
             vec!["one".into()],
         );
+        let bit_array = state.bit_array(
+            plan.bit_array_list_function_id(0).type_id(),
+            vec![EvaluatedBitArray::new(bitvec::vec::BitVec::from_vec(vec![
+                1,
+            ]))],
+        );
+        let utf_codepoint = state.utf_codepoint(
+            plan.utf_codepoint_list_function_id(0).type_id(),
+            vec!['\u{10ffff}'],
+        );
         let float = state.float(plan.float_list_function_id(0).type_id(), vec![1.5]);
         let bool_ = state.bool(plan.bool_list_function_id(0).type_id(), vec![true]);
         let nil = state.nil(plan.nil_list_function_id(0).type_id(), 1);
@@ -697,6 +751,8 @@ pub fn main() { 0 }
         let values = [
             ListValueId::Int(int),
             ListValueId::String(string),
+            ListValueId::BitArray(bit_array),
+            ListValueId::UtfCodepoint(utf_codepoint),
             ListValueId::Float(float),
             ListValueId::Bool(bool_),
             ListValueId::Nil(nil),

--- a/src/runtime/value.rs
+++ b/src/runtime/value.rs
@@ -14,7 +14,7 @@ pub use self::function::FunctionValue;
 pub(crate) use self::function::{
     BitArrayFunctionValue, BoolFunctionValue, FloatFunctionValue, FunctionFunctionValue,
     FunctionValueKind, IntFunctionValue, ListFunctionValue, NilFunctionValue, StringFunctionValue,
-    TupleFunctionValue,
+    TupleFunctionValue, UtfCodepointFunctionValue,
 };
 pub use self::list::{ListValue, ListValueItemTypeMismatch};
 
@@ -24,6 +24,7 @@ pub enum Value {
     Float(f64),
     String(EcoString),
     BitArray(BitArrayValue),
+    UtfCodepoint(char),
     Bool(bool),
     Nil,
     Tuple(Vec<Value>),
@@ -38,6 +39,7 @@ impl Value {
             Self::Float(_) => ValueType::Float,
             Self::String(_) => ValueType::String,
             Self::BitArray(_) => ValueType::BitArray,
+            Self::UtfCodepoint(_) => ValueType::UtfCodepoint,
             Self::Bool(_) => ValueType::Bool,
             Self::Nil => ValueType::Nil,
             Self::Tuple(values) => ValueType::Tuple(values.iter().map(Self::value_type).collect()),
@@ -58,6 +60,10 @@ mod tests {
         assert_eq!(
             Value::BitArray(BitArrayValue::from_bytes(vec![1])).value_type(),
             ValueType::BitArray,
+        );
+        assert_eq!(
+            Value::UtfCodepoint('\u{10ffff}').value_type(),
+            ValueType::UtfCodepoint,
         );
         assert_eq!(Value::Bool(true).value_type(), ValueType::Bool);
         assert_eq!(Value::Nil.value_type(), ValueType::Nil);

--- a/src/runtime/value/capture.rs
+++ b/src/runtime/value/capture.rs
@@ -4,7 +4,7 @@ use num_bigint::BigInt;
 use super::{
     BitArrayFunctionValue, BitArrayValue, BoolFunctionValue, FloatFunctionValue,
     FunctionFunctionValue, IntFunctionValue, ListFunctionValue, ListValue, NilFunctionValue,
-    StringFunctionValue, TupleFunctionValue, Value,
+    StringFunctionValue, TupleFunctionValue, UtfCodepointFunctionValue, Value,
 };
 use crate::plan::execution::{
     BitArrayFunctionLocalId, BitArrayListLocalId, BitArrayLocalId, BoolFunctionLocalId,
@@ -12,7 +12,8 @@ use crate::plan::execution::{
     FunctionFunctionLocalId, FunctionListLocalId, IntFunctionLocalId, IntListLocalId, IntLocalId,
     ListFunctionLocal, ListListLocalId, NilFunctionLocalId, NilListLocalId, NilLocalId,
     StringFunctionLocalId, StringListLocalId, StringLocalId, TupleFunctionLocalId,
-    TupleListLocalId, TupleLocalId,
+    TupleListLocalId, TupleLocalId, UtfCodepointFunctionLocalId, UtfCodepointListLocalId,
+    UtfCodepointLocalId,
 };
 use crate::plan::{FunctionType, ValueType};
 
@@ -38,6 +39,10 @@ pub(crate) enum CaptureValueKind {
     BitArray {
         local: BitArrayLocalId,
         value: BitArrayValue,
+    },
+    UtfCodepoint {
+        local: UtfCodepointLocalId,
+        value: char,
     },
     Bool {
         local: BoolLocalId,
@@ -66,6 +71,10 @@ pub(crate) enum CaptureValueKind {
     BitArrayFunction {
         local: BitArrayFunctionLocalId,
         value: BitArrayFunctionValue,
+    },
+    UtfCodepointFunction {
+        local: UtfCodepointFunctionLocalId,
+        value: UtfCodepointFunctionValue,
     },
     BoolFunction {
         local: BoolFunctionLocalId,
@@ -102,6 +111,10 @@ pub(crate) enum CaptureListValue {
     BitArray {
         local: BitArrayListLocalId,
         value: Vec<BitArrayValue>,
+    },
+    UtfCodepoint {
+        local: UtfCodepointListLocalId,
+        value: Vec<char>,
     },
     Float {
         local: FloatListLocalId,
@@ -154,6 +167,12 @@ impl CaptureValue {
     pub(crate) fn bit_array(local: BitArrayLocalId, value: BitArrayValue) -> Self {
         Self {
             kind: CaptureValueKind::BitArray { local, value },
+        }
+    }
+
+    pub(crate) fn utf_codepoint(local: UtfCodepointLocalId, value: char) -> Self {
+        Self {
+            kind: CaptureValueKind::UtfCodepoint { local, value },
         }
     }
 
@@ -211,6 +230,15 @@ impl CaptureValue {
         }
     }
 
+    pub(crate) fn utf_codepoint_function(
+        local: UtfCodepointFunctionLocalId,
+        value: UtfCodepointFunctionValue,
+    ) -> Self {
+        Self {
+            kind: CaptureValueKind::UtfCodepointFunction { local, value },
+        }
+    }
+
     pub(crate) fn bool_function(local: BoolFunctionLocalId, value: BoolFunctionValue) -> Self {
         Self {
             kind: CaptureValueKind::BoolFunction { local, value },
@@ -255,13 +283,14 @@ mod tests {
         IntFunctionId, IntFunctionLocalId, IntListFunctionLocalId, IntListLocalId, IntLocalId,
         ListFunctionId, ListFunctionLocal, NilFunctionId, NilFunctionLocalId, NilLocalId,
         StringFunctionId, StringFunctionLocalId, StringLocalId, TupleFunctionId,
-        TupleFunctionLocalId, TupleLocalId,
+        TupleFunctionLocalId, TupleLocalId, UtfCodepointFunctionId, UtfCodepointFunctionLocalId,
+        UtfCodepointListLocalId, UtfCodepointLocalId,
     };
     use crate::plan::{FunctionType, ValueType};
     use crate::runtime::{
         BitArrayFunctionValue, BitArrayValue, BoolFunctionValue, FloatFunctionValue,
         FunctionFunctionValue, IntFunctionValue, ListFunctionValue, NilFunctionValue,
-        StringFunctionValue, TupleFunctionValue, Value,
+        StringFunctionValue, TupleFunctionValue, UtfCodepointFunctionValue, Value,
     };
 
     #[test]
@@ -296,6 +325,12 @@ mod tests {
             Vec::new(),
             Vec::new(),
             FunctionType::new(Vec::new(), ValueType::BitArray),
+        );
+        let utf_codepoint_function = UtfCodepointFunctionValue::new_with_captures(
+            UtfCodepointFunctionId(0),
+            Vec::new(),
+            Vec::new(),
+            FunctionType::new(Vec::new(), ValueType::UtfCodepoint),
         );
         let bool_function = BoolFunctionValue::new_with_captures(
             BoolFunctionId(0),
@@ -341,6 +376,7 @@ mod tests {
             CaptureValue::float(FloatLocalId(0), 1.5),
             CaptureValue::string(StringLocalId(0), "one".into()),
             CaptureValue::bit_array(BitArrayLocalId(0), BitArrayValue::from_bytes(vec![1])),
+            CaptureValue::utf_codepoint(UtfCodepointLocalId(0), '\u{10ffff}'),
             CaptureValue::bool(BoolLocalId(0), true),
             CaptureValue::nil(NilLocalId(0)),
             CaptureValue::tuple(TupleLocalId(0), vec![Value::Int(1.into())]),
@@ -352,12 +388,20 @@ mod tests {
                 local: BitArrayListLocalId(0),
                 value: vec![BitArrayValue::from_bytes(vec![2])],
             }),
+            CaptureValue::list(CaptureListValue::UtfCodepoint {
+                local: UtfCodepointListLocalId(0),
+                value: vec!['\u{10ffff}'],
+            }),
             CaptureValue::int_function(IntFunctionLocalId(0), int_function.clone()),
             CaptureValue::float_function(FloatFunctionLocalId(0), float_function.clone()),
             CaptureValue::string_function(StringFunctionLocalId(0), string_function.clone()),
             CaptureValue::bit_array_function(
                 BitArrayFunctionLocalId(0),
                 bit_array_function.clone(),
+            ),
+            CaptureValue::utf_codepoint_function(
+                UtfCodepointFunctionLocalId(0),
+                utf_codepoint_function.clone(),
             ),
             CaptureValue::bool_function(BoolFunctionLocalId(0), bool_function.clone()),
             CaptureValue::nil_function(NilFunctionLocalId(0), nil_function.clone()),
@@ -382,6 +426,10 @@ mod tests {
                 local: BitArrayLocalId(0),
                 value: BitArrayValue::from_bytes(vec![1]),
             },
+            CaptureValueKind::UtfCodepoint {
+                local: UtfCodepointLocalId(0),
+                value: '\u{10ffff}',
+            },
             CaptureValueKind::Bool {
                 local: BoolLocalId(0),
                 value: true,
@@ -401,6 +449,10 @@ mod tests {
                 local: BitArrayListLocalId(0),
                 value: vec![BitArrayValue::from_bytes(vec![2])],
             }),
+            CaptureValueKind::List(CaptureListValue::UtfCodepoint {
+                local: UtfCodepointListLocalId(0),
+                value: vec!['\u{10ffff}'],
+            }),
             CaptureValueKind::IntFunction {
                 local: IntFunctionLocalId(0),
                 value: int_function.clone(),
@@ -416,6 +468,10 @@ mod tests {
             CaptureValueKind::BitArrayFunction {
                 local: BitArrayFunctionLocalId(0),
                 value: bit_array_function,
+            },
+            CaptureValueKind::UtfCodepointFunction {
+                local: UtfCodepointFunctionLocalId(0),
+                value: utf_codepoint_function,
             },
             CaptureValueKind::BoolFunction {
                 local: BoolFunctionLocalId(0),

--- a/src/runtime/value/function.rs
+++ b/src/runtime/value/function.rs
@@ -4,6 +4,7 @@ use crate::plan::FunctionType;
 use crate::plan::execution::{
     BitArrayFunctionId, BoolFunctionId, FloatFunctionId, FunctionFunctionId, IntFunctionId,
     ListFunctionId, NilFunctionId, ParamLocal, StringFunctionId, TupleFunctionId,
+    UtfCodepointFunctionId,
 };
 #[cfg(test)]
 use crate::plan::execution::{FunctionReturnFamily, RuntimeFunctionId};
@@ -19,6 +20,7 @@ pub(crate) enum FunctionValueKind {
     Float(FloatFunctionValue),
     String(StringFunctionValue),
     BitArray(BitArrayFunctionValue),
+    UtfCodepoint(UtfCodepointFunctionValue),
     Bool(BoolFunctionValue),
     Nil(NilFunctionValue),
     Tuple(TupleFunctionValue),
@@ -53,6 +55,14 @@ pub(crate) struct StringFunctionValue {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct BitArrayFunctionValue {
     runtime_id: BitArrayFunctionId,
+    params: Vec<ParamLocal>,
+    captures: Vec<CaptureValue>,
+    type_: FunctionType,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct UtfCodepointFunctionValue {
+    runtime_id: UtfCodepointFunctionId,
     params: Vec<ParamLocal>,
     captures: Vec<CaptureValue>,
     type_: FunctionType,
@@ -122,6 +132,9 @@ impl FunctionValue {
             RuntimeFunctionId::BitArray(runtime_id) => FunctionValueKind::BitArray(
                 BitArrayFunctionValue::new_with_captures(runtime_id, params, Vec::new(), type_),
             ),
+            RuntimeFunctionId::UtfCodepoint(runtime_id) => FunctionValueKind::UtfCodepoint(
+                UtfCodepointFunctionValue::new_with_captures(runtime_id, params, Vec::new(), type_),
+            ),
             RuntimeFunctionId::Bool(runtime_id) => FunctionValueKind::Bool(
                 BoolFunctionValue::new_with_captures(runtime_id, params, Vec::new(), type_),
             ),
@@ -160,6 +173,7 @@ impl FunctionValue {
             FunctionValueKind::Float(value) => value.type_(),
             FunctionValueKind::String(value) => value.type_(),
             FunctionValueKind::BitArray(value) => value.type_(),
+            FunctionValueKind::UtfCodepoint(value) => value.type_(),
             FunctionValueKind::Bool(value) => value.type_(),
             FunctionValueKind::Nil(value) => value.type_(),
             FunctionValueKind::Tuple(value) => value.type_(),
@@ -182,6 +196,7 @@ impl FunctionValueKind {
             Self::Float(_) => FunctionReturnFamily::Float,
             Self::String(_) => FunctionReturnFamily::String,
             Self::BitArray(_) => FunctionReturnFamily::BitArray,
+            Self::UtfCodepoint(_) => FunctionReturnFamily::UtfCodepoint,
             Self::Bool(_) => FunctionReturnFamily::Bool,
             Self::Nil(_) => FunctionReturnFamily::Nil,
             Self::Tuple(_) => FunctionReturnFamily::Tuple,
@@ -263,6 +278,26 @@ impl StringFunctionValue {
 impl BitArrayFunctionValue {
     pub(crate) fn new_with_captures(
         runtime_id: BitArrayFunctionId,
+        params: Vec<ParamLocal>,
+        captures: Vec<CaptureValue>,
+        type_: FunctionType,
+    ) -> Self {
+        Self {
+            runtime_id,
+            params,
+            captures,
+            type_,
+        }
+    }
+
+    pub(crate) fn type_(&self) -> FunctionType {
+        self.type_.clone()
+    }
+}
+
+impl UtfCodepointFunctionValue {
+    pub(crate) fn new_with_captures(
+        runtime_id: UtfCodepointFunctionId,
         params: Vec<ParamLocal>,
         captures: Vec<CaptureValue>,
         type_: FunctionType,
@@ -417,6 +452,14 @@ impl From<BitArrayFunctionValue> for FunctionValue {
     }
 }
 
+impl From<UtfCodepointFunctionValue> for FunctionValue {
+    fn from(value: UtfCodepointFunctionValue) -> Self {
+        Self {
+            kind: FunctionValueKind::UtfCodepoint(value),
+        }
+    }
+}
+
 impl From<BoolFunctionValue> for FunctionValue {
     fn from(value: BoolFunctionValue) -> Self {
         Self {
@@ -487,6 +530,11 @@ mod tests {
                 FunctionReturnFamily::BitArray,
             ),
             (
+                "fn value() -> UtfCodepoint { let assert <<value:utf8_codepoint>> = <<65>> value } pub fn main() { value() }",
+                ValueType::UtfCodepoint,
+                FunctionReturnFamily::UtfCodepoint,
+            ),
+            (
                 "pub fn main() -> Bool { True }",
                 ValueType::Bool,
                 FunctionReturnFamily::Bool,
@@ -533,6 +581,10 @@ mod tests {
             ("pub fn main() -> Float { 1.0 }", ValueType::Float),
             ("pub fn main() -> String { \"one\" }", ValueType::String),
             ("pub fn main() -> BitArray { <<1>> }", ValueType::BitArray),
+            (
+                "fn value() -> UtfCodepoint { let assert <<value:utf8_codepoint>> = <<65>> value } pub fn main() { value() }",
+                ValueType::UtfCodepoint,
+            ),
             ("pub fn main() -> Bool { True }", ValueType::Bool),
             ("pub fn main() -> Nil { Nil }", ValueType::Nil),
             (
@@ -561,6 +613,7 @@ mod tests {
                 FunctionValueKind::Float(value) => FunctionValue::from(value.clone()),
                 FunctionValueKind::String(value) => FunctionValue::from(value.clone()),
                 FunctionValueKind::BitArray(value) => FunctionValue::from(value.clone()),
+                FunctionValueKind::UtfCodepoint(value) => FunctionValue::from(value.clone()),
                 FunctionValueKind::Bool(value) => FunctionValue::from(value.clone()),
                 FunctionValueKind::Nil(value) => FunctionValue::from(value.clone()),
                 FunctionValueKind::Tuple(value) => FunctionValue::from(value.clone()),

--- a/src/runtime/value/list.rs
+++ b/src/runtime/value/list.rs
@@ -25,6 +25,7 @@ pub(crate) enum ListValueKind {
     Int(Vec<BigInt>),
     String(Vec<EcoString>),
     BitArray(Vec<BitArrayValue>),
+    UtfCodepoint(Vec<char>),
     Float(Vec<f64>),
     Bool(Vec<bool>),
     Nil(usize),
@@ -58,6 +59,12 @@ impl ListValue {
     pub fn bit_array(values: Vec<BitArrayValue>) -> Self {
         Self {
             kind: ListValueKind::BitArray(values),
+        }
+    }
+
+    pub fn utf_codepoint(values: Vec<char>) -> Self {
+        Self {
+            kind: ListValueKind::UtfCodepoint(values),
         }
     }
 
@@ -159,6 +166,7 @@ impl ListValue {
             ValueType::Int => Self::int(Vec::new()),
             ValueType::String => Self::string(Vec::new()),
             ValueType::BitArray => Self::bit_array(Vec::new()),
+            ValueType::UtfCodepoint => Self::utf_codepoint(Vec::new()),
             ValueType::Float => Self::float(Vec::new()),
             ValueType::Bool => Self::bool(Vec::new()),
             ValueType::Nil => Self::nil(0),
@@ -188,6 +196,7 @@ impl ListValue {
             ListValueKind::Int(_) => ValueType::Int,
             ListValueKind::String(_) => ValueType::String,
             ListValueKind::BitArray(_) => ValueType::BitArray,
+            ListValueKind::UtfCodepoint(_) => ValueType::UtfCodepoint,
             ListValueKind::Float(_) => ValueType::Float,
             ListValueKind::Bool(_) => ValueType::Bool,
             ListValueKind::Nil(_) => ValueType::Nil,
@@ -204,6 +213,7 @@ impl ListValue {
             ListValueKind::Int(values) => values.len(),
             ListValueKind::String(values) => values.len(),
             ListValueKind::BitArray(values) => values.len(),
+            ListValueKind::UtfCodepoint(values) => values.len(),
             ListValueKind::Float(values) => values.len(),
             ListValueKind::Bool(values) => values.len(),
             ListValueKind::Nil(len) => *len,
@@ -223,6 +233,9 @@ impl ListValue {
             ListValueKind::String(values) => values.iter().cloned().map(Value::String).collect(),
             ListValueKind::BitArray(values) => {
                 values.iter().cloned().map(Value::BitArray).collect()
+            }
+            ListValueKind::UtfCodepoint(values) => {
+                values.iter().copied().map(Value::UtfCodepoint).collect()
             }
             ListValueKind::Float(values) => values.iter().copied().map(Value::Float).collect(),
             ListValueKind::Bool(values) => values.iter().copied().map(Value::Bool).collect(),
@@ -272,6 +285,7 @@ mod tests {
                 BitArrayValue::from_bytes(vec![1]),
                 BitArrayValue::from_bytes(vec![2]),
             ]),
+            ListValue::utf_codepoint(vec!['a', '\u{10ffff}']),
             ListValue::float(vec![1.5, 2.5]),
             ListValue::bool(vec![true, false]),
             ListValue::nil(2),
@@ -295,6 +309,7 @@ mod tests {
             ValueType::Int,
             ValueType::String,
             ValueType::BitArray,
+            ValueType::UtfCodepoint,
             ValueType::Float,
             ValueType::Bool,
             ValueType::Nil,
@@ -314,6 +329,7 @@ mod tests {
             ValueType::Int,
             ValueType::String,
             ValueType::BitArray,
+            ValueType::UtfCodepoint,
             ValueType::Float,
             ValueType::Bool,
             ValueType::Nil,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -45,6 +45,13 @@ mod values {
         bit_array_list_case_result,
         bit_array_list_function_paths,
         bit_array_returned_closure_capture,
+        utf_codepoint_binding_paths,
+        utf_codepoint_composition,
+        utf_codepoint_expression_paths,
+        utf_codepoint_function_value_paths,
+        utf_codepoint_list_function_paths,
+        utf_codepoint_returned_closure_capture,
+        utf_codepoint_segments,
         tuple_value,
         tuple_expression_shapes,
         list_value,
@@ -65,6 +72,7 @@ mod expressions {
         bit_array,
         bit_array_float_16,
         list_bit_array_element,
+        list_utf_codepoint_element,
     );
 }
 
@@ -239,6 +247,7 @@ mod control_flow {
             bit_array_pattern_floats,
             bit_array_pattern_strings,
             bit_array_pattern_composition,
+            bit_array_pattern_utf_codepoint,
             tuple_inner_bit_array_pattern,
             list_inner_bit_array_pattern,
             list_inner_bit_array_pattern_fallthrough,
@@ -270,6 +279,8 @@ mod functions {
         list_bit_array_return,
         anonymous_bit_array_argument,
         anonymous_bit_array_return,
+        utf_codepoint_argument,
+        utf_codepoint_return,
     );
 
     mod basic {
@@ -426,12 +437,14 @@ mod execution_errors {
             panic_int,
             panic_string,
             panic_bit_array,
+            panic_utf_codepoint,
             panic_float,
             panic_bool,
             panic_tuple,
             panic_list,
             panic_list_string,
             panic_list_bit_array,
+            panic_list_utf_codepoint,
             panic_list_float,
             panic_list_bool,
             panic_list_nil,
@@ -441,6 +454,7 @@ mod execution_errors {
             panic_int_function,
             panic_string_function,
             panic_bit_array_function,
+            panic_utf_codepoint_function,
             panic_float_function,
             panic_bool_function,
             panic_nil_function,
@@ -448,6 +462,9 @@ mod execution_errors {
             panic_list_function,
             panic_function_function,
             todo,
+            todo_utf_codepoint,
+            todo_list_utf_codepoint,
+            todo_utf_codepoint_function,
             todo_message,
             todo_assignment,
             empty_function,
@@ -462,6 +479,14 @@ mod execution_errors {
             return_float_case_subject,
             return_string_case_subject,
             return_block_step,
+            utf_codepoint_return_tuple_subject,
+            utf_codepoint_return_bool_case_subject,
+            utf_codepoint_return_int_case_subject,
+            utf_codepoint_return_string_case_subject,
+            utf_codepoint_return_float_case_subject,
+            utf_codepoint_return_block_step,
+            utf_codepoint_list_call_argument,
+            utf_codepoint_let_step,
         );
 
         mod use_syntax {
@@ -481,6 +506,8 @@ mod execution_errors {
             let_assert_empty_list,
             let_assert_message,
             let_assert_bit_array_pattern,
+            let_assert_bit_array_utf_codepoint_default_message,
+            let_assert_bit_array_utf_codepoint_message_error,
         );
     }
 
@@ -519,8 +546,6 @@ mod rejection {
             unsupported_body_after_main,
             result_argument,
             result_return,
-            utf_codepoint_argument,
-            utf_codepoint_return,
         );
     }
 
@@ -528,7 +553,6 @@ mod rejection {
         rejection_cases!("expressions";
             echo,
             result_constructor,
-            list_utf_codepoint_element,
             bit_array_native_endian,
             bit_array_dynamic_size,
             bit_array_sized_bits,
@@ -556,7 +580,6 @@ mod rejection {
     mod case_patterns {
         rejection_cases!("case_patterns";
             result_subject,
-            bit_array_pattern_utf_codepoint,
             bit_array_pattern_native_endian,
         );
     }
@@ -684,6 +707,7 @@ fn render_value(value: &Value) -> String {
             value.bytes(),
             value.bit_len(),
         ),
+        Value::UtfCodepoint(value) => format!("UtfCodepoint({value:?})"),
         Value::Bool(value) => format!("Bool({value})"),
         Value::Nil => "Nil".into(),
         Value::Tuple(values) => format!(
@@ -728,6 +752,7 @@ fn render_value_type(type_: &ValueType) -> String {
         ValueType::Float => "Float".into(),
         ValueType::String => "String".into(),
         ValueType::BitArray => "BitArray".into(),
+        ValueType::UtfCodepoint => "UtfCodepoint".into(),
         ValueType::Bool => "Bool".into(),
         ValueType::Nil => "Nil".into(),
         ValueType::Tuple(elements) => format!(

--- a/tests/fixtures/execution/control_flow/case/bit_array_pattern_utf_codepoint.gleam
+++ b/tests/fixtures/execution/control_flow/case/bit_array_pattern_utf_codepoint.gleam
@@ -4,3 +4,5 @@ pub fn main() {
     _ -> 0
   }
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/expressions/list_utf_codepoint_element.gleam
+++ b/tests/fixtures/execution/expressions/list_utf_codepoint_element.gleam
@@ -1,0 +1,8 @@
+pub fn main() {
+  case <<"A":utf8>> {
+    <<value:utf8_codepoint>> -> [value]
+    _ -> []
+  }
+}
+
+// geam:expect List(UtfCodepoint)([UtfCodepoint('A')])

--- a/tests/fixtures/execution/functions/utf_codepoint_argument.gleam
+++ b/tests/fixtures/execution/functions/utf_codepoint_argument.gleam
@@ -1,0 +1,15 @@
+fn inspect(value: UtfCodepoint) {
+  case <<value:utf8_codepoint>> {
+    <<"A":utf8>> -> 1
+    _ -> 0
+  }
+}
+
+pub fn main() {
+  case <<"A":utf8>> {
+    <<value:utf8_codepoint>> -> inspect(value)
+    _ -> 0
+  }
+}
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/functions/utf_codepoint_return.gleam
+++ b/tests/fixtures/execution/functions/utf_codepoint_return.gleam
@@ -1,0 +1,15 @@
+fn codepoint() -> UtfCodepoint {
+  case <<"A":utf8>> {
+    <<value:utf8_codepoint>> -> value
+    _ -> panic
+  }
+}
+
+pub fn main() {
+  case <<codepoint():utf8_codepoint>> {
+    <<"A":utf8>> -> 1
+    _ -> 0
+  }
+}
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/values/utf_codepoint_binding_paths.gleam
+++ b/tests/fixtures/execution/values/utf_codepoint_binding_paths.gleam
@@ -1,0 +1,25 @@
+fn codepoint() -> UtfCodepoint {
+  let assert <<value:utf8_codepoint>> = <<65>>
+  value
+}
+
+fn with_value(
+  value: UtfCodepoint,
+  callback: fn(UtfCodepoint) -> #(UtfCodepoint, UtfCodepoint),
+) -> #(UtfCodepoint, UtfCodepoint) {
+  callback(value)
+}
+
+fn bind(value: UtfCodepoint) {
+  let direct as alias = value
+  let #(from_tuple, _) = #(alias, Nil)
+  let _ = direct
+  use from_use <- with_value(from_tuple)
+  #(alias, from_use)
+}
+
+pub fn main() {
+  bind(codepoint())
+}
+
+// geam:expect Tuple([UtfCodepoint('A'), UtfCodepoint('A')])

--- a/tests/fixtures/execution/values/utf_codepoint_composition.gleam
+++ b/tests/fixtures/execution/values/utf_codepoint_composition.gleam
@@ -1,0 +1,60 @@
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  value
+}
+
+fn list_tail(count: Int, value: UtfCodepoint) -> List(UtfCodepoint) {
+  case count {
+    0 -> [value]
+    _ -> list_tail(count - 1, value)
+  }
+}
+
+fn function_tail(count: Int) -> fn(UtfCodepoint) -> UtfCodepoint {
+  case count {
+    0 -> identity
+    _ -> function_tail(count - 1)
+  }
+}
+
+fn capture(value: UtfCodepoint) {
+  fn() { value }
+}
+
+pub fn main() {
+  case <<"AB":utf8>> {
+    <<first:utf8_codepoint, second:utf8_codepoint>> -> {
+      let values = [first, ..[second]]
+      let assert [head, ..tail] = values
+      let assert [last] = tail
+      let selected = case values {
+        [value, ..] -> value
+        _ -> second
+      }
+      let returned = capture(last)
+
+      #(
+        identity(head),
+        function_tail(2)(last),
+        list_tail(2, selected),
+        returned(),
+        head == selected,
+        head != last,
+        values == [first, second],
+        #(head, [last]) == #(first, [second]),
+        #(head, [last]),
+        case <<"A":utf8>>, <<"B":utf8>> {
+          <<_ as alias:utf8_codepoint>>, <<right:utf8_codepoint>>
+            if alias != right -> #(alias, right)
+          _, _ -> #(second, first)
+        },
+        case <<"B":utf8>> {
+          <<value:utf8_codepoint>> | <<value:utf16_codepoint-big>> -> value
+          _ -> first
+        },
+      )
+    }
+    _ -> panic
+  }
+}
+
+// geam:expect Tuple([UtfCodepoint('A'), UtfCodepoint('B'), List(UtfCodepoint)([UtfCodepoint('A')]), UtfCodepoint('B'), Bool(true), Bool(true), Bool(true), Bool(true), Tuple([UtfCodepoint('A'), List(UtfCodepoint)([UtfCodepoint('B')])]), Tuple([UtfCodepoint('A'), UtfCodepoint('B')]), UtfCodepoint('B')])

--- a/tests/fixtures/execution/values/utf_codepoint_expression_paths.gleam
+++ b/tests/fixtures/execution/values/utf_codepoint_expression_paths.gleam
@@ -1,0 +1,117 @@
+fn codepoint(value: Int) -> UtfCodepoint {
+  case <<value>> {
+    <<value:utf8_codepoint>> -> value
+    _ -> panic
+  }
+}
+
+fn bits(value: UtfCodepoint) -> BitArray {
+  <<value:utf8_codepoint>>
+}
+
+fn direct(value: Int) -> UtfCodepoint {
+  codepoint(value)
+}
+
+fn choose_bool(value: Bool) -> UtfCodepoint {
+  case value {
+    True -> codepoint(3)
+    False -> codepoint(4)
+  }
+}
+
+fn choose_int(value: Int) -> UtfCodepoint {
+  case value {
+    1 -> codepoint(5)
+    _ -> codepoint(6)
+  }
+}
+
+fn choose_string(value: String) -> UtfCodepoint {
+  case value {
+    "hit" -> codepoint(7)
+    _ -> codepoint(8)
+  }
+}
+
+fn choose_float(value: Float) -> UtfCodepoint {
+  case value {
+    1.0 -> codepoint(9)
+    _ -> codepoint(10)
+  }
+}
+
+pub fn main() {
+  let local = codepoint(1)
+  let function = direct
+  let pair = #(codepoint(11))
+  let assert [from_list] = [codepoint(12)]
+  let from_bool_case = case True {
+    True -> codepoint(14)
+    False -> codepoint(15)
+  }
+  let from_bool_case_fallback = case False {
+    True -> codepoint(14)
+    False -> codepoint(15)
+  }
+  let from_int_case = case 1 {
+    1 -> codepoint(16)
+    _ -> codepoint(17)
+  }
+  let from_int_case_fallback = case 0 {
+    1 -> codepoint(16)
+    _ -> codepoint(17)
+  }
+  let from_string_case = case "hit" {
+    "hit" -> codepoint(18)
+    _ -> codepoint(19)
+  }
+  let from_string_case_fallback = case "miss" {
+    "hit" -> codepoint(18)
+    _ -> codepoint(19)
+  }
+  let from_float_case = case 1.0 {
+    1.0 -> codepoint(20)
+    _ -> codepoint(21)
+  }
+  let from_float_case_fallback = case 0.0 {
+    1.0 -> codepoint(20)
+    _ -> codepoint(21)
+  }
+  let from_list_case = case [codepoint(22)] {
+    [value] -> value
+    _ -> panic
+  }
+  let from_block = {
+    let ignored = 1
+    codepoint(13)
+  }
+
+  #(
+    bits(local),
+    bits(direct(2)),
+    bits(function(3)),
+    bits(pair.0),
+    bits(from_list),
+    bits(choose_bool(True)),
+    bits(choose_bool(False)),
+    bits(choose_int(1)),
+    bits(choose_int(0)),
+    bits(choose_string("hit")),
+    bits(choose_string("miss")),
+    bits(choose_float(1.0)),
+    bits(choose_float(0.0)),
+    bits(from_bool_case),
+    bits(from_bool_case_fallback),
+    bits(from_int_case),
+    bits(from_int_case_fallback),
+    bits(from_string_case),
+    bits(from_string_case_fallback),
+    bits(from_float_case),
+    bits(from_float_case_fallback),
+    bits(from_list_case),
+    bits(from_block),
+  )
+}
+
+// geam:expect Tuple([BitArray(bytes=[1], bit_len=8), BitArray(bytes=[2], bit_len=8), BitArray(bytes=[3], bit_len=8), BitArray(bytes=[11], bit_len=8), BitArray(bytes=[12], bit_len=8), BitArray(bytes=[3], bit_len=8), BitArray(bytes=[4], bit_len=8), BitArray(bytes=[5], bit_len=8), BitArray(bytes=[6], bit_len=8), BitArray(bytes=[7], bit_len=8), BitArray(bytes=[8], bit_len=8), BitArray(bytes=[9], bit_len=8), BitArray(bytes=[10], bit_len=8), BitArray(bytes=[14], bit_len=8), BitArray(bytes=[15], bit_len=8), BitArray(bytes=[16], bit_len=8), BitArray(bytes=[17], bit_len=8), BitArray(bytes=[18], bit_len=8), BitArray(bytes=[19], bit_len=8), BitArray(bytes=[20], bit_len=8), BitArray(bytes=[21], bit_len=8), BitArray(bytes=[22], bit_len=8), BitArray(bytes=[13], bit_len=8)])

--- a/tests/fixtures/execution/values/utf_codepoint_function_value_paths.gleam
+++ b/tests/fixtures/execution/values/utf_codepoint_function_value_paths.gleam
@@ -1,0 +1,156 @@
+fn codepoint(value: Int) -> UtfCodepoint {
+  case <<value>> {
+    <<value:utf8_codepoint>> -> value
+    _ -> panic
+  }
+}
+
+fn bits(value: UtfCodepoint) -> BitArray {
+  <<value:utf8_codepoint>>
+}
+
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  value
+}
+
+fn other(_: UtfCodepoint) -> UtfCodepoint {
+  codepoint(99)
+}
+
+fn getter(_: Nil) -> fn(UtfCodepoint) -> UtfCodepoint {
+  identity
+}
+
+fn selector() -> fn(Nil) -> fn(UtfCodepoint) -> UtfCodepoint {
+  getter
+}
+
+fn apply(function: fn(UtfCodepoint) -> UtfCodepoint, value: UtfCodepoint) {
+  function(value)
+}
+
+fn first(values: List(UtfCodepoint)) -> UtfCodepoint {
+  let assert [value, ..] = values
+  value
+}
+
+fn choose_bool(value: Bool) {
+  case value {
+    True -> identity
+    False -> other
+  }
+}
+
+fn choose_int(value: Int) {
+  case value {
+    1 -> identity
+    _ -> other
+  }
+}
+
+fn choose_string(value: String) {
+  case value {
+    "hit" -> identity
+    _ -> other
+  }
+}
+
+fn choose_float(value: Float) {
+  case value {
+    1.0 -> identity
+    _ -> other
+  }
+}
+
+pub fn main() {
+  let local = identity
+  let closure = fn(value) { value }
+  let pair = #(identity)
+  let assert [from_list] = [identity]
+  let from_list_case = case [identity] {
+    [function] -> function
+    _ -> other
+  }
+  let from_direct_call = getter(Nil)
+  let selected = selector()
+  let from_function_call = selected(Nil)
+  let from_function_subject = case identity {
+    function -> function
+  }
+  let from_guarded_function_subject = case identity {
+    function if True -> function
+    _ -> other
+  }
+  let from_bool_case = case True {
+    True -> identity
+    False -> other
+  }
+  let from_bool_case_fallback = case False {
+    True -> identity
+    False -> other
+  }
+  let from_int_case = case 1 {
+    1 -> identity
+    _ -> other
+  }
+  let from_int_case_fallback = case 0 {
+    1 -> identity
+    _ -> other
+  }
+  let from_string_case = case "hit" {
+    "hit" -> identity
+    _ -> other
+  }
+  let from_string_case_fallback = case "miss" {
+    "hit" -> identity
+    _ -> other
+  }
+  let from_float_case = case 1.0 {
+    1.0 -> identity
+    _ -> other
+  }
+  let from_float_case_fallback = case 0.0 {
+    1.0 -> identity
+    _ -> other
+  }
+  let from_block = {
+    let ignored = 1
+    identity
+  }
+  let captured_function = identity
+  let capturing_closure = fn(value) { captured_function(value) }
+
+  #(
+    bits(local(codepoint(1))),
+    bits(closure(codepoint(2))),
+    bits(pair.0(codepoint(3))),
+    bits(from_list(codepoint(4))),
+    bits(from_list_case(codepoint(24))),
+    bits(from_direct_call(codepoint(5))),
+    bits(from_function_call(codepoint(6))),
+    bits(from_function_subject(codepoint(23))),
+    bits(from_guarded_function_subject(codepoint(25))),
+    bits(choose_bool(True)(codepoint(7))),
+    bits(choose_bool(False)(codepoint(8))),
+    bits(choose_int(1)(codepoint(9))),
+    bits(choose_int(0)(codepoint(10))),
+    bits(choose_string("hit")(codepoint(11))),
+    bits(choose_string("miss")(codepoint(12))),
+    bits(choose_float(1.0)(codepoint(13))),
+    bits(choose_float(0.0)(codepoint(14))),
+    bits(from_bool_case(codepoint(16))),
+    bits(from_bool_case_fallback(codepoint(16))),
+    bits(from_int_case(codepoint(17))),
+    bits(from_int_case_fallback(codepoint(17))),
+    bits(from_string_case(codepoint(18))),
+    bits(from_string_case_fallback(codepoint(18))),
+    bits(from_float_case(codepoint(19))),
+    bits(from_float_case_fallback(codepoint(19))),
+    bits(from_block(codepoint(15))),
+    bits(apply(identity, codepoint(20))),
+    bits(first([codepoint(21)])),
+    bits(capturing_closure(codepoint(22))),
+  )
+}
+
+// geam:expect Tuple([BitArray(bytes=[1], bit_len=8), BitArray(bytes=[2], bit_len=8), BitArray(bytes=[3], bit_len=8), BitArray(bytes=[4], bit_len=8), BitArray(bytes=[24], bit_len=8), BitArray(bytes=[5], bit_len=8), BitArray(bytes=[6], bit_len=8), BitArray(bytes=[23], bit_len=8), BitArray(bytes=[25], bit_len=8), BitArray(bytes=[7], bit_len=8), BitArray(bytes=[99], bit_len=8), BitArray(bytes=[9], bit_len=8), BitArray(bytes=[99], bit_len=8), BitArray(bytes=[11], bit_len=8), BitArray(bytes=[99], bit_len=8), BitArray(bytes=[13], bit_len=8), BitArray(bytes=[99], bit_len=8), BitArray(bytes=[16], bit_len=8), BitArray(bytes=[99], bit_len=8), BitArray(bytes=[17], bit_len=8), BitArray(bytes=[99], bit_len=8), BitArray(bytes=[18], bit_len=8), BitArray(bytes=[99], bit_len=8), BitArray(bytes=[19], bit_len=8), BitArray(bytes=[99], bit_len=8), BitArray(bytes=[15], bit_len=8), BitArray(bytes=[20], bit_len=8), BitArray(bytes=[21], bit_len=8), BitArray(bytes=[22], bit_len=8)])

--- a/tests/fixtures/execution/values/utf_codepoint_list_function_paths.gleam
+++ b/tests/fixtures/execution/values/utf_codepoint_list_function_paths.gleam
@@ -1,0 +1,44 @@
+fn codepoint() -> UtfCodepoint {
+  case <<"A":utf8>> {
+    <<value:utf8_codepoint>> -> value
+    _ -> panic
+  }
+}
+
+fn values() {
+  [codepoint()]
+}
+
+fn getter() {
+  values
+}
+
+fn selector() {
+  getter
+}
+
+fn first(function: fn() -> List(UtfCodepoint)) {
+  let assert [value] = function()
+  value
+}
+
+pub fn main() {
+  let functions = [values]
+  let assert [from_assert] = functions
+  let from_case = case functions {
+    [function] -> function
+    _ -> values
+  }
+  let assert [from_direct] = values()
+
+  #(
+    from_direct,
+    first(values),
+    first(getter()),
+    first(selector()()),
+    first(from_assert),
+    first(from_case),
+  )
+}
+
+// geam:expect Tuple([UtfCodepoint('A'), UtfCodepoint('A'), UtfCodepoint('A'), UtfCodepoint('A'), UtfCodepoint('A'), UtfCodepoint('A')])

--- a/tests/fixtures/execution/values/utf_codepoint_returned_closure_capture.gleam
+++ b/tests/fixtures/execution/values/utf_codepoint_returned_closure_capture.gleam
@@ -1,0 +1,23 @@
+fn identity(value: UtfCodepoint) -> UtfCodepoint {
+  value
+}
+
+pub fn main() -> fn(UtfCodepoint) -> UtfCodepoint {
+  case <<"A":utf8>>, <<"B":utf8>> {
+    <<first:utf8_codepoint>>, <<second:utf8_codepoint>> -> {
+      let values = [second]
+      let function = identity
+
+      fn(value) {
+        let assert [captured] = values
+        case first == value {
+          True -> function(captured)
+          False -> function(value)
+        }
+      }
+    }
+    _, _ -> identity
+  }
+}
+
+// geam:expect Function(fn(UtfCodepoint) -> UtfCodepoint)

--- a/tests/fixtures/execution/values/utf_codepoint_segments.gleam
+++ b/tests/fixtures/execution/values/utf_codepoint_segments.gleam
@@ -1,0 +1,85 @@
+fn utf8(bits: BitArray) -> UtfCodepoint {
+  case bits {
+    <<value:utf8_codepoint>> -> value
+    _ -> panic
+  }
+}
+
+fn utf32(bits: BitArray) -> UtfCodepoint {
+  case bits {
+    <<value:utf32_codepoint-big>> -> value
+    _ -> panic
+  }
+}
+
+fn utf16_big(bits: BitArray) -> UtfCodepoint {
+  case bits {
+    <<value:utf16_codepoint-big>> -> value
+    _ -> panic
+  }
+}
+
+fn utf16_little(bits: BitArray) -> UtfCodepoint {
+  case bits {
+    <<value:utf16_codepoint-little>> -> value
+    _ -> panic
+  }
+}
+
+fn utf32_little(bits: BitArray) -> UtfCodepoint {
+  case bits {
+    <<value:utf32_codepoint-little>> -> value
+    _ -> panic
+  }
+}
+
+pub fn main() {
+  let ascii = utf8(<<"A":utf8>>)
+  let won = utf8(<<"안":utf8>>)
+  let smile = utf8(<<"😀":utf8>>)
+  let null = utf32(<<0, 0, 0, 0>>)
+  let before_surrogate = utf32(<<0, 0, 215, 255>>)
+  let after_surrogate = utf32(<<0, 0, 224, 0>>)
+  let maximum = utf32(<<0, 16, 255, 255>>)
+
+  #(
+    ascii,
+    <<ascii:utf8_codepoint>>,
+    <<won:utf8_codepoint>>,
+    <<smile:utf8_codepoint>>,
+    <<smile:utf16_codepoint-big>>,
+    <<smile:utf16_codepoint-little>>,
+    <<smile:utf32_codepoint-big>>,
+    <<smile:utf32_codepoint-little>>,
+    utf16_big(<<smile:utf16_codepoint-big>>),
+    utf16_little(<<smile:utf16_codepoint-little>>),
+    utf32(<<smile:utf32_codepoint-big>>),
+    utf32_little(<<smile:utf32_codepoint-little>>),
+    <<null:utf32_codepoint-big>>,
+    <<before_surrogate:utf32_codepoint-big>>,
+    <<after_surrogate:utf32_codepoint-big>>,
+    <<maximum:utf32_codepoint-big>>,
+    case <<255>> {
+      <<_:utf8_codepoint>> -> 1
+      _ -> 0
+    },
+    case <<216, 0>> {
+      <<_:utf16_codepoint-big>> -> 1
+      _ -> 0
+    },
+    case <<0, 0, 216, 0>> {
+      <<_:utf32_codepoint-big>> -> 1
+      _ -> 0
+    },
+    case <<0, 17, 0, 0>> {
+      <<_:utf32_codepoint-big>> -> 1
+      _ -> 0
+    },
+    case <<226, 130>> {
+      <<_:utf8_codepoint>> -> 1
+      _ -> 0
+    },
+  )
+}
+
+// geam:expect Tuple([UtfCodepoint('A'), BitArray(bytes=[65], bit_len=8), BitArray(bytes=[236, 149, 136], bit_len=24), BitArray(bytes=[240, 159, 152, 128], bit_len=32), BitArray(bytes=[216, 61, 222, 0], bit_len=32), BitArray(bytes=[61, 216, 0, 222], bit_len=32), BitArray(bytes=[0, 1, 246, 0], bit_len=32), BitArray(bytes=[0, 246, 1, 0], bit_len=32), UtfCodepoint('😀'), UtfCodepoint('😀'), UtfCodepoint('😀'), UtfCodepoint('😀'), BitArray(bytes=[0, 0, 0, 0], bit_len=32), BitArray(bytes=[0, 0, 215, 255], bit_len=32), BitArray(bytes=[0, 0, 224, 0], bit_len=32), BitArray(bytes=[0, 16, 255, 255], bit_len=32), Int(0), Int(0), Int(0), Int(0), Int(0)])

--- a/tests/fixtures/execution_errors/expressions/panic_list_utf_codepoint.gleam
+++ b/tests/fixtures/execution_errors/expressions/panic_list_utf_codepoint.gleam
@@ -1,0 +1,15 @@
+pub fn main() -> List(UtfCodepoint) {
+  panic
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: `panic` expression evaluated.
+//    ,-[tests/fixtures/execution_errors/expressions/panic_list_utf_codepoint.gleam:2:3]
+//  1 | pub fn main() -> List(UtfCodepoint) {
+//  2 |   panic
+//    :   ^^|^^
+//    :     `-- panic in main.main
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/expressions/panic_utf_codepoint.gleam
+++ b/tests/fixtures/execution_errors/expressions/panic_utf_codepoint.gleam
@@ -1,0 +1,15 @@
+pub fn main() -> UtfCodepoint {
+  panic
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: `panic` expression evaluated.
+//    ,-[tests/fixtures/execution_errors/expressions/panic_utf_codepoint.gleam:2:3]
+//  1 | pub fn main() -> UtfCodepoint {
+//  2 |   panic
+//    :   ^^|^^
+//    :     `-- panic in main.main
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/expressions/panic_utf_codepoint_function.gleam
+++ b/tests/fixtures/execution_errors/expressions/panic_utf_codepoint_function.gleam
@@ -1,0 +1,15 @@
+pub fn main() -> fn() -> UtfCodepoint {
+  panic
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: `panic` expression evaluated.
+//    ,-[tests/fixtures/execution_errors/expressions/panic_utf_codepoint_function.gleam:2:3]
+//  1 | pub fn main() -> fn() -> UtfCodepoint {
+//  2 |   panic
+//    :   ^^|^^
+//    :     `-- panic in main.main
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/expressions/todo_list_utf_codepoint.gleam
+++ b/tests/fixtures/execution_errors/expressions/todo_list_utf_codepoint.gleam
@@ -1,0 +1,15 @@
+pub fn main() -> List(UtfCodepoint) {
+  todo
+}
+
+// geam:expect-error
+// geam::todo
+//
+//   x todo: `todo` expression evaluated. This code has not yet been implemented.
+//    ,-[tests/fixtures/execution_errors/expressions/todo_list_utf_codepoint.gleam:2:3]
+//  1 | pub fn main() -> List(UtfCodepoint) {
+//  2 |   todo
+//    :   ^^|^
+//    :     `-- todo in main.main
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/expressions/todo_utf_codepoint.gleam
+++ b/tests/fixtures/execution_errors/expressions/todo_utf_codepoint.gleam
@@ -1,0 +1,15 @@
+pub fn main() -> UtfCodepoint {
+  todo
+}
+
+// geam:expect-error
+// geam::todo
+//
+//   x todo: `todo` expression evaluated. This code has not yet been implemented.
+//    ,-[tests/fixtures/execution_errors/expressions/todo_utf_codepoint.gleam:2:3]
+//  1 | pub fn main() -> UtfCodepoint {
+//  2 |   todo
+//    :   ^^|^
+//    :     `-- todo in main.main
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/expressions/todo_utf_codepoint_function.gleam
+++ b/tests/fixtures/execution_errors/expressions/todo_utf_codepoint_function.gleam
@@ -1,0 +1,15 @@
+pub fn main() -> fn() -> UtfCodepoint {
+  todo
+}
+
+// geam:expect-error
+// geam::todo
+//
+//   x todo: `todo` expression evaluated. This code has not yet been implemented.
+//    ,-[tests/fixtures/execution_errors/expressions/todo_utf_codepoint_function.gleam:2:3]
+//  1 | pub fn main() -> fn() -> UtfCodepoint {
+//  2 |   todo
+//    :   ^^|^
+//    :     `-- todo in main.main
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/functions/utf_codepoint_let_step.gleam
+++ b/tests/fixtures/execution_errors/functions/utf_codepoint_let_step.gleam
@@ -1,0 +1,21 @@
+fn fail() -> UtfCodepoint {
+  panic as "step"
+}
+
+pub fn main() {
+  let value = fail()
+  let _ = value
+  Nil
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: step
+//    ,-[tests/fixtures/execution_errors/functions/utf_codepoint_let_step.gleam:2:3]
+//  1 | fn fail() -> UtfCodepoint {
+//  2 |   panic as "step"
+//    :   ^^^^^^^|^^^^^^^
+//    :          `-- panic in main.fail
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/functions/utf_codepoint_list_call_argument.gleam
+++ b/tests/fixtures/execution_errors/functions/utf_codepoint_list_call_argument.gleam
@@ -1,0 +1,19 @@
+fn values(_: Int) -> List(UtfCodepoint) {
+  []
+}
+
+pub fn main() {
+  values(panic as "argument")
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: argument
+//    ,-[tests/fixtures/execution_errors/functions/utf_codepoint_list_call_argument.gleam:6:10]
+//  5 | pub fn main() {
+//  6 |   values(panic as "argument")
+//    :          ^^^^^^^^^|^^^^^^^^^
+//    :                   `-- panic in main.main
+//  7 | }
+//    `----

--- a/tests/fixtures/execution_errors/functions/utf_codepoint_return_block_step.gleam
+++ b/tests/fixtures/execution_errors/functions/utf_codepoint_return_block_step.gleam
@@ -1,0 +1,20 @@
+fn fail() -> Nil {
+  panic as "step"
+}
+
+pub fn main() -> UtfCodepoint {
+  let _ = fail()
+  panic
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: step
+//    ,-[tests/fixtures/execution_errors/functions/utf_codepoint_return_block_step.gleam:2:3]
+//  1 | fn fail() -> Nil {
+//  2 |   panic as "step"
+//    :   ^^^^^^^|^^^^^^^
+//    :          `-- panic in main.fail
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/functions/utf_codepoint_return_bool_case_subject.gleam
+++ b/tests/fixtures/execution_errors/functions/utf_codepoint_return_bool_case_subject.gleam
@@ -1,0 +1,22 @@
+fn fail() -> Bool {
+  panic as "subject"
+}
+
+pub fn main() -> UtfCodepoint {
+  case fail() {
+    True -> panic
+    False -> panic
+  }
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: subject
+//    ,-[tests/fixtures/execution_errors/functions/utf_codepoint_return_bool_case_subject.gleam:2:3]
+//  1 | fn fail() -> Bool {
+//  2 |   panic as "subject"
+//    :   ^^^^^^^^^|^^^^^^^^
+//    :            `-- panic in main.fail
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/functions/utf_codepoint_return_float_case_subject.gleam
+++ b/tests/fixtures/execution_errors/functions/utf_codepoint_return_float_case_subject.gleam
@@ -1,0 +1,22 @@
+fn fail() -> Float {
+  panic as "subject"
+}
+
+pub fn main() -> UtfCodepoint {
+  case fail() {
+    1.0 -> panic
+    _ -> panic
+  }
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: subject
+//    ,-[tests/fixtures/execution_errors/functions/utf_codepoint_return_float_case_subject.gleam:2:3]
+//  1 | fn fail() -> Float {
+//  2 |   panic as "subject"
+//    :   ^^^^^^^^^|^^^^^^^^
+//    :            `-- panic in main.fail
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/functions/utf_codepoint_return_int_case_subject.gleam
+++ b/tests/fixtures/execution_errors/functions/utf_codepoint_return_int_case_subject.gleam
@@ -1,0 +1,22 @@
+fn fail() -> Int {
+  panic as "subject"
+}
+
+pub fn main() -> UtfCodepoint {
+  case fail() {
+    1 -> panic
+    _ -> panic
+  }
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: subject
+//    ,-[tests/fixtures/execution_errors/functions/utf_codepoint_return_int_case_subject.gleam:2:3]
+//  1 | fn fail() -> Int {
+//  2 |   panic as "subject"
+//    :   ^^^^^^^^^|^^^^^^^^
+//    :            `-- panic in main.fail
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/functions/utf_codepoint_return_string_case_subject.gleam
+++ b/tests/fixtures/execution_errors/functions/utf_codepoint_return_string_case_subject.gleam
@@ -1,0 +1,22 @@
+fn fail() -> String {
+  panic as "subject"
+}
+
+pub fn main() -> UtfCodepoint {
+  case fail() {
+    "match" -> panic
+    _ -> panic
+  }
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: subject
+//    ,-[tests/fixtures/execution_errors/functions/utf_codepoint_return_string_case_subject.gleam:2:3]
+//  1 | fn fail() -> String {
+//  2 |   panic as "subject"
+//    :   ^^^^^^^^^|^^^^^^^^
+//    :            `-- panic in main.fail
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/functions/utf_codepoint_return_tuple_subject.gleam
+++ b/tests/fixtures/execution_errors/functions/utf_codepoint_return_tuple_subject.gleam
@@ -1,0 +1,19 @@
+fn fail() -> #(UtfCodepoint) {
+  panic as "subject"
+}
+
+pub fn main() -> UtfCodepoint {
+  fail().0
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: subject
+//    ,-[tests/fixtures/execution_errors/functions/utf_codepoint_return_tuple_subject.gleam:2:3]
+//  1 | fn fail() -> #(UtfCodepoint) {
+//  2 |   panic as "subject"
+//    :   ^^^^^^^^^|^^^^^^^^
+//    :            `-- panic in main.fail
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/patterns/let_assert_bit_array_utf_codepoint_default_message.gleam
+++ b/tests/fixtures/execution_errors/patterns/let_assert_bit_array_utf_codepoint_default_message.gleam
@@ -1,0 +1,18 @@
+pub fn main() {
+  let assert <<_:utf8_codepoint>> = <<255>>
+  0
+}
+
+// geam:expect-error
+// geam::let_assert
+//
+//   x let_assert: Pattern match failed, no pattern matched the value.
+//    ,-[tests/fixtures/execution_errors/patterns/let_assert_bit_array_utf_codepoint_default_message.gleam:2:3]
+//  1 | pub fn main() {
+//  2 |   let assert <<_:utf8_codepoint>> = <<255>>
+//    :   ^^^^^|^^^^ ^^^^^^^^^^|^^^^^^^^^
+//    :        |               `-- pattern
+//    :        `-- let assert in main.main
+//  3 |   0
+//    `----
+//   help: failed value: BitArray(bytes=[255], bit_len=8)

--- a/tests/fixtures/execution_errors/patterns/let_assert_bit_array_utf_codepoint_message_error.gleam
+++ b/tests/fixtures/execution_errors/patterns/let_assert_bit_array_utf_codepoint_message_error.gleam
@@ -1,0 +1,20 @@
+fn fail_message() -> String {
+  panic as "message"
+}
+
+pub fn main() {
+  let assert <<_:utf8_codepoint>> = <<255>> as fail_message()
+  0
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: message
+//    ,-[tests/fixtures/execution_errors/patterns/let_assert_bit_array_utf_codepoint_message_error.gleam:2:3]
+//  1 | fn fail_message() -> String {
+//  2 |   panic as "message"
+//    :   ^^^^^^^^^|^^^^^^^^
+//    :            `-- panic in main.fail_message
+//  3 | }
+//    `----

--- a/tests/fixtures/rejection/expressions/list_utf_codepoint_element.gleam
+++ b/tests/fixtures/rejection/expressions/list_utf_codepoint_element.gleam
@@ -1,4 +1,0 @@
-pub fn main() {
-  let values: List(UtfCodepoint) = []
-  1
-}

--- a/tests/fixtures/rejection/functions/utf_codepoint_argument.gleam
+++ b/tests/fixtures/rejection/functions/utf_codepoint_argument.gleam
@@ -1,7 +1,0 @@
-pub fn main() {
-  1
-}
-
-fn inspect(value: UtfCodepoint) {
-  1
-}

--- a/tests/fixtures/rejection/functions/utf_codepoint_return.gleam
+++ b/tests/fixtures/rejection/functions/utf_codepoint_return.gleam
@@ -1,7 +1,0 @@
-pub fn main() {
-  1
-}
-
-fn codepoint() -> UtfCodepoint {
-  panic
-}


### PR DESCRIPTION
- Carry UtfCodepoint through planning, execution, runtime values, functions, and typed lists.
- Encode and match UTF-8, UTF-16, and UTF-32 codepoint BitArray segments.
- Move supported UtfCodepoint fixtures into execution coverage.
