### PR TITLE
Complete let assert pattern support

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -7,7 +7,7 @@ mod value_type;
 #[cfg(test)]
 pub(crate) use module::ListReturn;
 pub(crate) use module::{
-    AssertBinding, AssertPattern, BitArrayAssertPattern, BitArrayBindingPattern, BitArrayExprKind,
+    AssertBinding, AssertPattern, AssertSubject, BitArrayBindingPattern, BitArrayExprKind,
     BitArrayFunctionExprKind, BitArrayFunctionReference, BitArrayFunctionReturn, BitArrayPattern,
     BitArrayPatternSegment, BitArrayPatternSize, BitArrayPatternSizeExpr, BitArrayPatternValue,
     BitArrayReturn, BitArraySegment, BitArrayStringPattern, BoolCaseBranches, BoolExprKind,

--- a/src/plan/execution.rs
+++ b/src/plan/execution.rs
@@ -77,8 +77,8 @@ pub(crate) use return_::{
     UtfCodepointFunctionReturn, UtfCodepointListReturn, UtfCodepointReturn,
 };
 pub(crate) use step::{
-    AssertBinding, AssertPattern, BitArrayAssertPattern, ListAssertPattern, ListAssertTail, Step,
-    StepKind, StringAssertBinding,
+    AssertBinding, AssertPattern, AssertSubject, ListAssertPattern, ListAssertTail, Step, StepKind,
+    StringAssertBinding,
 };
 #[cfg(test)]
 pub(crate) use value_shape::ValueShapeDescriptor;

--- a/src/plan/execution/lowering/step.rs
+++ b/src/plan/execution/lowering/step.rs
@@ -186,40 +186,14 @@ fn lower_step(step: module::Step, context: &mut super::LoweringContext) -> execu
             local: function_function_local(local, context),
             value: typed_function_expr(value, context, function_function_expr),
         },
-        M::AssertList {
-            local,
+        M::AssertPattern {
+            subject,
             pattern,
             message,
             site,
             pattern_span,
-        } => E::AssertList {
-            local: list_local(local, context),
-            pattern: assert_pattern(pattern, context),
-            message: message.map(|message| string_expr(message, context)),
-            site,
-            pattern_span,
-        },
-        M::AssertBitArray {
-            local,
-            pattern,
-            message,
-            site,
-            pattern_span,
-        } => E::AssertBitArray {
-            local: execution::BitArrayLocalId(local.0),
-            pattern: bit_array_assert_pattern(pattern),
-            message: message.map(|message| string_expr(message, context)),
-            site,
-            pattern_span,
-        },
-        M::AssertCustom {
-            local,
-            pattern,
-            message,
-            site,
-            pattern_span,
-        } => E::AssertCustom {
-            local: custom_local(local, context),
+        } => E::AssertPattern {
+            subject: assert_subject(subject, context),
             pattern: assert_pattern(pattern, context),
             message: message.map(|message| string_expr(message, context)),
             site,
@@ -242,21 +216,38 @@ fn lower_step(step: module::Step, context: &mut super::LoweringContext) -> execu
     })
 }
 
