### PR TITLE
Support function equality by runtime identity

### DIFF
--- a/docs/runtime-semantics.md
+++ b/docs/runtime-semantics.md
@@ -37,6 +37,26 @@ Do not add a custom wrapper or semantic normalization only to hide Rust floating
 point behavior. Add one only when it is required to match a documented Gleam
 semantic boundary or an explicit Geam runtime policy.
 
+## Function Equality
+
+Function equality follows runtime identity rather than comparing function code,
+types, or captured values structurally.
+
+- Repeated evaluation of the same top-level function reference produces the
+  same identity.
+- Evaluating an anonymous closure produces a fresh identity, including closures
+  with no captures.
+- Evaluating a custom type constructor as a first-class function produces a
+  fresh identity.
+- Moving or cloning a function value through locals, arguments, captures,
+  containers, calls, or returns preserves its identity.
+- Tuple, list, custom, and `Result` equality applies these rules recursively to
+  contained function values.
+
+The public Rust `FunctionValue` representation is an owned materialized value;
+its `PartialEq` implementation is not the identity used by Gleam source-level
+function equality.
+
 ## Numeric Division By Zero
 
 Integer division and remainder by zero are normalized because Gleam defines

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -13,10 +13,9 @@ pub use error::{
     InvalidCallShapeReason, InvalidCaseShapeReason, InvalidCustomTypeReason,
     InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
     InvalidPipelineShapeReason, InvalidRecordUpdateShapeReason, InvalidTypedAstReason,
-    InvalidUseShapeReason, PlanError, UnsupportedArgumentReason, UnsupportedBinOpKind,
-    UnsupportedBitArraySegmentReason, UnsupportedCaseReason, UnsupportedExpressionKind,
-    UnsupportedFunctionReason, UnsupportedPatternKind, UnsupportedPipelineReason,
-    UnsupportedTopLevelKind,
+    InvalidUseShapeReason, PlanError, UnsupportedArgumentReason, UnsupportedBitArraySegmentReason,
+    UnsupportedCaseReason, UnsupportedExpressionKind, UnsupportedFunctionReason,
+    UnsupportedPatternKind, UnsupportedPipelineReason, UnsupportedTopLevelKind,
 };
 pub use module::{plan_module, plan_module_with_source};
 

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -25,8 +25,7 @@ use crate::plan::{
     UtfCodepointListLocalId, UtfCodepointLocalId, ValueType,
 };
 use crate::plan::{
-    CustomConstructorRefinement, CustomType, CustomTypeName, CustomValueShape, FunctionShape,
-    ValueShape,
+    CustomConstructorRefinement, CustomType, CustomValueShape, FunctionShape, ValueShape,
 };
 use crate::planner::error::{
     InvalidCustomTypeReason, InvalidExpressionShapeKind, InvalidTypedAstReason, PlanError,
@@ -36,7 +35,7 @@ use ecow::EcoString;
 use gleam_core::type_::{
     PRELUDE_MODULE_NAME, PatternConstructor, Type, ValueConstructor, ValueConstructorVariant,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub(super) struct FunctionInfo {
@@ -152,12 +151,6 @@ enum LocalBinding {
         binding: FunctionLocalBinding,
         shape: FunctionShape,
     },
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-struct CustomFunctionShape {
-    name: CustomTypeName,
-    arguments: Vec<bool>,
 }
 
 pub(super) struct CaptureBinding {
@@ -1291,15 +1284,6 @@ impl<'a> PlanContext<'a> {
         local
     }
 
-    #[cfg(test)]
-    pub(super) fn define_custom_local(
-        &mut self,
-        name: EcoString,
-        type_: CustomType,
-    ) -> CustomLocalId {
-        self.define_custom_local_shape(name, CustomValueShape::any(type_))
-    }
-
     pub(super) fn define_custom_local_shape(
         &mut self,
         name: EcoString,
@@ -2058,170 +2042,6 @@ impl<'a> PlanContext<'a> {
             constructor: CustomConstructor::new(type_, name, variant_index, fields),
             constructor_count,
         })
-    }
-
-    pub(super) fn contains_function_value(&self, type_: &ValueType) -> Result<bool, PlanError> {
-        self.contains_function_value_with_visited(type_, &mut HashSet::new())
-    }
-
-    fn contains_function_value_with_visited(
-        &self,
-        type_: &ValueType,
-        visited: &mut HashSet<CustomFunctionShape>,
-    ) -> Result<bool, PlanError> {
-        match type_ {
-            ValueType::Function(_) => Ok(true),
-            ValueType::Tuple(elements) => {
-                for element in elements {
-                    if self.contains_function_value_with_visited(element, visited)? {
-                        return Ok(true);
-                    }
-                }
-                Ok(false)
-            }
-            ValueType::List(element) => self.contains_function_value_with_visited(element, visited),
-            ValueType::Custom(type_) => self.custom_type_contains_function(type_, visited),
-            ValueType::Int
-            | ValueType::Float
-            | ValueType::String
-            | ValueType::BitArray
-            | ValueType::UtfCodepoint
-            | ValueType::Bool
-            | ValueType::Nil => Ok(false),
-        }
-    }
-
-    fn custom_type_contains_function(
-        &self,
-        type_: &CustomType,
-        visited: &mut HashSet<CustomFunctionShape>,
-    ) -> Result<bool, PlanError> {
-        let arguments = type_
-            .arguments()
-            .iter()
-            .map(|argument| self.contains_function_value_with_visited(argument, visited))
-            .collect::<Result<Vec<_>, _>>()?;
-        self.custom_shape_contains_function(type_.type_name(), arguments, visited)
-    }
-
-    fn custom_shape_contains_function(
-        &self,
-        name: &CustomTypeName,
-        arguments: Vec<bool>,
-        visited: &mut HashSet<CustomFunctionShape>,
-    ) -> Result<bool, PlanError> {
-        let shape = CustomFunctionShape {
-            name: name.clone(),
-            arguments,
-        };
-        if !visited.insert(shape.clone()) {
-            return Ok(false);
-        }
-
-        let result = if name.package().is_empty()
-            && name.module() == PRELUDE_MODULE_NAME
-            && name.name() == "Result"
-        {
-            if shape.arguments.len() != 2 {
-                return Err(PlanError::InvalidTypedAst {
-                    reason: InvalidTypedAstReason::CustomType {
-                        name: name.name().clone(),
-                        reason: InvalidCustomTypeReason::TypeArgumentCount,
-                    },
-                });
-            }
-            Ok(shape.arguments.iter().copied().any(|argument| argument))
-        } else {
-            let Some(definition) = self
-                .custom_types
-                .iter()
-                .find(|definition| definition.name() == name)
-            else {
-                return Err(PlanError::InvalidTypedAst {
-                    reason: InvalidTypedAstReason::CustomType {
-                        name: name.name().clone(),
-                        reason: InvalidCustomTypeReason::UnknownDefinition,
-                    },
-                });
-            };
-            if definition.parameters().len() != shape.arguments.len() {
-                return Err(PlanError::InvalidTypedAst {
-                    reason: InvalidTypedAstReason::CustomType {
-                        name: name.name().clone(),
-                        reason: InvalidCustomTypeReason::TypeArgumentCount,
-                    },
-                });
-            }
-            let mut contains_function = false;
-            'constructors: for constructor in definition.constructors() {
-                for field in constructor.fields() {
-                    if self.custom_template_contains_function(
-                        field.type_(),
-                        name,
-                        &shape.arguments,
-                        visited,
-                    )? {
-                        contains_function = true;
-                        break 'constructors;
-                    }
-                }
-            }
-            Ok(contains_function)
-        };
-
-        visited.remove(&shape);
-        result
-    }
-
-    fn custom_template_contains_function(
-        &self,
-        template: &CustomTypeTemplate,
-        owner: &CustomTypeName,
-        arguments: &[bool],
-        visited: &mut HashSet<CustomFunctionShape>,
-    ) -> Result<bool, PlanError> {
-        match template {
-            CustomTypeTemplate::Function { .. } => Ok(true),
-            CustomTypeTemplate::Tuple(elements) => {
-                let mut contains_function = false;
-                for element in elements {
-                    contains_function |=
-                        self.custom_template_contains_function(element, owner, arguments, visited)?;
-                }
-                Ok(contains_function)
-            }
-            CustomTypeTemplate::List(element) => {
-                self.custom_template_contains_function(element, owner, arguments, visited)
-            }
-            CustomTypeTemplate::Custom {
-                name,
-                arguments: templates,
-            } => {
-                let mut nested_arguments = Vec::with_capacity(templates.len());
-                for template in templates {
-                    let contains_function = self
-                        .custom_template_contains_function(template, owner, arguments, visited)?;
-                    nested_arguments.push(contains_function);
-                }
-                self.custom_shape_contains_function(name, nested_arguments, visited)
-            }
-            CustomTypeTemplate::Parameter(parameter) => match arguments.get(parameter.0).copied() {
-                Some(contains_function) => Ok(contains_function),
-                None => Err(PlanError::InvalidTypedAst {
-                    reason: InvalidTypedAstReason::CustomType {
-                        name: owner.name().clone(),
-                        reason: InvalidCustomTypeReason::ParameterType,
-                    },
-                }),
-            },
-            CustomTypeTemplate::Int
-            | CustomTypeTemplate::Float
-            | CustomTypeTemplate::String
-            | CustomTypeTemplate::BitArray
-            | CustomTypeTemplate::UtfCodepoint
-            | CustomTypeTemplate::Bool
-            | CustomTypeTemplate::Nil => Ok(false),
-        }
     }
 
     pub(super) fn lookup_function_local(
@@ -3984,13 +3804,6 @@ mod tests {
                 InvalidCustomTypeReason::TypeArgumentCount,
             )),
         );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(generic_without_arguments.clone())),
-            Err(invalid_custom_constructor_error(
-                &generic_without_arguments,
-                InvalidCustomTypeReason::TypeArgumentCount,
-            )),
-        );
 
         let result_type = CustomType::new(
             CustomTypeName::new(
@@ -4074,13 +3887,6 @@ mod tests {
                 InvalidCustomTypeReason::TypeArgumentCount,
             )),
         );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(malformed_result_type.clone())),
-            Err(invalid_custom_constructor_error(
-                &malformed_result_type,
-                InvalidCustomTypeReason::TypeArgumentCount,
-            )),
-        );
         let non_prelude_result = CustomType::new(
             CustomTypeName::new(
                 "other".into(),
@@ -4102,82 +3908,6 @@ mod tests {
                 InvalidCustomTypeReason::UnknownDefinition,
             )),
         );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(non_prelude_result.clone())),
-            Err(invalid_custom_constructor_error(
-                &non_prelude_result,
-                InvalidCustomTypeReason::UnknownDefinition,
-            )),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(generic_int)),
-            Ok(false),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                recursive_name,
-                Vec::new(),
-            ))),
-            Ok(false),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Tuple(vec![
-                ValueType::Int,
-                ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::String,))),
-            ])),
-            Ok(true),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Tuple(vec![
-                ValueType::Int,
-                ValueType::String,
-            ])),
-            Ok(false),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::List(Box::new(ValueType::Function(
-                Box::new(FunctionType::new(Vec::new(), ValueType::Nil)),
-            )))),
-            Ok(true),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                function_name,
-                Vec::new(),
-            ))),
-            Ok(true),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                tuple_function_name,
-                Vec::new(),
-            ))),
-            Ok(true),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                list_function_name,
-                Vec::new(),
-            ))),
-            Ok(true),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                result_type.type_name().clone(),
-                vec![
-                    ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int,))),
-                    ValueType::String,
-                ],
-            ))),
-            Ok(true),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                result_type.type_name().clone(),
-                vec![ValueType::Int, ValueType::String],
-            ))),
-            Ok(false),
-        );
         let broken = CustomType::new(broken_name, vec![ValueType::Int]);
         assert_eq!(
             context.custom_constructor_from_parts(
@@ -4191,84 +3921,6 @@ mod tests {
                 reason: InvalidTypedAstReason::CustomType {
                     name: "Broken".into(),
                     reason: InvalidCustomTypeReason::ParameterType,
-                },
-            }),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(broken.clone())),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CustomType {
-                    name: "Broken".into(),
-                    reason: InvalidCustomTypeReason::ParameterType,
-                },
-            }),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                tuple_broken_name,
-                Vec::new(),
-            ))),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CustomType {
-                    name: "TupleBroken".into(),
-                    reason: InvalidCustomTypeReason::ParameterType,
-                },
-            }),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                custom_argument_broken_name,
-                Vec::new(),
-            ))),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CustomType {
-                    name: "CustomArgumentBroken".into(),
-                    reason: InvalidCustomTypeReason::ParameterType,
-                },
-            }),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                result_type.type_name().clone(),
-                vec![ValueType::String, ValueType::Custom(broken.clone())],
-            ))),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CustomType {
-                    name: "Broken".into(),
-                    reason: InvalidCustomTypeReason::ParameterType,
-                },
-            }),
-        );
-        let missing = CustomType::new(missing_name, Vec::new());
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(missing.clone())),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CustomType {
-                    name: "Missing".into(),
-                    reason: InvalidCustomTypeReason::UnknownDefinition,
-                },
-            }),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Tuple(vec![ValueType::Custom(
-                missing.clone(),
-            )])),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CustomType {
-                    name: "Missing".into(),
-                    reason: InvalidCustomTypeReason::UnknownDefinition,
-                },
-            }),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Custom(CustomType::new(
-                nested_broken_name,
-                Vec::new(),
-            ))),
-            Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::CustomType {
-                    name: "Missing".into(),
-                    reason: InvalidCustomTypeReason::UnknownDefinition,
                 },
             }),
         );
@@ -4327,52 +3979,6 @@ mod tests {
                 &missing_parameter,
             ),
             parameter_error,
-        );
-    }
-
-    #[test]
-    fn reject_margin_custom_function_shape_errors_through_module_planning() {
-        let mut tuple_parameter = crate::planner::support::compile(
-            "pub type Box(value) { Box(#(Int, value)) } fn equal(value: Box(Int)) { value == value } pub fn main() { 0 }",
-        );
-        let missing_parameter = type_::generic_var(99);
-        tuple_parameter.definitions.custom_types[0]
-            .typed_parameters
-            .push(missing_parameter.clone());
-        tuple_parameter.definitions.custom_types[0].constructors[0].arguments[0].type_ =
-            type_::tuple(vec![type_::int(), missing_parameter]);
-        let type_argument_count_error = PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CustomType {
-                name: "Box".into(),
-                reason: InvalidCustomTypeReason::TypeArgumentCount,
-            },
-        };
-        assert_eq!(
-            crate::planner::plan_module(tuple_parameter),
-            Err(type_argument_count_error.clone()),
-        );
-
-        let mut custom_argument = crate::planner::support::compile(
-            "pub type Wrapper(value) { Wrapper(value) } pub type Box(value) { Box(Wrapper(value)) } fn equal(value: Box(Int)) { value == value } pub fn main() { 0 }",
-        );
-        let box_type = custom_argument
-            .definitions
-            .custom_types
-            .iter_mut()
-            .find(|type_| type_.name == "Box")
-            .expect("compiled module should contain Box");
-        let missing_parameter = type_::generic_var(99);
-        box_type.typed_parameters.push(missing_parameter.clone());
-        box_type.constructors[0].arguments[0].type_ = type_::named(
-            "main",
-            "main",
-            "Wrapper",
-            Publicity::Public,
-            vec![missing_parameter],
-        );
-        assert_eq!(
-            crate::planner::plan_module(custom_argument),
-            Err(type_argument_count_error),
         );
     }
 