-fn bit_array_assert_pattern(
-    pattern: module::BitArrayAssertPattern,
-) -> execution::BitArrayAssertPattern {
-    match pattern {
-        module::BitArrayAssertPattern::Pattern(pattern) => {
-            execution::BitArrayAssertPattern::Pattern(super::pattern::bit_array_pattern(pattern))
+fn assert_subject(
+    subject: module::AssertSubject,
+    context: &mut super::LoweringContext,
+) -> execution::AssertSubject {
+    match subject {
+        module::AssertSubject::Int(local) => {
+            execution::AssertSubject::Int(execution::IntLocalId(local.0))
         }
-        module::BitArrayAssertPattern::Alias {
-            pattern,
-            local,
-            name: _,
-        } => execution::BitArrayAssertPattern::Alias {
-            pattern: Box::new(bit_array_assert_pattern(*pattern)),
-            local: execution::BitArrayLocalId(local.0),
-        },
+        module::AssertSubject::Float(local) => {
+            execution::AssertSubject::Float(execution::FloatLocalId(local.0))
+        }
+        module::AssertSubject::String(local) => {
+            execution::AssertSubject::String(execution::StringLocalId(local.0))
+        }
+        module::AssertSubject::BitArray(local) => {
+            execution::AssertSubject::BitArray(execution::BitArrayLocalId(local.0))
+        }
+        module::AssertSubject::Custom(local) => {
+            execution::AssertSubject::Custom(custom_local(local, context))
+        }
+        module::AssertSubject::Bool(local) => {
+            execution::AssertSubject::Bool(execution::BoolLocalId(local.0))
+        }
+        module::AssertSubject::Nil(local) => {
+            execution::AssertSubject::Nil(execution::NilLocalId(local.0))
+        }
+        module::AssertSubject::Tuple(local) => {
+            execution::AssertSubject::Tuple(execution::TupleLocalId(local.0))
+        }
+        module::AssertSubject::List(local) => {
+            execution::AssertSubject::List(list_local(local, context))
+        }
     }
 }
 
@@ -396,11 +387,11 @@ fn assert_tail(
 #[cfg(test)]
 mod tests {
     use crate::plan::execution::{
-        AssertBinding, AssertPattern, BitArrayAssertPattern, BitArrayBindingPattern,
-        BitArrayLocalId, BitArrayPatternSegment, BitArrayPatternSizeExpr, BitArrayPatternValue,
-        ExecutionPlan, IntFunctionId, IntListLocalId, IntLocalId, ListAssertPattern,
-        ListAssertTail, ListFunctionId, ListListFunctionId, ListListTypeId, ListLocal,
-        ListLocalExpr, ParamLocal, RuntimeFunctionId, Step, StepKind,
+        AssertBinding, AssertPattern, AssertSubject, BitArrayBindingPattern, BitArrayLocalId,
+        BitArrayPatternSegment, BitArrayPatternSizeExpr, BitArrayPatternValue, ExecutionPlan,
+        IntFunctionId, IntListLocalId, IntLocalId, ListAssertPattern, ListAssertTail,
+        ListFunctionId, ListListFunctionId, ListListTypeId, ListLocal, ListLocalExpr, ParamLocal,
+        RuntimeFunctionId, Step, StepKind,
     };
 
     #[test]
@@ -580,9 +571,9 @@ pub fn main() {
         BitArrayLocalId,
         u8,
     ) {
-        if let StepKind::AssertBitArray {
-            local,
-            pattern: BitArrayAssertPattern::Pattern(pattern),
+        if let StepKind::AssertPattern {
+            subject: AssertSubject::BitArray(local),
+            pattern: AssertPattern::BitArray(pattern),
             ..
         } = step.kind()
             && let [
@@ -624,7 +615,11 @@ pub fn main() {
 
     fn expect_list_assert(step: &Step) -> (&ListLocal, &AssertPattern) {
         match step.kind() {
-            StepKind::AssertList { local, pattern, .. } => (local, pattern),
+            StepKind::AssertPattern {
+                subject: AssertSubject::List(local),
+                pattern,
+                ..
+            } => (local, pattern),
             _ => panic!("expected a list-assert step"),
         }
     }

--- a/src/plan/execution/step.rs
+++ b/src/plan/execution/step.rs
@@ -51,12 +51,16 @@ pub(crate) enum AssertPattern {
     },
 }
 
-pub(crate) enum BitArrayAssertPattern {
-    Pattern(BitArrayPattern),
-    Alias {
-        pattern: Box<BitArrayAssertPattern>,
-        local: BitArrayLocalId,
-    },
+pub(crate) enum AssertSubject {
+    Int(IntLocalId),
+    Float(FloatLocalId),
+    String(StringLocalId),
+    BitArray(BitArrayLocalId),
+    Custom(CustomLocal),
+    Bool(BoolLocalId),
+    Nil(NilLocalId),
+    Tuple(TupleLocalId),
+    List(ListLocal),
 }
 
 pub(crate) struct ListAssertPattern {
@@ -154,22 +158,8 @@ pub(crate) enum StepKind {
         local: FunctionFunctionLocal,
         value: TypedFunctionExpr<FunctionFunctionExpr>,
     },
-    AssertList {
-        local: ListLocal,
-        pattern: AssertPattern,
-        message: Option<StringExpr>,
-        site: PanicSite,
-        pattern_span: SourceSpan,
-    },
-    AssertBitArray {
-        local: BitArrayLocalId,
-        pattern: BitArrayAssertPattern,
-        message: Option<StringExpr>,
-        site: PanicSite,
-        pattern_span: SourceSpan,
-    },
-    AssertCustom {
-        local: CustomLocal,
+    AssertPattern {
+        subject: AssertSubject,
         pattern: AssertPattern,
         message: Option<StringExpr>,
         site: PanicSite,

--- a/src/plan/module.rs
+++ b/src/plan/module.rs
@@ -99,8 +99,8 @@ pub(crate) use reference::{
 };
 pub use step::Step;
 pub(crate) use step::{
-    AssertBinding, AssertPattern, BitArrayAssertPattern, ListAssertPattern, ListAssertTail,
-    StepKind, StringAssertBinding,
+    AssertBinding, AssertPattern, AssertSubject, ListAssertPattern, ListAssertTail, StepKind,
+    StringAssertBinding,
 };
 
 #[derive(Debug, PartialEq)]

--- a/src/plan/module/frame/step.rs
+++ b/src/plan/module/frame/step.rs
@@ -1,7 +1,7 @@
 use super::FrameLayout;
 use crate::plan::{
-    AssertPattern, BitArrayAssertPattern, CustomBindingPattern, ListAssertPattern, ListAssertTail,
-    Step, StepKind, TotalBindingPattern,
+    AssertPattern, AssertSubject, CustomBindingPattern, ListAssertPattern, ListAssertTail, Step,
+    StepKind, TotalBindingPattern,
 };
 
 impl FrameLayout {
@@ -94,37 +94,13 @@ impl FrameLayout {
                 self.include_function_function_expr(value.expression());
                 self.include_function_function(local.clone());
             }
-            StepKind::AssertList {
-                local,
+            StepKind::AssertPattern {
+                subject,
                 pattern,
                 message,
                 ..
             } => {
-                self.include_list(local);
-                self.include_assert_pattern(pattern);
-                if let Some(message) = message {
-                    self.include_string_expr(message);
-                }
-            }
-            StepKind::AssertBitArray {
-                local,
-                pattern,
-                message,
-                ..
-            } => {
-                self.include_bit_array(*local);
-                self.include_bit_array_assert_pattern(pattern);
-                if let Some(message) = message {
-                    self.include_string_expr(message);
-                }
-            }
-            StepKind::AssertCustom {
-                local,
-                pattern,
-                message,
-                ..
-            } => {
-                self.include_custom(local.clone());
+                self.include_assert_subject(subject);
                 self.include_assert_pattern(pattern);
                 if let Some(message) = message {
                     self.include_string_expr(message);
@@ -187,13 +163,17 @@ impl FrameLayout {
         }
     }
 
-    fn include_bit_array_assert_pattern(&mut self, pattern: &BitArrayAssertPattern) {
-        match pattern {
-            BitArrayAssertPattern::Pattern(pattern) => self.include_bit_array_pattern(pattern),
-            BitArrayAssertPattern::Alias { pattern, local, .. } => {
-                self.include_bit_array_assert_pattern(pattern);
-                self.include_bit_array(*local);
-            }
+    fn include_assert_subject(&mut self, subject: &AssertSubject) {
+        match subject {
+            AssertSubject::Int(local) => self.include_int(*local),
+            AssertSubject::Float(local) => self.include_float(*local),
+            AssertSubject::String(local) => self.include_string(*local),
+            AssertSubject::BitArray(local) => self.include_bit_array(*local),
+            AssertSubject::Custom(local) => self.include_custom(local.clone()),
+            AssertSubject::Bool(local) => self.include_bool(*local),
+            AssertSubject::Nil(local) => self.include_nil(*local),
+            AssertSubject::Tuple(local) => self.include_tuple(*local),
+            AssertSubject::List(local) => self.include_list(local),
         }
     }
 
@@ -241,11 +221,11 @@ impl FrameLayout {
 mod tests {
     use super::FrameLayout;
     use crate::plan::{
-        AssertBinding, AssertPattern, BoolExpr, BoolFunctionExpr, BoolFunctionLocalId, BoolLocalId,
-        Expr, IntExpr, IntFunctionId, IntLocalId, ListAssertPattern, ListAssertTail, ListLocal,
-        NilExpr, NilFunctionExpr, NilFunctionLocalId, NilLocalId, PanicSite, ParamLocal,
-        ReturnExpr, SourceSpan, StringExpr, StringFunctionExpr, StringFunctionLocalId,
-        StringLocalId, TupleListLocalId, ValueShape, ValueType,
+        AssertBinding, AssertPattern, AssertSubject, BoolExpr, BoolFunctionExpr,
+        BoolFunctionLocalId, BoolLocalId, Expr, IntExpr, IntFunctionId, IntLocalId,
+        ListAssertPattern, ListAssertTail, ListLocal, NilExpr, NilFunctionExpr, NilFunctionLocalId,
+        NilLocalId, PanicSite, ParamLocal, ReturnExpr, SourceSpan, StringExpr, StringFunctionExpr,
+        StringFunctionLocalId, StringLocalId, TupleListLocalId, ValueShape, ValueType,
     };
 
     #[test]
@@ -395,8 +375,8 @@ mod tests {
         let list_element_type = ValueType::Tuple(tuple_type.clone());
         let subject_local = ListLocal::tuple(TupleListLocalId(0), tuple_type.clone());
         let tail_local = ListLocal::tuple(TupleListLocalId(1), tuple_type.clone());
-        let steps = [crate::plan::Step::assert_list_at(
-            subject_local,
+        let steps = [crate::plan::Step::assert_pattern_at(
+            AssertSubject::List(subject_local),
             AssertPattern::list(ListAssertPattern::new(
                 list_element_type.clone(),
                 vec![AssertPattern::Tuple(vec![

--- a/src/plan/module/step.rs
+++ b/src/plan/module/step.rs
@@ -59,14 +59,17 @@ pub(crate) enum AssertPattern {
     },
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum BitArrayAssertPattern {
-    Pattern(BitArrayPattern),
-    Alias {
-        pattern: Box<BitArrayAssertPattern>,
-        local: BitArrayLocalId,
-        name: EcoString,
-    },
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AssertSubject {
+    Int(IntLocalId),
+    Float(FloatLocalId),
+    String(StringLocalId),
+    BitArray(BitArrayLocalId),
+    Custom(CustomLocal),
+    Bool(BoolLocalId),
+    Nil(NilLocalId),
+    Tuple(TupleLocalId),
+    List(ListLocal),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -193,22 +196,8 @@ pub(crate) enum StepKind {
         name: EcoString,
         value: TypedFunctionExpr<FunctionFunctionExpr>,
     },
-    AssertList {
-        local: ListLocal,
-        pattern: AssertPattern,
-        message: Option<StringExpr>,
-        site: PanicSite,
-        pattern_span: SourceSpan,
-    },
-    AssertBitArray {
-        local: BitArrayLocalId,
-        pattern: BitArrayAssertPattern,
-        message: Option<StringExpr>,
-        site: PanicSite,
-        pattern_span: SourceSpan,
-    },
-    AssertCustom {
-        local: CustomLocal,
+    AssertPattern {
+        subject: AssertSubject,
         pattern: AssertPattern,
         message: Option<StringExpr>,
         site: PanicSite,
@@ -275,20 +264,6 @@ impl AssertPattern {
 
     pub(crate) fn custom(pattern: crate::plan::CustomPattern) -> Self {
         Self::Custom(pattern)
-    }
-}
-
-impl BitArrayAssertPattern {
-    pub(crate) fn pattern(pattern: BitArrayPattern) -> Self {
-        Self::Pattern(pattern)
-    }
-
-    pub(crate) fn alias(pattern: Self, local: BitArrayLocalId, name: EcoString) -> Self {
-        Self::Alias {
-            pattern: Box::new(pattern),
-            local,
-            name,
-        }
     }
 }
 
@@ -655,52 +630,16 @@ impl Step {
         }
     }
 
-    pub(crate) fn assert_list_at(
-        local: ListLocal,
+    pub(crate) fn assert_pattern_at(
+        subject: AssertSubject,
         pattern: AssertPattern,
         message: Option<StringExpr>,
         site: PanicSite,
         pattern_span: SourceSpan,
     ) -> Self {
         Self {
-            kind: StepKind::AssertList {
-                local,
-                pattern,
-                message,
-                site,
-                pattern_span,
-            },
-        }
-    }
-
-    pub(crate) fn assert_bit_array_at(
-        local: BitArrayLocalId,
-        pattern: BitArrayAssertPattern,
-        message: Option<StringExpr>,
-        site: PanicSite,
-        pattern_span: SourceSpan,
-    ) -> Self {
-        Self {
-            kind: StepKind::AssertBitArray {
-                local,
-                pattern,
-                message,
-                site,
-                pattern_span,
-            },
-        }
-    }
-
-    pub(crate) fn assert_custom_at(
-        local: CustomLocal,
-        pattern: AssertPattern,
-        message: Option<StringExpr>,
-        site: PanicSite,
-        pattern_span: SourceSpan,
-    ) -> Self {
-        Self {
-            kind: StepKind::AssertCustom {
-                local,
+            kind: StepKind::AssertPattern {
+                subject,
                 pattern,
                 message,
                 site,
@@ -729,12 +668,12 @@ impl Step {
 mod tests {
     use super::{Step, StepKind};
     use crate::plan::{
-        AssertPattern, BoolExpr, CustomFunctionExpr, CustomFunctionLocal, CustomFunctionLocalId,
-        CustomFunctionType, CustomType, CustomTypeName, Expr, FunctionFunctionExpr,
-        FunctionFunctionLocal, FunctionFunctionLocalId, FunctionFunctionType, FunctionType,
-        IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionReference, IntListLocalId,
-        IntLocalId, ListAssertPattern, ListAssertTail, ListLocal, PanicExpr, PanicSite, ParamLocal,
-        StringExpr, TypedFunctionExpr, ValueShape, ValueType,
+        AssertPattern, AssertSubject, BoolExpr, CustomFunctionExpr, CustomFunctionLocal,
+        CustomFunctionLocalId, CustomFunctionType, CustomType, CustomTypeName, Expr,
+        FunctionFunctionExpr, FunctionFunctionLocal, FunctionFunctionLocalId, FunctionFunctionType,
+        FunctionType, IntExpr, IntFunctionId, IntFunctionLocalId, IntFunctionReference,
+        IntListLocalId, IntLocalId, ListAssertPattern, ListAssertTail, ListLocal, PanicExpr,
+        PanicSite, ParamLocal, StringExpr, TypedFunctionExpr, ValueShape, ValueType,
     };
     use num_bigint::BigInt;
 
@@ -777,8 +716,8 @@ mod tests {
             },
         );
         assert_eq!(
-            Step::assert_list_at(
-                ListLocal::int(IntListLocalId(0)),
+            Step::assert_pattern_at(
+                AssertSubject::List(ListLocal::int(IntListLocalId(0))),
                 AssertPattern::list(ListAssertPattern::new(
                     ValueType::Int,
                     vec![AssertPattern::Discard],
@@ -792,8 +731,8 @@ mod tests {
                 crate::plan::SourceSpan::new(0, 0),
             )
             .kind(),
-            &StepKind::AssertList {
-                local: ListLocal::int(IntListLocalId(0)),
+            &StepKind::AssertPattern {
+                subject: AssertSubject::List(ListLocal::int(IntListLocalId(0))),
                 pattern: AssertPattern::list(ListAssertPattern::new(
                     ValueType::Int,
                     vec![AssertPattern::Discard],

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -344,7 +344,6 @@ mod tests {
     use crate::planner::error::{
         InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
         InvalidPipelineShapeReason, InvalidTypedAstReason, PlanError, UnsupportedExpressionKind,
-        UnsupportedPatternKind,
     };
     use crate::planner::plan_module;
     use crate::planner::support::{compile, dummy_span};
@@ -1066,26 +1065,6 @@ pub fn main() {
                 reason: InvalidTypedAstReason::PipelineShape {
                     reason: InvalidPipelineShapeReason::NonCallStep,
                 },
-            }),
-        );
-    }
-
-    #[test]
-    fn reject_profile_anonymous_function_let_assert_constructor_pattern() {
-        assert_eq!(
-            plan_module(compile(
-                r#"
-pub fn main() {
-  fn() {
-    let assert True = True
-    1
-  }
-  1
-}
-"#,
-            )),
-            Err(PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::Constructor,
             }),
         );
     }

--- a/src/planner/expression/function/free_variables.rs
+++ b/src/planner/expression/function/free_variables.rs
@@ -778,6 +778,30 @@ pub fn main() {
     }
 
     #[test]
+    fn anonymous_free_variables_treat_nested_let_assert_pattern_names_as_bound() {
+        assert_eq!(
+            anonymous_function_free_variables(
+                r#"
+pub type Payload {
+  Payload(Int)
+}
+
+pub fn main() {
+  let subject = #([Payload(1)], <<2>>, "prefix")
+  let message = "missing"
+  fn() {
+    let assert #([Payload(value)], <<bit>>, "pre" <> suffix) = subject as message
+    #(value, bit, suffix)
+  }
+  1
+}
+"#,
+            ),
+            vec!["subject".to_string(), "message".to_string()],
+        );
+    }
+
+    #[test]
     fn anonymous_free_variables_include_synthetic_negate_int() {
         let body = Vec1::new(Statement::Expression(TypedExpr::NegateInt {
             location: dummy_span(),

--- a/src/planner/statement/assignment.rs
+++ b/src/planner/statement/assignment.rs
@@ -2518,23 +2518,6 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_profile_let_assert_literal_alias_pattern() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  let assert 1 as one = 1
-  one
-}
-"#,
-            ),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::Literal,
-            },
-        );
-    }
-
-    #[test]
     fn plan_binding_pattern_accepts_supported_shapes() {
         let variable = |name: &str| Pattern::Variable {
             location: dummy_span(),

--- a/src/planner/statement/assignment/assert.rs
+++ b/src/planner/statement/assignment/assert.rs
@@ -3,15 +3,14 @@ use super::{
     plan_ordinary_assignment_value, value_type_expression_type,
 };
 use crate::plan::{
-    BitArrayAssertPattern, BitArrayExpr, Expr, ListExpr, ListLocal, Step, StringExpr, ValueType,
+    AssertSubject, BitArrayExpr, BoolExpr, CustomExpr, CustomLocal, Expr, ExprKind, FloatExpr,
+    IntExpr, ListExpr, ListLocal, NilExpr, Step, StringExpr, TupleExpr, ValueType,
 };
 use crate::planner::context::PlanContext;
-use crate::planner::error::{
-    InvalidExpressionType, InvalidTypedAstReason, PlanError, UnsupportedPatternKind,
-};
+use crate::planner::error::{InvalidExpressionType, InvalidTypedAstReason, PlanError};
 use crate::planner::expression::plan_expr;
 use ecow::EcoString;
-use gleam_core::ast::{Pattern, SrcSpan, TypedExpr, TypedPattern};
+use gleam_core::ast::{SrcSpan, TypedExpr, TypedPattern};
 
 pub(super) fn plan_assert_assignment(
     location: SrcSpan,
@@ -20,78 +19,21 @@ pub(super) fn plan_assert_assignment(
     message: Option<TypedExpr>,
     context: &mut PlanContext<'_>,
 ) -> Result<PlannedAssignment, PlanError> {
-    if let Some(pattern_type) = assert_custom_pattern_type(&pattern) {
-        return plan_assert_custom_assignment(
-            location,
-            pattern,
-            pattern_type,
-            value,
-            message,
-            context,
-        );
-    }
-    if assert_bit_array_pattern(&pattern) {
-        return plan_assert_bit_array_assignment(location, pattern, value, message, context);
-    }
-    let Some(pattern_type) = assert_list_pattern_type(&pattern) else {
-        let pattern = plan_assert_exhaustive_pattern(pattern, context)?;
-        let value = plan_ordinary_assignment_value(&pattern, value, context)?;
-        return plan_bound_assignment(pattern, value, context);
-    };
-
-    let value = plan_expr(value, context)?;
-    let actual = value.value_type();
-    let value = value
-        .into_list()
-        .ok_or_else(|| list_assert_value_must_be_list(actual))?;
-    let element_type = value.element_type().clone();
-    if ValueType::from_gleam(pattern_type.as_ref())
-        != Some(ValueType::List(Box::new(element_type.clone())))
-    {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::InvalidPattern,
-        });
-    }
-    let message = message
-        .map(|message| plan_assert_message(message, context))
-        .transpose()?;
-
-    let item_shape = value.item_shape().clone();
-    let (local, list_value) = context.define_internal_list_value(value);
-    let name = internal_list_name(&local);
-    let site = context.panic_site(location);
-    let pattern_span = pattern.location().into();
-    let pattern = crate::planner::pattern::plan_runtime_pattern(pattern, context)?.pattern;
-    let list_local = ListExpr::local_get(local.clone(), name.clone()).with_item_shape(item_shape);
-    let steps = vec![
-        Step::let_list_expr(name, list_value),
-        Step::assert_list_at(local, pattern, message, site, pattern_span),
-    ];
-
-    Ok(PlannedAssignment {
-        steps,
-        value: Expr::list(list_local),
-    })
-}
-
-fn plan_bit_array_assert_pattern(
-    pattern: TypedPattern,
-    context: &mut PlanContext<'_>,
-) -> Result<BitArrayAssertPattern, PlanError> {
-    match pattern {
-        Pattern::BitArray { segments, .. } => {
-            let (pattern, _) = crate::planner::pattern::plan_bit_array_pattern(segments, context)?;
-            Ok(BitArrayAssertPattern::pattern(pattern))
+    if let Some(binding) = plan_total_assert_pattern(pattern.clone(), context)? {
+        if binding_pattern_depends_on_source_shape(&binding) {
+            let value = plan_expr(value, context)?;
+            if binding_pattern_accepts_shape(&binding, value.shape()) {
+                return plan_bound_assignment(binding, value, context);
+            }
+            return plan_refutable_assert_assignment_from_expr(
+                location, pattern, value, message, context,
+            );
         }
-        Pattern::Assign { name, pattern, .. } => {
-            let pattern = plan_bit_array_assert_pattern(*pattern, context)?;
-            let local = context.define_bit_array_local(name.clone());
-            Ok(BitArrayAssertPattern::alias(pattern, local, name))
-        }
-        _ => Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::InvalidPattern,
-        }),
+        let value = plan_ordinary_assignment_value(&binding, value, context)?;
+        return plan_bound_assignment(binding, value, context);
     }
+
+    plan_refutable_assert_assignment(location, pattern, value, message, context)
 }
 
 pub(super) fn plan_assert_assignment_steps(
@@ -101,19 +43,88 @@ pub(super) fn plan_assert_assignment_steps(
     message: Option<TypedExpr>,
     context: &mut PlanContext<'_>,
 ) -> Result<Vec<Step>, PlanError> {
-    if assert_custom_pattern_type(&pattern).is_some()
-        || assert_list_pattern_type(&pattern).is_some()
-        || assert_bit_array_pattern(&pattern)
-    {
-        return Ok(plan_assert_assignment(location, pattern, value, message, context)?.steps);
+    if let Some(binding) = plan_total_assert_pattern(pattern.clone(), context)? {
+        if binding_pattern_depends_on_source_shape(&binding) {
+            let value = plan_expr(value, context)?;
+            if binding_pattern_accepts_shape(&binding, value.shape()) {
+                return plan_assignment_steps(binding, value, context);
+            }
+            return Ok(plan_refutable_assert_assignment_from_expr(
+                location, pattern, value, message, context,
+            )?
+            .steps);
+        }
+        let value = plan_ordinary_assignment_value(&binding, value, context)?;
+        return plan_assignment_steps(binding, value, context);
     }
 
-    let pattern = plan_assert_exhaustive_pattern(pattern, context)?;
-    let value = plan_ordinary_assignment_value(&pattern, value, context)?;
-    plan_assignment_steps(pattern, value, context)
+    Ok(plan_refutable_assert_assignment(location, pattern, value, message, context)?.steps)
 }
 
-fn plan_assert_bit_array_assignment(
+fn plan_total_assert_pattern(
+    pattern: TypedPattern,
+    context: &PlanContext<'_>,
+) -> Result<Option<BindingPattern>, PlanError> {
+    match super::plan_binding_pattern_in_context(pattern, context) {
+        Ok(pattern) => Ok(Some(pattern)),
+        Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::InvalidPattern,
+        }) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn binding_pattern_depends_on_source_shape(pattern: &BindingPattern) -> bool {
+    match pattern {
+        BindingPattern::Custom { .. } => true,
+        BindingPattern::Tuple(elements) => {
+            elements.iter().any(binding_pattern_depends_on_source_shape)
+        }
+        BindingPattern::Alias { pattern, .. } => binding_pattern_depends_on_source_shape(pattern),
+        BindingPattern::Named(_) | BindingPattern::Discard | BindingPattern::ListTail { .. } => {
+            false
+        }
+    }
+}
+
+fn binding_pattern_accepts_shape(
+    pattern: &BindingPattern,
+    shape: &crate::plan::ValueShape,
+) -> bool {
+    match pattern {
+        BindingPattern::Named(_) | BindingPattern::Discard => true,
+        BindingPattern::Tuple(elements) => {
+            let crate::plan::ValueShape::Tuple(shapes) = shape else {
+                return false;
+            };
+            elements.len() == shapes.len()
+                && elements
+                    .iter()
+                    .zip(shapes)
+                    .all(|(pattern, shape)| binding_pattern_accepts_shape(pattern, shape))
+        }
+        BindingPattern::ListTail { element_type, .. } => {
+            shape.value_type() == ValueType::List(Box::new(element_type.clone()))
+        }
+        BindingPattern::Custom {
+            source_shape,
+            constructor_count,
+            constructor,
+            ..
+        } => {
+            let crate::plan::ValueShape::Custom(actual) = shape else {
+                return false;
+            };
+            actual.type_() == source_shape.type_()
+                && (*constructor_count == 1
+                    || actual.constructor()
+                        == crate::plan::CustomConstructorRefinement::Exact(constructor.index()))
+        }
+        BindingPattern::Alias { pattern, .. } => binding_pattern_accepts_shape(pattern, shape),
+    }
+}
+
+fn plan_refutable_assert_assignment(
     location: SrcSpan,
     pattern: TypedPattern,
     value: TypedExpr,
@@ -121,82 +132,149 @@ fn plan_assert_bit_array_assignment(
     context: &mut PlanContext<'_>,
 ) -> Result<PlannedAssignment, PlanError> {
     let value = plan_expr(value, context)?;
-    let actual = value.value_type();
-    let value = value
-        .into_bit_array()
-        .ok_or_else(|| bit_array_assert_value_must_be_bit_array(actual))?;
-    let message = message
-        .map(|message| plan_assert_message(message, context))
-        .transpose()?;
-    let local = context.define_internal_bit_array_local();
-    let name = internal_bit_array_name(local);
-    let local_value = BitArrayExpr::local_get(local, name.clone());
-    let site = context.panic_site(location);
-    let pattern_span = pattern.location().into();
-    let pattern = plan_bit_array_assert_pattern(pattern, context)?;
-
-    Ok(PlannedAssignment {
-        steps: vec![
-            Step::let_bit_array(local, name, value),
-            Step::assert_bit_array_at(local, pattern, message, site, pattern_span),
-        ],
-        value: Expr::bit_array(local_value),
-    })
+    plan_refutable_assert_assignment_from_expr(location, pattern, value, message, context)
 }
 
-fn plan_assert_custom_assignment(
+fn plan_refutable_assert_assignment_from_expr(
     location: SrcSpan,
     pattern: TypedPattern,
-    pattern_type: std::sync::Arc<gleam_core::type_::Type>,
-    value: TypedExpr,
+    value: Expr,
     message: Option<TypedExpr>,
     context: &mut PlanContext<'_>,
 ) -> Result<PlannedAssignment, PlanError> {
-    let Some(ValueType::Custom(pattern_type)) = ValueType::from_gleam(pattern_type.as_ref()) else {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::InvalidPattern,
-        });
-    };
-    let value = plan_expr(value, context)?;
-    let actual = value.value_type();
-    let value = value
-        .into_custom()
-        .ok_or_else(|| custom_assert_value_must_be_custom(actual))?;
-    if value.type_() != &pattern_type {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::InvalidPattern,
-        });
-    }
+    validate_pattern_value_type(&pattern, value.value_type())?;
     let message = message
         .map(|message| plan_assert_message(message, context))
         .transpose()?;
-    let local = context.define_internal_custom_local();
-    let typed_local = crate::plan::CustomLocal::from_shape(local, value.shape().clone());
-    let name = internal_custom_name(local);
-    let local_value = crate::plan::CustomExpr::local_get(typed_local.clone(), name.clone());
+    let (let_step, subject, local_value) = plan_assert_subject(value, context)?;
     let site = context.panic_site(location);
     let pattern_span = pattern.location().into();
     let pattern = crate::planner::pattern::plan_runtime_pattern(pattern, context)?.pattern;
 
     Ok(PlannedAssignment {
         steps: vec![
-            Step::let_custom(local, name, value),
-            Step::assert_custom_at(typed_local, pattern, message, site, pattern_span),
+            let_step,
+            Step::assert_pattern_at(subject, pattern, message, site, pattern_span),
         ],
-        value: Expr::custom(local_value),
+        value: local_value,
     })
 }
 
-fn plan_assert_exhaustive_pattern(
-    pattern: TypedPattern,
-    context: &PlanContext<'_>,
-) -> Result<BindingPattern, PlanError> {
-    match super::plan_binding_pattern_in_context(pattern.clone(), context) {
-        Ok(pattern) => Ok(pattern),
-        Err(PlanError::InvalidTypedAst {
+fn validate_pattern_value_type(pattern: &TypedPattern, actual: ValueType) -> Result<(), PlanError> {
+    let expected = crate::planner::pattern::pattern_value_type(pattern)?;
+    if expected == actual {
+        return Ok(());
+    }
+    let expected_family = value_type_expression_type(expected);
+    let actual_family = value_type_expression_type(actual);
+    if expected_family == actual_family {
+        return Err(PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::InvalidPattern,
-        }) => Err(unsupported_assert_exhaustive_pattern_error(&pattern)),
-        Err(error) => Err(error),
+        });
+    }
+    Err(PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionType {
+            expected: expected_family,
+            actual: actual_family,
+        },
+    })
+}
+
+fn plan_assert_subject(
+    value: Expr,
+    context: &mut PlanContext<'_>,
+) -> Result<(Step, AssertSubject, Expr), PlanError> {
+    match value.into_kind() {
+        ExprKind::Int(value) => {
+            let local = context.define_internal_int_local();
+            let name = internal_assert_name("int", local.0);
+            Ok((
+                Step::let_int(local, name.clone(), value),
+                AssertSubject::Int(local),
+                Expr::int(IntExpr::local_get(local, name)),
+            ))
+        }
+        ExprKind::Float(value) => {
+            let local = context.define_internal_float_local();
+            let name = internal_assert_name("float", local.0);
+            Ok((
+                Step::let_float(local, name.clone(), value),
+                AssertSubject::Float(local),
+                Expr::float(FloatExpr::local_get(local, name)),
+            ))
+        }
+        ExprKind::String(value) => {
+            let local = context.define_internal_string_local();
+            let name = internal_assert_name("string", local.0);
+            Ok((
+                Step::let_string(local, name.clone(), value),
+                AssertSubject::String(local),
+                Expr::string(StringExpr::local_get(local, name)),
+            ))
+        }
+        ExprKind::BitArray(value) => {
+            let local = context.define_internal_bit_array_local();
+            let name = internal_bit_array_name(local);
+            Ok((
+                Step::let_bit_array(local, name.clone(), value),
+                AssertSubject::BitArray(local),
+                Expr::bit_array(BitArrayExpr::local_get(local, name)),
+            ))
+        }
+        ExprKind::Custom(value) => {
+            let local = context.define_internal_custom_local();
+            let local = CustomLocal::from_shape(local, value.shape().clone());
+            let name = internal_custom_name(local.id());
+            Ok((
+                Step::let_custom(local.id(), name.clone(), value),
+                AssertSubject::Custom(local.clone()),
+                Expr::custom(CustomExpr::local_get(local, name)),
+            ))
+        }
+        ExprKind::Bool(value) => {
+            let local = context.define_internal_bool_local();
+            let name = internal_assert_name("bool", local.0);
+            Ok((
+                Step::let_bool(local, name.clone(), value),
+                AssertSubject::Bool(local),
+                Expr::bool(BoolExpr::local_get(local, name)),
+            ))
+        }
+        ExprKind::Nil(value) => {
+            let local = context.define_internal_nil_local();
+            let name = internal_assert_name("nil", local.0);
+            Ok((
+                Step::let_nil(local, name.clone(), value),
+                AssertSubject::Nil(local),
+                Expr::nil(NilExpr::local_get(local, name)),
+            ))
+        }
+        ExprKind::Tuple(value) => {
+            let local = context.define_internal_tuple_local();
+            let name = internal_assert_name("tuple", local.0);
+            let type_ = value.type_().to_vec();
+            let shape = value.shape().to_vec().into_boxed_slice();
+            Ok((
+                Step::let_tuple(local, name.clone(), value),
+                AssertSubject::Tuple(local),
+                Expr::tuple(TupleExpr::local_get(local, name, type_).with_shape(shape)),
+            ))
+        }
+        ExprKind::List(value) => {
+            let item_shape = value.item_shape().clone();
+            let (local, value) = context.define_internal_list_value(value);
+            let name = internal_list_name(&local);
+            let local_value =
+                ListExpr::local_get(local.clone(), name.clone()).with_item_shape(item_shape);
+            Ok((
+                Step::let_list_expr(name, value),
+                AssertSubject::List(local),
+                Expr::list(local_value),
+            ))
+        }
+        ExprKind::UtfCodepoint(_) | ExprKind::Function(_) => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::InvalidPattern,
+        }),
     }
 }
 
@@ -216,93 +294,6 @@ fn plan_assert_message(
         })
 }
 
-fn assert_bit_array_pattern(pattern: &TypedPattern) -> bool {
-    match pattern {
-        Pattern::BitArray { .. } => true,
-        Pattern::Assign { pattern, .. } => assert_bit_array_pattern(pattern),
-        _ => false,
-    }
-}
-
-fn assert_custom_pattern_type(
-    pattern: &TypedPattern,
-) -> Option<std::sync::Arc<gleam_core::type_::Type>> {
-    match pattern {
-        Pattern::Constructor { type_, .. }
-            if matches!(
-                ValueType::from_gleam(type_.as_ref()),
-                Some(ValueType::Custom(_))
-            ) =>
-        {
-            Some(type_.clone())
-        }
-        Pattern::Assign { pattern, .. } => assert_custom_pattern_type(pattern),
-        _ => None,
-    }
-}
-
-fn assert_list_pattern_type(
-    pattern: &TypedPattern,
-) -> Option<std::sync::Arc<gleam_core::type_::Type>> {
-    match pattern {
-        Pattern::List { type_, .. } => Some(type_.clone()),
-        Pattern::Assign { pattern, .. } => assert_list_pattern_type(pattern),
-        Pattern::Int { .. }
-        | Pattern::Float { .. }
-        | Pattern::String { .. }
-        | Pattern::Variable { .. }
-        | Pattern::BitArraySize(_)
-        | Pattern::Discard { .. }
-        | Pattern::Constructor { .. }
-        | Pattern::Tuple { .. }
-        | Pattern::BitArray { .. }
-        | Pattern::StringPrefix { .. }
-        | Pattern::Invalid { .. } => None,
-    }
-}
-
-fn unsupported_assert_pattern_error(pattern: &TypedPattern) -> PlanError {
-    match pattern {
-        Pattern::List { .. } => PlanError::UnsupportedPattern {
-            kind: UnsupportedPatternKind::List,
-        },
-        Pattern::Int { .. } | Pattern::Float { .. } | Pattern::String { .. } => {
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::Literal,
-            }
-        }
-        Pattern::Constructor { .. } => PlanError::UnsupportedPattern {
-            kind: UnsupportedPatternKind::Constructor,
-        },
-        Pattern::StringPrefix { .. } => PlanError::UnsupportedPattern {
-            kind: UnsupportedPatternKind::StringPrefix,
-        },
-        Pattern::Assign { pattern, .. } => unsupported_assert_pattern_error(pattern),
-        Pattern::Invalid { .. }
-        | Pattern::BitArray { .. }
-        | Pattern::BitArraySize(_)
-        | Pattern::Discard { .. }
-        | Pattern::Variable { .. }
-        | Pattern::Tuple { .. } => PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::InvalidPattern,
-        },
-    }
-}
-
-fn unsupported_assert_exhaustive_pattern_error(pattern: &TypedPattern) -> PlanError {
-    match pattern {
-        Pattern::Tuple { elements, .. } => elements
-            .iter()
-            .map(unsupported_assert_exhaustive_pattern_error)
-            .find(|error| matches!(error, PlanError::UnsupportedPattern { .. }))
-            .unwrap_or(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::InvalidPattern,
-            }),
-        Pattern::Assign { pattern, .. } => unsupported_assert_exhaustive_pattern_error(pattern),
-        pattern => unsupported_assert_pattern_error(pattern),
-    }
-}
-
 fn internal_list_name(local: &ListLocal) -> EcoString {
     format!("<list:{}:{}>", local.family_name(), local.index()).into()
 }
@@ -315,41 +306,22 @@ fn internal_custom_name(local: crate::plan::CustomLocalId) -> EcoString {
     format!("<custom:{}>", local.0).into()
 }
 
-fn list_assert_value_must_be_list(actual: ValueType) -> PlanError {
-    PlanError::InvalidTypedAst {
-        reason: InvalidTypedAstReason::ExpressionType {
-            expected: InvalidExpressionType::List,
-            actual: value_type_expression_type(actual),
-        },
-    }
-}
-
-fn bit_array_assert_value_must_be_bit_array(actual: ValueType) -> PlanError {
-    PlanError::InvalidTypedAst {
-        reason: InvalidTypedAstReason::ExpressionType {
-            expected: InvalidExpressionType::BitArray,
-            actual: value_type_expression_type(actual),
-        },
-    }
-}
-
-fn custom_assert_value_must_be_custom(actual: ValueType) -> PlanError {
-    PlanError::InvalidTypedAst {
-        reason: InvalidTypedAstReason::ExpressionType {
-            expected: InvalidExpressionType::Custom,
-            actual: value_type_expression_type(actual),
-        },
-    }
+fn internal_assert_name(family: &str, index: usize) -> EcoString {
+    format!("<assert:{family}:{index}>").into()
 }
 
 #[cfg(test)]
 mod tests {
     use crate::plan::{
-        AssertBinding, AssertPattern, BitArrayAssertPattern, BitArrayExpr, BitArrayListLocalId,
+        AssertBinding, AssertPattern, AssertSubject, BitArrayExpr, BitArrayListLocalId,
         BitArrayLocalId, BitArrayPattern, BitArrayPatternSegment, BitArrayPatternSize,
-        BitArrayPatternSizeExpr, BitArrayPatternValue, BitArraySegment, Endianness, IntExpr,
-        IntListLocalId, IntLocalId, ListAssertPattern, ListAssertTail, ListLocal, PanicSite,
-        ParamLocal, Signedness, SourceSpan, Step, StringExpr, ValueShape, ValueType,
+        BitArrayPatternSizeExpr, BitArrayPatternValue, BitArraySegment,
+        CustomConstructorRefinement, CustomLocal, CustomLocalId, CustomType, CustomTypeName,
+        CustomValueShape, Endianness, FloatLocalId, FunctionExpr, IntExpr, IntFunctionExpr,
+        IntFunctionId, IntFunctionReference, IntListLocalId, IntLocalId, ListAssertPattern,
+        ListAssertTail, ListLocal, NilLocalId, PanicSite, ParamLocal, Signedness, SourceSpan, Step,
+        StepKind, StringExpr, StringLocalId, TupleLocalId, UtfCodepointExpr, UtfCodepointLocalId,
+        ValueShape, ValueType,
     };
     use crate::planner::context::{AnonymousFunctions, PlanContext};
     use crate::planner::dsl::{
@@ -357,20 +329,21 @@ mod tests {
         module, tuple,
     };
     use crate::planner::plan_module;
-    use crate::planner::support::{compile, dummy_span, expect_plan_error};
+    use crate::planner::support::{compile, dummy_span};
     use crate::planner::{
         InvalidExpressionShapeKind, InvalidExpressionType, InvalidTypedAstReason, PlanError,
-        UnsupportedExpressionKind, UnsupportedPatternKind,
+        UnsupportedExpressionKind,
     };
-    use ecow::EcoString;
     use gleam_core::ast::{
-        AssignName, AssignmentKind, BitArraySegment as BitArrayPatternSegmentAst, Pattern,
-        Statement, TailPattern, TypedAssignment, TypedExpr,
+        AssignmentKind, BitArraySegment as BitArrayPatternSegmentAst, Pattern, Statement,
+        TailPattern, TypedAssignment, TypedExpr,
     };
     use gleam_core::exhaustiveness::CompiledCase;
     use gleam_core::type_::{self, error::VariableOrigin};
     use num_bigint::BigInt;
     use std::collections::HashMap;
+
+    use super::super::{BindingPattern, ListTailBinding};
 
     #[test]
     fn plan_let_assert_named_assignment_reuses_exhaustive_binding_semantics() {
@@ -390,6 +363,259 @@ pub fn main() {
         );
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn refutable_let_assert_uses_each_reachable_typed_subject_family() {
+        let actual = plan_module(compile(
+            r#"
+pub type Choice { Empty Full(Int) }
+fn choice(value: Bool) -> Choice {
+  case value { True -> Full(1) False -> Empty }
+}
+pub fn main() {
+  let assert 1 = 1
+  let assert 1.5 = 1.5
+  let assert "one" = "one"
+  let assert <<1>> = <<1>>
+  let assert Full(_) = choice(True)
+  let assert True = True
+  let assert Nil = Nil
+  let assert #(1) = #(1)
+  let assert [1] = [1]
+  0
+}
+"#,
+        ))
+        .expect("source should plan");
+        let subjects = actual
+            .main_function()
+            .steps()
+            .iter()
+            .filter_map(|step| match step.kind() {
+                StepKind::AssertPattern { subject, .. } => Some(subject.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let custom_type = CustomType::new(
+            CustomTypeName::new("geam".into(), "main".into(), "Choice".into()),
+            Vec::new(),
+        );
+
+        assert_eq!(
+            subjects,
+            vec![
+                AssertSubject::Int(IntLocalId(0)),
+                AssertSubject::Float(FloatLocalId(0)),
+                AssertSubject::String(StringLocalId(0)),
+                AssertSubject::BitArray(BitArrayLocalId(0)),
+                AssertSubject::Custom(CustomLocal::from_shape(
+                    CustomLocalId(0),
+                    CustomValueShape::any(custom_type),
+                )),
+                AssertSubject::Bool(crate::plan::BoolLocalId(0)),
+                AssertSubject::Nil(NilLocalId(0)),
+                AssertSubject::Tuple(TupleLocalId(0)),
+                AssertSubject::List(ListLocal::int(IntListLocalId(0))),
+            ],
+        );
+    }
+
+    #[test]
+    fn final_custom_let_assert_uses_constructor_shape_to_select_binding_or_assertion() {
+        let total = plan_module(compile(
+            r#"
+pub type Choice { Empty Full(Int) }
+pub fn main() {
+  let assert Full(value) = Full(1)
+}
+"#,
+        ))
+        .expect("matching final custom assertion should plan");
+        let refutable = plan_module(compile(
+            r#"
+pub type Choice { Empty Full(Int) }
+pub fn main() {
+  let assert Full(value) = Empty
+}
+"#,
+        ))
+        .expect("mismatched final custom assertion should plan as refutable");
+        let plans = [("total", &total), ("refutable", &refutable)];
+        let custom_bindings = plans
+            .iter()
+            .flat_map(|(kind, plan)| {
+                plan.main_function()
+                    .steps()
+                    .iter()
+                    .filter_map(move |step| match step.kind() {
+                        StepKind::BindCustomFields { .. } => Some(*kind),
+                        _ => None,
+                    })
+            })
+            .collect::<Vec<_>>();
+        let assertion_subjects = plans
+            .iter()
+            .flat_map(|(kind, plan)| {
+                plan.main_function()
+                    .steps()
+                    .iter()
+                    .filter_map(move |step| match step.kind() {
+                        StepKind::AssertPattern { subject, .. } => Some((*kind, subject.clone())),
+                        _ => None,
+                    })
+            })
+            .collect::<Vec<_>>();
+        let choice_name = CustomTypeName::new("geam".into(), "main".into(), "Choice".into());
+
+        assert_eq!(custom_bindings, vec!["total"]);
+        assert_eq!(
+            assertion_subjects,
+            vec![(
+                "refutable",
+                AssertSubject::Custom(CustomLocal::from_shape(
+                    CustomLocalId(0),
+                    CustomValueShape::new(
+                        choice_name,
+                        Vec::new(),
+                        CustomConstructorRefinement::Exact(0),
+                    ),
+                )),
+            )],
+        );
+    }
+
+    #[test]
+    fn total_binding_shape_compatibility_checks_each_recursive_owner() {
+        let named = BindingPattern::Named("value".into());
+        let discard = BindingPattern::Discard;
+        let alias = BindingPattern::Alias {
+            pattern: Box::new(BindingPattern::Discard),
+            name: "whole".into(),
+        };
+        let tuple = BindingPattern::Tuple(vec![
+            BindingPattern::Named("first".into()),
+            BindingPattern::ListTail {
+                tail: ListTailBinding::Discard,
+                element_type: ValueType::Int,
+            },
+        ]);
+        let list = BindingPattern::ListTail {
+            tail: ListTailBinding::Named("rest".into()),
+            element_type: ValueType::Int,
+        };
+
+        assert!(super::binding_pattern_accepts_shape(
+            &named,
+            &ValueShape::Int
+        ));
+        assert!(super::binding_pattern_accepts_shape(
+            &discard,
+            &ValueShape::String,
+        ));
+        assert!(super::binding_pattern_accepts_shape(
+            &alias,
+            &ValueShape::Bool
+        ));
+        assert!(!super::binding_pattern_accepts_shape(
+            &tuple,
+            &ValueShape::Int
+        ));
+        assert!(!super::binding_pattern_accepts_shape(
+            &tuple,
+            &ValueShape::Tuple(vec![ValueShape::Int].into_boxed_slice()),
+        ));
+        assert!(super::binding_pattern_accepts_shape(
+            &tuple,
+            &ValueShape::Tuple(
+                vec![ValueShape::Int, ValueShape::List(Box::new(ValueShape::Int))]
+                    .into_boxed_slice(),
+            ),
+        ));
+        assert!(!super::binding_pattern_accepts_shape(
+            &tuple,
+            &ValueShape::Tuple(
+                vec![
+                    ValueShape::Int,
+                    ValueShape::List(Box::new(ValueShape::String)),
+                ]
+                .into_boxed_slice(),
+            ),
+        ));
+        assert!(super::binding_pattern_accepts_shape(
+            &list,
+            &ValueShape::List(Box::new(ValueShape::Int)),
+        ));
+        assert!(!super::binding_pattern_accepts_shape(
+            &list,
+            &ValueShape::List(Box::new(ValueShape::String)),
+        ));
+    }
+
+    #[test]
+    fn assert_subject_rejects_root_families_without_refutable_patterns() {
+        let module_name = "main".into();
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module_name, &functions, &mut anonymous);
+        let cases = [
+            (
+                Pattern::Variable {
+                    location: dummy_span(),
+                    name: "codepoint".into(),
+                    type_: type_::utf_codepoint(),
+                    origin: VariableOrigin::generated(),
+                },
+                crate::plan::Expr::utf_codepoint(UtfCodepointExpr::local_get(
+                    UtfCodepointLocalId(0),
+                    "codepoint".into(),
+                )),
+            ),
+            (
+                Pattern::Variable {
+                    location: dummy_span(),
+                    name: "function".into(),
+                    type_: type_::fn_(Vec::new(), type_::int()),
+                    origin: VariableOrigin::generated(),
+                },
+                crate::plan::Expr::function(FunctionExpr::int(IntFunctionExpr::reference(
+                    IntFunctionReference::new(IntFunctionId(0), Vec::new()),
+                ))),
+            ),
+        ];
+
+        for (pattern, expression) in cases {
+            assert_eq!(
+                super::plan_refutable_assert_assignment_from_expr(
+                    dummy_span(),
+                    pattern,
+                    expression,
+                    None,
+                    &mut context,
+                )
+                .map(|_| ()),
+                Err(PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::InvalidPattern,
+                }),
+            );
+        }
+    }
+
+    #[test]
+    fn assertion_type_validation_propagates_malformed_pattern_shape() {
+        assert_eq!(
+            super::validate_pattern_value_type(
+                &Pattern::BitArraySize(gleam_core::ast::BitArraySize::Int {
+                    location: dummy_span(),
+                    value: "1".into(),
+                    int_value: BigInt::from(1),
+                }),
+                ValueType::Int,
+            ),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::InvalidPattern,
+            }),
+        );
     }
 
     #[test]
@@ -437,36 +663,16 @@ pub fn main() {
         assert_eq!(
             plan_module(nominal_mismatch),
             Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::InvalidPattern,
-            }),
-        );
-
-        let module_name = "main".into();
-        let functions = HashMap::new();
-        let mut anonymous = AnonymousFunctions::default();
-        let mut context = PlanContext::new(&module_name, &functions, &mut anonymous);
-        assert_eq!(
-            super::plan_assert_custom_assignment(
-                dummy_span(),
-                Pattern::Discard {
-                    name: "_".into(),
-                    location: dummy_span(),
-                    type_: type_::int(),
+                reason: InvalidTypedAstReason::CustomType {
+                    name: "Second".into(),
+                    reason: crate::planner::InvalidCustomTypeReason::ConstructorName,
                 },
-                type_::int(),
-                typed_int_expr(1),
-                None,
-                &mut context,
-            )
-            .map(|_| ()),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::InvalidPattern,
             }),
         );
     }
 
     #[test]
-    fn custom_let_assert_propagates_value_message_and_pattern_errors() {
+    fn total_custom_let_assert_propagates_value_and_pattern_errors_but_not_message() {
         let source = r#"
 pub type Boxed { Boxed(Int) }
 pub fn main() {
@@ -482,6 +688,18 @@ pub fn main() {
 
         let mut invalid_value = compile(source);
         let assignment = expect_assignment_mut(&mut invalid_value.definitions.functions[0].body[0]);
+        assignment.value = invalid_expr(assignment.value.type_());
+
+        let mut invalid_final_value = compile(
+            r#"
+pub type Boxed { Boxed(Int) }
+pub fn main() {
+  let assert Boxed(value) = Boxed(1)
+}
+"#,
+        );
+        let assignment =
+            expect_assignment_mut(&mut invalid_final_value.definitions.functions[0].body[0]);
         assignment.value = invalid_expr(assignment.value.type_());
 
         let mut invalid_message = compile(source);
@@ -503,16 +721,23 @@ pub fn main() {
             int_value: BigInt::from(1),
         });
 
-        for invalid in [invalid_value, invalid_message] {
-            assert_eq!(
-                plan_module(invalid),
-                Err(PlanError::InvalidTypedAst {
-                    reason: InvalidTypedAstReason::ExpressionShape {
-                        kind: InvalidExpressionShapeKind::Invalid,
-                    },
-                }),
-            );
-        }
+        assert_eq!(
+            plan_module(invalid_value),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+        assert_eq!(
+            plan_module(invalid_final_value),
+            Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            }),
+        );
+        assert_eq!(plan_module(invalid_message), plan_module(compile(source)));
         assert_eq!(
             plan_module(invalid_pattern),
             Err(PlanError::InvalidTypedAst {
@@ -666,8 +891,8 @@ pub fn main() {
                     "<list:int:0>",
                     list([int(1), int(2)], ValueType::Int),
                 ))
-                .step(Step::assert_list_at(
-                    ListLocal::int(IntListLocalId(0)),
+                .step(Step::assert_pattern_at(
+                    AssertSubject::List(ListLocal::int(IntListLocalId(0))),
                     AssertPattern::list(ListAssertPattern::new(
                         ValueType::Int,
                         vec![AssertPattern::Bind(AssertBinding::new(
@@ -709,8 +934,8 @@ pub fn main() {
                     "<list:int:0>",
                     list([int(1)], ValueType::Int),
                 ))
-                .step(Step::assert_list_at(
-                    ListLocal::int(IntListLocalId(0)),
+                .step(Step::assert_pattern_at(
+                    AssertSubject::List(ListLocal::int(IntListLocalId(0))),
                     AssertPattern::list(ListAssertPattern::new(
                         ValueType::Int,
                         vec![AssertPattern::Bind(AssertBinding::new(
@@ -728,23 +953,6 @@ pub fn main() {
         );
 
         assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn reject_profile_let_assert_tuple_containing_list_pattern() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  let assert #([first]) = #([1])
-  first
-}
-"#,
-            ),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::List,
-            },
-        );
     }
 
     #[test]
@@ -779,9 +987,9 @@ pub fn main() {
                         endianness: Endianness::Big,
                     }]),
                 ))
-                .step(Step::assert_bit_array_at(
-                    BitArrayLocalId(0),
-                    BitArrayAssertPattern::pattern(pattern),
+                .step(Step::assert_pattern_at(
+                    AssertSubject::BitArray(BitArrayLocalId(0)),
+                    AssertPattern::BitArray(pattern),
                     None,
                     PanicSite::new("main".into(), "main".into(), SourceSpan::new(19, 29)),
                     SourceSpan::new(30, 39),
@@ -827,8 +1035,8 @@ pub fn main() {
                         ValueType::BitArray,
                     ),
                 ))
-                .step(Step::assert_list_at(
-                    ListLocal::bit_array(BitArrayListLocalId(0)),
+                .step(Step::assert_pattern_at(
+                    AssertSubject::List(ListLocal::bit_array(BitArrayListLocalId(0))),
                     AssertPattern::list(ListAssertPattern::new(
                         ValueType::BitArray,
                         vec![AssertPattern::BitArray(pattern)],
@@ -952,49 +1160,6 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_margin_bit_array_assert_pattern_must_end_in_a_bit_array_pattern() {
-        let module = EcoString::from("main");
-        let functions = HashMap::new();
-        let mut anonymous = AnonymousFunctions::default();
-        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
-
-        assert_eq!(
-            super::plan_bit_array_assert_pattern(
-                Pattern::Assign {
-                    location: dummy_span(),
-                    name: "whole".into(),
-                    pattern: Box::new(Pattern::Int {
-                        location: dummy_span(),
-                        value: "1".into(),
-                        int_value: BigInt::from(1),
-                    }),
-                },
-                &mut context,
-            ),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::InvalidPattern,
-            }),
-        );
-    }
-
-    #[test]
-    fn reject_profile_let_assert_string_prefix_pattern() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub fn main() {
-  let assert "pre" <> rest = "prefix"
-  rest
-}
-"#,
-            ),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::StringPrefix,
-            },
-        );
-    }
-
-    #[test]
     fn reject_margin_let_assert_list_pattern_type_mismatch() {
         let module_name = "main".into();
         let functions = HashMap::new();
@@ -1052,7 +1217,7 @@ pub fn main() {
     }
 
     #[test]
-    fn reject_margin_let_assert_tuple_pattern_rejects_nested_list_pattern() {
+    fn reject_margin_let_assert_tuple_pattern_rejects_non_tuple_value() {
         let module_name = "main".into();
         let functions = HashMap::new();
         let mut anonymous = AnonymousFunctions::default();
@@ -1070,8 +1235,11 @@ pub fn main() {
                 &mut context,
             )
             .err(),
-            Some(PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::List,
+            Some(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionType {
+                    expected: InvalidExpressionType::Tuple,
+                    actual: InvalidExpressionType::Int,
+                },
             }),
         );
     }
@@ -1107,10 +1275,11 @@ pub fn main() {
         let module_name = "main".into();
         let functions = HashMap::new();
         let mut anonymous = AnonymousFunctions::default();
-        let context = PlanContext::new(&module_name, &functions, &mut anonymous);
+        let mut context = PlanContext::new(&module_name, &functions, &mut anonymous);
 
         assert_eq!(
-            super::plan_assert_exhaustive_pattern(
+            super::plan_assert_assignment(
+                dummy_span(),
                 Pattern::Tuple {
                     location: dummy_span(),
                     elements: vec![Pattern::List {
@@ -1128,8 +1297,11 @@ pub fn main() {
                         type_: type_::list(type_::generic_var(0)),
                     }],
                 },
-                &context
-            ),
+                typed_int_expr(1),
+                None,
+                &mut context,
+            )
+            .map(|_| ()),
             Err(PlanError::UnsupportedExpression {
                 kind: UnsupportedExpressionKind::UnsupportedListElementType,
             }),
@@ -1256,99 +1428,6 @@ pub fn main() {
             Some(PlanError::UnsupportedExpression {
                 kind: UnsupportedExpressionKind::Echo,
             }),
-        );
-    }
-
-    #[test]
-    fn assert_list_pattern_type_only_accepts_list_wrappers() {
-        let list = int_list_pattern();
-        let alias = Pattern::Assign {
-            location: dummy_span(),
-            name: "values".into(),
-            pattern: Box::new(list.clone()),
-        };
-
-        assert_eq!(
-            super::assert_list_pattern_type(&list),
-            Some(type_::list(type_::int())),
-        );
-        assert_eq!(
-            super::assert_list_pattern_type(&alias),
-            Some(type_::list(type_::int())),
-        );
-        assert_eq!(
-            super::assert_list_pattern_type(&Pattern::Variable {
-                location: dummy_span(),
-                name: "value".into(),
-                type_: type_::int(),
-                origin: VariableOrigin::generated(),
-            }),
-            None,
-        );
-    }
-
-    #[test]
-    fn unsupported_assert_pattern_error_reports_profile_boundaries() {
-        let list = Pattern::List {
-            location: dummy_span(),
-            elements: Vec::new(),
-            tail: None,
-            type_: type_::list(type_::int()),
-        };
-        let string_prefix = Pattern::StringPrefix {
-            location: dummy_span(),
-            left_location: dummy_span(),
-            left_side_assignment: None,
-            right_location: dummy_span(),
-            left_side_string: "pre".into(),
-            right_side_assignment: AssignName::Variable("rest".into()),
-        };
-        let invalid = Pattern::Invalid {
-            location: dummy_span(),
-            type_: type_::int(),
-        };
-        let alias = Pattern::Assign {
-            location: dummy_span(),
-            name: "alias".into(),
-            pattern: Box::new(string_prefix.clone()),
-        };
-
-        assert_eq!(
-            super::unsupported_assert_pattern_error(&list),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::List,
-            },
-        );
-        assert_eq!(
-            super::unsupported_assert_pattern_error(&string_prefix),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::StringPrefix,
-            },
-        );
-        assert_eq!(
-            super::unsupported_assert_pattern_error(&alias),
-            PlanError::UnsupportedPattern {
-                kind: UnsupportedPatternKind::StringPrefix,
-            },
-        );
-        assert_eq!(
-            super::unsupported_assert_pattern_error(&invalid),
-            PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::InvalidPattern,
-            },
-        );
-    }
-
-    #[test]
-    fn list_assert_value_must_be_list_reports_actual_family() {
-        assert_eq!(
-            super::list_assert_value_must_be_list(ValueType::Int),
-            PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionType {
-                    expected: InvalidExpressionType::List,
-                    actual: InvalidExpressionType::Int,
-                },
-            },
         );
     }
 

--- a/src/runtime/function/steps.rs
+++ b/src/runtime/function/steps.rs
@@ -1,12 +1,13 @@
 use crate::plan::ValueType;
 use crate::plan::execution::ExecutionPlan;
 use crate::plan::execution::{
-    AssertBinding, AssertPattern, BitArrayFunctionLocalId, BitArrayLocalId, BoolFunctionLocalId,
-    BoolLocalId, CustomBindingPattern, CustomConstructorId, CustomFunctionLocal, CustomLocal,
-    FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocal, IntFunctionLocalId, IntLocalId,
-    ListAssertPattern, ListAssertTail, ListFunctionLocal, NilFunctionLocalId, NilLocalId,
-    ParamLocal, StepKind, StringFunctionLocalId, StringLocalId, TotalBindingPattern,
-    TupleFunctionLocalId, TupleLocalId, UtfCodepointFunctionLocalId, UtfCodepointLocalId,
+    AssertBinding, AssertPattern, AssertSubject, BitArrayFunctionLocalId, BitArrayLocalId,
+    BoolFunctionLocalId, BoolLocalId, CustomBindingPattern, CustomConstructorId,
+    CustomFunctionLocal, CustomLocal, FloatFunctionLocalId, FloatLocalId, FunctionFunctionLocal,
+    IntFunctionLocalId, IntLocalId, ListAssertPattern, ListAssertTail, ListFunctionLocal,
+    NilFunctionLocalId, NilLocalId, ParamLocal, StepKind, StringFunctionLocalId, StringLocalId,
+    TotalBindingPattern, TupleFunctionLocalId, TupleLocalId, UtfCodepointFunctionLocalId,
+    UtfCodepointLocalId,
 };
 use crate::runtime::error::ExecutionResult;
 use crate::runtime::expression::{
@@ -24,12 +25,11 @@ use crate::runtime::expression::{
 use crate::runtime::frame::Frame;
 use crate::runtime::state::{ListValueId, RuntimeState};
 use crate::runtime::{
-    BitArrayValue, EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction,
-    EvaluatedCustomFunction, EvaluatedCustomValue, EvaluatedFloatFunction,
-    EvaluatedFunctionFunction, EvaluatedFunctionValue, EvaluatedFunctionValueKind,
-    EvaluatedIntFunction, EvaluatedListCapture, EvaluatedListFunction, EvaluatedNilFunction,
-    EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedUtfCodepointFunction, EvaluatedValue,
-    Value,
+    EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedCustomFunction,
+    EvaluatedCustomValue, EvaluatedFloatFunction, EvaluatedFunctionFunction,
+    EvaluatedFunctionValue, EvaluatedFunctionValueKind, EvaluatedIntFunction, EvaluatedListCapture,
+    EvaluatedListFunction, EvaluatedNilFunction, EvaluatedStringFunction, EvaluatedTupleFunction,
+    EvaluatedUtfCodepointFunction, EvaluatedValue,
 };
 use crate::runtime::{ExecutionError, PanicKind};
 use ecow::EcoString;
@@ -155,24 +155,17 @@ pub(in crate::runtime) fn execute_steps(
                 )?;
                 frame.set_function_function(local, value);
             }
-            StepKind::AssertList {
-                local,
+            StepKind::AssertPattern {
+                subject,
                 pattern,
                 message,
                 site,
                 pattern_span,
             } => {
-                let value = get_list_value(frame, local);
+                let value = assert_subject_value(frame, subject);
                 let mut bindings = Vec::new();
-                if match_assert_pattern(
-                    plan,
-                    state,
-                    frame,
-                    pattern,
-                    &EvaluatedValue::List(value.clone()),
-                    &mut bindings,
-                )?
-                .is_none()
+                if match_assert_pattern(plan, state, frame, pattern, &value, &mut bindings)?
+                    .is_none()
                 {
                     let message = match message {
                         Some(message) => Some(eval_string_expr(plan, state, frame, message)?),
@@ -182,76 +175,7 @@ pub(in crate::runtime) fn execute_steps(
                         plan.source_context(),
                         message,
                         site.clone(),
-                        crate::runtime::materialize::value(
-                            plan,
-                            state,
-                            EvaluatedValue::List(value),
-                        ),
-                        *pattern_span,
-                    ));
-                }
-                for binding in bindings {
-                    frame_set_binding(frame, binding);
-                }
-            }
-            StepKind::AssertBitArray {
-                local,
-                pattern,
-                message,
-                site,
-                pattern_span,
-            } => {
-                let value = frame.get_bit_array(*local);
-                let mut bindings = Vec::new();
-                if match_bit_array_assert_pattern(frame, pattern, &value, &mut bindings).is_none() {
-                    let message = match message {
-                        Some(message) => Some(eval_string_expr(plan, state, frame, message)?),
-                        None => None,
-                    };
-                    return Err(ExecutionError::let_assert_panic(
-                        plan.source_context(),
-                        message,
-                        site.clone(),
-                        Value::BitArray(BitArrayValue::from_evaluated(value.bits())),
-                        *pattern_span,
-                    ));
-                }
-                for binding in bindings {
-                    frame_set_binding(frame, binding);
-                }
-            }
-            StepKind::AssertCustom {
-                local,
-                pattern,
-                message,
-                site,
-                pattern_span,
-            } => {
-                let value = frame.get_custom(*local);
-                let mut bindings = Vec::new();
-                if match_assert_pattern(
-                    plan,
-                    state,
-                    frame,
-                    pattern,
-                    &EvaluatedValue::Custom(value.clone()),
-                    &mut bindings,
-                )?
-                .is_none()
-                {
-                    let message = match message {
-                        Some(message) => Some(eval_string_expr(plan, state, frame, message)?),
-                        None => None,
-                    };
-                    return Err(ExecutionError::let_assert_panic(
-                        plan.source_context(),
-                        message,
-                        site.clone(),
-                        crate::runtime::materialize::value(
-                            plan,
-                            state,
-                            EvaluatedValue::Custom(value),
-                        ),
+                        crate::runtime::materialize::value(plan, state, value),
                         *pattern_span,
                     ));
                 }
@@ -294,21 +218,20 @@ pub(in crate::runtime) fn execute_steps(
     Ok(())
 }
 
-fn match_bit_array_assert_pattern(
-    frame: &mut Frame,
-    pattern: &crate::plan::execution::BitArrayAssertPattern,
-    value: &EvaluatedBitArray,
-    bindings: &mut Vec<PendingBinding>,
-) -> Option<()> {
-    match pattern {
-        crate::plan::execution::BitArrayAssertPattern::Pattern(pattern) => {
-            crate::runtime::pattern::match_bit_array_pattern(frame, value, pattern).then_some(())
+fn assert_subject_value(frame: &Frame, subject: &AssertSubject) -> EvaluatedValue {
+    match subject {
+        AssertSubject::Int(local) => EvaluatedValue::Int(frame.get_int(*local)),
+        AssertSubject::Float(local) => EvaluatedValue::Float(frame.get_float(*local)),
+        AssertSubject::String(local) => EvaluatedValue::String(frame.get_string(*local)),
+        AssertSubject::BitArray(local) => EvaluatedValue::BitArray(frame.get_bit_array(*local)),
+        AssertSubject::Custom(local) => EvaluatedValue::Custom(frame.get_custom(*local)),
+        AssertSubject::Bool(local) => EvaluatedValue::Bool(frame.get_bool(*local)),
+        AssertSubject::Nil(local) => {
+            frame.get_nil(*local);
+            EvaluatedValue::Nil
         }
-        crate::plan::execution::BitArrayAssertPattern::Alias { pattern, local } => {
-            match_bit_array_assert_pattern(frame, pattern, value, bindings)?;
-            bindings.push(PendingBinding::BitArray(*local, value.clone()));
-            Some(())
-        }
+        AssertSubject::Tuple(local) => EvaluatedValue::Tuple(frame.get_tuple(*local)),
+        AssertSubject::List(local) => EvaluatedValue::List(get_list_value(frame, local)),
     }
 }
 
@@ -930,9 +853,9 @@ mod tests {
     };
     use crate::plan::ValueType;
     use crate::plan::execution::{
-        AssertPattern, CustomLocal, FunctionFunctionId, IntFunctionFunctionId, IntFunctionId,
-        IntListLocalId, IntLocalId, ListAssertPattern, ListLocal, Step, StepKind, StringFunctionId,
-        StringLocalId,
+        AssertPattern, AssertSubject, CustomLocal, FunctionFunctionId, IntFunctionFunctionId,
+        IntFunctionId, IntListLocalId, IntLocalId, ListAssertPattern, ListLocal, Step, StepKind,
+        StringFunctionId, StringLocalId,
     };
     use crate::runtime::expression::eval_custom_expr;
     use crate::runtime::frame::Frame;
@@ -1277,7 +1200,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");
@@ -1322,7 +1245,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");
@@ -1354,7 +1277,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");
@@ -1386,7 +1309,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");
@@ -1471,7 +1394,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => {
+                StepKind::AssertPattern { pattern, .. } => {
                     Some(&expect_list_assert_pattern(pattern).elements()[0])
                 }
                 _ => None,
@@ -1500,7 +1423,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => {
+                StepKind::AssertPattern { pattern, .. } => {
                     Some(&expect_list_assert_pattern(pattern).elements()[0])
                 }
                 _ => None,
@@ -1539,9 +1462,12 @@ pub fn main() {
     fn assert_steps_propagate_custom_field_family_mismatches() {
         let custom_plan = crate::runtime::plan_src(
             r#"
-pub type Boxed { Boxed(Int) }
+pub type Boxed { Boxed(Int) Other }
+fn boxed(value: Bool) -> Boxed {
+  case value { True -> Boxed(1) False -> Other }
+}
 pub fn main() {
-  let assert Boxed(value) = Boxed(1)
+  let assert Boxed(value) = boxed(True)
   value
 }
 "#,
@@ -1552,7 +1478,10 @@ pub fn main() {
             .iter()
             .enumerate()
             .find_map(|(index, step)| match step.kind() {
-                StepKind::AssertCustom { local, .. } => Some((index, *local)),
+                StepKind::AssertPattern {
+                    subject: AssertSubject::Custom(local),
+                    ..
+                } => Some((index, *local)),
                 _ => None,
             })
             .expect("source should lower an assert-custom step");
@@ -1602,8 +1531,8 @@ pub fn main() {
             .iter()
             .enumerate()
             .find_map(|(index, step)| match step.kind() {
-                StepKind::AssertList {
-                    local: ListLocal::Tuple { local, type_id },
+                StepKind::AssertPattern {
+                    subject: AssertSubject::List(ListLocal::Tuple { local, type_id }),
                     ..
                 } => Some((index, *local, *type_id)),
                 _ => None,
@@ -1654,8 +1583,12 @@ pub type Choice {
   Other
 }
 
+fn choice(value: Bool) -> Choice {
+  case value { True -> Boxed(1) False -> Other }
+}
+
 pub fn main() {
-  let assert Boxed(value) = Boxed(1)
+  let assert Boxed(value) = choice(True)
   value
 }
 "#,
@@ -1665,7 +1598,8 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertCustom {
+                StepKind::AssertPattern {
+                    subject: AssertSubject::Custom(_),
                     pattern: pattern @ AssertPattern::Custom(custom_pattern),
                     ..
                 } => Some((pattern, custom_pattern)),
@@ -1735,8 +1669,8 @@ pub fn main() {
             .iter()
             .enumerate()
             .find_map(|(index, step)| match step.kind() {
-                StepKind::AssertList {
-                    local: ListLocal::Tuple { type_id, .. },
+                StepKind::AssertPattern {
+                    subject: AssertSubject::List(ListLocal::Tuple { type_id, .. }),
                     pattern: AssertPattern::List(pattern),
                     ..
                 } => Some((index, *type_id, pattern)),
@@ -1806,7 +1740,8 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertCustom {
+                StepKind::AssertPattern {
+                    subject: AssertSubject::Custom(_),
                     pattern: pattern @ AssertPattern::Custom(custom_pattern),
                     ..
                 } => Some((pattern, custom_pattern.constructor())),
@@ -2103,7 +2038,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");
@@ -2122,7 +2057,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");
@@ -2176,7 +2111,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");
@@ -2212,7 +2147,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");
@@ -2246,7 +2181,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");
@@ -2283,7 +2218,7 @@ pub fn main() {
 fn strings() -> List(String) { [] }
 fn target() { 1 }
 pub fn main() {
-  let assert [..rest] = [1]
+  let assert [_, ..rest] = [1]
   let assert [values] = [[1]]
   let assert [function] = [target]
   #(rest, values, function())
@@ -2295,7 +2230,9 @@ pub fn main() {
             .steps()
             .iter()
             .filter_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(expect_list_assert_pattern(pattern)),
+                StepKind::AssertPattern { pattern, .. } => {
+                    Some(expect_list_assert_pattern(pattern))
+                }
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -2371,7 +2308,7 @@ pub fn main() {
             .steps()
             .iter()
             .find_map(|step| match step.kind() {
-                StepKind::AssertList { pattern, .. } => Some(pattern),
+                StepKind::AssertPattern { pattern, .. } => Some(pattern),
                 _ => None,
             })
             .expect("source should lower an assert-list step");

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -135,6 +135,11 @@ mod bindings {
         let_assert_list_destructuring,
         let_assert_fixed_list,
         let_assert_empty_list,
+        let_assert_literal_pattern,
+        let_assert_constructor_pattern,
+        let_assert_string_prefix_pattern,
+        let_assert_nested_list_pattern,
+        let_assert_pattern_families,
         let_assert_discard_alias,
         final_let_assert_list,
         expression_steps,
@@ -534,6 +539,11 @@ mod execution_errors {
             let_assert_bit_array_pattern,
             let_assert_bit_array_utf_codepoint_default_message,
             let_assert_bit_array_utf_codepoint_message_error,
+            let_assert_literal_pattern,
+            let_assert_bool_pattern,
+            let_assert_string_prefix_pattern,
+            let_assert_nested_compound_pattern,
+            let_assert_message_failure,
         );
     }
 
@@ -591,15 +601,6 @@ mod rejection {
             nested_generic_custom_function_equality,
             recursive_custom_function_equality,
             result_function_equality,
-        );
-    }
-
-    mod patterns {
-        rejection_cases!("patterns";
-            let_assert_literal_pattern,
-            let_assert_constructor_pattern,
-            let_assert_string_prefix_pattern,
-            let_assert_nested_list_pattern,
         );
     }
 

--- a/tests/fixtures/execution/bindings/let_assert_constructor_pattern.gleam
+++ b/tests/fixtures/execution/bindings/let_assert_constructor_pattern.gleam
@@ -2,3 +2,5 @@ pub fn main() {
   let assert True = True
   1
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/bindings/let_assert_literal_pattern.gleam
+++ b/tests/fixtures/execution/bindings/let_assert_literal_pattern.gleam
@@ -2,3 +2,5 @@ pub fn main() {
   let assert 1 = 1
   1
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/bindings/let_assert_nested_list_pattern.gleam
+++ b/tests/fixtures/execution/bindings/let_assert_nested_list_pattern.gleam
@@ -2,3 +2,5 @@ pub fn main() {
   let assert #([first]) = #([1])
   first
 }
+
+// geam:expect Int(1)

--- a/tests/fixtures/execution/bindings/let_assert_pattern_families.gleam
+++ b/tests/fixtures/execution/bindings/let_assert_pattern_families.gleam
@@ -1,0 +1,60 @@
+pub type Payload {
+  Payload(Int, BitArray, String, fn(Int) -> Int)
+  Empty
+}
+
+fn add(captured: Int) {
+  fn(value) { captured + value }
+}
+
+fn final_literal(value: Int) {
+  let assert 42 = value
+}
+
+pub fn main() {
+  let assert 1 as one = 1
+  let assert 1.5 = 1.5
+  let assert "ready" = "ready"
+  let assert Nil = Nil
+
+  let function = add(10)
+  let subject = #(
+    [1],
+    <<2>>,
+    Payload(3, <<4>>, "prefix", function),
+  )
+  let assert #(
+    [first],
+    <<second>>,
+    Payload(third, <<fourth>>, "pre" <> suffix, nested_function) as payload,
+  ) as whole = subject
+  let assert #(
+    [whole_first],
+    <<whole_second>>,
+    Payload(whole_third, _, _, whole_function),
+  ) = whole
+  let assert Payload(payload_number, _, _, payload_function) = payload
+
+  let captured = 5
+  let message = "unused"
+  let closure = fn(value) {
+    let assert #(captured_value, [item]) = #(captured, [value]) as message
+    captured_value + item
+  }
+
+  #(
+    first,
+    one,
+    second,
+    third,
+    fourth,
+    suffix,
+    nested_function(1),
+    whole_first + whole_second + whole_third + whole_function(1),
+    payload_number + payload_function(1),
+    closure(6),
+    final_literal(42),
+  )
+}
+
+// geam:expect Tuple([Int(1), Int(1), Int(2), Int(3), Int(4), String("fix"), Int(11), Int(17), Int(14), Int(11), Int(42)])

--- a/tests/fixtures/execution/bindings/let_assert_string_prefix_pattern.gleam
+++ b/tests/fixtures/execution/bindings/let_assert_string_prefix_pattern.gleam
@@ -2,3 +2,5 @@ pub fn main() {
   let assert "pre" <> rest = "prefix"
   rest
 }
+
+// geam:expect String("fix")

--- a/tests/fixtures/execution_errors/patterns/let_assert_bool_pattern.gleam
+++ b/tests/fixtures/execution_errors/patterns/let_assert_bool_pattern.gleam
@@ -1,0 +1,18 @@
+pub fn main() {
+  let assert True = False
+  0
+}
+
+// geam:expect-error
+// geam::let_assert
+//
+//   x let_assert: Pattern match failed, no pattern matched the value.
+//    ,-[tests/fixtures/execution_errors/patterns/let_assert_bool_pattern.gleam:2:3]
+//  1 | pub fn main() {
+//  2 |   let assert True = False
+//    :   ^^^^^|^^^^ ^^|^
+//    :        |       `-- pattern
+//    :        `-- let assert in main.main
+//  3 |   0
+//    `----
+//   help: failed value: Bool(false)

--- a/tests/fixtures/execution_errors/patterns/let_assert_literal_pattern.gleam
+++ b/tests/fixtures/execution_errors/patterns/let_assert_literal_pattern.gleam
@@ -1,0 +1,18 @@
+pub fn main() {
+  let assert 1 = 2
+  0
+}
+
+// geam:expect-error
+// geam::let_assert
+//
+//   x let_assert: Pattern match failed, no pattern matched the value.
+//    ,-[tests/fixtures/execution_errors/patterns/let_assert_literal_pattern.gleam:2:3]
+//  1 | pub fn main() {
+//  2 |   let assert 1 = 2
+//    :   ^^^^^|^^^^ |
+//    :        |     `-- pattern
+//    :        `-- let assert in main.main
+//  3 |   0
+//    `----
+//   help: failed value: Int(2)

--- a/tests/fixtures/execution_errors/patterns/let_assert_message_failure.gleam
+++ b/tests/fixtures/execution_errors/patterns/let_assert_message_failure.gleam
@@ -1,0 +1,20 @@
+fn fail_message() -> String {
+  panic as "message failed"
+}
+
+pub fn main() {
+  let assert 1 = 2 as fail_message()
+  0
+}
+
+// geam:expect-error
+// geam::panic
+//
+//   x panic: message failed
+//    ,-[tests/fixtures/execution_errors/patterns/let_assert_message_failure.gleam:2:3]
+//  1 | fn fail_message() -> String {
+//  2 |   panic as "message failed"
+//    :   ^^^^^^^^^^^^|^^^^^^^^^^^^
+//    :               `-- panic in main.fail_message
+//  3 | }
+//    `----

--- a/tests/fixtures/execution_errors/patterns/let_assert_nested_compound_pattern.gleam
+++ b/tests/fixtures/execution_errors/patterns/let_assert_nested_compound_pattern.gleam
@@ -1,0 +1,22 @@
+pub type Payload {
+  Payload(Int)
+}
+
+pub fn main() {
+  let assert #([1], Payload(2), <<3>>) = #([1], Payload(9), <<3>>)
+  0
+}
+
+// geam:expect-error
+// geam::let_assert
+//
+//   x let_assert: Pattern match failed, no pattern matched the value.
+//    ,-[tests/fixtures/execution_errors/patterns/let_assert_nested_compound_pattern.gleam:6:3]
+//  5 | pub fn main() {
+//  6 |   let assert #([1], Payload(2), <<3>>) = #([1], Payload(9), <<3>>)
+//    :   ^^^^^|^^^^ ^^^^^^^^^^^^|^^^^^^^^^^^^
+//    :        |                 `-- pattern
+//    :        `-- let assert in main.main
+//  7 |   0
+//    `----
+//   help: failed value: Tuple([List(Int)([Int(1)]), geam/main/Payload::Payload(Int(9)), BitArray(bytes=[3], bit_len=8)])

--- a/tests/fixtures/execution_errors/patterns/let_assert_string_prefix_pattern.gleam
+++ b/tests/fixtures/execution_errors/patterns/let_assert_string_prefix_pattern.gleam
@@ -1,0 +1,18 @@
+pub fn main() {
+  let assert "pre" <> rest = "other"
+  rest
+}
+
+// geam:expect-error
+// geam::let_assert
+//
+//   x let_assert: Pattern match failed, no pattern matched the value.
+//    ,-[tests/fixtures/execution_errors/patterns/let_assert_string_prefix_pattern.gleam:2:3]
+//  1 | pub fn main() {
+//  2 |   let assert "pre" <> rest = "other"
+//    :   ^^^^^|^^^^ ^^^^^^|^^^^^^
+//    :        |           `-- pattern
+//    :        `-- let assert in main.main
+//  3 |   rest
+//    `----
+//   help: failed value: String("other")


### PR DESCRIPTION
- Route total patterns through proof-bearing bindings and refutable patterns through typed assertion subjects.
- Replace list, BitArray, and custom assertion steps with one recursive pattern path.
- Move literal, constructor, string-prefix, and nested patterns into execution coverage.