--- a/src/planner/error.rs
+++ b/src/planner/error.rs
@@ -11,9 +11,9 @@ pub use invalid::{
     InvalidUseShapeReason,
 };
 pub use unsupported::{
-    UnsupportedArgumentReason, UnsupportedBinOpKind, UnsupportedBitArraySegmentReason,
-    UnsupportedCaseReason, UnsupportedExpressionKind, UnsupportedFunctionReason,
-    UnsupportedPatternKind, UnsupportedPipelineReason, UnsupportedTopLevelKind,
+    UnsupportedArgumentReason, UnsupportedBitArraySegmentReason, UnsupportedCaseReason,
+    UnsupportedExpressionKind, UnsupportedFunctionReason, UnsupportedPatternKind,
+    UnsupportedPipelineReason, UnsupportedTopLevelKind,
 };
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -43,9 +43,6 @@ pub enum PlanError {
     UnsupportedBitArraySegment {
         reason: UnsupportedBitArraySegmentReason,
     },
-
-    #[error("unsupported binary operator: {operator}")]
-    UnsupportedBinOp { operator: UnsupportedBinOpKind },
 
     #[error("unsupported case: {reason}")]
     UnsupportedCase { reason: UnsupportedCaseReason },

--- a/src/planner/error/unsupported.rs
+++ b/src/planner/error/unsupported.rs
@@ -59,14 +59,6 @@ pub enum UnsupportedBitArraySegmentReason {
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
-pub enum UnsupportedBinOpKind {
-    #[error("equal function")]
-    EqFunction,
-    #[error("not equal function")]
-    NotEqFunction,
-}
-
-#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum UnsupportedCaseReason {
     #[error("case subject type is not supported")]
     UnsupportedSubjectType,

--- a/src/planner/expression/call/function_value.rs
+++ b/src/planner/expression/call/function_value.rs
@@ -257,8 +257,9 @@ mod tests {
     use crate::planner::dsl::{
         block_int_function, bool_, bool_case_int_function, call_int_function, function,
         function_function_ref, function_ref, int, int_case_int_function, int_function_call_arg,
-        int_function_ref, let_int_function_step, local_int, local_int_function, local_tuple,
-        module, module_with_anonymous, string, tuple, tuple_arg, tuple_function_ref,
+        int_function_closure, int_function_ref, let_int_function_step, local_int,
+        local_int_function, local_tuple, module, module_with_anonymous, string, tuple, tuple_arg,
+        tuple_function_ref,
     };
     use crate::planner::expression::call::support::expect_call_statement_mut;
     use crate::planner::expression::{typed_int_expr, typed_string_expr};
@@ -279,7 +280,7 @@ mod tests {
             function(
                 "main",
                 call_int_function(
-                    int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                    int_function_closure(1, [LocalId::Int(IntLocalId(0))], []),
                     [int_function_call_arg(0, int(41))],
                 ),
             ),

--- a/src/planner/expression/case/guard.rs
+++ b/src/planner/expression/case/guard.rs
@@ -8,7 +8,6 @@ use crate::plan::{
 use crate::planner::context::{FunctionLocalBinding, PlanContext};
 use crate::planner::error::{
     InvalidExpressionShapeKind, InvalidExpressionType, InvalidTypedAstReason, PlanError,
-    UnsupportedBinOpKind,
 };
 use ecow::EcoString;
 use gleam_core::ast::{BinOp, ClauseGuard};
@@ -91,20 +90,8 @@ fn plan_binary_operator(
     match operator {
         BinOp::And => bool_binary_operator(left, right, context, BoolExpr::and),
         BinOp::Or => bool_binary_operator(left, right, context, BoolExpr::or),
-        BinOp::Eq => equality(
-            left,
-            right,
-            context,
-            UnsupportedBinOpKind::EqFunction,
-            false,
-        ),
-        BinOp::NotEq => equality(
-            left,
-            right,
-            context,
-            UnsupportedBinOpKind::NotEqFunction,
-            true,
-        ),
+        BinOp::Eq => equality_operator(left, right, context, BoolExpr::equal),
+        BinOp::NotEq => equality_operator(left, right, context, BoolExpr::not_equal),
         BinOp::GtInt => int_comparison_operator(left, right, context, BoolExpr::gt_int),
         BinOp::GtEqInt => int_comparison_operator(left, right, context, BoolExpr::gte_int),
         BinOp::LtInt => int_comparison_operator(left, right, context, BoolExpr::lt_int),
@@ -192,27 +179,15 @@ fn string_binary_operator(
     Ok(Expr::string(operator(left, right)))
 }
 
-fn equality(
+fn equality_operator(
     left: ClauseGuard<Arc<Type>>,
     right: ClauseGuard<Arc<Type>>,
     context: &mut PlanContext<'_>,
-    operator: UnsupportedBinOpKind,
-    negated: bool,
+    operator: fn(Expr, Expr) -> BoolExpr,
 ) -> Result<Expr, PlanError> {
     let left = plan_expr(left, context)?;
     let right = plan_expr(right, context)?;
-    if context.contains_function_value(&left.value_type())?
-        || context.contains_function_value(&right.value_type())?
-    {
-        return Err(PlanError::UnsupportedBinOp { operator });
-    }
-
-    let expression = if negated {
-        BoolExpr::not_equal(left, right)
-    } else {
-        BoolExpr::equal(left, right)
-    };
-    Ok(Expr::bool(expression))
+    Ok(Expr::bool(operator(left, right)))
 }
 
 fn plan_int(
@@ -419,22 +394,21 @@ mod tests {
     use super::{function_local_get, invalid_expression_type, plan_expr};
     use crate::plan::{
         BitArrayExpr, BitArrayFunctionExpr, BitArrayFunctionLocalId, BitArrayLocalId, BoolExpr,
-        BoolFunctionExpr, BoolFunctionLocalId, BoolLocalId, CustomFunctionExpr,
-        CustomFunctionLocal, CustomFunctionLocalId, CustomFunctionType, CustomType, CustomTypeName,
-        Expr, FloatExpr, FloatFunctionExpr, FloatFunctionLocalId, FunctionExpr,
-        FunctionFunctionExpr, FunctionFunctionLocal, FunctionFunctionLocalId, FunctionFunctionType,
-        FunctionShape, FunctionType, IntExpr, IntFunctionExpr, IntFunctionLocalId, IntLocalId,
-        ListExpr, ListFunctionExpr, ListLocal, LocalId, NilExpr, NilFunctionExpr,
-        NilFunctionLocalId, NilLocalId, StringExpr, StringFunctionExpr, StringFunctionLocalId,
-        StringListLocalId, TupleExpr, TupleFunctionExpr, TupleFunctionLocalId, TupleLocalId,
-        UtfCodepointExpr, UtfCodepointFunctionExpr, UtfCodepointFunctionLocalId,
-        UtfCodepointLocalId, ValueType,
+        BoolFunctionExpr, BoolFunctionLocalId, BoolLocalId, CustomExpr, CustomFunctionExpr,
+        CustomFunctionLocal, CustomFunctionLocalId, CustomFunctionType, CustomLocal, CustomType,
+        CustomTypeName, CustomValueShape, Expr, FloatExpr, FloatFunctionExpr, FloatFunctionLocalId,
+        FunctionExpr, FunctionFunctionExpr, FunctionFunctionLocal, FunctionFunctionLocalId,
+        FunctionFunctionType, FunctionShape, FunctionType, IntExpr, IntFunctionExpr,
+        IntFunctionLocalId, IntLocalId, ListExpr, ListFunctionExpr, ListLocal, LocalId, NilExpr,
+        NilFunctionExpr, NilFunctionLocalId, NilLocalId, StringExpr, StringFunctionExpr,
+        StringFunctionLocalId, StringListLocalId, TupleExpr, TupleFunctionExpr,
+        TupleFunctionLocalId, TupleLocalId, UtfCodepointExpr, UtfCodepointFunctionExpr,
+        UtfCodepointFunctionLocalId, UtfCodepointLocalId, ValueType,
     };
     use crate::planner::context::{AnonymousFunctions, FunctionLocalBinding, PlanContext};
     use crate::planner::support::dummy_span;
     use crate::planner::{
         InvalidExpressionShapeKind, InvalidExpressionType, InvalidTypedAstReason, PlanError,
-        UnsupportedBinOpKind,
     };
     use ecow::EcoString;
     use gleam_core::ast::{BinOp, ClauseGuard, Constant, Publicity};
@@ -452,6 +426,12 @@ mod tests {
         let mut context = PlanContext::new(&module, &functions, &mut anonymous);
         context.define_bool_local("flag".into());
         context.define_tuple_local("pair".into(), vec![ValueType::Int, ValueType::String]);
+        let custom_type = CustomType::new(
+            CustomTypeName::new("geam".into(), module.clone(), "Holder".into()),
+            Vec::new(),
+        );
+        let custom_shape = CustomValueShape::any(custom_type);
+        let custom_local = context.define_custom_local_shape("holder".into(), custom_shape.clone());
 
         assert_eq!(
             plan_expr(int_constant(1), &mut context),
@@ -505,6 +485,19 @@ mod tests {
         assert_eq!(
             plan_expr(module_select("main", int_constant_literal(3)), &mut context),
             Ok(Expr::int(IntExpr::value(3.into()))),
+        );
+        assert_eq!(
+            plan_expr(
+                var(
+                    "holder",
+                    type_::named("geam", "main", "Holder", Publicity::Public, Vec::new(),),
+                ),
+                &mut context,
+            ),
+            Ok(Expr::custom(CustomExpr::local_get(
+                CustomLocal::from_shape(custom_local, custom_shape),
+                "holder".into(),
+            ))),
         );
     }
 
@@ -1034,6 +1027,70 @@ mod tests {
     }
 
     #[test]
+    fn reject_margin_equality_operand_errors() {
+        let module = EcoString::from("main");
+        let functions = HashMap::new();
+        let mut anonymous = AnonymousFunctions::default();
+        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
+        let expected = Err(invalid_expression_shape(
+            InvalidExpressionShapeKind::Invalid,
+        ));
+
+        assert_eq!(
+            super::plan_binary_operator(
+                BinOp::Eq,
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                },
+                int_constant(1),
+                &mut context,
+            ),
+            expected.clone(),
+        );
+        assert_eq!(
+            super::plan_binary_operator(
+                BinOp::Eq,
+                int_constant(1),
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                },
+                &mut context,
+            ),
+            expected,
+        );
+        assert_eq!(
+            super::plan_binary_operator(
+                BinOp::NotEq,
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                },
+                int_constant(1),
+                &mut context,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+        assert_eq!(
+            super::plan_binary_operator(
+                BinOp::NotEq,
+                int_constant(1),
+                ClauseGuard::Invalid {
+                    location: dummy_span(),
+                    type_: type_::int(),
+                },
+                &mut context,
+            ),
+            Err(invalid_expression_shape(
+                InvalidExpressionShapeKind::Invalid
+            )),
+        );
+    }
+
+    #[test]
     fn plan_tuple_index_rejects_invalid_typed_ast_shapes() {
         let module = EcoString::from("main");
         let functions = HashMap::new();
@@ -1388,46 +1445,7 @@ mod tests {
     }
 
     #[test]
-    fn guard_helper_type_classification_is_exact() {
-        let module = EcoString::from("main");
-        let functions = HashMap::new();
-        let mut anonymous = AnonymousFunctions::default();
-        let context = PlanContext::new(&module, &functions, &mut anonymous);
-
-        assert_eq!(
-            context.contains_function_value(&ValueType::Function(Box::new(FunctionType::new(
-                Vec::new(),
-                ValueType::Int
-            ),))),
-            Ok(true),
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Tuple(vec![
-                ValueType::Int,
-                ValueType::Function(Box::new(FunctionType::new(Vec::new(), ValueType::Int))),
-            ])),
-            Ok(true)
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::List(Box::new(ValueType::Function(
-                Box::new(FunctionType::new(Vec::new(), ValueType::Int))
-            ),))),
-            Ok(true)
-        );
-        assert_eq!(
-            context.contains_function_value(&ValueType::Tuple(vec![
-                ValueType::Int,
-                ValueType::Float,
-                ValueType::String,
-                ValueType::BitArray,
-                ValueType::UtfCodepoint,
-                ValueType::Bool,
-                ValueType::Nil,
-                ValueType::List(Box::new(ValueType::Int)),
-            ])),
-            Ok(false)
-        );
-
+    fn invalid_expression_type_classification_is_exact() {
         assert_eq!(
             [
                 ValueType::Int,
@@ -1463,130 +1481,45 @@ mod tests {
     }
 
     #[test]
-    fn guard_equality_preserves_custom_type_definition_errors_from_either_operand() {
+    fn equality_accepts_function_value_guards() {
         let module = EcoString::from("main");
         let functions = HashMap::new();
         let mut anonymous = AnonymousFunctions::default();
         let mut context = PlanContext::new(&module, &functions, &mut anonymous);
-        let custom_name = CustomTypeName::new("geam".into(), module.clone(), "Missing".into());
-        context.define_custom_local("missing".into(), CustomType::new(custom_name, Vec::new()));
-        let gleam_type = Arc::new(Type::Named {
-            publicity: Publicity::Private,
-            name: "Missing".into(),
-            module: module.clone(),
-            package: "geam".into(),
-            arguments: Vec::new(),
-            inferred_variant: None,
-        });
-        let expected = Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CustomType {
-                name: "Missing".into(),
-                reason: crate::planner::InvalidCustomTypeReason::UnknownDefinition,
-            },
-        });
-
-        assert_eq!(
-            super::equality(
-                var("missing", gleam_type.clone()),
-                int_constant(1),
-                &mut context,
-                UnsupportedBinOpKind::EqFunction,
-                false,
-            ),
-            expected.clone(),
-        );
-        assert_eq!(
-            super::equality(
-                int_constant(1),
-                var("missing", gleam_type),
-                &mut context,
-                UnsupportedBinOpKind::EqFunction,
-                false,
-            ),
-            expected,
-        );
-    }
-
-    #[test]
-    fn equality_rejects_function_value_guard() {
-        let module = EcoString::from("main");
-        let functions = HashMap::new();
-        let mut anonymous = AnonymousFunctions::default();
-        let mut context = PlanContext::new(&module, &functions, &mut anonymous);
-        context.define_int_function_local(
+        let function_type = FunctionType::new(vec![ValueType::Int], ValueType::Int);
+        context.define_int_function_local("callback".into(), function_type.clone());
+        let gleam_type = type_::fn_(vec![type_::int()], type_::int());
+        let expected = Expr::function(FunctionExpr::int(IntFunctionExpr::local_get(
+            IntFunctionLocalId(0),
             "callback".into(),
-            FunctionType::new(vec![ValueType::Int], ValueType::Int),
-        );
-        let function_type = type_::fn_(vec![type_::int()], type_::int());
+            function_type,
+        )));
 
         assert_eq!(
             super::plan_bool(
                 ClauseGuard::BinaryOperator {
                     location: dummy_span(),
-                    operator: gleam_core::ast::BinOp::Eq,
+                    operator: BinOp::Eq,
                     operator_start: 0,
-                    left: Box::new(var("callback", function_type.clone())),
-                    right: Box::new(var("callback", function_type)),
+                    left: Box::new(var("callback", gleam_type.clone())),
+                    right: Box::new(var("callback", gleam_type.clone())),
                 },
                 &mut context,
             ),
-            Err(PlanError::UnsupportedBinOp {
-                operator: UnsupportedBinOpKind::EqFunction,
-            }),
+            Ok(BoolExpr::equal(expected.clone(), expected.clone())),
         );
         assert_eq!(
-            plan_expr(
+            super::plan_bool(
                 ClauseGuard::BinaryOperator {
                     location: dummy_span(),
                     operator: BinOp::NotEq,
                     operator_start: 0,
-                    left: Box::new(int_constant(1)),
-                    right: Box::new(var(
-                        "callback",
-                        type_::fn_(vec![type_::int()], type_::int())
-                    )),
+                    left: Box::new(var("callback", gleam_type.clone())),
+                    right: Box::new(var("callback", gleam_type)),
                 },
                 &mut context,
             ),
-            Err(PlanError::UnsupportedBinOp {
-                operator: UnsupportedBinOpKind::NotEqFunction,
-            }),
-        );
-        assert_eq!(
-            plan_expr(
-                ClauseGuard::BinaryOperator {
-                    location: dummy_span(),
-                    operator: BinOp::Eq,
-                    operator_start: 0,
-                    left: Box::new(ClauseGuard::Invalid {
-                        location: dummy_span(),
-                        type_: type_::int(),
-                    }),
-                    right: Box::new(int_constant(1)),
-                },
-                &mut context,
-            ),
-            Err(invalid_expression_shape(
-                InvalidExpressionShapeKind::Invalid
-            )),
-        );
-        assert_eq!(
-            plan_expr(
-                ClauseGuard::BinaryOperator {
-                    location: dummy_span(),
-                    operator: BinOp::Eq,
-                    operator_start: 0,
-                    left: Box::new(int_constant(1)),
-                    right: Box::new(ClauseGuard::Invalid {
-                        location: dummy_span(),
-                        type_: type_::int(),
-                    }),
-                },
-                &mut context,
-            ),
-            Err(invalid_expression_shape(
-                InvalidExpressionShapeKind::Invalid
-            )),
+            Ok(BoolExpr::not_equal(expected.clone(), expected)),
         );
     }
 

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -82,16 +82,12 @@ fn plan_anonymous_with_captures(
     let planned = planned?;
     let (name, info) =
         context.allocate_anonymous_function_shape(name, return_shape, params, runtime_id);
-    let value = if planned.captures.is_empty() {
-        FunctionExpr::reference(info.reference())
-    } else {
-        closure_expr(
-            &info.runtime_id,
-            info.param_slots(),
-            planned.captures.clone(),
-            &function_shape,
-        )
-    };
+    let value = closure_expr(
+        &info.runtime_id,
+        info.param_slots(),
+        planned.captures.clone(),
+        &function_shape,
+    );
     let function = anonymous_function_plan(info, name, planned);
     context.push_anonymous_function(function);
     value
@@ -335,11 +331,10 @@ mod tests {
         RuntimeFunctionId, SourceSpan, StringExpr, TupleFunctionId, ValueType,
     };
     use crate::planner::dsl::{
-        call_int_function, capture_int, capture_tuple, function, function_function_closure,
-        function_function_ref, function_ref, int, int_arg, int_function_call_arg,
-        int_function_closure, int_function_ref, int_return_tail_call, let_int_function_step,
-        let_int_step, let_tuple_step, local_int, local_int_function, local_tuple,
-        module_with_anonymous, string, tuple, tuple_function_closure,
+        call_int_function, capture_int, capture_tuple, function, function_function_closure, int,
+        int_arg, int_function_call_arg, int_function_closure, int_return_tail_call,
+        let_int_function_step, let_int_step, let_tuple_step, local_int, local_int_function,
+        local_tuple, module_with_anonymous, string, tuple, tuple_function_closure,
     };
     use crate::planner::error::{
         InvalidExpressionShapeKind, InvalidExpressionType, InvalidFunctionShapeReason,
@@ -365,7 +360,11 @@ pub fn main() {
 "#,
         ))
         .expect("source should plan");
-        let add_one = int_function_ref(1, [LocalId::Int(IntLocalId(0))]);
+        let add_one = int_function_closure(
+            1,
+            [LocalId::Int(IntLocalId(0))],
+            Vec::<crate::plan::CaptureArg>::new(),
+        );
         let expected = module_with_anonymous(
             "main",
             function(
@@ -399,7 +398,11 @@ pub fn main() {
         .expect("source should plan");
         let expected = module_with_anonymous(
             "main",
-            function("main", int(42)).evaluate(int_function_ref(1, [LocalId::Int(IntLocalId(0))])),
+            function("main", int(42)).evaluate(int_function_closure(
+                1,
+                [LocalId::Int(IntLocalId(0))],
+                Vec::<crate::plan::CaptureArg>::new(),
+            )),
             [],
             [function("<anonymous:0>", int(1)).discard_int_param(0)],
         );
@@ -422,7 +425,11 @@ pub fn main() {
 "#,
         ))
         .expect("source should plan");
-        let wrapped = int_function_ref(2, [LocalId::Int(IntLocalId(0))]);
+        let wrapped = int_function_closure(
+            2,
+            [LocalId::Int(IntLocalId(0))],
+            Vec::<crate::plan::CaptureArg>::new(),
+        );
         let expected = module_with_anonymous(
             "main",
             function(
@@ -458,9 +465,10 @@ pub fn main() {
             "main",
             function(
                 "main",
-                function_ref(
-                    RuntimeFunctionId::Int(IntFunctionId(0)),
+                int_function_closure(
+                    0,
                     [LocalId::Int(IntLocalId(0))],
+                    Vec::<crate::plan::CaptureArg>::new(),
                 ),
             ),
             [],
@@ -488,9 +496,10 @@ pub fn main() {
             "main",
             function(
                 "main",
-                function_function_ref(
+                function_function_closure(
                     FunctionFunctionId::Int(IntFunctionFunctionId(0)),
                     Vec::<ParamLocal>::new(),
+                    Vec::<crate::plan::CaptureArg>::new(),
                     returned_function_type.clone(),
                 ),
             ),
@@ -500,9 +509,10 @@ pub fn main() {
                     .param_int(0, "value"),
                 function(
                     "<anonymous:0>",
-                    function_ref(
-                        RuntimeFunctionId::Int(IntFunctionId(0)),
+                    int_function_closure(
+                        0,
                         [LocalId::Int(IntLocalId(0))],
+                        Vec::<crate::plan::CaptureArg>::new(),
                     ),
                 ),
             ],
@@ -688,7 +698,11 @@ pub fn main() {
 "#,
         ))
         .expect("source should plan");
-        let add_one = int_function_ref(2, [LocalId::Int(IntLocalId(0))]);
+        let add_one = int_function_closure(
+            2,
+            [LocalId::Int(IntLocalId(0))],
+            Vec::<crate::plan::CaptureArg>::new(),
+        );
         let expected = module_with_anonymous(
             "main",
             function(
@@ -735,7 +749,11 @@ pub fn main() {
 "#,
         ))
         .expect("source should plan");
-        let add_one = int_function_ref(2, [LocalId::Int(IntLocalId(0))]);
+        let add_one = int_function_closure(
+            2,
+            [LocalId::Int(IntLocalId(0))],
+            Vec::<crate::plan::CaptureArg>::new(),
+        );
         let expected = module_with_anonymous(
             "main",
             function(

--- a/src/planner/expression/operator/equality.rs
+++ b/src/planner/expression/operator/equality.rs
@@ -1,6 +1,6 @@
 use crate::plan::{BoolExpr, Expr};
 use crate::planner::context::PlanContext;
-use crate::planner::error::{PlanError, UnsupportedBinOpKind};
+use crate::planner::error::PlanError;
 use gleam_core::ast::TypedExpr;
 
 pub(super) fn equal(
@@ -10,8 +10,6 @@ pub(super) fn equal(
 ) -> Result<Expr, PlanError> {
     let left = super::super::plan_expr(left, context)?;
     let right = super::super::plan_expr(right, context)?;
-    reject_function_equality(&left, &right, UnsupportedBinOpKind::EqFunction, context)?;
-
     Ok(Expr::bool(BoolExpr::equal(left, right)))
 }
 
@@ -22,39 +20,15 @@ pub(super) fn not_equal(
 ) -> Result<Expr, PlanError> {
     let left = super::super::plan_expr(left, context)?;
     let right = super::super::plan_expr(right, context)?;
-    reject_function_equality(&left, &right, UnsupportedBinOpKind::NotEqFunction, context)?;
-
     Ok(Expr::bool(BoolExpr::not_equal(left, right)))
-}
-
-fn reject_function_equality(
-    left: &Expr,
-    right: &Expr,
-    operator: UnsupportedBinOpKind,
-    context: &PlanContext<'_>,
-) -> Result<(), PlanError> {
-    if context.contains_function_value(&left.value_type())?
-        || context.contains_function_value(&right.value_type())?
-    {
-        return Err(PlanError::UnsupportedBinOp { operator });
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::plan::{CustomExpr, CustomLocalId, CustomType, CustomTypeName, Expr, IntExpr};
-    use crate::planner::context::{AnonymousFunctions, FunctionInfo, PlanContext};
     use crate::planner::dsl::{bool_, equal, function, int, module, not_equal};
     use crate::planner::plan_module;
     use crate::planner::support::{compile, expect_plan_error};
-    use crate::planner::{
-        InvalidCustomTypeReason, InvalidTypedAstReason, PlanError, UnsupportedBinOpKind,
-        UnsupportedExpressionKind,
-    };
-    use ecow::EcoString;
-    use std::collections::HashMap;
+    use crate::planner::{PlanError, UnsupportedExpressionKind};
 
     #[test]
     fn plan_equality_operators() {
@@ -80,7 +54,7 @@ pub fn not_equal() {
     }
 
     #[test]
-    fn reject_profile_equality_operand_expression_errors_propagate() {
+    fn equality_operand_expression_errors_propagate() {
         for (name, src) in [
             (
                 "equal left",
@@ -127,191 +101,13 @@ pub fn main() {
 "#,
             ),
         ] {
-            assert_echo_reject(name, src);
+            assert_eq!(
+                expect_plan_error(src),
+                PlanError::UnsupportedExpression {
+                    kind: UnsupportedExpressionKind::Echo,
+                },
+                "{name}",
+            );
         }
-    }
-
-    #[test]
-    fn reject_profile_function_equality_operators() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  add_one == add_one
-}
-"#,
-            ),
-            PlanError::UnsupportedBinOp {
-                operator: UnsupportedBinOpKind::EqFunction,
-            },
-        );
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  add_one != add_one
-}
-"#,
-            ),
-            PlanError::UnsupportedBinOp {
-                operator: UnsupportedBinOpKind::NotEqFunction,
-            },
-        );
-        assert_eq!(
-            expect_plan_error(
-                r#"
-pub type Boxed(value) {
-  Boxed(value)
-}
-
-pub type Wrapper(value) {
-  Wrapper(Boxed(value))
-}
-
-fn value() {
-  1
-}
-
-pub fn main() {
-  Wrapper(Boxed(value)) == Wrapper(Boxed(value))
-}
-"#,
-            ),
-            PlanError::UnsupportedBinOp {
-                operator: UnsupportedBinOpKind::EqFunction,
-            },
-        );
-    }
-
-    #[test]
-    fn equality_preserves_custom_type_definition_errors_from_either_operand() {
-        let module = EcoString::from("main");
-        let functions = HashMap::<EcoString, FunctionInfo>::new();
-        let mut anonymous = AnonymousFunctions::default();
-        let context = PlanContext::new(&module, &functions, &mut anonymous);
-        let missing = CustomType::new(
-            CustomTypeName::new("geam".into(), module.clone(), "Missing".into()),
-            Vec::new(),
-        );
-        let custom = Expr::custom(CustomExpr::local_get(
-            crate::plan::CustomLocal::new(CustomLocalId(0), missing),
-            "missing".into(),
-        ));
-        let int = Expr::int(IntExpr::value(1.into()));
-        let expected = Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::CustomType {
-                name: "Missing".into(),
-                reason: InvalidCustomTypeReason::UnknownDefinition,
-            },
-        });
-
-        assert_eq!(
-            super::reject_function_equality(
-                &custom,
-                &int,
-                UnsupportedBinOpKind::EqFunction,
-                &context,
-            ),
-            expected.clone(),
-        );
-        assert_eq!(
-            super::reject_function_equality(
-                &int,
-                &custom,
-                UnsupportedBinOpKind::EqFunction,
-                &context,
-            ),
-            expected,
-        );
-    }
-
-    #[test]
-    fn reject_profile_tuple_equality_containing_function_value() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  #(1, add_one) == #(1, add_one)
-}
-"#,
-            ),
-            PlanError::UnsupportedBinOp {
-                operator: UnsupportedBinOpKind::EqFunction,
-            },
-        );
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  #(#(add_one)) != #(#(add_one))
-}
-"#,
-            ),
-            PlanError::UnsupportedBinOp {
-                operator: UnsupportedBinOpKind::NotEqFunction,
-            },
-        );
-    }
-
-    #[test]
-    fn reject_profile_list_equality_containing_function_value() {
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  [add_one] == [add_one]
-}
-"#,
-            ),
-            PlanError::UnsupportedBinOp {
-                operator: UnsupportedBinOpKind::EqFunction,
-            },
-        );
-        assert_eq!(
-            expect_plan_error(
-                r#"
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  [[add_one]] != [[add_one]]
-}
-"#,
-            ),
-            PlanError::UnsupportedBinOp {
-                operator: UnsupportedBinOpKind::NotEqFunction,
-            },
-        );
-    }
-
-    fn assert_echo_reject(name: &str, src: &str) {
-        assert_eq!(
-            expect_plan_error(src),
-            PlanError::UnsupportedExpression {
-                kind: UnsupportedExpressionKind::Echo,
-            },
-            "{name}",
-        );
     }
 }

--- a/src/planner/expression/pipeline.rs
+++ b/src/planner/expression/pipeline.rs
@@ -107,8 +107,8 @@ mod tests {
     use crate::plan::{IntLocalId, LocalId};
     use crate::planner::dsl::{
         block_int, bool_, bool_arg, bool_return_block, bool_return_tail_call, call_int,
-        call_int_function, function, int, int_arg, int_function_call_arg, int_function_ref,
-        int_return_block, int_return_expr, int_return_tail_call, let_bool_step,
+        call_int_function, function, int, int_arg, int_function_call_arg, int_function_closure,
+        int_function_ref, int_return_block, int_return_expr, int_return_tail_call, let_bool_step,
         let_int_function_step, let_int_step, let_nil_step, let_string_step, local_bool, local_int,
         local_int_function, local_nil, local_string, module, module_with_anonymous, nil, nil_arg,
         nil_return_block, nil_return_tail_call, string, string_arg, string_return_block,
@@ -441,7 +441,7 @@ pub fn main() {
                 int_return_block(
                     [let_int_step(0, "_pipe", int(1))],
                     int_return_expr(call_int_function(
-                        int_function_ref(1, [LocalId::Int(IntLocalId(0))]),
+                        int_function_closure(1, [LocalId::Int(IntLocalId(0))], []),
                         [int_function_call_arg(0, local_int(0, "_pipe"))],
                     )),
                 ),

--- a/src/planner/function.rs
+++ b/src/planner/function.rs
@@ -175,7 +175,7 @@ mod tests {
         function_function_ref, function_function_return_block, function_function_return_expr,
         function_function_return_int_case, function_function_return_string_case,
         function_function_return_tail_call, function_ref, int, int_arg, int_function_arg,
-        int_function_call_arg, int_function_ref, int_function_return_block,
+        int_function_call_arg, int_function_closure, int_function_ref, int_function_return_block,
         int_function_return_bool_case, int_function_return_expr, int_function_return_int_case,
         int_function_return_string_case, int_function_return_tail_call, int_return_block,
         int_return_bool_case, int_return_expr, int_return_int_case, int_return_tail_call,
@@ -1172,7 +1172,7 @@ pub fn main() {
             .step(let_int_function_step(
                 0,
                 "main",
-                int_function_ref(1, Vec::<LocalId>::new()),
+                int_function_closure(1, Vec::<LocalId>::new(), []),
             )),
             [],
             [function("<anonymous:0>", int(0))],

--- a/src/planner/statement/use_.rs
+++ b/src/planner/statement/use_.rs
@@ -58,8 +58,8 @@ mod tests {
     use crate::planner::context::{AnonymousFunctions, PlanContext};
     use crate::planner::dsl::{
         call_int_function, capture_int, function, int, int_arg, int_function_arg,
-        int_function_call_arg, int_function_closure, int_function_ref, int_return_tail_call,
-        let_list_step, let_tuple_step, local_int, local_int_function, local_list, local_tuple,
+        int_function_call_arg, int_function_closure, int_return_tail_call, let_list_step,
+        let_tuple_step, local_int, local_int_function, local_list, local_tuple,
         module_with_anonymous, tuple, tuple_arg,
     };
     use crate::planner::plan_module;
@@ -100,7 +100,7 @@ fn pair(callback: fn() -> Int) {
                     1,
                     [int_function_arg(
                         0,
-                        int_function_ref(2, Vec::<LocalId>::new()),
+                        int_function_closure(2, Vec::<LocalId>::new(), []),
                     )],
                 ),
             ),
@@ -141,7 +141,7 @@ pub fn main() {
                     1,
                     [int_function_arg(
                         0,
-                        int_function_ref(2, [LocalId::Int(IntLocalId(0))]),
+                        int_function_closure(2, [LocalId::Int(IntLocalId(0))], []),
                     )],
                 ),
             ),
@@ -250,7 +250,10 @@ pub fn main() {
                     1,
                     [
                         int_arg(0, int(41)),
-                        int_function_arg(0, int_function_ref(2, [LocalId::Int(IntLocalId(0))])),
+                        int_function_arg(
+                            0,
+                            int_function_closure(2, [LocalId::Int(IntLocalId(0))], []),
+                        ),
                     ],
                 ),
             ),
@@ -290,7 +293,7 @@ pub fn main() {
         let type_ = [ValueType::Int, ValueType::Int];
         let tuple_type = ValueType::Tuple(type_.to_vec());
         let anonymous_ref =
-            int_function_ref(2, [ParamLocal::tuple(TupleLocalId(0), type_.to_vec())]);
+            int_function_closure(2, [ParamLocal::tuple(TupleLocalId(0), type_.to_vec())], []);
         let internal_tuple = local_tuple(1, "<tuple:1>", type_.clone());
         let expected = module_with_anonymous(
             "main",
@@ -395,7 +398,7 @@ pub fn main() {
                     1,
                     [int_function_arg(
                         0,
-                        int_function_ref(2, [LocalId::Int(IntLocalId(0))]),
+                        int_function_closure(2, [LocalId::Int(IntLocalId(0))], []),
                     )],
                 ),
             ),
@@ -448,9 +451,10 @@ pub fn main() {
                     1,
                     [int_function_arg(
                         0,
-                        int_function_ref(
+                        int_function_closure(
                             2,
                             [ParamLocal::tuple(TupleLocalId(0), outer_type.to_vec())],
+                            [],
                         ),
                     )],
                 ),

--- a/src/runtime/evaluated.rs
+++ b/src/runtime/evaluated.rs
@@ -1396,44 +1396,35 @@ pub fn main() { 0 }
         for (left, right) in function_pairs {
             let family = left.kind().family();
             assert_eq!(family, right.kind().family());
-            assert_eq!(
-                values_equal(
-                    &plan,
-                    &state,
-                    &EvaluatedValue::Function(left),
-                    &EvaluatedValue::Function(right),
-                ),
-                true,
-            );
+            assert!(values_equal(
+                &plan,
+                &state,
+                &EvaluatedValue::Function(left),
+                &EvaluatedValue::Function(right),
+            ));
         }
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(custom_function)),
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(constructor_function)),
-            ),
-            false,
-        );
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(int_function.clone())),
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(
-                    EvaluatedFloatFunction::reference(
-                        FloatFunctionId(0),
+        assert!(!values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(custom_function)),
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(constructor_function)),
+        ));
+        assert!(!values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(int_function.clone())),
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(
+                EvaluatedFloatFunction::reference(
+                    FloatFunctionId(0),
+                    Vec::new(),
+                    Vec::new(),
+                    crate::plan::execution::FunctionType::new(
                         Vec::new(),
-                        Vec::new(),
-                        crate::plan::execution::FunctionType::new(
-                            Vec::new(),
-                            crate::plan::execution::ValueType::Float,
-                        ),
+                        crate::plan::execution::ValueType::Float,
                     ),
-                )),
-            ),
-            false,
-        );
+                ),
+            )),
+        ));
 
         let int_lists = (
             state.int(plan.int_list_function_id(0).type_id(), vec![1.into()]),
@@ -1537,52 +1528,37 @@ pub fn main() { 0 }
         ];
 
         for (left, right) in list_pairs {
-            assert_eq!(
-                values_equal(
-                    &plan,
-                    &state,
-                    &EvaluatedValue::List(left),
-                    &EvaluatedValue::List(right),
-                ),
-                true,
-            );
+            assert!(values_equal(
+                &plan,
+                &state,
+                &EvaluatedValue::List(left),
+                &EvaluatedValue::List(right),
+            ));
         }
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::List(ListValueId::Int(int_lists.0)),
-                &EvaluatedValue::List(ListValueId::String(string_lists.0)),
-            ),
-            false,
-        );
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
-                &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
-            ),
-            true,
-        );
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
-                &EvaluatedValue::Tuple(Vec::new()),
-            ),
-            false,
-        );
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Int(1.into()),
-                &EvaluatedValue::String("one".into()),
-            ),
-            false,
-        );
+        assert!(!values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::List(ListValueId::Int(int_lists.0)),
+            &EvaluatedValue::List(ListValueId::String(string_lists.0)),
+        ));
+        assert!(values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
+            &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
+        ));
+        assert!(!values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
+            &EvaluatedValue::Tuple(Vec::new()),
+        ));
+        assert!(!values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Int(1.into()),
+            &EvaluatedValue::String("one".into()),
+        ));
     }
 
     #[test]
@@ -1629,55 +1605,40 @@ pub fn main() { 0 }
             int_type,
         );
 
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(reference.clone())),
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(
-                    same_target_with_different_metadata,
-                )),
-            ),
-            true,
-        );
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(reference)),
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(different_target)),
-            ),
-            false,
-        );
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(
-                    reference_for_instance_comparison,
-                )),
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(closure.clone())),
-            ),
-            false,
-        );
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(closure.clone())),
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(same_closure)),
-            ),
-            true,
-        );
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(closure)),
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(separate_closure)),
-            ),
-            false,
-        );
+        assert!(values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(reference.clone())),
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(
+                same_target_with_different_metadata,
+            )),
+        ));
+        assert!(!values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(reference)),
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(different_target)),
+        ));
+        assert!(!values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(
+                reference_for_instance_comparison,
+            )),
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(closure.clone())),
+        ));
+        assert!(values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(closure.clone())),
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(same_closure)),
+        ));
+        assert!(!values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(closure)),
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(separate_closure)),
+        ));
     }
 
     #[test]
@@ -1849,23 +1810,17 @@ pub fn main() { 0 }
         let same = first.clone();
         let separate = EvaluatedCustomFunction::constructor(constructor_id, type_);
 
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(first.clone())),
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(same)),
-            ),
-            true,
-        );
-        assert_eq!(
-            values_equal(
-                &plan,
-                &state,
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(first)),
-                &EvaluatedValue::Function(EvaluatedFunctionValue::from(separate)),
-            ),
-            false,
-        );
+        assert!(values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(first.clone())),
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(same)),
+        ));
+        assert!(!values_equal(
+            &plan,
+            &state,
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(first)),
+            &EvaluatedValue::Function(EvaluatedFunctionValue::from(separate)),
+        ));
     }
 }

--- a/src/runtime/evaluated.rs
+++ b/src/runtime/evaluated.rs
@@ -83,10 +83,65 @@ pub(in crate::runtime) enum EvaluatedValue {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(in crate::runtime) struct EvaluatedFunction<Id> {
+    identity: EvaluatedFunctionIdentity,
     runtime_id: Id,
     params: Vec<ParamLocal>,
     captures: Vec<EvaluatedCapture>,
     type_: FunctionType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::runtime) struct FunctionReferenceIdentity {
+    table: FunctionTableIdentity,
+    index: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FunctionTableIdentity {
+    Value(FunctionReturnFamily),
+    List(ListFunctionReturnFamily),
+    Function(FunctionReturnFamily),
+    ReturningListFunction(ListFunctionReturnFamily),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ListFunctionReturnFamily {
+    Int,
+    String,
+    BitArray,
+    UtfCodepoint,
+    Custom,
+    Float,
+    Bool,
+    Nil,
+    Tuple,
+    List,
+    Function,
+}
+
+#[derive(Debug, Clone)]
+enum EvaluatedFunctionIdentity {
+    Reference(FunctionReferenceIdentity),
+    Instance(Rc<FunctionInstance>),
+}
+
+#[derive(Debug)]
+struct FunctionInstance;
+
+impl PartialEq for EvaluatedFunctionIdentity {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Reference(left), Self::Reference(right)) => left == right,
+            (Self::Instance(left), Self::Instance(right)) => Rc::ptr_eq(left, right),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for EvaluatedFunctionIdentity {}
+
+pub(in crate::runtime) trait FunctionReferenceId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity;
 }
 
 pub(in crate::runtime) type EvaluatedIntFunction = EvaluatedFunction<IntFunctionId>;
@@ -105,6 +160,229 @@ pub(in crate::runtime) type EvaluatedNilFunction = EvaluatedFunction<NilFunction
 pub(in crate::runtime) type EvaluatedTupleFunction = EvaluatedFunction<TupleFunctionId>;
 pub(in crate::runtime) type EvaluatedListFunction = EvaluatedFunction<ListFunctionId>;
 pub(in crate::runtime) type EvaluatedFunctionFunction = EvaluatedFunction<FunctionFunctionId>;
+
+impl FunctionReferenceIdentity {
+    fn value(family: FunctionReturnFamily, index: usize) -> Self {
+        Self {
+            table: FunctionTableIdentity::Value(family),
+            index,
+        }
+    }
+
+    fn list(family: ListFunctionReturnFamily, index: usize) -> Self {
+        Self {
+            table: FunctionTableIdentity::List(family),
+            index,
+        }
+    }
+
+    fn function(family: FunctionReturnFamily, index: usize) -> Self {
+        Self {
+            table: FunctionTableIdentity::Function(family),
+            index,
+        }
+    }
+
+    fn returning_list_function(family: ListFunctionReturnFamily, index: usize) -> Self {
+        Self {
+            table: FunctionTableIdentity::ReturningListFunction(family),
+            index,
+        }
+    }
+}
+
+impl FunctionReferenceId for IntFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        FunctionReferenceIdentity::value(FunctionReturnFamily::Int, self.0)
+    }
+}
+
+impl FunctionReferenceId for FloatFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        FunctionReferenceIdentity::value(FunctionReturnFamily::Float, self.0)
+    }
+}
+
+impl FunctionReferenceId for StringFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        FunctionReferenceIdentity::value(FunctionReturnFamily::String, self.0)
+    }
+}
+
+impl FunctionReferenceId for BitArrayFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        FunctionReferenceIdentity::value(FunctionReturnFamily::BitArray, self.0)
+    }
+}
+
+impl FunctionReferenceId for UtfCodepointFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        FunctionReferenceIdentity::value(FunctionReturnFamily::UtfCodepoint, self.0)
+    }
+}
+
+impl FunctionReferenceId for CustomFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        FunctionReferenceIdentity::value(FunctionReturnFamily::Custom, self.index())
+    }
+}
+
+impl FunctionReferenceId for BoolFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        FunctionReferenceIdentity::value(FunctionReturnFamily::Bool, self.0)
+    }
+}
+
+impl FunctionReferenceId for NilFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        FunctionReferenceIdentity::value(FunctionReturnFamily::Nil, self.0)
+    }
+}
+
+impl FunctionReferenceId for TupleFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        FunctionReferenceIdentity::value(FunctionReturnFamily::Tuple, self.0)
+    }
+}
+
+impl FunctionReferenceId for ListFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        match self {
+            Self::Int(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Int, id.index())
+            }
+            Self::String(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::String, id.index())
+            }
+            Self::BitArray(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::BitArray, id.index())
+            }
+            Self::UtfCodepoint(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::UtfCodepoint, id.index())
+            }
+            Self::Custom(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Custom, id.index())
+            }
+            Self::Float(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Float, id.index())
+            }
+            Self::Bool(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Bool, id.index())
+            }
+            Self::Nil(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Nil, id.index())
+            }
+            Self::Tuple(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Tuple, id.index())
+            }
+            Self::List(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::List, id.index())
+            }
+            Self::Function(id) => {
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Function, id.index())
+            }
+        }
+    }
+}
+
+impl FunctionReferenceId for FunctionFunctionId {
+    fn reference_identity(&self) -> FunctionReferenceIdentity {
+        match self {
+            Self::Int(id) => FunctionReferenceIdentity::function(FunctionReturnFamily::Int, id.0),
+            Self::Float(id) => {
+                FunctionReferenceIdentity::function(FunctionReturnFamily::Float, id.0)
+            }
+            Self::String(id) => {
+                FunctionReferenceIdentity::function(FunctionReturnFamily::String, id.0)
+            }
+            Self::BitArray(id) => {
+                FunctionReferenceIdentity::function(FunctionReturnFamily::BitArray, id.0)
+            }
+            Self::UtfCodepoint(id) => {
+                FunctionReferenceIdentity::function(FunctionReturnFamily::UtfCodepoint, id.0)
+            }
+            Self::Custom(id) => {
+                FunctionReferenceIdentity::function(FunctionReturnFamily::Custom, id.index())
+            }
+            Self::Bool(id) => FunctionReferenceIdentity::function(FunctionReturnFamily::Bool, id.0),
+            Self::Nil(id) => FunctionReferenceIdentity::function(FunctionReturnFamily::Nil, id.0),
+            Self::Tuple(id) => {
+                FunctionReferenceIdentity::function(FunctionReturnFamily::Tuple, id.0)
+            }
+            Self::List(id) => match id {
+                crate::plan::execution::ListFunctionFunctionId::Int { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::Int,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::String { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::String,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::BitArray { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::BitArray,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::UtfCodepoint { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::UtfCodepoint,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::Custom { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::Custom,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::Float { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::Float,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::Bool { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::Bool,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::Nil { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::Nil,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::Tuple { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::Tuple,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::List { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::List,
+                        id.0,
+                    )
+                }
+                crate::plan::execution::ListFunctionFunctionId::Function { id, .. } => {
+                    FunctionReferenceIdentity::returning_list_function(
+                        ListFunctionReturnFamily::Function,
+                        id.0,
+                    )
+                }
+            },
+            Self::Function(id) => {
+                FunctionReferenceIdentity::function(FunctionReturnFamily::Function, id.index())
+            }
+        }
+    }
+}
 
 pub(in crate::runtime) fn function_type_from_slots(
     plan: &crate::plan::execution::ExecutionPlan,
@@ -299,14 +577,33 @@ impl EvaluatedValue {
     }
 }
 
+impl<Id: Clone + FunctionReferenceId> EvaluatedFunction<Id> {
+    pub(in crate::runtime) fn reference(
+        runtime_id: Id,
+        params: Vec<ParamLocal>,
+        captures: Vec<EvaluatedCapture>,
+        type_: FunctionType,
+    ) -> Self {
+        let identity = EvaluatedFunctionIdentity::Reference(runtime_id.reference_identity());
+        Self {
+            identity,
+            runtime_id,
+            params,
+            captures,
+            type_,
+        }
+    }
+}
+
 impl<Id: Clone> EvaluatedFunction<Id> {
-    pub(in crate::runtime) fn new(
+    pub(in crate::runtime) fn closure(
         runtime_id: Id,
         params: Vec<ParamLocal>,
         captures: Vec<EvaluatedCapture>,
         type_: FunctionType,
     ) -> Self {
         Self {
+            identity: EvaluatedFunctionIdentity::Instance(Rc::new(FunctionInstance)),
             runtime_id,
             params,
             captures,
@@ -337,20 +634,33 @@ impl<Id: Clone> EvaluatedFunction<Id> {
 }
 
 impl EvaluatedCustomFunction {
-    pub(in crate::runtime) fn function(
+    pub(in crate::runtime) fn reference(
         runtime_id: CustomFunctionId,
         params: Vec<ParamLocal>,
         captures: Vec<EvaluatedCapture>,
         type_: FunctionType,
     ) -> Self {
-        Self::Function(EvaluatedFunction::new(runtime_id, params, captures, type_))
+        Self::Function(EvaluatedFunction::reference(
+            runtime_id, params, captures, type_,
+        ))
+    }
+
+    pub(in crate::runtime) fn closure(
+        runtime_id: CustomFunctionId,
+        params: Vec<ParamLocal>,
+        captures: Vec<EvaluatedCapture>,
+        type_: FunctionType,
+    ) -> Self {
+        Self::Function(EvaluatedFunction::closure(
+            runtime_id, params, captures, type_,
+        ))
     }
 
     pub(in crate::runtime) fn constructor(
         constructor: CustomConstructorId,
         type_: FunctionType,
     ) -> Self {
-        Self::Constructor(EvaluatedFunction::new(
+        Self::Constructor(EvaluatedFunction::closure(
             constructor,
             Vec::new(),
             Vec::new(),
@@ -653,7 +963,7 @@ pub(in crate::runtime) fn values_equal(
             lists_equal(plan, state, left, right)
         }
         (EvaluatedValue::Function(left), EvaluatedValue::Function(right)) => {
-            functions_equal(plan, state, left, right)
+            functions_equal(left, right)
         }
         _ => false,
     }
@@ -678,387 +988,64 @@ fn lists_equal(
             .all(|(left, right)| values_equal(plan, state, left, right))
 }
 
-fn functions_equal(
-    plan: &crate::ExecutionPlan,
-    state: &RuntimeState,
-    left: &EvaluatedFunctionValue,
-    right: &EvaluatedFunctionValue,
-) -> bool {
+fn functions_equal(left: &EvaluatedFunctionValue, right: &EvaluatedFunctionValue) -> bool {
     match (left.kind(), right.kind()) {
         (EvaluatedFunctionValueKind::Int(left), EvaluatedFunctionValueKind::Int(right)) => {
-            function_values_equal(plan, state, left, right)
+            function_values_equal(left, right)
         }
         (EvaluatedFunctionValueKind::Float(left), EvaluatedFunctionValueKind::Float(right)) => {
-            function_values_equal(plan, state, left, right)
+            function_values_equal(left, right)
         }
         (EvaluatedFunctionValueKind::String(left), EvaluatedFunctionValueKind::String(right)) => {
-            function_values_equal(plan, state, left, right)
+            function_values_equal(left, right)
         }
         (
             EvaluatedFunctionValueKind::BitArray(left),
             EvaluatedFunctionValueKind::BitArray(right),
-        ) => function_values_equal(plan, state, left, right),
+        ) => function_values_equal(left, right),
         (
             EvaluatedFunctionValueKind::UtfCodepoint(left),
             EvaluatedFunctionValueKind::UtfCodepoint(right),
-        ) => function_values_equal(plan, state, left, right),
+        ) => function_values_equal(left, right),
         (EvaluatedFunctionValueKind::Custom(left), EvaluatedFunctionValueKind::Custom(right)) => {
-            custom_function_values_equal(plan, state, left, right)
+            custom_function_values_equal(left, right)
         }
         (EvaluatedFunctionValueKind::Bool(left), EvaluatedFunctionValueKind::Bool(right)) => {
-            function_values_equal(plan, state, left, right)
+            function_values_equal(left, right)
         }
         (EvaluatedFunctionValueKind::Nil(left), EvaluatedFunctionValueKind::Nil(right)) => {
-            function_values_equal(plan, state, left, right)
+            function_values_equal(left, right)
         }
         (EvaluatedFunctionValueKind::Tuple(left), EvaluatedFunctionValueKind::Tuple(right)) => {
-            function_values_equal(plan, state, left, right)
+            function_values_equal(left, right)
         }
         (EvaluatedFunctionValueKind::List(left), EvaluatedFunctionValueKind::List(right)) => {
-            function_values_equal(plan, state, left, right)
+            function_values_equal(left, right)
         }
         (
             EvaluatedFunctionValueKind::Function(left),
             EvaluatedFunctionValueKind::Function(right),
-        ) => function_values_equal(plan, state, left, right),
+        ) => function_values_equal(left, right),
         _ => false,
     }
 }
 
-fn function_values_equal<Id: PartialEq>(
-    plan: &crate::ExecutionPlan,
-    state: &RuntimeState,
-    left: &EvaluatedFunction<Id>,
-    right: &EvaluatedFunction<Id>,
-) -> bool {
-    left.runtime_id == right.runtime_id
-        && left.params == right.params
-        && left.type_ == right.type_
-        && left.captures.len() == right.captures.len()
-        && left
-            .captures
-            .iter()
-            .zip(&right.captures)
-            .all(|(left, right)| captures_equal(plan, state, left, right))
+fn function_values_equal<Id>(left: &EvaluatedFunction<Id>, right: &EvaluatedFunction<Id>) -> bool {
+    left.identity == right.identity
 }
 
 fn custom_function_values_equal(
-    plan: &crate::ExecutionPlan,
-    state: &RuntimeState,
     left: &EvaluatedCustomFunction,
     right: &EvaluatedCustomFunction,
 ) -> bool {
     match (left, right) {
         (EvaluatedCustomFunction::Function(left), EvaluatedCustomFunction::Function(right)) => {
-            function_values_equal(plan, state, left, right)
+            function_values_equal(left, right)
         }
         (
             EvaluatedCustomFunction::Constructor(left),
             EvaluatedCustomFunction::Constructor(right),
-        ) => function_values_equal(plan, state, left, right),
-        _ => false,
-    }
-}
-
-fn captures_equal(
-    plan: &crate::ExecutionPlan,
-    state: &RuntimeState,
-    left: &EvaluatedCapture,
-    right: &EvaluatedCapture,
-) -> bool {
-    match (left.kind(), right.kind()) {
-        (
-            EvaluatedCaptureKind::Int {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::Int {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && left == right,
-        (
-            EvaluatedCaptureKind::Float {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::Float {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && left == right,
-        (
-            EvaluatedCaptureKind::String {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::String {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && left == right,
-        (
-            EvaluatedCaptureKind::UtfCodepoint {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::UtfCodepoint {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && left == right,
-        (
-            EvaluatedCaptureKind::Bool {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::Bool {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && left == right,
-        (EvaluatedCaptureKind::Nil { local: left }, EvaluatedCaptureKind::Nil { local: right }) => {
-            left == right
-        }
-        (
-            EvaluatedCaptureKind::Tuple {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::Tuple {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && values_equal(
-                    plan,
-                    state,
-                    &EvaluatedValue::Tuple(left.clone()),
-                    &EvaluatedValue::Tuple(right.clone()),
-                )
-        }
-        (EvaluatedCaptureKind::List(left), EvaluatedCaptureKind::List(right)) => {
-            list_captures_equal(plan, state, left, right)
-        }
-        (
-            EvaluatedCaptureKind::IntFunction {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::IntFunction {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && function_values_equal(plan, state, left, right),
-        (
-            EvaluatedCaptureKind::FloatFunction {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::FloatFunction {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && function_values_equal(plan, state, left, right),
-        (
-            EvaluatedCaptureKind::StringFunction {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::StringFunction {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && function_values_equal(plan, state, left, right),
-        (
-            EvaluatedCaptureKind::UtfCodepointFunction {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::UtfCodepointFunction {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && function_values_equal(plan, state, left, right),
-        (
-            EvaluatedCaptureKind::BoolFunction {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::BoolFunction {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && function_values_equal(plan, state, left, right),
-        (
-            EvaluatedCaptureKind::NilFunction {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::NilFunction {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && function_values_equal(plan, state, left, right),
-        (
-            EvaluatedCaptureKind::TupleFunction {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::TupleFunction {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && function_values_equal(plan, state, left, right),
-        (
-            EvaluatedCaptureKind::ListFunction {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::ListFunction {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && function_values_equal(plan, state, left, right),
-        (
-            EvaluatedCaptureKind::FunctionFunction {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedCaptureKind::FunctionFunction {
-                local: right_local,
-                value: right,
-            },
-        ) => left_local == right_local && function_values_equal(plan, state, left, right),
-        _ => false,
-    }
-}
-
-fn list_captures_equal(
-    plan: &crate::ExecutionPlan,
-    state: &RuntimeState,
-    left: &EvaluatedListCapture,
-    right: &EvaluatedListCapture,
-) -> bool {
-    match (left, right) {
-        (
-            EvaluatedListCapture::Int {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedListCapture::Int {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
-        }
-        (
-            EvaluatedListCapture::String {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedListCapture::String {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
-        }
-        (
-            EvaluatedListCapture::UtfCodepoint {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedListCapture::UtfCodepoint {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
-        }
-        (
-            EvaluatedListCapture::Float {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedListCapture::Float {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
-        }
-        (
-            EvaluatedListCapture::Bool {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedListCapture::Bool {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
-        }
-        (
-            EvaluatedListCapture::Nil {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedListCapture::Nil {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
-        }
-        (
-            EvaluatedListCapture::Tuple {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedListCapture::Tuple {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
-        }
-        (
-            EvaluatedListCapture::List {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedListCapture::List {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
-        }
-        (
-            EvaluatedListCapture::Function {
-                local: left_local,
-                value: left,
-            },
-            EvaluatedListCapture::Function {
-                local: right_local,
-                value: right,
-            },
-        ) => {
-            left_local == right_local
-                && lists_equal(plan, state, &left.clone().into(), &right.clone().into())
-        }
+        ) => function_values_equal(left, right),
         _ => false,
     }
 }
@@ -1068,20 +1055,21 @@ mod tests {
     use super::{
         EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedCapture,
         EvaluatedCustomFunction, EvaluatedFloatFunction, EvaluatedFunctionFunction,
-        EvaluatedFunctionValue, EvaluatedIntFunction, EvaluatedListCapture, EvaluatedListFunction,
-        EvaluatedNilFunction, EvaluatedStringFunction, EvaluatedTupleFunction,
-        EvaluatedUtfCodepointFunction, EvaluatedValue, values_equal,
+        EvaluatedFunctionValue, EvaluatedIntFunction, EvaluatedListFunction, EvaluatedNilFunction,
+        EvaluatedStringFunction, EvaluatedTupleFunction, EvaluatedUtfCodepointFunction,
+        EvaluatedValue, FunctionReferenceId, FunctionReferenceIdentity, ListFunctionReturnFamily,
+        values_equal,
     };
     use crate::plan::ValueType;
     use crate::plan::execution::{
-        BitArrayFunctionId, BoolFunctionId, BoolFunctionLocalId, BoolListLocalId, BoolLocalId,
-        FloatFunctionId, FloatFunctionLocalId, FloatListLocalId, FloatLocalId, FunctionFunctionId,
-        FunctionListLocalId, IntFunctionFunctionId, IntFunctionId, IntFunctionLocalId,
-        IntListFunctionLocalId, IntListLocalId, IntLocalId, ListFunctionId, ListFunctionLocal,
-        ListListLocalId, NilFunctionId, NilFunctionLocalId, NilListLocalId, NilLocalId, ParamLocal,
-        StringFunctionId, StringFunctionLocalId, StringListLocalId, StringLocalId, TupleFunctionId,
-        TupleFunctionLocalId, TupleListLocalId, TupleLocalId, UtfCodepointFunctionId,
-        UtfCodepointFunctionLocalId, UtfCodepointListLocalId, UtfCodepointLocalId,
+        BitArrayFunctionId, BitArrayListFunctionFunctionId, BoolFunctionId,
+        BoolListFunctionFunctionId, CustomListFunctionFunctionId, FloatFunctionId,
+        FloatListFunctionFunctionId, FunctionFunctionId, FunctionListFunctionFunctionId,
+        IntFunctionFunctionId, IntFunctionId, IntListFunctionFunctionId, IntLocalId,
+        ListFunctionFunctionId, ListFunctionId, ListListFunctionFunctionId, NilFunctionId,
+        NilListFunctionFunctionId, ParamLocal, StringFunctionId, StringListFunctionFunctionId,
+        TupleFunctionId, TupleListFunctionFunctionId, UtfCodepointFunctionId,
+        UtfCodepointListFunctionFunctionId,
     };
     use crate::runtime::state::{ListValueId, RuntimeState};
     use bitvec::order::Msb0;
@@ -1119,7 +1107,7 @@ pub fn main() { 0 }
         let plan = crate::runtime::plan_src(EVERY_LIST_FAMILY_SOURCE);
         let mut state = RuntimeState::new();
         let list = state.int(plan.int_list_function_id(0).type_id(), vec![1.into()]);
-        let function = EvaluatedIntFunction::new(
+        let function = EvaluatedIntFunction::reference(
             IntFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -1169,14 +1157,14 @@ pub fn main() { 0 }
             Vec::new(),
             crate::plan::execution::ValueType::Int,
         );
-        let int_function = EvaluatedIntFunction::new(
+        let int_function = EvaluatedIntFunction::reference(
             IntFunctionId(0),
             Vec::new(),
             Vec::new(),
             execution_int_type.clone(),
         );
         let custom_type = plan.custom_list_function_id(0).type_id().item_type();
-        let custom_function = EvaluatedCustomFunction::function(
+        let custom_function = EvaluatedCustomFunction::reference(
             plan.custom_function_id(0),
             Vec::new(),
             Vec::new(),
@@ -1204,7 +1192,7 @@ pub fn main() { 0 }
                 EvaluatedFunctionValue::from(int_function.clone()),
             ),
             (
-                EvaluatedFunctionValue::from(EvaluatedFloatFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedFloatFunction::reference(
                     FloatFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1213,7 +1201,7 @@ pub fn main() { 0 }
                         crate::plan::execution::ValueType::Float,
                     ),
                 )),
-                EvaluatedFunctionValue::from(EvaluatedFloatFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedFloatFunction::reference(
                     FloatFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1224,7 +1212,7 @@ pub fn main() { 0 }
                 )),
             ),
             (
-                EvaluatedFunctionValue::from(EvaluatedStringFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedStringFunction::reference(
                     StringFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1233,7 +1221,7 @@ pub fn main() { 0 }
                         crate::plan::execution::ValueType::String,
                     ),
                 )),
-                EvaluatedFunctionValue::from(EvaluatedStringFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedStringFunction::reference(
                     StringFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1244,7 +1232,7 @@ pub fn main() { 0 }
                 )),
             ),
             (
-                EvaluatedFunctionValue::from(EvaluatedBitArrayFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedBitArrayFunction::reference(
                     BitArrayFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1253,7 +1241,7 @@ pub fn main() { 0 }
                         crate::plan::execution::ValueType::BitArray,
                     ),
                 )),
-                EvaluatedFunctionValue::from(EvaluatedBitArrayFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedBitArrayFunction::reference(
                     BitArrayFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1264,7 +1252,7 @@ pub fn main() { 0 }
                 )),
             ),
             (
-                EvaluatedFunctionValue::from(EvaluatedUtfCodepointFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedUtfCodepointFunction::reference(
                     UtfCodepointFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1273,7 +1261,7 @@ pub fn main() { 0 }
                         crate::plan::execution::ValueType::UtfCodepoint,
                     ),
                 )),
-                EvaluatedFunctionValue::from(EvaluatedUtfCodepointFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedUtfCodepointFunction::reference(
                     UtfCodepointFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1292,7 +1280,7 @@ pub fn main() { 0 }
                 EvaluatedFunctionValue::from(constructor_function.clone()),
             ),
             (
-                EvaluatedFunctionValue::from(EvaluatedBoolFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedBoolFunction::reference(
                     BoolFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1301,7 +1289,7 @@ pub fn main() { 0 }
                         crate::plan::execution::ValueType::Bool,
                     ),
                 )),
-                EvaluatedFunctionValue::from(EvaluatedBoolFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedBoolFunction::reference(
                     BoolFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1312,7 +1300,7 @@ pub fn main() { 0 }
                 )),
             ),
             (
-                EvaluatedFunctionValue::from(EvaluatedNilFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedNilFunction::reference(
                     NilFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1321,7 +1309,7 @@ pub fn main() { 0 }
                         crate::plan::execution::ValueType::Nil,
                     ),
                 )),
-                EvaluatedFunctionValue::from(EvaluatedNilFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedNilFunction::reference(
                     NilFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1332,7 +1320,7 @@ pub fn main() { 0 }
                 )),
             ),
             (
-                EvaluatedFunctionValue::from(EvaluatedTupleFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedTupleFunction::reference(
                     TupleFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1343,7 +1331,7 @@ pub fn main() { 0 }
                         ]),
                     ),
                 )),
-                EvaluatedFunctionValue::from(EvaluatedTupleFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedTupleFunction::reference(
                     TupleFunctionId(0),
                     Vec::new(),
                     Vec::new(),
@@ -1356,7 +1344,7 @@ pub fn main() { 0 }
                 )),
             ),
             (
-                EvaluatedFunctionValue::from(EvaluatedListFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedListFunction::reference(
                     ListFunctionId::Int(plan.int_list_function_id(0)),
                     Vec::new(),
                     Vec::new(),
@@ -1367,7 +1355,7 @@ pub fn main() { 0 }
                         ),
                     ),
                 )),
-                EvaluatedFunctionValue::from(EvaluatedListFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedListFunction::reference(
                     ListFunctionId::Int(plan.int_list_function_id(0)),
                     Vec::new(),
                     Vec::new(),
@@ -1380,7 +1368,7 @@ pub fn main() { 0 }
                 )),
             ),
             (
-                EvaluatedFunctionValue::from(EvaluatedFunctionFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedFunctionFunction::reference(
                     FunctionFunctionId::Int(IntFunctionFunctionId(0)),
                     Vec::new(),
                     Vec::new(),
@@ -1391,7 +1379,7 @@ pub fn main() { 0 }
                         )),
                     ),
                 )),
-                EvaluatedFunctionValue::from(EvaluatedFunctionFunction::new(
+                EvaluatedFunctionValue::from(EvaluatedFunctionFunction::reference(
                     FunctionFunctionId::Int(IntFunctionFunctionId(0)),
                     Vec::new(),
                     Vec::new(),
@@ -1408,29 +1396,32 @@ pub fn main() { 0 }
         for (left, right) in function_pairs {
             let family = left.kind().family();
             assert_eq!(family, right.kind().family());
-            assert!(
+            assert_eq!(
                 values_equal(
                     &plan,
                     &state,
                     &EvaluatedValue::Function(left),
                     &EvaluatedValue::Function(right),
                 ),
-                "matching function families must compare equal",
+                true,
             );
         }
-        assert!(!values_equal(
-            &plan,
-            &state,
-            &EvaluatedValue::Function(EvaluatedFunctionValue::from(custom_function)),
-            &EvaluatedValue::Function(EvaluatedFunctionValue::from(constructor_function)),
-        ));
-        assert!(
-            !values_equal(
+        assert_eq!(
+            values_equal(
+                &plan,
+                &state,
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(custom_function)),
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(constructor_function)),
+            ),
+            false,
+        );
+        assert_eq!(
+            values_equal(
                 &plan,
                 &state,
                 &EvaluatedValue::Function(EvaluatedFunctionValue::from(int_function.clone())),
                 &EvaluatedValue::Function(EvaluatedFunctionValue::from(
-                    EvaluatedFloatFunction::new(
+                    EvaluatedFloatFunction::reference(
                         FloatFunctionId(0),
                         Vec::new(),
                         Vec::new(),
@@ -1441,7 +1432,7 @@ pub fn main() { 0 }
                     ),
                 )),
             ),
-            "different function families must not compare equal",
+            false,
         );
 
         let int_lists = (
@@ -1546,512 +1537,335 @@ pub fn main() { 0 }
         ];
 
         for (left, right) in list_pairs {
-            assert!(
+            assert_eq!(
                 values_equal(
                     &plan,
                     &state,
                     &EvaluatedValue::List(left),
                     &EvaluatedValue::List(right),
                 ),
-                "matching list families must compare equal",
+                true,
             );
         }
-        assert!(
-            !values_equal(
+        assert_eq!(
+            values_equal(
                 &plan,
                 &state,
                 &EvaluatedValue::List(ListValueId::Int(int_lists.0)),
                 &EvaluatedValue::List(ListValueId::String(string_lists.0)),
             ),
-            "different list families must not compare equal",
+            false,
         );
-        assert!(
+        assert_eq!(
             values_equal(
                 &plan,
                 &state,
                 &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
                 &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
             ),
-            "matching tuple values must compare equal",
+            true,
         );
-        assert!(
-            !values_equal(
+        assert_eq!(
+            values_equal(
                 &plan,
                 &state,
                 &EvaluatedValue::Tuple(vec![EvaluatedValue::Int(1.into())]),
                 &EvaluatedValue::Tuple(Vec::new()),
             ),
-            "different tuple lengths must not compare equal",
+            false,
         );
-        assert!(
-            !values_equal(
+        assert_eq!(
+            values_equal(
                 &plan,
                 &state,
                 &EvaluatedValue::Int(1.into()),
                 &EvaluatedValue::String("one".into()),
             ),
-            "different value families must not compare equal",
+            false,
         );
     }
 
     #[test]
-    fn semantic_function_equality_covers_every_capture_family() {
+    fn function_identity_distinguishes_references_and_instances() {
         let plan = crate::runtime::plan_src(EVERY_LIST_FAMILY_SOURCE);
-        let mut state = RuntimeState::new();
-        let execution_int_type = crate::plan::execution::FunctionType::new(
+        let state = RuntimeState::new();
+        let int_type = crate::plan::execution::FunctionType::new(
             Vec::new(),
             crate::plan::execution::ValueType::Int,
         );
-        let captured_int_function = EvaluatedIntFunction::new(
+        let reference = EvaluatedIntFunction::reference(
+            IntFunctionId(0),
+            Vec::new(),
+            Vec::new(),
+            int_type.clone(),
+        );
+        let same_target_with_different_metadata = EvaluatedIntFunction::reference(
+            IntFunctionId(0),
+            vec![ParamLocal::Int(IntLocalId(0))],
+            Vec::new(),
+            crate::plan::execution::FunctionType::new(
+                vec![crate::plan::execution::ValueType::Int],
+                crate::plan::execution::ValueType::Int,
+            ),
+        );
+        let different_target = EvaluatedIntFunction::reference(
             IntFunctionId(1),
             Vec::new(),
             Vec::new(),
-            execution_int_type.clone(),
+            int_type.clone(),
         );
-        let captured_float_function = EvaluatedFloatFunction::new(
-            FloatFunctionId(0),
+        let reference_for_instance_comparison = reference.clone();
+        let closure = EvaluatedIntFunction::closure(
+            IntFunctionId(0),
             Vec::new(),
+            vec![EvaluatedCapture::int(IntLocalId(0), 1.into())],
+            int_type.clone(),
+        );
+        let same_closure = closure.clone();
+        let separate_closure = EvaluatedIntFunction::closure(
+            IntFunctionId(0),
             Vec::new(),
-            crate::plan::execution::FunctionType::new(
-                Vec::new(),
-                crate::plan::execution::ValueType::Float,
-            ),
-        );
-        let captured_string_function = EvaluatedStringFunction::new(
-            StringFunctionId(0),
-            Vec::new(),
-            Vec::new(),
-            crate::plan::execution::FunctionType::new(
-                Vec::new(),
-                crate::plan::execution::ValueType::String,
-            ),
-        );
-        let captured_utf_codepoint_function = EvaluatedUtfCodepointFunction::new(
-            UtfCodepointFunctionId(0),
-            Vec::new(),
-            Vec::new(),
-            crate::plan::execution::FunctionType::new(
-                Vec::new(),
-                crate::plan::execution::ValueType::UtfCodepoint,
-            ),
-        );
-        let captured_bool_function = EvaluatedBoolFunction::new(
-            BoolFunctionId(0),
-            Vec::new(),
-            Vec::new(),
-            crate::plan::execution::FunctionType::new(
-                Vec::new(),
-                crate::plan::execution::ValueType::Bool,
-            ),
-        );
-        let captured_nil_function = EvaluatedNilFunction::new(
-            NilFunctionId(0),
-            Vec::new(),
-            Vec::new(),
-            crate::plan::execution::FunctionType::new(
-                Vec::new(),
-                crate::plan::execution::ValueType::Nil,
-            ),
-        );
-        let captured_tuple_function = EvaluatedTupleFunction::new(
-            TupleFunctionId(0),
-            Vec::new(),
-            Vec::new(),
-            crate::plan::execution::FunctionType::new(
-                Vec::new(),
-                crate::plan::execution::ValueType::Tuple(vec![
-                    crate::plan::execution::ValueType::Int,
-                ]),
-            ),
-        );
-        let list_function_id = ListFunctionId::Int(plan.int_list_function_id(0));
-        let captured_list_function = EvaluatedListFunction::new(
-            list_function_id.clone(),
-            Vec::new(),
-            Vec::new(),
-            crate::plan::execution::FunctionType::new(
-                Vec::new(),
-                crate::plan::execution::ValueType::List(
-                    plan.int_list_function_id(0).type_id().list_type(),
-                ),
-            ),
-        );
-        let captured_function_function = EvaluatedFunctionFunction::new(
-            FunctionFunctionId::Int(IntFunctionFunctionId(0)),
-            Vec::new(),
-            Vec::new(),
-            crate::plan::execution::FunctionType::new(
-                Vec::new(),
-                crate::plan::execution::ValueType::Function(Box::new(execution_int_type.clone())),
-            ),
-        );
-        let function_function_local = plan
-            .int_function(IntFunctionId(1))
-            .frame_layout()
-            .function_functions()[0]
-            .clone();
-        let left_int_list = state.int(plan.int_list_function_id(0).type_id(), vec![1.into()]);
-        let right_int_list = state.int(plan.int_list_function_id(0).type_id(), vec![1.into()]);
-        let left_string_list = state.string(
-            plan.string_list_function_id(0).type_id(),
-            vec!["one".into()],
-        );
-        let right_string_list = state.string(
-            plan.string_list_function_id(0).type_id(),
-            vec!["one".into()],
-        );
-        let left_utf_codepoint_list =
-            state.utf_codepoint(plan.utf_codepoint_list_function_id(0).type_id(), vec!['a']);
-        let right_utf_codepoint_list =
-            state.utf_codepoint(plan.utf_codepoint_list_function_id(0).type_id(), vec!['a']);
-        let left_float_list = state.float(plan.float_list_function_id(0).type_id(), vec![1.5]);
-        let right_float_list = state.float(plan.float_list_function_id(0).type_id(), vec![1.5]);
-        let left_bool_list = state.bool(plan.bool_list_function_id(0).type_id(), vec![true]);
-        let right_bool_list = state.bool(plan.bool_list_function_id(0).type_id(), vec![true]);
-        let left_nil_list = state.nil(plan.nil_list_function_id(0).type_id(), 1);
-        let right_nil_list = state.nil(plan.nil_list_function_id(0).type_id(), 1);
-        let left_tuple_list = state.tuple(
-            plan.tuple_list_function_id(0).type_id(),
-            vec![vec![EvaluatedValue::Int(1.into())]],
-        );
-        let right_tuple_list = state.tuple(
-            plan.tuple_list_function_id(0).type_id(),
-            vec![vec![EvaluatedValue::Int(1.into())]],
-        );
-        let left_child = state.int(plan.int_list_function_id(0).type_id(), vec![1.into()]);
-        let right_child = state.int(plan.int_list_function_id(0).type_id(), vec![1.into()]);
-        let left_nested_list = state.list(
-            plan.list_list_function_id(0).type_id(),
-            vec![left_child.into_core()],
-        );
-        let right_nested_list = state.list(
-            plan.list_list_function_id(0).type_id(),
-            vec![right_child.into_core()],
-        );
-        let left_function_list = state.function(
-            plan.function_list_function_id(0).type_id(),
-            vec![EvaluatedFunctionValue::from(captured_int_function.clone())],
-        );
-        let right_function_list = state.function(
-            plan.function_list_function_id(0).type_id(),
-            vec![EvaluatedFunctionValue::from(captured_int_function.clone())],
-        );
-        let list_function_local = ListFunctionLocal::Int {
-            local: IntListFunctionLocalId(0),
-            type_: execution_int_type.clone(),
-            list_type: plan.int_list_function_id(0).type_id(),
-        };
-        let captures = [
-            (
-                EvaluatedCapture::int(IntLocalId(0), 1.into()),
-                EvaluatedCapture::int(IntLocalId(0), 1.into()),
-            ),
-            (
-                EvaluatedCapture::float(FloatLocalId(0), 1.5),
-                EvaluatedCapture::float(FloatLocalId(0), 1.5),
-            ),
-            (
-                EvaluatedCapture::string(StringLocalId(0), "one".into()),
-                EvaluatedCapture::string(StringLocalId(0), "one".into()),
-            ),
-            (
-                EvaluatedCapture::utf_codepoint(UtfCodepointLocalId(0), 'a'),
-                EvaluatedCapture::utf_codepoint(UtfCodepointLocalId(0), 'a'),
-            ),
-            (
-                EvaluatedCapture::bool(BoolLocalId(0), true),
-                EvaluatedCapture::bool(BoolLocalId(0), true),
-            ),
-            (
-                EvaluatedCapture::nil(NilLocalId(0)),
-                EvaluatedCapture::nil(NilLocalId(0)),
-            ),
-            (
-                EvaluatedCapture::tuple(TupleLocalId(0), vec![EvaluatedValue::Int(1.into())]),
-                EvaluatedCapture::tuple(TupleLocalId(0), vec![EvaluatedValue::Int(1.into())]),
-            ),
-            (
-                EvaluatedCapture::list(EvaluatedListCapture::Int {
-                    local: IntListLocalId(0),
-                    value: left_int_list,
-                }),
-                EvaluatedCapture::list(EvaluatedListCapture::Int {
-                    local: IntListLocalId(0),
-                    value: right_int_list,
-                }),
-            ),
-            (
-                EvaluatedCapture::list(EvaluatedListCapture::String {
-                    local: StringListLocalId(0),
-                    value: left_string_list,
-                }),
-                EvaluatedCapture::list(EvaluatedListCapture::String {
-                    local: StringListLocalId(0),
-                    value: right_string_list,
-                }),
-            ),
-            (
-                EvaluatedCapture::list(EvaluatedListCapture::UtfCodepoint {
-                    local: UtfCodepointListLocalId(0),
-                    value: left_utf_codepoint_list,
-                }),
-                EvaluatedCapture::list(EvaluatedListCapture::UtfCodepoint {
-                    local: UtfCodepointListLocalId(0),
-                    value: right_utf_codepoint_list,
-                }),
-            ),
-            (
-                EvaluatedCapture::list(EvaluatedListCapture::Float {
-                    local: FloatListLocalId(0),
-                    value: left_float_list,
-                }),
-                EvaluatedCapture::list(EvaluatedListCapture::Float {
-                    local: FloatListLocalId(0),
-                    value: right_float_list,
-                }),
-            ),
-            (
-                EvaluatedCapture::list(EvaluatedListCapture::Bool {
-                    local: BoolListLocalId(0),
-                    value: left_bool_list,
-                }),
-                EvaluatedCapture::list(EvaluatedListCapture::Bool {
-                    local: BoolListLocalId(0),
-                    value: right_bool_list,
-                }),
-            ),
-            (
-                EvaluatedCapture::list(EvaluatedListCapture::Nil {
-                    local: NilListLocalId(0),
-                    value: left_nil_list,
-                }),
-                EvaluatedCapture::list(EvaluatedListCapture::Nil {
-                    local: NilListLocalId(0),
-                    value: right_nil_list,
-                }),
-            ),
-            (
-                EvaluatedCapture::list(EvaluatedListCapture::Tuple {
-                    local: TupleListLocalId(0),
-                    value: left_tuple_list,
-                }),
-                EvaluatedCapture::list(EvaluatedListCapture::Tuple {
-                    local: TupleListLocalId(0),
-                    value: right_tuple_list,
-                }),
-            ),
-            (
-                EvaluatedCapture::list(EvaluatedListCapture::List {
-                    local: ListListLocalId(0),
-                    value: left_nested_list,
-                }),
-                EvaluatedCapture::list(EvaluatedListCapture::List {
-                    local: ListListLocalId(0),
-                    value: right_nested_list,
-                }),
-            ),
-            (
-                EvaluatedCapture::list(EvaluatedListCapture::Function {
-                    local: FunctionListLocalId(0),
-                    value: left_function_list,
-                }),
-                EvaluatedCapture::list(EvaluatedListCapture::Function {
-                    local: FunctionListLocalId(0),
-                    value: right_function_list,
-                }),
-            ),
-            (
-                EvaluatedCapture::int_function(
-                    IntFunctionLocalId(0),
-                    captured_int_function.clone(),
-                ),
-                EvaluatedCapture::int_function(
-                    IntFunctionLocalId(0),
-                    captured_int_function.clone(),
-                ),
-            ),
-            (
-                EvaluatedCapture::float_function(
-                    FloatFunctionLocalId(0),
-                    captured_float_function.clone(),
-                ),
-                EvaluatedCapture::float_function(
-                    FloatFunctionLocalId(0),
-                    captured_float_function.clone(),
-                ),
-            ),
-            (
-                EvaluatedCapture::string_function(
-                    StringFunctionLocalId(0),
-                    captured_string_function.clone(),
-                ),
-                EvaluatedCapture::string_function(
-                    StringFunctionLocalId(0),
-                    captured_string_function.clone(),
-                ),
-            ),
-            (
-                EvaluatedCapture::utf_codepoint_function(
-                    UtfCodepointFunctionLocalId(0),
-                    captured_utf_codepoint_function.clone(),
-                ),
-                EvaluatedCapture::utf_codepoint_function(
-                    UtfCodepointFunctionLocalId(0),
-                    captured_utf_codepoint_function,
-                ),
-            ),
-            (
-                EvaluatedCapture::bool_function(
-                    BoolFunctionLocalId(0),
-                    captured_bool_function.clone(),
-                ),
-                EvaluatedCapture::bool_function(
-                    BoolFunctionLocalId(0),
-                    captured_bool_function.clone(),
-                ),
-            ),
-            (
-                EvaluatedCapture::nil_function(
-                    NilFunctionLocalId(0),
-                    captured_nil_function.clone(),
-                ),
-                EvaluatedCapture::nil_function(
-                    NilFunctionLocalId(0),
-                    captured_nil_function.clone(),
-                ),
-            ),
-            (
-                EvaluatedCapture::tuple_function(
-                    TupleFunctionLocalId(0),
-                    captured_tuple_function.clone(),
-                ),
-                EvaluatedCapture::tuple_function(
-                    TupleFunctionLocalId(0),
-                    captured_tuple_function.clone(),
-                ),
-            ),
-            (
-                EvaluatedCapture::list_function(
-                    list_function_local.clone(),
-                    captured_list_function.clone(),
-                ),
-                EvaluatedCapture::list_function(
-                    list_function_local,
-                    captured_list_function.clone(),
-                ),
-            ),
-            (
-                EvaluatedCapture::function_function(
-                    function_function_local.clone(),
-                    captured_function_function.clone(),
-                ),
-                EvaluatedCapture::function_function(
-                    function_function_local,
-                    captured_function_function,
-                ),
-            ),
-        ];
-
-        for (left_capture, right_capture) in captures {
-            let left =
-                EvaluatedValue::Function(EvaluatedFunctionValue::from(EvaluatedIntFunction::new(
-                    IntFunctionId(0),
-                    Vec::new(),
-                    vec![left_capture],
-                    execution_int_type.clone(),
-                )));
-            let right =
-                EvaluatedValue::Function(EvaluatedFunctionValue::from(EvaluatedIntFunction::new(
-                    IntFunctionId(0),
-                    Vec::new(),
-                    vec![right_capture],
-                    execution_int_type.clone(),
-                )));
-            assert!(
-                values_equal(&plan, &state, &left, &right),
-                "matching capture families must compare equal",
-            );
-        }
-
-        let mismatched_capture =
-            EvaluatedValue::Function(EvaluatedFunctionValue::from(EvaluatedIntFunction::new(
-                IntFunctionId(0),
-                Vec::new(),
-                vec![EvaluatedCapture::int(IntLocalId(0), 1.into())],
-                execution_int_type.clone(),
-            )));
-        let mismatched_kind =
-            EvaluatedValue::Function(EvaluatedFunctionValue::from(EvaluatedIntFunction::new(
-                IntFunctionId(0),
-                Vec::new(),
-                vec![EvaluatedCapture::string(StringLocalId(0), "one".into())],
-                execution_int_type.clone(),
-            )));
-        assert!(
-            !values_equal(&plan, &state, &mismatched_capture, &mismatched_kind,),
-            "different capture families must not compare equal",
+            vec![EvaluatedCapture::int(IntLocalId(0), 1.into())],
+            int_type,
         );
 
-        let mismatched_list_capture =
-            EvaluatedValue::Function(EvaluatedFunctionValue::from(EvaluatedIntFunction::new(
-                IntFunctionId(0),
-                Vec::new(),
-                vec![EvaluatedCapture::list(EvaluatedListCapture::Int {
-                    local: IntListLocalId(0),
-                    value: state.int(plan.int_list_function_id(0).type_id(), vec![1.into()]),
-                })],
-                execution_int_type.clone(),
-            )));
-        let mismatched_list_capture_kind =
-            EvaluatedValue::Function(EvaluatedFunctionValue::from(EvaluatedIntFunction::new(
-                IntFunctionId(0),
-                Vec::new(),
-                vec![EvaluatedCapture::list(EvaluatedListCapture::String {
-                    local: StringListLocalId(0),
-                    value: state.string(
-                        plan.string_list_function_id(0).type_id(),
-                        vec!["one".into()],
-                    ),
-                })],
-                execution_int_type.clone(),
-            )));
-        assert!(
-            !values_equal(
+        assert_eq!(
+            values_equal(
                 &plan,
                 &state,
-                &mismatched_list_capture,
-                &mismatched_list_capture_kind,
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(reference.clone())),
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(
+                    same_target_with_different_metadata,
+                )),
             ),
-            "different captured list families must not compare equal",
+            true,
         );
+        assert_eq!(
+            values_equal(
+                &plan,
+                &state,
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(reference)),
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(different_target)),
+            ),
+            false,
+        );
+        assert_eq!(
+            values_equal(
+                &plan,
+                &state,
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(
+                    reference_for_instance_comparison,
+                )),
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(closure.clone())),
+            ),
+            false,
+        );
+        assert_eq!(
+            values_equal(
+                &plan,
+                &state,
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(closure.clone())),
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(same_closure)),
+            ),
+            true,
+        );
+        assert_eq!(
+            values_equal(
+                &plan,
+                &state,
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(closure)),
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(separate_closure)),
+            ),
+            false,
+        );
+    }
 
-        let different_id =
-            EvaluatedValue::Function(EvaluatedFunctionValue::from(EvaluatedIntFunction::new(
-                IntFunctionId(1),
-                Vec::new(),
-                Vec::new(),
-                execution_int_type.clone(),
-            )));
-        let different_params =
-            EvaluatedValue::Function(EvaluatedFunctionValue::from(EvaluatedIntFunction::new(
-                IntFunctionId(0),
-                vec![ParamLocal::Int(IntLocalId(0))],
-                Vec::new(),
-                crate::plan::execution::FunctionType::new(
-                    vec![crate::plan::execution::ValueType::Int],
-                    crate::plan::execution::ValueType::Int,
-                ),
-            )));
-        let base = EvaluatedValue::Function(EvaluatedFunctionValue::from(
-            EvaluatedIntFunction::new(IntFunctionId(0), Vec::new(), Vec::new(), execution_int_type),
-        ));
-        assert!(
-            !values_equal(&plan, &state, &base, &different_id),
-            "different function ids must not compare equal",
+    #[test]
+    fn list_function_reference_identity_uses_item_family_table_target() {
+        let plan = crate::runtime::plan_src(EVERY_LIST_FAMILY_SOURCE);
+        let ids = [
+            ListFunctionId::Int(plan.int_list_function_id(0)),
+            ListFunctionId::String(plan.string_list_function_id(0)),
+            ListFunctionId::BitArray(plan.bit_array_list_function_id(0)),
+            ListFunctionId::UtfCodepoint(plan.utf_codepoint_list_function_id(0)),
+            ListFunctionId::Custom(plan.custom_list_function_id(0)),
+            ListFunctionId::Float(plan.float_list_function_id(0)),
+            ListFunctionId::Bool(plan.bool_list_function_id(0)),
+            ListFunctionId::Nil(plan.nil_list_function_id(0)),
+            ListFunctionId::Tuple(plan.tuple_list_function_id(0)),
+            ListFunctionId::List(plan.list_list_function_id(0)),
+            ListFunctionId::Function(plan.function_list_function_id(0)),
+        ];
+
+        assert_eq!(
+            ids.map(|id| id.reference_identity()),
+            [
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Int, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::String, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::BitArray, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::UtfCodepoint, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Custom, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Float, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Bool, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Nil, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Tuple, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::List, 0),
+                FunctionReferenceIdentity::list(ListFunctionReturnFamily::Function, 0),
+            ],
         );
-        assert!(
-            !values_equal(&plan, &state, &base, &different_params),
-            "different function parameters must not compare equal",
+    }
+
+    #[test]
+    fn function_returning_list_reference_identity_uses_table_target() {
+        let plan = crate::runtime::plan_src(EVERY_LIST_FAMILY_SOURCE);
+        let type_ = crate::plan::execution::FunctionType::new(
+            Vec::new(),
+            crate::plan::execution::ValueType::Int,
+        );
+        let ids = [
+            ListFunctionFunctionId::Int {
+                id: IntListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.int_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::String {
+                id: StringListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.string_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::BitArray {
+                id: BitArrayListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.bit_array_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::UtfCodepoint {
+                id: UtfCodepointListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.utf_codepoint_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::Custom {
+                id: CustomListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.custom_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::Float {
+                id: FloatListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.float_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::Bool {
+                id: BoolListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.bool_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::Nil {
+                id: NilListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.nil_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::Tuple {
+                id: TupleListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.tuple_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::List {
+                id: ListListFunctionFunctionId(0),
+                type_: type_.clone(),
+                list_type: plan.list_list_function_id(0).type_id(),
+            },
+            ListFunctionFunctionId::Function {
+                id: FunctionListFunctionFunctionId(0),
+                type_,
+                list_type: plan.function_list_function_id(0).type_id(),
+            },
+        ];
+
+        assert_eq!(
+            ids.map(|id| FunctionFunctionId::List(id).reference_identity()),
+            [
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::Int,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::String,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::BitArray,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::UtfCodepoint,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::Custom,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::Float,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::Bool,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::Nil,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::Tuple,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::List,
+                    0,
+                ),
+                FunctionReferenceIdentity::returning_list_function(
+                    ListFunctionReturnFamily::Function,
+                    0,
+                ),
+            ],
+        );
+    }
+
+    #[test]
+    fn constructor_callable_identity_is_fresh_and_clone_preserving() {
+        let plan = crate::runtime::plan_src(EVERY_LIST_FAMILY_SOURCE);
+        let state = RuntimeState::new();
+        let constructor_id = plan.custom_constructor_id(0, 0);
+        let constructor = plan.custom_constructor(constructor_id);
+        let type_ = crate::plan::execution::FunctionType::new(
+            constructor
+                .fields()
+                .iter()
+                .map(|field| field.type_().clone())
+                .collect(),
+            crate::plan::execution::ValueType::Custom(constructor_id.type_id()),
+        );
+        let first = EvaluatedCustomFunction::constructor(constructor_id, type_.clone());
+        let same = first.clone();
+        let separate = EvaluatedCustomFunction::constructor(constructor_id, type_);
+
+        assert_eq!(
+            values_equal(
+                &plan,
+                &state,
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(first.clone())),
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(same)),
+            ),
+            true,
+        );
+        assert_eq!(
+            values_equal(
+                &plan,
+                &state,
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(first)),
+                &EvaluatedValue::Function(EvaluatedFunctionValue::from(separate)),
+            ),
+            false,
         );
     }
 }

--- a/src/runtime/expression.rs
+++ b/src/runtime/expression.rs
@@ -583,7 +583,7 @@ pub fn main() { function_function }
             }),
         );
 
-        let wrong_string_function = EvaluatedStringFunction::new(
+        let wrong_string_function = EvaluatedStringFunction::reference(
             StringFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -592,7 +592,7 @@ pub fn main() { function_function }
                 crate::plan::execution::ValueType::String,
             ),
         );
-        let wrong_int_function = EvaluatedIntFunction::new(
+        let wrong_int_function = EvaluatedIntFunction::reference(
             IntFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -805,7 +805,7 @@ pub fn main() { Nil }
         let function = plan.utf_codepoint_function_function(UtfCodepointFunctionFunctionId(0));
         let expression = expression_return(function.return_().body())
             .expect("source function should have an expression return body");
-        let expected = EvaluatedUtfCodepointFunction::new(
+        let expected = EvaluatedUtfCodepointFunction::reference(
             UtfCodepointFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -825,7 +825,7 @@ pub fn main() { Nil }
             Ok(expected),
         );
 
-        let wrong_function = EvaluatedIntFunction::new(
+        let wrong_function = EvaluatedIntFunction::reference(
             IntFunctionId(0),
             Vec::new(),
             Vec::new(),

--- a/src/runtime/expression/function/bit_array.rs
+++ b/src/runtime/expression/function/bit_array.rs
@@ -21,7 +21,7 @@ pub(in crate::runtime) fn eval_bit_array_function_expr(
     expression: &BitArrayFunctionExpr,
 ) -> Result<EvaluatedBitArrayFunction, ExecutionError> {
     match expression.kind() {
-        BitArrayFunctionExprKind::Reference(reference) => Ok(EvaluatedBitArrayFunction::new(
+        BitArrayFunctionExprKind::Reference(reference) => Ok(EvaluatedBitArrayFunction::reference(
             *reference.function(),
             reference.param_locals(),
             Vec::new(),
@@ -31,7 +31,7 @@ pub(in crate::runtime) fn eval_bit_array_function_expr(
                 crate::plan::execution::ValueType::BitArray,
             ),
         )),
-        BitArrayFunctionExprKind::Closure(template) => Ok(EvaluatedBitArrayFunction::new(
+        BitArrayFunctionExprKind::Closure(template) => Ok(EvaluatedBitArrayFunction::closure(
             *template.function(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/bool.rs
+++ b/src/runtime/expression/function/bool.rs
@@ -20,7 +20,7 @@ pub(in crate::runtime) fn eval_bool_function_expr(
     expression: &BoolFunctionExpr,
 ) -> Result<EvaluatedBoolFunction, ExecutionError> {
     match expression.kind() {
-        BoolFunctionExprKind::Reference(reference) => Ok(EvaluatedBoolFunction::new(
+        BoolFunctionExprKind::Reference(reference) => Ok(EvaluatedBoolFunction::reference(
             *reference.function(),
             reference.param_locals(),
             Vec::new(),
@@ -30,7 +30,7 @@ pub(in crate::runtime) fn eval_bool_function_expr(
                 crate::plan::execution::ValueType::Bool,
             ),
         )),
-        BoolFunctionExprKind::Closure(template) => Ok(EvaluatedBoolFunction::new(
+        BoolFunctionExprKind::Closure(template) => Ok(EvaluatedBoolFunction::closure(
             *template.function(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/custom.rs
+++ b/src/runtime/expression/function/custom.rs
@@ -41,7 +41,7 @@ pub(in crate::runtime) fn eval_custom_function_expr_kind(
         CustomFunctionExprKind::Constructor(constructor) => Ok(
             EvaluatedCustomFunction::constructor(*constructor, type_.to_function_type()),
         ),
-        CustomFunctionExprKind::Reference(reference) => Ok(EvaluatedCustomFunction::function(
+        CustomFunctionExprKind::Reference(reference) => Ok(EvaluatedCustomFunction::reference(
             *reference.function(),
             reference.param_locals(),
             Vec::new(),
@@ -51,7 +51,7 @@ pub(in crate::runtime) fn eval_custom_function_expr_kind(
                 crate::plan::execution::ValueType::Custom(type_.return_().type_id()),
             ),
         )),
-        CustomFunctionExprKind::Closure(template) => Ok(EvaluatedCustomFunction::function(
+        CustomFunctionExprKind::Closure(template) => Ok(EvaluatedCustomFunction::closure(
             *template.function(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/float.rs
+++ b/src/runtime/expression/function/float.rs
@@ -20,7 +20,7 @@ pub(in crate::runtime) fn eval_float_function_expr(
     expression: &FloatFunctionExpr,
 ) -> Result<EvaluatedFloatFunction, ExecutionError> {
     match expression.kind() {
-        FloatFunctionExprKind::Reference(reference) => Ok(EvaluatedFloatFunction::new(
+        FloatFunctionExprKind::Reference(reference) => Ok(EvaluatedFloatFunction::reference(
             *reference.function(),
             reference.param_locals(),
             Vec::new(),
@@ -30,7 +30,7 @@ pub(in crate::runtime) fn eval_float_function_expr(
                 crate::plan::execution::ValueType::Float,
             ),
         )),
-        FloatFunctionExprKind::Closure(template) => Ok(EvaluatedFloatFunction::new(
+        FloatFunctionExprKind::Closure(template) => Ok(EvaluatedFloatFunction::closure(
             *template.function(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/int.rs
+++ b/src/runtime/expression/function/int.rs
@@ -20,7 +20,7 @@ pub(in crate::runtime) fn eval_int_function_expr(
     expression: &IntFunctionExpr,
 ) -> Result<EvaluatedIntFunction, ExecutionError> {
     match expression.kind() {
-        IntFunctionExprKind::Reference(reference) => Ok(EvaluatedIntFunction::new(
+        IntFunctionExprKind::Reference(reference) => Ok(EvaluatedIntFunction::reference(
             *reference.function(),
             reference.param_locals(),
             Vec::new(),
@@ -30,7 +30,7 @@ pub(in crate::runtime) fn eval_int_function_expr(
                 crate::plan::execution::ValueType::Int,
             ),
         )),
-        IntFunctionExprKind::Closure(template) => Ok(EvaluatedIntFunction::new(
+        IntFunctionExprKind::Closure(template) => Ok(EvaluatedIntFunction::closure(
             *template.function(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/list.rs
+++ b/src/runtime/expression/function/list.rs
@@ -20,7 +20,7 @@ pub(in crate::runtime) fn eval_list_function_expr(
     expression: &ListFunctionExpr,
 ) -> Result<EvaluatedListFunction, ExecutionError> {
     match expression.kind() {
-        ListFunctionExprKind::Reference(reference) => Ok(EvaluatedListFunction::new(
+        ListFunctionExprKind::Reference(reference) => Ok(EvaluatedListFunction::reference(
             reference.function().clone(),
             reference.param_locals(),
             Vec::new(),
@@ -30,7 +30,7 @@ pub(in crate::runtime) fn eval_list_function_expr(
                 crate::plan::execution::ValueType::List(reference.function().list_type()),
             ),
         )),
-        ListFunctionExprKind::Closure(template) => Ok(EvaluatedListFunction::new(
+        ListFunctionExprKind::Closure(template) => Ok(EvaluatedListFunction::closure(
             template.function().clone(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/nil.rs
+++ b/src/runtime/expression/function/nil.rs
@@ -20,7 +20,7 @@ pub(in crate::runtime) fn eval_nil_function_expr(
     expression: &NilFunctionExpr,
 ) -> Result<EvaluatedNilFunction, ExecutionError> {
     match expression.kind() {
-        NilFunctionExprKind::Reference(reference) => Ok(EvaluatedNilFunction::new(
+        NilFunctionExprKind::Reference(reference) => Ok(EvaluatedNilFunction::reference(
             *reference.function(),
             reference.param_locals(),
             Vec::new(),
@@ -30,7 +30,7 @@ pub(in crate::runtime) fn eval_nil_function_expr(
                 crate::plan::execution::ValueType::Nil,
             ),
         )),
-        NilFunctionExprKind::Closure(template) => Ok(EvaluatedNilFunction::new(
+        NilFunctionExprKind::Closure(template) => Ok(EvaluatedNilFunction::closure(
             *template.function(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/returning_function.rs
+++ b/src/runtime/expression/function/returning_function.rs
@@ -38,13 +38,13 @@ pub(in crate::runtime) fn eval_function_function_expr_kind(
     kind: &FunctionFunctionExprKind,
 ) -> Result<EvaluatedFunctionFunction, ExecutionError> {
     match kind {
-        FunctionFunctionExprKind::Reference(reference) => Ok(EvaluatedFunctionFunction::new(
+        FunctionFunctionExprKind::Reference(reference) => Ok(EvaluatedFunctionFunction::reference(
             reference.function().clone(),
             reference.param_locals(),
             Vec::new(),
             type_.to_function_type(),
         )),
-        FunctionFunctionExprKind::Closure(template) => Ok(EvaluatedFunctionFunction::new(
+        FunctionFunctionExprKind::Closure(template) => Ok(EvaluatedFunctionFunction::closure(
             template.function().clone(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/string.rs
+++ b/src/runtime/expression/function/string.rs
@@ -20,7 +20,7 @@ pub(in crate::runtime) fn eval_string_function_expr(
     expression: &StringFunctionExpr,
 ) -> Result<EvaluatedStringFunction, ExecutionError> {
     match expression.kind() {
-        StringFunctionExprKind::Reference(reference) => Ok(EvaluatedStringFunction::new(
+        StringFunctionExprKind::Reference(reference) => Ok(EvaluatedStringFunction::reference(
             *reference.function(),
             reference.param_locals(),
             Vec::new(),
@@ -30,7 +30,7 @@ pub(in crate::runtime) fn eval_string_function_expr(
                 crate::plan::execution::ValueType::String,
             ),
         )),
-        StringFunctionExprKind::Closure(template) => Ok(EvaluatedStringFunction::new(
+        StringFunctionExprKind::Closure(template) => Ok(EvaluatedStringFunction::closure(
             *template.function(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/tuple.rs
+++ b/src/runtime/expression/function/tuple.rs
@@ -20,13 +20,13 @@ pub(in crate::runtime) fn eval_tuple_function_expr(
     expression: &TupleFunctionExpr,
 ) -> Result<EvaluatedTupleFunction, ExecutionError> {
     match expression.kind() {
-        TupleFunctionExprKind::Reference(reference) => Ok(EvaluatedTupleFunction::new(
+        TupleFunctionExprKind::Reference(reference) => Ok(EvaluatedTupleFunction::reference(
             *reference.function(),
             reference.param_locals(),
             Vec::new(),
             expression.type_().clone(),
         )),
-        TupleFunctionExprKind::Closure(template) => Ok(EvaluatedTupleFunction::new(
+        TupleFunctionExprKind::Closure(template) => Ok(EvaluatedTupleFunction::closure(
             *template.function(),
             template.param_locals(),
             function::eval_capture_args(plan, state, frame, template.captures())?,

--- a/src/runtime/expression/function/utf_codepoint.rs
+++ b/src/runtime/expression/function/utf_codepoint.rs
@@ -22,7 +22,7 @@ pub(in crate::runtime) fn eval_utf_codepoint_function_expr(
 ) -> Result<EvaluatedUtfCodepointFunction, ExecutionError> {
     match expression.kind() {
         UtfCodepointFunctionExprKind::Reference(reference) => {
-            Ok(EvaluatedUtfCodepointFunction::new(
+            Ok(EvaluatedUtfCodepointFunction::reference(
                 *reference.function(),
                 reference.param_locals(),
                 Vec::new(),
@@ -33,16 +33,18 @@ pub(in crate::runtime) fn eval_utf_codepoint_function_expr(
                 ),
             ))
         }
-        UtfCodepointFunctionExprKind::Closure(template) => Ok(EvaluatedUtfCodepointFunction::new(
-            *template.function(),
-            template.param_locals(),
-            function::eval_capture_args(plan, state, frame, template.captures())?,
-            crate::runtime::evaluated::function_type_from_slots(
-                plan,
-                template.params(),
-                crate::plan::execution::ValueType::UtfCodepoint,
-            ),
-        )),
+        UtfCodepointFunctionExprKind::Closure(template) => {
+            Ok(EvaluatedUtfCodepointFunction::closure(
+                *template.function(),
+                template.param_locals(),
+                function::eval_capture_args(plan, state, frame, template.captures())?,
+                crate::runtime::evaluated::function_type_from_slots(
+                    plan,
+                    template.params(),
+                    crate::plan::execution::ValueType::UtfCodepoint,
+                ),
+            ))
+        }
         UtfCodepointFunctionExprKind::LocalGet { local, .. } => {
             Ok(frame.get_utf_codepoint_function(*local))
         }

--- a/src/runtime/function.rs
+++ b/src/runtime/function.rs
@@ -1807,7 +1807,7 @@ fn functions(function: fn() -> List(fn() -> Int)) { function() }
 pub fn main() { Nil }
 "#,
         );
-        let wrong_int = crate::runtime::EvaluatedListFunction::new(
+        let wrong_int = crate::runtime::EvaluatedListFunction::reference(
             ListFunctionId::Int(plan.int_list_function_id(0)),
             Vec::new(),
             Vec::new(),
@@ -1818,7 +1818,7 @@ pub fn main() { Nil }
                 ),
             ),
         );
-        let wrong_string = crate::runtime::EvaluatedListFunction::new(
+        let wrong_string = crate::runtime::EvaluatedListFunction::reference(
             ListFunctionId::String(plan.string_list_function_id(0)),
             Vec::new(),
             Vec::new(),
@@ -2052,7 +2052,7 @@ pub fn main() { #(list_function, custom_function, function_function) }
         .list()
         .expect("list_function should return a list function");
         assert_eq!(functions, Vec::new());
-        let wrong_string = crate::runtime::EvaluatedFunctionFunction::new(
+        let wrong_string = crate::runtime::EvaluatedFunctionFunction::reference(
             FunctionFunctionId::String(StringFunctionFunctionId(0)),
             Vec::new(),
             Vec::new(),
@@ -2061,7 +2061,7 @@ pub fn main() { #(list_function, custom_function, function_function) }
                 crate::plan::execution::ValueType::String,
             ),
         );
-        let wrong_int = crate::runtime::EvaluatedFunctionFunction::new(
+        let wrong_int = crate::runtime::EvaluatedFunctionFunction::reference(
             FunctionFunctionId::Int(IntFunctionFunctionId(0)),
             Vec::new(),
             Vec::new(),
@@ -2293,7 +2293,7 @@ pub fn main() { #(list_function, custom_function, function_function) }
         .list()
         .expect("list_function should return a list function");
         assert_eq!(functions, Vec::new());
-        let wrong_string = crate::runtime::EvaluatedStringFunction::new(
+        let wrong_string = crate::runtime::EvaluatedStringFunction::reference(
             StringFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -2302,7 +2302,7 @@ pub fn main() { #(list_function, custom_function, function_function) }
                 crate::plan::execution::ValueType::String,
             ),
         );
-        let wrong_int = crate::runtime::EvaluatedIntFunction::new(
+        let wrong_int = crate::runtime::EvaluatedIntFunction::reference(
             IntFunctionId(0),
             Vec::new(),
             Vec::new(),

--- a/src/runtime/function/bind.rs
+++ b/src/runtime/function/bind.rs
@@ -1021,7 +1021,7 @@ pub fn main() {
         let mut state = crate::runtime::RuntimeState::new();
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         let custom_function_local = function.frame_layout().custom_functions()[0].clone();
-        let custom_function = crate::runtime::EvaluatedCustomFunction::function(
+        let custom_function = crate::runtime::EvaluatedCustomFunction::reference(
             plan.custom_function_id(0),
             Vec::new(),
             Vec::new(),

--- a/src/runtime/function/steps.rs
+++ b/src/runtime/function/steps.rs
@@ -2187,7 +2187,7 @@ pub fn main() {
             .expect("source should lower an assert-list step");
         let alias_pattern = &expect_list_assert_pattern(pattern).elements()[0];
         let mut frame = Frame::new(function.frame_layout(), &mut state);
-        let wrong_kind = EvaluatedFunctionValue::from(EvaluatedFunctionFunction::new(
+        let wrong_kind = EvaluatedFunctionValue::from(EvaluatedFunctionFunction::reference(
             FunctionFunctionId::Int(IntFunctionFunctionId(0)),
             Vec::new(),
             Vec::new(),
@@ -2269,7 +2269,7 @@ pub fn main() {
         assert_eq!(bindings, Vec::new());
 
         let wrong_function =
-            EvaluatedFunctionValue::from(crate::runtime::EvaluatedIntFunction::new(
+            EvaluatedFunctionValue::from(crate::runtime::EvaluatedIntFunction::reference(
                 IntFunctionId(0),
                 Vec::new(),
                 Vec::new(),

--- a/src/runtime/materialize.rs
+++ b/src/runtime/materialize.rs
@@ -568,7 +568,7 @@ pub fn main() { 0 }
             0,
             vec![CustomFieldValue::from_evaluated(None, Value::Int(1.into()))],
         );
-        let int_function = EvaluatedIntFunction::new(
+        let int_function = EvaluatedIntFunction::reference(
             IntFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -737,13 +737,13 @@ pub fn main() { 0 }
             crate::plan::execution::ValueType::Int,
         );
         let module_int_type = FunctionType::new(Vec::new(), ValueType::Int);
-        let int_function = EvaluatedIntFunction::new(
+        let int_function = EvaluatedIntFunction::reference(
             IntFunctionId(0),
             Vec::new(),
             Vec::new(),
             execution_int_type.clone(),
         );
-        let float_function = EvaluatedFloatFunction::new(
+        let float_function = EvaluatedFloatFunction::reference(
             FloatFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -752,7 +752,7 @@ pub fn main() { 0 }
                 crate::plan::execution::ValueType::Float,
             ),
         );
-        let string_function = EvaluatedStringFunction::new(
+        let string_function = EvaluatedStringFunction::reference(
             StringFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -761,7 +761,7 @@ pub fn main() { 0 }
                 crate::plan::execution::ValueType::String,
             ),
         );
-        let bit_array_function = EvaluatedBitArrayFunction::new(
+        let bit_array_function = EvaluatedBitArrayFunction::reference(
             BitArrayFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -770,7 +770,7 @@ pub fn main() { 0 }
                 crate::plan::execution::ValueType::BitArray,
             ),
         );
-        let utf_codepoint_function = EvaluatedUtfCodepointFunction::new(
+        let utf_codepoint_function = EvaluatedUtfCodepointFunction::reference(
             UtfCodepointFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -779,7 +779,7 @@ pub fn main() { 0 }
                 crate::plan::execution::ValueType::UtfCodepoint,
             ),
         );
-        let custom_function = EvaluatedCustomFunction::function(
+        let custom_function = EvaluatedCustomFunction::reference(
             plan.custom_function_id(0),
             Vec::new(),
             Vec::new(),
@@ -788,7 +788,7 @@ pub fn main() { 0 }
                 crate::plan::execution::ValueType::Custom(custom_type_id),
             ),
         );
-        let bool_function = EvaluatedBoolFunction::new(
+        let bool_function = EvaluatedBoolFunction::reference(
             BoolFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -797,7 +797,7 @@ pub fn main() { 0 }
                 crate::plan::execution::ValueType::Bool,
             ),
         );
-        let nil_function = EvaluatedNilFunction::new(
+        let nil_function = EvaluatedNilFunction::reference(
             NilFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -806,7 +806,7 @@ pub fn main() { 0 }
                 crate::plan::execution::ValueType::Nil,
             ),
         );
-        let tuple_function = EvaluatedTupleFunction::new(
+        let tuple_function = EvaluatedTupleFunction::reference(
             TupleFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -818,7 +818,7 @@ pub fn main() { 0 }
             ),
         );
         let list_function_id = ListFunctionId::Int(plan.int_list_function_id(0));
-        let list_function = EvaluatedListFunction::new(
+        let list_function = EvaluatedListFunction::reference(
             list_function_id.clone(),
             Vec::new(),
             Vec::new(),
@@ -829,7 +829,7 @@ pub fn main() { 0 }
                 ),
             ),
         );
-        let function_function = EvaluatedFunctionFunction::new(
+        let function_function = EvaluatedFunctionFunction::reference(
             FunctionFunctionId::Int(IntFunctionFunctionId(0)),
             Vec::new(),
             Vec::new(),
@@ -1163,7 +1163,7 @@ pub fn main() { 0 }
             vec![crate::plan::execution::ValueType::Int],
             crate::plan::execution::ValueType::Int,
         );
-        let function = EvaluatedIntFunction::new(
+        let function = EvaluatedIntFunction::reference(
             IntFunctionId(0),
             vec![crate::plan::execution::ParamLocal::Int(IntLocalId(0))],
             vec![EvaluatedCapture::int(IntLocalId(1), 42.into())],

--- a/src/runtime/state.rs
+++ b/src/runtime/state.rs
@@ -777,7 +777,7 @@ pub fn main() { 0 }
     fn list_value_facade_reconstructs_every_exact_storage_family() {
         let plan = crate::runtime::plan_src(EVERY_LIST_FAMILY_SOURCE);
         let mut state = RuntimeState::new();
-        let int_function = EvaluatedIntFunction::new(
+        let int_function = EvaluatedIntFunction::reference(
             crate::plan::execution::IntFunctionId(0),
             Vec::new(),
             Vec::new(),
@@ -909,7 +909,7 @@ pub fn main() { 0 }
         let mut state = RuntimeState::new();
         let value = state.int(type_id, vec![1.into()]);
         let slot = value.core.slot();
-        let closure = EvaluatedIntFunction::new(
+        let closure = EvaluatedIntFunction::reference(
             crate::plan::execution::IntFunctionId(0),
             Vec::new(),
             vec![EvaluatedCapture::list(

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -169,6 +169,16 @@ mod operators {
         float_division,
         tuple_equality,
         list_equality,
+        function_equality,
+        function_inequality,
+        function_identity,
+        function_identity_families,
+        tuple_function_equality,
+        list_function_equality,
+        custom_function_equality,
+        nested_generic_custom_function_equality,
+        recursive_custom_function_equality,
+        result_function_equality,
         string_concatenation,
         bool_operators,
         short_circuit_block_scope,
@@ -603,19 +613,6 @@ mod rejection {
             echo,
             bit_array_native_endian,
             polymorphic_custom_constructor,
-        );
-    }
-
-    mod operators {
-        rejection_cases!("operators";
-            function_equality,
-            function_inequality,
-            tuple_function_equality,
-            list_function_equality,
-            custom_function_equality,
-            nested_generic_custom_function_equality,
-            recursive_custom_function_equality,
-            result_function_equality,
         );
     }
 

--- a/tests/fixtures/execution/operators/custom_function_equality.gleam
+++ b/tests/fixtures/execution/operators/custom_function_equality.gleam
@@ -10,4 +10,4 @@ pub fn main() {
   Holder(identity) == Holder(identity)
 }
 
-// geam:reject unsupported binary operator: equality on function values
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/operators/function_equality.gleam
+++ b/tests/fixtures/execution/operators/function_equality.gleam
@@ -3,5 +3,7 @@ fn add_one(value: Int) {
 }
 
 pub fn main() {
-  #(1, add_one) == #(1, add_one)
+  add_one == add_one
 }
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/operators/function_identity.gleam
+++ b/tests/fixtures/execution/operators/function_identity.gleam
@@ -1,0 +1,82 @@
+pub type Boxed(value) {
+  Boxed(value)
+}
+
+pub type Holder {
+  Holder(fn(Int) -> Int)
+}
+
+fn add_one(value: Int) {
+  value + 1
+}
+
+fn subtract_one(value: Int) {
+  value - 1
+}
+
+fn identity_function(function: fn(Int) -> Int) {
+  function
+}
+
+fn make_identity() -> fn(Int) -> Int {
+  fn(value) { value }
+}
+
+fn make_adder(amount: Int) {
+  fn(value) { value + amount }
+}
+
+fn direct_guard(left: fn(Int) -> Int, right: fn(Int) -> Int) {
+  case Nil {
+    Nil if left == right -> True
+    _ -> False
+  }
+}
+
+fn nested_guard(left: Holder, right: Holder) {
+  case Nil {
+    Nil if left == right -> True
+    _ -> False
+  }
+}
+
+pub fn main() {
+  let closure = make_adder(1)
+  let returned = make_identity()
+  let captured = fn() { closure }
+  let through_case = case True {
+    True -> closure
+    False -> add_one
+  }
+  let through_block = {
+    let value = closure
+    value
+  }
+  let constructor: fn(Int) -> Boxed(Int) = Boxed
+  let other_constructor: fn(Int) -> Boxed(Int) = Boxed
+
+  #(
+    add_one == add_one,
+    add_one == subtract_one,
+    closure == closure,
+    make_identity() == make_identity(),
+    make_adder(1) == make_adder(1),
+    constructor == constructor,
+    constructor == other_constructor,
+    identity_function(closure) == closure,
+    captured() == closure,
+    returned == identity_function(returned),
+    through_case == closure,
+    through_block == closure,
+    [Holder(closure)] == [Holder(closure)],
+    [Holder(make_identity())] == [Holder(make_identity())],
+    direct_guard(closure, closure),
+    direct_guard(make_identity(), make_identity()),
+    nested_guard(Holder(closure), Holder(closure)),
+    nested_guard(Holder(make_identity()), Holder(make_identity())),
+    add_one != add_one,
+    make_identity() != make_identity(),
+  )
+}
+
+// geam:expect Tuple([Bool(true), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true)])

--- a/tests/fixtures/execution/operators/function_identity_families.gleam
+++ b/tests/fixtures/execution/operators/function_identity_families.gleam
@@ -1,0 +1,122 @@
+pub type Boxed {
+  Boxed
+}
+
+fn int_value() -> Int {
+  1
+}
+
+fn int_closure() -> fn() -> Int {
+  fn() { 1 }
+}
+
+fn float_value() -> Float {
+  1.0
+}
+
+fn float_closure() -> fn() -> Float {
+  fn() { 1.0 }
+}
+
+fn string_value() -> String {
+  "one"
+}
+
+fn string_closure() -> fn() -> String {
+  fn() { "one" }
+}
+
+fn bit_array_value() -> BitArray {
+  <<>>
+}
+
+fn bit_array_closure() -> fn() -> BitArray {
+  fn() { <<>> }
+}
+
+fn utf_codepoint_value(value: UtfCodepoint) -> UtfCodepoint {
+  value
+}
+
+fn utf_codepoint_closure(value: UtfCodepoint) -> fn() -> UtfCodepoint {
+  fn() { value }
+}
+
+fn custom_value() -> Boxed {
+  Boxed
+}
+
+fn custom_closure() -> fn() -> Boxed {
+  fn() { Boxed }
+}
+
+fn bool_value() -> Bool {
+  True
+}
+
+fn bool_closure() -> fn() -> Bool {
+  fn() { True }
+}
+
+fn nil_value() -> Nil {
+  Nil
+}
+
+fn nil_closure() -> fn() -> Nil {
+  fn() { Nil }
+}
+
+fn tuple_value() -> #(Int) {
+  #(1)
+}
+
+fn tuple_closure() -> fn() -> #(Int) {
+  fn() { #(1) }
+}
+
+fn list_value() -> List(Int) {
+  [1]
+}
+
+fn list_closure() -> fn() -> List(Int) {
+  fn() { [1] }
+}
+
+fn function_value() -> fn() -> Int {
+  int_value
+}
+
+fn function_closure() -> fn() -> fn() -> Int {
+  fn() { int_value }
+}
+
+pub fn main() {
+  let assert <<codepoint:utf8_codepoint>> = <<"a":utf8>>
+
+  #(
+    int_value == int_value,
+    int_closure() == int_closure(),
+    float_value == float_value,
+    float_closure() == float_closure(),
+    string_value == string_value,
+    string_closure() == string_closure(),
+    bit_array_value == bit_array_value,
+    bit_array_closure() == bit_array_closure(),
+    utf_codepoint_value == utf_codepoint_value,
+    utf_codepoint_closure(codepoint) == utf_codepoint_closure(codepoint),
+    custom_value == custom_value,
+    custom_closure() == custom_closure(),
+    bool_value == bool_value,
+    bool_closure() == bool_closure(),
+    nil_value == nil_value,
+    nil_closure() == nil_closure(),
+    tuple_value == tuple_value,
+    tuple_closure() == tuple_closure(),
+    list_value == list_value,
+    list_closure() == list_closure(),
+    function_value == function_value,
+    function_closure() == function_closure(),
+  )
+}
+
+// geam:expect Tuple([Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)])

--- a/tests/fixtures/execution/operators/function_inequality.gleam
+++ b/tests/fixtures/execution/operators/function_inequality.gleam
@@ -3,5 +3,7 @@ fn add_one(value: Int) {
 }
 
 pub fn main() {
-  add_one == add_one
+  add_one != add_one
 }
+
+// geam:expect Bool(false)

--- a/tests/fixtures/execution/operators/list_function_equality.gleam
+++ b/tests/fixtures/execution/operators/list_function_equality.gleam
@@ -5,3 +5,5 @@ fn add_one(value: Int) {
 pub fn main() {
   [add_one] == [add_one]
 }
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/operators/nested_generic_custom_function_equality.gleam
+++ b/tests/fixtures/execution/operators/nested_generic_custom_function_equality.gleam
@@ -14,4 +14,4 @@ pub fn main() {
   Wrapper(Boxed(value)) == Wrapper(Boxed(value))
 }
 
-// geam:reject unsupported binary operator: equality on function values
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/operators/recursive_custom_function_equality.gleam
+++ b/tests/fixtures/execution/operators/recursive_custom_function_equality.gleam
@@ -12,4 +12,4 @@ pub fn main() {
   Next(Function(value)) == Next(Function(value))
 }
 
-// geam:reject unsupported binary operator: equality on function values
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/operators/result_function_equality.gleam
+++ b/tests/fixtures/execution/operators/result_function_equality.gleam
@@ -1,0 +1,11 @@
+fn identity(value: Int) {
+  value
+}
+
+pub fn main() {
+  let left: Result(fn(Int) -> Int, Nil) = Ok(identity)
+  let right: Result(fn(Int) -> Int, Nil) = Ok(identity)
+  left == right
+}
+
+// geam:expect Bool(true)

--- a/tests/fixtures/execution/operators/tuple_function_equality.gleam
+++ b/tests/fixtures/execution/operators/tuple_function_equality.gleam
@@ -1,0 +1,9 @@
+fn add_one(value: Int) {
+  value + 1
+}
+
+pub fn main() {
+  #(1, add_one) == #(1, add_one)
+}
+
+// geam:expect Bool(true)

--- a/tests/fixtures/rejection/operators/function_inequality.gleam
+++ b/tests/fixtures/rejection/operators/function_inequality.gleam
@@ -1,7 +1,0 @@
-fn add_one(value: Int) {
-  value + 1
-}
-
-pub fn main() {
-  add_one != add_one
-}

--- a/tests/fixtures/rejection/operators/result_function_equality.gleam
+++ b/tests/fixtures/rejection/operators/result_function_equality.gleam
@@ -1,9 +1,0 @@
-fn identity(value: Int) {
-  value
-}
-
-pub fn main() {
-  Ok(identity) == Ok(identity)
-}
-
-// geam:reject unsupported binary operator: equality on function values


### PR DESCRIPTION
- Give top-level references stable table identities and closures fresh instance identities.
- Preserve function identity through calls, captures, returns, and nested values.
- Enable function equality across expressions and guards with exact runtime coverage.
