### PR TITLE
Group execution invariant errors

### DIFF
--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -39,32 +39,35 @@ definitions must not import them outside the consuming lowering modules.
 Source spans/sites and immutable value/function type metadata are the narrow
 shared domains; runtime `Value` and evaluated captures are not plan data.
 
-`ExecutionError` has two allowed roles:
+`ExecutionError` separates two allowed domains:
 
 - Source-reachable execution stops accepted by the Geam profile use
   `ExecutionError::Panic(Panic)`, with `PanicKind` as the source-level tag.
   Cover them with execution-error fixtures that compile and plan successfully
   before failing at runtime. Do not add speculative `PanicKind` variants.
-- All other `ExecutionError` variants are execution invariant failures that
-  Rust cannot encode in the current plan shape. Adding a non-`Panic` execution
-  error variant or invariant kind requires explicit design review.
+- Runtime invariant failures that Rust cannot encode in the current plan shape
+  use `ExecutionError::Invariant(InvariantError)`. Adding an invariant
+  kind requires explicit design review.
 
 Runtime tag dispatch is allowed only for planner-validated recursive plan
 shapes, and only as execution routing. It must not become validation, fallback
 behavior, or a source-visible semantic difference.
 
-Typed projections have the following approved execution invariants:
+The following execution invariants are approved:
 
-- `ExecutionError::TupleIndexFamilyMismatch` is only for typed tuple-index
-  plan evaluation when the runtime tuple value lacks the planner-selected
-  element or that element has a different value family.
-- `ExecutionError::ListIndexOutOfBounds` is only for typed list-index plan
-  evaluation when the runtime list value lacks the planner-selected element.
-  Source-reachable list matching must guard list-index projections with the
-  planner-selected length condition.
-- `ExecutionError::CustomFieldFamilyMismatch` is only for a planner-selected
-  custom field projection or binding whose runtime field has a different
-  exact value type.
+- `InvariantError::FunctionReturnFamilyMismatch` is only for a typed
+  function call or return path whose evaluated target cannot serve the
+  planner-selected function family.
+- `InvariantError::TupleIndexFamilyMismatch` is only for typed
+  tuple-index plan evaluation when the runtime tuple value lacks the
+  planner-selected element or that element has a different value family.
+- `InvariantError::ListIndexOutOfBounds` is only for typed list-index
+  plan evaluation when the runtime list value lacks the planner-selected
+  element. Source-reachable list matching must guard list-index projections
+  with the planner-selected length condition.
+- `InvariantError::CustomFieldFamilyMismatch` is only for a
+  planner-selected custom field projection or binding whose runtime field has
+  a different exact value type.
 
 Planner-established type, shape, and discriminant relationships must be
 preserved structurally through lowering. Runtime must not revalidate them

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,6 @@ pub use plan::{
 pub use planner::{PlanError, plan_module, plan_module_with_source};
 pub use runtime::{
     BitArraySegmentPanicReason, BitArrayValue, BitArrayValueLengthError, CustomFieldValue,
-    CustomValue, ExecutionError, FunctionValue, ListValue, ListValueItemTypeMismatch, Panic,
-    PanicDetails, PanicKind, PanicMessage, Value, run_main,
+    CustomValue, ExecutionError, FunctionValue, InvariantError, ListValue,
+    ListValueItemTypeMismatch, Panic, PanicDetails, PanicKind, PanicMessage, Value, run_main,
 };

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,7 +9,8 @@ mod state;
 mod value;
 
 pub use error::{
-    BitArraySegmentPanicReason, ExecutionError, Panic, PanicDetails, PanicKind, PanicMessage,
+    BitArraySegmentPanicReason, ExecutionError, InvariantError, Panic, PanicDetails, PanicKind,
+    PanicMessage,
 };
 pub(in crate::runtime) use evaluated::{
     EvaluatedBitArray, EvaluatedBitArrayFunction, EvaluatedBoolFunction, EvaluatedCapture,

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -1,11 +1,12 @@
 mod diagnostic;
+mod invariant;
 mod panic;
 
-use crate::plan::execution::FunctionReturnFamily;
-use crate::plan::{PanicSite, SourceContext, SourceSpan, ValueType};
+use crate::plan::{PanicSite, SourceContext, SourceSpan};
 use crate::runtime::Value;
 use ecow::EcoString;
 
+pub use self::invariant::InvariantError;
 pub use self::panic::{BitArraySegmentPanicReason, Panic, PanicDetails, PanicKind, PanicMessage};
 
 pub(crate) type ExecutionResult<T> = Result<T, ExecutionError>;
@@ -14,32 +15,8 @@ pub(crate) type ExecutionResult<T> = Result<T, ExecutionError>;
 pub enum ExecutionError {
     #[error("{0}")]
     Panic(Panic),
-    #[error("function return family mismatch (expected {expected}, got {actual})")]
-    FunctionReturnFamilyMismatch {
-        expected: FunctionReturnFamily,
-        actual: FunctionReturnFamily,
-    },
-    #[error("tuple index family mismatch (expected {expected:?}, got {actual:?})")]
-    TupleIndexFamilyMismatch {
-        expected: ValueType,
-        actual: ValueType,
-    },
-    #[error(
-        "custom field family mismatch in {custom_type:?}::{constructor} field {field_index} (expected {expected:?}, got {actual:?})"
-    )]
-    CustomFieldFamilyMismatch {
-        custom_type: crate::plan::CustomType,
-        constructor: EcoString,
-        field_index: usize,
-        expected: ValueType,
-        actual: ValueType,
-    },
-    #[error("list index out of bounds for {item_type:?} list (index {index}, length {length})")]
-    ListIndexOutOfBounds {
-        item_type: ValueType,
-        index: usize,
-        length: usize,
-    },
+    #[error("{0}")]
+    Invariant(InvariantError),
 }
 
 impl ExecutionError {
@@ -94,67 +71,20 @@ impl ExecutionError {
 
 #[cfg(test)]
 mod tests {
-    use super::ExecutionError;
-    use crate::plan::ValueType;
+    use super::{ExecutionError, InvariantError};
     use crate::plan::execution::FunctionReturnFamily;
 
     #[test]
-    fn function_return_family_mismatch_display() {
-        let error = ExecutionError::FunctionReturnFamilyMismatch {
+    fn invariant_display_delegates_to_invariant_error() {
+        let invariant = InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::Int,
             actual: FunctionReturnFamily::String,
         };
+        let error = ExecutionError::Invariant(invariant);
 
         assert_eq!(
             error.to_string(),
             "function return family mismatch (expected Int, got String)",
-        );
-    }
-
-    #[test]
-    fn tuple_index_family_mismatch_display() {
-        let error = ExecutionError::TupleIndexFamilyMismatch {
-            expected: ValueType::Tuple(vec![ValueType::Int]),
-            actual: ValueType::String,
-        };
-
-        assert_eq!(
-            error.to_string(),
-            "tuple index family mismatch (expected Tuple([Int]), got String)",
-        );
-    }
-
-    #[test]
-    fn list_index_out_of_bounds_display() {
-        let error = ExecutionError::ListIndexOutOfBounds {
-            item_type: ValueType::Int,
-            index: 1,
-            length: 1,
-        };
-
-        assert_eq!(
-            error.to_string(),
-            "list index out of bounds for Int list (index 1, length 1)",
-        );
-    }
-
-    #[test]
-    fn custom_field_family_mismatch_display() {
-        let custom_type = crate::plan::CustomType::new(
-            crate::plan::CustomTypeName::new("app".into(), "main".into(), "Box".into()),
-            vec![ValueType::Int],
-        );
-        let error = ExecutionError::CustomFieldFamilyMismatch {
-            custom_type,
-            constructor: "Box".into(),
-            field_index: 0,
-            expected: ValueType::Int,
-            actual: ValueType::String,
-        };
-
-        assert_eq!(
-            error.to_string(),
-            "custom field family mismatch in CustomType { name: CustomTypeName { package: \"app\", module: \"main\", name: \"Box\" }, arguments: [Int] }::Box field 0 (expected Int, got String)",
         );
     }
 }

--- a/src/runtime/error/diagnostic.rs
+++ b/src/runtime/error/diagnostic.rs
@@ -1,4 +1,4 @@
-use super::{BitArraySegmentPanicReason, ExecutionError, Panic, PanicDetails};
+use super::{BitArraySegmentPanicReason, ExecutionError, InvariantError, Panic, PanicDetails};
 use crate::plan::{FunctionType, ValueType};
 use crate::runtime::Value;
 use miette::{Diagnostic, LabeledSpan, SourceCode};
@@ -55,6 +55,35 @@ impl Diagnostic for ExecutionError {
     fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
         match self {
             Self::Panic(panic) => panic.code(),
+            Self::Invariant(error) => error.code(),
+        }
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        match self {
+            Self::Panic(panic) => panic.help(),
+            Self::Invariant(error) => error.help(),
+        }
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        match self {
+            Self::Panic(panic) => panic.source_code(),
+            Self::Invariant(error) => error.source_code(),
+        }
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        match self {
+            Self::Panic(panic) => panic.labels(),
+            Self::Invariant(error) => error.labels(),
+        }
+    }
+}
+
+impl Diagnostic for InvariantError {
+    fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        match self {
             Self::FunctionReturnFamilyMismatch { .. } => {
                 Some(Box::new("geam::function_return_family_mismatch"))
             }
@@ -67,33 +96,15 @@ impl Diagnostic for ExecutionError {
     }
 
     fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
-        match self {
-            Self::Panic(panic) => panic.help(),
-            Self::FunctionReturnFamilyMismatch { .. }
-            | Self::TupleIndexFamilyMismatch { .. }
-            | Self::CustomFieldFamilyMismatch { .. }
-            | Self::ListIndexOutOfBounds { .. } => None,
-        }
+        None
     }
 
     fn source_code(&self) -> Option<&dyn SourceCode> {
-        match self {
-            Self::Panic(panic) => panic.source_code(),
-            Self::FunctionReturnFamilyMismatch { .. }
-            | Self::TupleIndexFamilyMismatch { .. }
-            | Self::CustomFieldFamilyMismatch { .. }
-            | Self::ListIndexOutOfBounds { .. } => None,
-        }
+        None
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        match self {
-            Self::Panic(panic) => panic.labels(),
-            Self::FunctionReturnFamilyMismatch { .. }
-            | Self::TupleIndexFamilyMismatch { .. }
-            | Self::CustomFieldFamilyMismatch { .. }
-            | Self::ListIndexOutOfBounds { .. } => None,
-        }
+        None
     }
 }
 
@@ -210,7 +221,9 @@ mod tests {
         CustomType, CustomTypeName, FunctionType, PanicSite, SourceContext, SourceSpan, ValueType,
     };
     use crate::runtime::{BitArrayValue, FunctionValue, ListValue, Value};
-    use crate::runtime::{ExecutionError, Panic, PanicDetails, PanicKind, PanicMessage};
+    use crate::runtime::{
+        ExecutionError, InvariantError, Panic, PanicDetails, PanicKind, PanicMessage,
+    };
     use miette::Diagnostic;
 
     #[test]
@@ -289,23 +302,23 @@ mod tests {
 
     #[test]
     fn invariant_diagnostics_have_codes_without_source_labels_or_help() {
-        for (error, expected_code) in [
+        for (invariant, expected_code) in [
             (
-                ExecutionError::FunctionReturnFamilyMismatch {
+                InvariantError::FunctionReturnFamilyMismatch {
                     expected: FunctionReturnFamily::Int,
                     actual: FunctionReturnFamily::String,
                 },
                 "geam::function_return_family_mismatch",
             ),
             (
-                ExecutionError::TupleIndexFamilyMismatch {
+                InvariantError::TupleIndexFamilyMismatch {
                     expected: ValueType::Int,
                     actual: ValueType::String,
                 },
                 "geam::tuple_index_mismatch",
             ),
             (
-                ExecutionError::CustomFieldFamilyMismatch {
+                InvariantError::CustomFieldFamilyMismatch {
                     custom_type: CustomType::new(
                         CustomTypeName::new("geam".into(), "main".into(), "Boxed".into()),
                         Vec::new(),
@@ -318,7 +331,7 @@ mod tests {
                 "geam::custom_field_family_mismatch",
             ),
             (
-                ExecutionError::ListIndexOutOfBounds {
+                InvariantError::ListIndexOutOfBounds {
                     item_type: ValueType::Int,
                     index: 1,
                     length: 1,
@@ -326,6 +339,16 @@ mod tests {
                 "geam::list_index_out_of_bounds",
             ),
         ] {
+            assert_eq!(
+                invariant.code().map(|code| code.to_string()),
+                Some(expected_code.into()),
+            );
+            assert!(invariant.help().is_none());
+            assert!(invariant.source_code().is_none());
+            assert!(invariant.labels().is_none());
+
+            let error = ExecutionError::Invariant(invariant);
+
             assert_eq!(
                 error.code().map(|code| code.to_string()),
                 Some(expected_code.into()),

--- a/src/runtime/error/invariant.rs
+++ b/src/runtime/error/invariant.rs
@@ -1,0 +1,99 @@
+use crate::plan::execution::FunctionReturnFamily;
+use crate::plan::{CustomType, ValueType};
+use ecow::EcoString;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum InvariantError {
+    #[error("function return family mismatch (expected {expected}, got {actual})")]
+    FunctionReturnFamilyMismatch {
+        expected: FunctionReturnFamily,
+        actual: FunctionReturnFamily,
+    },
+    #[error("tuple index family mismatch (expected {expected:?}, got {actual:?})")]
+    TupleIndexFamilyMismatch {
+        expected: ValueType,
+        actual: ValueType,
+    },
+    #[error(
+        "custom field family mismatch in {custom_type:?}::{constructor} field {field_index} (expected {expected:?}, got {actual:?})"
+    )]
+    CustomFieldFamilyMismatch {
+        custom_type: CustomType,
+        constructor: EcoString,
+        field_index: usize,
+        expected: ValueType,
+        actual: ValueType,
+    },
+    #[error("list index out of bounds for {item_type:?} list (index {index}, length {length})")]
+    ListIndexOutOfBounds {
+        item_type: ValueType,
+        index: usize,
+        length: usize,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InvariantError;
+    use crate::plan::execution::FunctionReturnFamily;
+    use crate::plan::{CustomType, CustomTypeName, ValueType};
+
+    #[test]
+    fn function_return_family_mismatch_display() {
+        let error = InvariantError::FunctionReturnFamilyMismatch {
+            expected: FunctionReturnFamily::Int,
+            actual: FunctionReturnFamily::String,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "function return family mismatch (expected Int, got String)",
+        );
+    }
+
+    #[test]
+    fn tuple_index_family_mismatch_display() {
+        let error = InvariantError::TupleIndexFamilyMismatch {
+            expected: ValueType::Tuple(vec![ValueType::Int]),
+            actual: ValueType::String,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "tuple index family mismatch (expected Tuple([Int]), got String)",
+        );
+    }
+
+    #[test]
+    fn list_index_out_of_bounds_display() {
+        let error = InvariantError::ListIndexOutOfBounds {
+            item_type: ValueType::Int,
+            index: 1,
+            length: 1,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "list index out of bounds for Int list (index 1, length 1)",
+        );
+    }
+
+    #[test]
+    fn custom_field_family_mismatch_display() {
+        let error = InvariantError::CustomFieldFamilyMismatch {
+            custom_type: CustomType::new(
+                CustomTypeName::new("app".into(), "main".into(), "Box".into()),
+                vec![ValueType::Int],
+            ),
+            constructor: "Box".into(),
+            field_index: 0,
+            expected: ValueType::Int,
+            actual: ValueType::String,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "custom field family mismatch in CustomType { name: CustomTypeName { package: \"app\", module: \"main\", name: \"Box\" }, arguments: [Int] }::Box field 0 (expected Int, got String)",
+        );
+    }
+}

--- a/src/runtime/expression.rs
+++ b/src/runtime/expression.rs
@@ -210,7 +210,8 @@ mod tests {
     use crate::runtime::frame::Frame;
     use crate::runtime::{
         EvaluatedFunctionValue, EvaluatedIntFunction, EvaluatedStringFunction,
-        EvaluatedUtfCodepointFunction, EvaluatedValue, ExecutionError, FunctionValueKind, Value,
+        EvaluatedUtfCodepointFunction, EvaluatedValue, ExecutionError, FunctionValueKind,
+        InvariantError, Value,
     };
 
     #[test]
@@ -442,18 +443,22 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_int_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Int,
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Int,
+                    actual: actual.clone(),
+                }
+            )),
         );
         frame.set_tuple(TupleLocalId(0), Vec::new());
         assert_eq!(
             eval_int_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Int,
-                actual: ValueType::Tuple(Vec::new()),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Int,
+                    actual: ValueType::Tuple(Vec::new()),
+                }
+            )),
         );
 
         let function = plan.string_function(StringFunctionId(0));
@@ -464,10 +469,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_string_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::String,
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::String,
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.float_function(FloatFunctionId(0));
@@ -478,10 +485,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_float_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Float,
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Float,
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.bool_function(BoolFunctionId(0));
@@ -492,10 +501,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_bool_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Bool,
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Bool,
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.nil_function(NilFunctionId(0));
@@ -506,10 +517,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_nil_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Nil,
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Nil,
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.tuple_function(TupleFunctionId(0));
@@ -523,10 +536,12 @@ pub fn main() {
         );
         assert_eq!(
             eval_tuple_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Tuple(vec![ValueType::Int]),
-                actual: ValueType::String,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Tuple(vec![ValueType::Int]),
+                    actual: ValueType::String,
+                }
+            )),
         );
 
         let function = plan.int_list_function(plan.int_list_function_id(0));
@@ -537,10 +552,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_int_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::List(Box::new(ValueType::Int)),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::List(Box::new(ValueType::Int)),
+                    actual: actual.clone(),
+                }
+            )),
         );
         let function = plan.string_list_function(plan.string_list_function_id(0));
         let expression = expression_return(function.return_())
@@ -550,10 +567,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_string_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::List(Box::new(ValueType::String)),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::List(Box::new(ValueType::String)),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.float_list_function(plan.float_list_function_id(0));
@@ -564,10 +583,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_float_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::List(Box::new(ValueType::Float)),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::List(Box::new(ValueType::Float)),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.bool_list_function(plan.bool_list_function_id(0));
@@ -578,10 +599,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_bool_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::List(Box::new(ValueType::Bool)),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::List(Box::new(ValueType::Bool)),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.nil_list_function(plan.nil_list_function_id(0));
@@ -592,10 +615,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_nil_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::List(Box::new(ValueType::Nil)),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::List(Box::new(ValueType::Nil)),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.tuple_list_function(plan.tuple_list_function_id(0));
@@ -606,10 +631,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_tuple_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::List(Box::new(ValueType::Tuple(vec![ValueType::Int]))),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::List(Box::new(ValueType::Tuple(vec![ValueType::Int]))),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.list_list_function(plan.list_list_function_id(0));
@@ -620,10 +647,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_list_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::List(Box::new(ValueType::List(Box::new(ValueType::Int)))),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::List(Box::new(ValueType::List(Box::new(ValueType::Int)))),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.function_list_function(plan.function_list_function_id(0));
@@ -635,12 +664,14 @@ pub fn main() {
         let int_function_type = FunctionType::new(Vec::new(), ValueType::Int);
         assert_eq!(
             eval_function_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::List(Box::new(ValueType::Function(Box::new(
-                    int_function_type.clone(),
-                )))),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::List(Box::new(ValueType::Function(Box::new(
+                        int_function_type.clone(),
+                    )))),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let expected_function_types = [
@@ -662,10 +693,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_int_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[0].clone())),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[0].clone())),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.string_function_function(StringFunctionFunctionId(0));
@@ -676,10 +709,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_string_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[1].clone())),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[1].clone())),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.float_function_function(FloatFunctionFunctionId(0));
@@ -690,10 +725,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_float_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[2].clone())),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[2].clone())),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.bool_function_function(BoolFunctionFunctionId(0));
@@ -704,10 +741,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_bool_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[3].clone())),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[3].clone())),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.nil_function_function(NilFunctionFunctionId(0));
@@ -718,10 +757,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_nil_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[4].clone())),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[4].clone())),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.tuple_function_function(TupleFunctionFunctionId(0));
@@ -732,10 +773,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_tuple_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[5].clone())),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[5].clone())),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function =
@@ -747,10 +790,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), wrong_tuple.clone());
         assert_eq!(
             eval_list_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[6].clone())),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[6].clone())),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let function = plan.function_function_function(&function_function_id);
@@ -768,10 +813,12 @@ pub fn main() {
                 return_.type_(),
                 expression,
             ),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[7].clone())),
-                actual: actual.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[7].clone())),
+                    actual: actual.clone(),
+                }
+            )),
         );
 
         let wrong_string_function = EvaluatedStringFunction::reference(
@@ -810,10 +857,12 @@ pub fn main() {
         );
         assert_eq!(
             eval_int_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[0].clone())),
-                actual: wrong_string_type,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[0].clone())),
+                    actual: wrong_string_type,
+                }
+            )),
         );
 
         let function = plan.string_function_function(StringFunctionFunctionId(0));
@@ -827,10 +876,12 @@ pub fn main() {
         );
         assert_eq!(
             eval_string_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[1].clone())),
-                actual: wrong_int_type.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[1].clone())),
+                    actual: wrong_int_type.clone(),
+                }
+            )),
         );
 
         let function = plan.float_function_function(FloatFunctionFunctionId(0));
@@ -844,10 +895,12 @@ pub fn main() {
         );
         assert_eq!(
             eval_float_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[2].clone())),
-                actual: wrong_int_type.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[2].clone())),
+                    actual: wrong_int_type.clone(),
+                }
+            )),
         );
 
         let function = plan.bool_function_function(BoolFunctionFunctionId(0));
@@ -861,10 +914,12 @@ pub fn main() {
         );
         assert_eq!(
             eval_bool_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[3].clone())),
-                actual: wrong_int_type.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[3].clone())),
+                    actual: wrong_int_type.clone(),
+                }
+            )),
         );
 
         let function = plan.nil_function_function(NilFunctionFunctionId(0));
@@ -878,10 +933,12 @@ pub fn main() {
         );
         assert_eq!(
             eval_nil_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[4].clone())),
-                actual: wrong_int_type.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[4].clone())),
+                    actual: wrong_int_type.clone(),
+                }
+            )),
         );
 
         let function = plan.tuple_function_function(TupleFunctionFunctionId(0));
@@ -895,10 +952,12 @@ pub fn main() {
         );
         assert_eq!(
             eval_tuple_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[5].clone())),
-                actual: wrong_int_type.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[5].clone())),
+                    actual: wrong_int_type.clone(),
+                }
+            )),
         );
 
         let function =
@@ -913,10 +972,12 @@ pub fn main() {
         );
         assert_eq!(
             eval_list_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[6].clone())),
-                actual: wrong_int_type.clone(),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[6].clone())),
+                    actual: wrong_int_type.clone(),
+                }
+            )),
         );
 
         let function = plan.function_function_function(&function_function_id);
@@ -937,10 +998,12 @@ pub fn main() {
                 return_.type_(),
                 expression,
             ),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(expected_function_types[7].clone())),
-                actual: wrong_int_type,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(expected_function_types[7].clone())),
+                    actual: wrong_int_type,
+                }
+            )),
         );
     }
 
@@ -976,10 +1039,12 @@ pub fn main() {
         frame.set_tuple(TupleLocalId(0), vec![EvaluatedValue::Int(1.into())]);
         assert_eq!(
             eval_utf_codepoint_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::UtfCodepoint,
-                actual: ValueType::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::UtfCodepoint,
+                    actual: ValueType::Int,
+                }
+            )),
         );
 
         let function_id = plan.utf_codepoint_list_function_id(0);
@@ -1036,28 +1101,32 @@ pub fn main() {
         );
         assert_eq!(
             eval_utf_codepoint_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(FunctionType::new(
-                    Vec::new(),
-                    ValueType::UtfCodepoint,
-                ))),
-                actual: ValueType::Function(Box::new(FunctionType::new(
-                    Vec::new(),
-                    ValueType::Int,
-                ))),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(FunctionType::new(
+                        Vec::new(),
+                        ValueType::UtfCodepoint,
+                    ))),
+                    actual: ValueType::Function(Box::new(FunctionType::new(
+                        Vec::new(),
+                        ValueType::Int,
+                    ))),
+                }
+            )),
         );
 
         frame.set_tuple(TupleLocalId(0), vec![EvaluatedValue::Int(1.into())]);
         assert_eq!(
             eval_utf_codepoint_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Function(Box::new(FunctionType::new(
-                    Vec::new(),
-                    ValueType::UtfCodepoint,
-                ))),
-                actual: ValueType::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Function(Box::new(FunctionType::new(
+                        Vec::new(),
+                        ValueType::UtfCodepoint,
+                    ))),
+                    actual: ValueType::Int,
+                }
+            )),
         );
     }
 

--- a/src/runtime/expression/bit_array.rs
+++ b/src/runtime/expression/bit_array.rs
@@ -14,7 +14,7 @@ use crate::plan::execution::{
 use crate::runtime::evaluated::{EvaluatedBitArray, EvaluatedValue};
 use crate::runtime::frame::Frame;
 use crate::runtime::state::RuntimeState;
-use crate::runtime::{BitArraySegmentPanicReason, ExecutionError, function};
+use crate::runtime::{BitArraySegmentPanicReason, ExecutionError, InvariantError, function};
 
 pub(in crate::runtime) fn eval_bit_array_expr(
     plan: &ExecutionPlan,
@@ -53,10 +53,12 @@ pub(in crate::runtime) fn eval_bit_array_expr(
         BitArrayExprKind::TupleIndex { tuple, index } => {
             match project_tuple_expr(plan, state, frame, tuple, *index, ValueType::BitArray)? {
                 EvaluatedValue::BitArray(value) => Ok(value),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::BitArray,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::BitArray,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         BitArrayExprKind::CustomField(access) => {
@@ -65,13 +67,15 @@ pub(in crate::runtime) fn eval_bit_array_expr(
                 EvaluatedValue::BitArray(value) => Ok(value),
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected: ValueType::BitArray,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected: ValueType::BitArray,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }
@@ -383,7 +387,9 @@ mod tests {
         StringEncoding, StringExpr, TupleExpr, UtfCodepointExpr, ValueType,
     };
     use crate::runtime::BitArraySegmentPanicReason;
-    use crate::runtime::{BitArrayValue, ExecutionError, ListValue, Value, run_main};
+    use crate::runtime::{
+        BitArrayValue, ExecutionError, InvariantError, ListValue, Value, run_main,
+    };
 
     #[test]
     fn evaluated_segment_failures_preserve_exact_panic_reasons() {
@@ -526,10 +532,10 @@ mod tests {
 
         assert_eq!(
             run_module_bit_array_expression(expression),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::BitArray,
                 actual: ValueType::Int,
-            },
+            }),
         );
     }
 

--- a/src/runtime/expression/bool.rs
+++ b/src/runtime/expression/bool.rs
@@ -6,11 +6,11 @@ use super::{
 use crate::plan::ValueType;
 use crate::plan::execution::ExecutionPlan;
 use crate::plan::execution::{BoolExpr, BoolExprKind};
-use crate::runtime::ExecutionError;
 use crate::runtime::evaluated::EvaluatedValue;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
+use crate::runtime::{ExecutionError, InvariantError};
 
 pub(in crate::runtime) fn eval_bool_expr(
     plan: &ExecutionPlan,
@@ -37,10 +37,12 @@ pub(in crate::runtime) fn eval_bool_expr(
         BoolExprKind::TupleIndex { tuple, index } => {
             match project_tuple_expr(plan, state, frame, tuple, *index, ValueType::Bool)? {
                 EvaluatedValue::Bool(value) => Ok(value),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::Bool,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::Bool,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         BoolExprKind::CustomField(access) => {
@@ -49,13 +51,15 @@ pub(in crate::runtime) fn eval_bool_expr(
                 EvaluatedValue::Bool(value) => Ok(value),
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected: ValueType::Bool,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected: ValueType::Bool,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }

--- a/src/runtime/expression/custom.rs
+++ b/src/runtime/expression/custom.rs
@@ -8,7 +8,7 @@ use crate::plan::execution::{CustomExpr, CustomExprKind, ExecutionPlan};
 use crate::runtime::evaluated::{EvaluatedCustomValue, EvaluatedValue};
 use crate::runtime::frame::Frame;
 use crate::runtime::state::RuntimeState;
-use crate::runtime::{ExecutionError, function};
+use crate::runtime::{ExecutionError, InvariantError, function};
 
 pub(in crate::runtime) fn eval_custom_expr(
     plan: &ExecutionPlan,
@@ -60,10 +60,12 @@ pub(in crate::runtime) fn eval_custom_expr_kind(
             let expected = ValueType::Custom(plan.custom_value_type(type_id));
             match project_tuple_expr(plan, state, frame, tuple, *index, expected.clone())? {
                 EvaluatedValue::Custom(value) => Ok(value),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         CustomExprKind::CustomField(access) => {
@@ -73,13 +75,15 @@ pub(in crate::runtime) fn eval_custom_expr_kind(
                 EvaluatedValue::Custom(value) => Ok(value),
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }
@@ -155,7 +159,7 @@ mod tests {
         FunctionTemplateId, IntExpr, ModulePlan, PanicExpr, PanicSite, ReturnExpr, Step,
         StringExpr, TupleExpr, ValueType,
     };
-    use crate::runtime::{ExecutionError, run_main};
+    use crate::runtime::{ExecutionError, InvariantError, run_main};
 
     #[test]
     fn source_custom_expression_variants_evaluate_exact_values() {
@@ -218,10 +222,10 @@ pub fn main() {
 
         assert_eq!(
             run_module_custom_expression(expression),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::Custom(type_),
                 actual: ValueType::Int,
-            },
+            }),
         );
     }
 

--- a/src/runtime/expression/custom_field.rs
+++ b/src/runtime/expression/custom_field.rs
@@ -29,7 +29,8 @@ mod tests {
     };
     use crate::plan::{CustomFunctionExpr, CustomFunctionReference, FunctionTemplateId};
     use crate::runtime::{
-        BitArrayValue, CustomFieldValue, CustomValue, ExecutionError, ListValue, Value,
+        BitArrayValue, CustomFieldValue, CustomValue, ExecutionError, InvariantError, ListValue,
+        Value,
     };
 
     #[test]
@@ -114,10 +115,10 @@ mod tests {
                 Vec::new(),
             )
             .expect_err("direct-mutated tuple field should fail"),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::String,
                 actual: ValueType::Int,
-            },
+            }),
         );
     }
 
@@ -242,13 +243,15 @@ mod tests {
                     field_projection_definitions(&expected),
                     Vec::new(),
                 ),
-                Err(ExecutionError::CustomFieldFamilyMismatch {
-                    custom_type: boxed_type(),
-                    constructor: "Boxed".into(),
-                    field_index: 0,
-                    expected: expected.clone(),
-                    actual,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::CustomFieldFamilyMismatch {
+                        custom_type: boxed_type(),
+                        constructor: "Boxed".into(),
+                        field_index: 0,
+                        expected: expected.clone(),
+                        actual,
+                    }
+                )),
             );
             let (outer_actual, outer_actual_type) = match &expected {
                 ValueType::List(_) | ValueType::Function(_) => {
@@ -292,13 +295,15 @@ mod tests {
                     field_projection_definitions(&expected),
                     Vec::new(),
                 ),
-                Err(ExecutionError::CustomFieldFamilyMismatch {
-                    custom_type: boxed_type(),
-                    constructor: "Boxed".into(),
-                    field_index: 0,
-                    expected: expected.clone(),
-                    actual: outer_actual_type,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::CustomFieldFamilyMismatch {
+                        custom_type: boxed_type(),
+                        constructor: "Boxed".into(),
+                        field_index: 0,
+                        expected: expected.clone(),
+                        actual: outer_actual_type,
+                    }
+                )),
             );
             let access = CustomFieldAccess::new(
                 CustomExpr::tuple_index_shape(
@@ -321,10 +326,12 @@ mod tests {
                     field_projection_definitions(&expected),
                     Vec::new(),
                 ),
-                Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::Custom(boxed_type()),
-                    actual: ValueType::Int,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::Custom(boxed_type()),
+                        actual: ValueType::Int,
+                    }
+                )),
             );
         }
     }
@@ -385,13 +392,15 @@ mod tests {
                 ))),
                 vec![target],
             ),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: boxed_type(),
-                constructor: "Boxed".into(),
-                field_index: 0,
-                expected: ValueType::Function(Box::new(expected_function)),
-                actual: ValueType::Function(Box::new(actual_function)),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: boxed_type(),
+                    constructor: "Boxed".into(),
+                    field_index: 0,
+                    expected: ValueType::Function(Box::new(expected_function)),
+                    actual: ValueType::Function(Box::new(actual_function)),
+                }
+            )),
         );
     }
 
@@ -453,13 +462,15 @@ mod tests {
                 ))),
                 vec![target],
             ),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: boxed_type(),
-                constructor: "Boxed".into(),
-                field_index: 0,
-                expected: ValueType::Function(Box::new(expected_function)),
-                actual: ValueType::Function(Box::new(actual_function)),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: boxed_type(),
+                    constructor: "Boxed".into(),
+                    field_index: 0,
+                    expected: ValueType::Function(Box::new(expected_function)),
+                    actual: ValueType::Function(Box::new(actual_function)),
+                }
+            )),
         );
     }
 

--- a/src/runtime/expression/float.rs
+++ b/src/runtime/expression/float.rs
@@ -5,11 +5,11 @@ use super::{
 use crate::plan::ValueType;
 use crate::plan::execution::ExecutionPlan;
 use crate::plan::execution::{FloatExpr, FloatExprKind};
-use crate::runtime::ExecutionError;
 use crate::runtime::evaluated::EvaluatedValue;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
+use crate::runtime::{ExecutionError, InvariantError};
 
 pub(in crate::runtime) fn eval_float_expr(
     plan: &ExecutionPlan,
@@ -36,10 +36,12 @@ pub(in crate::runtime) fn eval_float_expr(
         FloatExprKind::TupleIndex { tuple, index } => {
             match project_tuple_expr(plan, state, frame, tuple, *index, ValueType::Float)? {
                 EvaluatedValue::Float(value) => Ok(value),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::Float,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::Float,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         FloatExprKind::CustomField(access) => {
@@ -48,13 +50,15 @@ pub(in crate::runtime) fn eval_float_expr(
                 EvaluatedValue::Float(value) => Ok(value),
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected: ValueType::Float,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected: ValueType::Float,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }

--- a/src/runtime/expression/function.rs
+++ b/src/runtime/expression/function.rs
@@ -19,7 +19,7 @@ use crate::runtime::frame::Frame;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedCustomFunction, EvaluatedFunction, EvaluatedFunctionValue, EvaluatedValue,
-    ExecutionError,
+    ExecutionError, InvariantError,
 };
 
 pub(in crate::runtime) use self::{
@@ -131,13 +131,15 @@ fn eval_custom_field_function(
     let expected = plan.value_type(descriptor.fields()[access.index()].type_());
     match value {
         EvaluatedValue::Function(value) => Ok((constructor, expected, value)),
-        other => Err(ExecutionError::CustomFieldFamilyMismatch {
-            custom_type: plan.custom_value_type(constructor.type_id()),
-            constructor: descriptor.name().clone(),
-            field_index: access.index(),
-            expected,
-            actual: other.value_type(plan),
-        }),
+        other => Err(ExecutionError::Invariant(
+            InvariantError::CustomFieldFamilyMismatch {
+                custom_type: plan.custom_value_type(constructor.type_id()),
+                constructor: descriptor.name().clone(),
+                field_index: access.index(),
+                expected,
+                actual: other.value_type(plan),
+            },
+        )),
     }
 }
 

--- a/src/runtime/expression/function/bit_array.rs
+++ b/src/runtime/expression/function/bit_array.rs
@@ -12,6 +12,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedBitArrayFunction, EvaluatedFunctionValueKind, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_bit_array_function_expr(
@@ -76,9 +77,13 @@ pub(in crate::runtime) fn eval_bit_array_function_expr(
             match value {
                 EvaluatedValue::Function(function) => match function.kind() {
                     EvaluatedFunctionValueKind::BitArray(value) => Ok(value.clone()),
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         BitArrayFunctionExprKind::CustomField(access) => {
@@ -88,13 +93,17 @@ pub(in crate::runtime) fn eval_bit_array_function_expr(
                 EvaluatedFunctionValueKind::BitArray(value) => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: ValueType::Function(Box::new(plan.function_type(function.type_()))),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: ValueType::Function(Box::new(
+                                plan.function_type(function.type_()),
+                            )),
+                        },
+                    ))
                 }
             }
         }
@@ -103,10 +112,12 @@ pub(in crate::runtime) fn eval_bit_array_function_expr(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::BitArray(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::BitArray,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::BitArray,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         BitArrayFunctionExprKind::Panic(panic) => {
@@ -177,7 +188,7 @@ mod tests {
         IntExpr, IntLocalId, ListExpr, ModulePlan, PanicExpr, PanicSite, ReturnExpr, Step,
         StringExpr, TupleExpr, ValueType,
     };
-    use crate::runtime::{BitArrayValue, ExecutionError, Value, run_main};
+    use crate::runtime::{BitArrayValue, ExecutionError, InvariantError, Value, run_main};
 
     #[test]
     fn module_expression_errors_propagate_through_bit_array_function_wrappers() {
@@ -311,7 +322,7 @@ mod tests {
 
         assert_eq!(
             run_module_bit_array_function_expression(expression),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::Function(Box::new(FunctionType::new(
                     Vec::new(),
                     ValueType::BitArray,
@@ -320,7 +331,7 @@ mod tests {
                     Vec::new(),
                     ValueType::Int,
                 ))),
-            },
+            }),
         );
 
         let tuple = TupleExpr::value(
@@ -337,13 +348,13 @@ mod tests {
         );
         assert_eq!(
             run_module_bit_array_function_expression(expression),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::Function(Box::new(FunctionType::new(
                     Vec::new(),
                     ValueType::BitArray,
                 ))),
                 actual: ValueType::Int,
-            },
+            }),
         );
     }
 

--- a/src/runtime/expression/function/bool.rs
+++ b/src/runtime/expression/function/bool.rs
@@ -11,6 +11,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedBoolFunction, EvaluatedFunctionValueKind, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_bool_function_expr(
@@ -73,9 +74,13 @@ pub(in crate::runtime) fn eval_bool_function_expr(
             match value {
                 EvaluatedValue::Function(function) => match function.kind() {
                     EvaluatedFunctionValueKind::Bool(value) => Ok(value.clone()),
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         BoolFunctionExprKind::CustomField(access) => {
@@ -85,13 +90,17 @@ pub(in crate::runtime) fn eval_bool_function_expr(
                 EvaluatedFunctionValueKind::Bool(value) => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: ValueType::Function(Box::new(plan.function_type(function.type_()))),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: ValueType::Function(Box::new(
+                                plan.function_type(function.type_()),
+                            )),
+                        },
+                    ))
                 }
             }
         }
@@ -100,10 +109,12 @@ pub(in crate::runtime) fn eval_bool_function_expr(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::Bool(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::Bool,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::Bool,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         BoolFunctionExprKind::Panic(panic) => {

--- a/src/runtime/expression/function/custom.rs
+++ b/src/runtime/expression/function/custom.rs
@@ -13,7 +13,7 @@ use crate::runtime::expression::{
 };
 use crate::runtime::frame::Frame;
 use crate::runtime::state::RuntimeState;
-use crate::runtime::{ExecutionError, function};
+use crate::runtime::{ExecutionError, InvariantError, function};
 
 pub(in crate::runtime) fn eval_custom_function_expr(
     plan: &ExecutionPlan,
@@ -93,9 +93,13 @@ pub(in crate::runtime) fn eval_custom_function_expr_kind(
                     EvaluatedFunctionValueKind::Custom(value) if actual == expected => {
                         Ok(value.clone())
                     }
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         CustomFunctionExprKind::CustomField(access) => {
@@ -108,13 +112,15 @@ pub(in crate::runtime) fn eval_custom_function_expr_kind(
                 }
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual,
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual,
+                        },
+                    ))
                 }
             }
         }
@@ -124,10 +130,12 @@ pub(in crate::runtime) fn eval_custom_function_expr_kind(
                 project_function_list_expr(plan, state, frame, list, *index, &public_type)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::Custom(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::Custom,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::Custom,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         CustomFunctionExprKind::Panic(panic) => {
@@ -202,7 +210,7 @@ mod tests {
         ParamLocal, ReturnExpr, Step, StringExpr, TupleExpr, ValueShape, ValueType,
         monomorphic_function_instantiation,
     };
-    use crate::runtime::{ExecutionError, run_main};
+    use crate::runtime::{ExecutionError, InvariantError, run_main};
 
     fn custom_function_instantiation(
         template: usize,
@@ -330,13 +338,13 @@ pub fn main() {
 
         assert_eq!(
             run_module_custom_function_expression(expression),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::Function(Box::new(type_.to_function_type())),
                 actual: ValueType::Function(Box::new(FunctionType::new(
                     Vec::new(),
                     ValueType::Int,
                 ))),
-            },
+            }),
         );
 
         let tuple = TupleExpr::value(
@@ -347,10 +355,10 @@ pub fn main() {
 
         assert_eq!(
             run_module_custom_function_expression(expression),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::Function(Box::new(type_.to_function_type())),
                 actual: ValueType::Int,
-            },
+            }),
         );
 
         let actual_type = CustomFunctionType::new(vec![ValueType::Int], boxed_type());
@@ -370,10 +378,10 @@ pub fn main() {
 
         assert_eq!(
             run_module_custom_function_expression(expression),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::Function(Box::new(type_.to_function_type())),
                 actual: ValueType::Function(Box::new(actual_type.to_function_type())),
-            },
+            }),
         );
     }
 

--- a/src/runtime/expression/function/float.rs
+++ b/src/runtime/expression/function/float.rs
@@ -11,6 +11,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFloatFunction, EvaluatedFunctionValueKind, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_float_function_expr(
@@ -73,9 +74,13 @@ pub(in crate::runtime) fn eval_float_function_expr(
             match value {
                 EvaluatedValue::Function(function) => match function.kind() {
                     EvaluatedFunctionValueKind::Float(value) => Ok(value.clone()),
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         FloatFunctionExprKind::CustomField(access) => {
@@ -85,13 +90,17 @@ pub(in crate::runtime) fn eval_float_function_expr(
                 EvaluatedFunctionValueKind::Float(value) => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: ValueType::Function(Box::new(plan.function_type(function.type_()))),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: ValueType::Function(Box::new(
+                                plan.function_type(function.type_()),
+                            )),
+                        },
+                    ))
                 }
             }
         }
@@ -100,10 +109,12 @@ pub(in crate::runtime) fn eval_float_function_expr(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::Float(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::Float,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::Float,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         FloatFunctionExprKind::Panic(panic) => {

--- a/src/runtime/expression/function/generic.rs
+++ b/src/runtime/expression/function/generic.rs
@@ -13,6 +13,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFunctionValueKind, EvaluatedGenericFunction, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_generic_function_expr(
@@ -86,9 +87,13 @@ pub(in crate::runtime) fn eval_generic_function_expr_kind(
                     EvaluatedFunctionValueKind::Generic(value) if actual == expected => {
                         Ok(value.clone())
                     }
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         GenericFunctionExprKind::CustomField(access) => {
@@ -101,13 +106,15 @@ pub(in crate::runtime) fn eval_generic_function_expr_kind(
                 }
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual,
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual,
+                        },
+                    ))
                 }
             }
         }
@@ -116,10 +123,12 @@ pub(in crate::runtime) fn eval_generic_function_expr_kind(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::Generic(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::Generic,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::Generic,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         GenericFunctionExprKind::Panic(panic) => {
@@ -205,7 +214,7 @@ mod tests {
     use crate::runtime::state::RuntimeState;
     use crate::runtime::{
         EvaluatedCustomValue, EvaluatedFunctionValue, EvaluatedFunctionValueKind,
-        EvaluatedIntFunction, EvaluatedValue, ExecutionError, PanicKind,
+        EvaluatedIntFunction, EvaluatedValue, ExecutionError, InvariantError, PanicKind,
     };
 
     #[test]
@@ -455,10 +464,12 @@ pub fn main() {
 
         assert_eq!(
             crate::run_main(&generic_function_plan(expression, vec![target])),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: expected.clone(),
-                actual: ValueType::Function(Box::new(wrong_type)),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: expected.clone(),
+                    actual: ValueType::Function(Box::new(wrong_type)),
+                }
+            )),
         );
 
         let expression = ModuleGenericFunctionExpr::tuple_index(
@@ -471,10 +482,12 @@ pub fn main() {
         );
         assert_eq!(
             crate::run_main(&generic_function_plan(expression, Vec::new())),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected,
-                actual: ValueType::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected,
+                    actual: ValueType::Int,
+                }
+            )),
         );
     }
 
@@ -519,10 +532,12 @@ pub fn main() {
 
         assert_eq!(
             eval_generic_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Generic,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Generic,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
     }
 
@@ -561,15 +576,17 @@ pub fn main() {
 
         assert_eq!(
             eval_generic_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: plan.custom_value_type(construction.constructor().type_id()),
-                constructor: descriptor.name().clone(),
-                field_index: access.index(),
-                expected: ValueType::Function(Box::new(generic_public_function_type(
-                    TypeParameterId(0),
-                ))),
-                actual: ValueType::Function(Box::new(plan.function_type(&wrong_type))),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: plan.custom_value_type(construction.constructor().type_id()),
+                    constructor: descriptor.name().clone(),
+                    field_index: access.index(),
+                    expected: ValueType::Function(Box::new(generic_public_function_type(
+                        TypeParameterId(0),
+                    ))),
+                    actual: ValueType::Function(Box::new(plan.function_type(&wrong_type))),
+                }
+            )),
         );
 
         let value = EvaluatedCustomValue::from_fields(
@@ -581,15 +598,17 @@ pub fn main() {
 
         assert_eq!(
             eval_generic_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: plan.custom_value_type(construction.constructor().type_id()),
-                constructor: descriptor.name().clone(),
-                field_index: access.index(),
-                expected: ValueType::Function(Box::new(generic_public_function_type(
-                    TypeParameterId(0),
-                ))),
-                actual: ValueType::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: plan.custom_value_type(construction.constructor().type_id()),
+                    constructor: descriptor.name().clone(),
+                    field_index: access.index(),
+                    expected: ValueType::Function(Box::new(generic_public_function_type(
+                        TypeParameterId(0),
+                    ))),
+                    actual: ValueType::Int,
+                }
+            )),
         );
     }
 

--- a/src/runtime/expression/function/int.rs
+++ b/src/runtime/expression/function/int.rs
@@ -11,6 +11,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFunctionValueKind, EvaluatedIntFunction, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_int_function_expr(
@@ -73,9 +74,13 @@ pub(in crate::runtime) fn eval_int_function_expr(
             match value {
                 EvaluatedValue::Function(function) => match function.kind() {
                     EvaluatedFunctionValueKind::Int(value) => Ok(value.clone()),
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         IntFunctionExprKind::CustomField(access) => {
@@ -85,13 +90,17 @@ pub(in crate::runtime) fn eval_int_function_expr(
                 EvaluatedFunctionValueKind::Int(value) => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: ValueType::Function(Box::new(plan.function_type(function.type_()))),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: ValueType::Function(Box::new(
+                                plan.function_type(function.type_()),
+                            )),
+                        },
+                    ))
                 }
             }
         }
@@ -100,10 +109,12 @@ pub(in crate::runtime) fn eval_int_function_expr(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::Int(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::Int,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::Int,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         IntFunctionExprKind::Panic(panic) => {

--- a/src/runtime/expression/function/list.rs
+++ b/src/runtime/expression/function/list.rs
@@ -11,6 +11,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFunctionValueKind, EvaluatedListFunction, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_list_function_expr(
@@ -81,15 +82,19 @@ pub(in crate::runtime) fn eval_list_function_expr(
             )? {
                 EvaluatedValue::Function(function) => match function.kind() {
                     EvaluatedFunctionValueKind::List(value) => Ok(value.clone()),
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch {
-                        expected: ValueType::Function(Box::new(plan.function_type(type_))),
-                        actual: EvaluatedValue::Function(function).value_type(plan),
-                    }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch {
+                            expected: ValueType::Function(Box::new(plan.function_type(type_))),
+                            actual: EvaluatedValue::Function(function).value_type(plan),
+                        },
+                    )),
                 },
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::Function(Box::new(plan.function_type(type_))),
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::Function(Box::new(plan.function_type(type_))),
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         ListFunctionExprKind::CustomField(access) => {
@@ -99,13 +104,17 @@ pub(in crate::runtime) fn eval_list_function_expr(
                 EvaluatedFunctionValueKind::List(value) => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: ValueType::Function(Box::new(plan.function_type(function.type_()))),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: ValueType::Function(Box::new(
+                                plan.function_type(function.type_()),
+                            )),
+                        },
+                    ))
                 }
             }
         }
@@ -114,10 +123,12 @@ pub(in crate::runtime) fn eval_list_function_expr(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::List(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::List,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::List,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         ListFunctionExprKind::Panic(panic) => {

--- a/src/runtime/expression/function/never.rs
+++ b/src/runtime/expression/function/never.rs
@@ -13,6 +13,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFunctionValueKind, EvaluatedNeverFunction, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_never_function_expr(
@@ -72,9 +73,13 @@ pub(in crate::runtime) fn eval_never_function_expr_kind(
                     EvaluatedFunctionValueKind::Never(value) if actual == expected => {
                         Ok(value.clone())
                     }
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         NeverFunctionExprKind::CustomField(access) => {
@@ -85,13 +90,15 @@ pub(in crate::runtime) fn eval_never_function_expr_kind(
                 EvaluatedFunctionValueKind::Never(value) if actual == expected => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual,
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual,
+                        },
+                    ))
                 }
             }
         }
@@ -100,10 +107,12 @@ pub(in crate::runtime) fn eval_never_function_expr_kind(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::Never(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::Never,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::Never,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         NeverFunctionExprKind::Panic(panic) => {
@@ -190,7 +199,7 @@ mod tests {
     use crate::runtime::expression::eval_never_function_expr;
     use crate::runtime::frame::Frame;
     use crate::runtime::state::RuntimeState;
-    use crate::runtime::{EvaluatedCustomValue, ExecutionError, PanicKind};
+    use crate::runtime::{EvaluatedCustomValue, ExecutionError, InvariantError, PanicKind};
 
     #[test]
     fn module_expression_errors_propagate_through_never_function_wrappers() {
@@ -421,10 +430,12 @@ pub fn main() {
 
         assert_eq!(
             eval_never_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Never,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Never,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
     }
 
@@ -473,16 +484,18 @@ pub fn main() { get(Box(diverge)) }
 
         assert_eq!(
             eval_never_function_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: plan.custom_value_type(construction.constructor().type_id()),
-                constructor: descriptor.name().clone(),
-                field_index: access.index(),
-                expected: ValueType::Function(Box::new(crate::plan::FunctionType::new(
-                    vec![ValueType::Int],
-                    ValueType::Parameter(TypeParameterId(0)),
-                ))),
-                actual: ValueType::Function(Box::new(plan.function_type(&wrong_type))),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: plan.custom_value_type(construction.constructor().type_id()),
+                    constructor: descriptor.name().clone(),
+                    field_index: access.index(),
+                    expected: ValueType::Function(Box::new(crate::plan::FunctionType::new(
+                        vec![ValueType::Int],
+                        ValueType::Parameter(TypeParameterId(0)),
+                    ))),
+                    actual: ValueType::Function(Box::new(plan.function_type(&wrong_type))),
+                }
+            )),
         );
     }
 
@@ -517,10 +530,12 @@ pub fn main() { get(Box(diverge)) }
 
         assert_eq!(
             crate::run_main(&never_function_plan(expression, vec![target])),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: expected.clone(),
-                actual: ValueType::Function(Box::new(wrong_type)),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: expected.clone(),
+                    actual: ValueType::Function(Box::new(wrong_type)),
+                }
+            )),
         );
 
         let expression = ModuleGenericFunctionExpr::tuple_index(
@@ -533,10 +548,12 @@ pub fn main() { get(Box(diverge)) }
         );
         assert_eq!(
             crate::run_main(&never_function_plan(expression, Vec::new())),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected,
-                actual: ValueType::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected,
+                    actual: ValueType::Int,
+                }
+            )),
         );
     }
 

--- a/src/runtime/expression/function/nil.rs
+++ b/src/runtime/expression/function/nil.rs
@@ -11,6 +11,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFunctionValueKind, EvaluatedNilFunction, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_nil_function_expr(
@@ -73,9 +74,13 @@ pub(in crate::runtime) fn eval_nil_function_expr(
             match value {
                 EvaluatedValue::Function(function) => match function.kind() {
                     EvaluatedFunctionValueKind::Nil(value) => Ok(value.clone()),
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         NilFunctionExprKind::CustomField(access) => {
@@ -85,13 +90,17 @@ pub(in crate::runtime) fn eval_nil_function_expr(
                 EvaluatedFunctionValueKind::Nil(value) => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: ValueType::Function(Box::new(plan.function_type(function.type_()))),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: ValueType::Function(Box::new(
+                                plan.function_type(function.type_()),
+                            )),
+                        },
+                    ))
                 }
             }
         }
@@ -100,10 +109,12 @@ pub(in crate::runtime) fn eval_nil_function_expr(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::Nil(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::Nil,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::Nil,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         NilFunctionExprKind::Panic(panic) => {

--- a/src/runtime/expression/function/returning_function.rs
+++ b/src/runtime/expression/function/returning_function.rs
@@ -13,6 +13,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFunctionFunction, EvaluatedFunctionValueKind, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_function_function_expr(
@@ -86,9 +87,13 @@ pub(in crate::runtime) fn eval_function_function_expr_kind(
                     EvaluatedFunctionValueKind::Function(value) if actual == expected => {
                         Ok(value.clone())
                     }
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         FunctionFunctionExprKind::CustomField(access) => {
@@ -101,13 +106,15 @@ pub(in crate::runtime) fn eval_function_function_expr_kind(
                 }
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual,
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual,
+                        },
+                    ))
                 }
             }
         }
@@ -117,10 +124,12 @@ pub(in crate::runtime) fn eval_function_function_expr_kind(
                 project_function_list_expr(plan, state, frame, list, *index, &public_type)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::Function(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::Function,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::Function,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         FunctionFunctionExprKind::Panic(panic) => {
@@ -192,7 +201,7 @@ mod tests {
         IntLocalId, ListExpr, ModulePlan, PanicExpr, PanicSite, Param, ParamLocal, ReturnExpr,
         Step, StringExpr, TupleExpr, ValueType,
     };
-    use crate::runtime::{ExecutionError, run_main};
+    use crate::runtime::{ExecutionError, InvariantError, run_main};
 
     #[test]
     fn source_function_function_expression_variants_evaluate_exact_values() {
@@ -378,10 +387,10 @@ pub fn main() {
 
         assert_eq!(
             run_module_function_function_expression(expression),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::Function(Box::new(expected_type.to_function_type())),
                 actual: ValueType::Function(Box::new(actual_type.to_function_type())),
-            },
+            }),
         );
     }
 

--- a/src/runtime/expression/function/string.rs
+++ b/src/runtime/expression/function/string.rs
@@ -11,6 +11,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFunctionValueKind, EvaluatedStringFunction, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_string_function_expr(
@@ -73,9 +74,13 @@ pub(in crate::runtime) fn eval_string_function_expr(
             match value {
                 EvaluatedValue::Function(function) => match function.kind() {
                     EvaluatedFunctionValueKind::String(value) => Ok(value.clone()),
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         StringFunctionExprKind::CustomField(access) => {
@@ -85,13 +90,17 @@ pub(in crate::runtime) fn eval_string_function_expr(
                 EvaluatedFunctionValueKind::String(value) => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: ValueType::Function(Box::new(plan.function_type(function.type_()))),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: ValueType::Function(Box::new(
+                                plan.function_type(function.type_()),
+                            )),
+                        },
+                    ))
                 }
             }
         }
@@ -100,10 +109,12 @@ pub(in crate::runtime) fn eval_string_function_expr(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::String(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::String,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::String,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         StringFunctionExprKind::Panic(panic) => {

--- a/src/runtime/expression/function/tuple.rs
+++ b/src/runtime/expression/function/tuple.rs
@@ -11,6 +11,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFunctionValueKind, EvaluatedTupleFunction, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_tuple_function_expr(
@@ -69,15 +70,19 @@ pub(in crate::runtime) fn eval_tuple_function_expr(
             )? {
                 EvaluatedValue::Function(function) => match function.kind() {
                     crate::runtime::EvaluatedFunctionValueKind::Tuple(value) => Ok(value.clone()),
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch {
-                        expected: ValueType::Function(Box::new(plan.function_type(type_))),
-                        actual: EvaluatedValue::Function(function).value_type(plan),
-                    }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch {
+                            expected: ValueType::Function(Box::new(plan.function_type(type_))),
+                            actual: EvaluatedValue::Function(function).value_type(plan),
+                        },
+                    )),
                 },
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::Function(Box::new(plan.function_type(type_))),
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::Function(Box::new(plan.function_type(type_))),
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         TupleFunctionExprKind::CustomField(access) => {
@@ -87,13 +92,17 @@ pub(in crate::runtime) fn eval_tuple_function_expr(
                 EvaluatedFunctionValueKind::Tuple(value) => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: ValueType::Function(Box::new(plan.function_type(function.type_()))),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: ValueType::Function(Box::new(
+                                plan.function_type(function.type_()),
+                            )),
+                        },
+                    ))
                 }
             }
         }
@@ -102,10 +111,12 @@ pub(in crate::runtime) fn eval_tuple_function_expr(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::Tuple(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::Tuple,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::Tuple,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         TupleFunctionExprKind::Panic(panic) => {

--- a/src/runtime/expression/function/utf_codepoint.rs
+++ b/src/runtime/expression/function/utf_codepoint.rs
@@ -12,6 +12,7 @@ use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
 use crate::runtime::{
     EvaluatedFunctionValueKind, EvaluatedUtfCodepointFunction, EvaluatedValue, ExecutionError,
+    InvariantError,
 };
 
 pub(in crate::runtime) fn eval_utf_codepoint_function_expr(
@@ -80,9 +81,13 @@ pub(in crate::runtime) fn eval_utf_codepoint_function_expr(
             match value {
                 EvaluatedValue::Function(function) => match function.kind() {
                     EvaluatedFunctionValueKind::UtfCodepoint(value) => Ok(value.clone()),
-                    _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                    _ => Err(ExecutionError::Invariant(
+                        InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                    )),
                 },
-                _ => Err(ExecutionError::TupleIndexFamilyMismatch { expected, actual }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch { expected, actual },
+                )),
             }
         }
         UtfCodepointFunctionExprKind::CustomField(access) => {
@@ -92,13 +97,17 @@ pub(in crate::runtime) fn eval_utf_codepoint_function_expr(
                 EvaluatedFunctionValueKind::UtfCodepoint(value) => Ok(value.clone()),
                 _ => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: ValueType::Function(Box::new(plan.function_type(function.type_()))),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: ValueType::Function(Box::new(
+                                plan.function_type(function.type_()),
+                            )),
+                        },
+                    ))
                 }
             }
         }
@@ -107,10 +116,12 @@ pub(in crate::runtime) fn eval_utf_codepoint_function_expr(
             let function = project_function_list_expr(plan, state, frame, list, *index, &type_)?;
             match function.kind() {
                 EvaluatedFunctionValueKind::UtfCodepoint(value) => Ok(value.clone()),
-                _ => Err(ExecutionError::FunctionReturnFamilyMismatch {
-                    expected: FunctionReturnFamily::UtfCodepoint,
-                    actual: function.kind().family(),
-                }),
+                _ => Err(ExecutionError::Invariant(
+                    InvariantError::FunctionReturnFamilyMismatch {
+                        expected: FunctionReturnFamily::UtfCodepoint,
+                        actual: function.kind().family(),
+                    },
+                )),
             }
         }
         UtfCodepointFunctionExprKind::Panic(panic) => {

--- a/src/runtime/expression/int.rs
+++ b/src/runtime/expression/int.rs
@@ -5,11 +5,11 @@ use super::{
 use crate::plan::ValueType;
 use crate::plan::execution::ExecutionPlan;
 use crate::plan::execution::{IntExpr, IntExprKind};
-use crate::runtime::ExecutionError;
 use crate::runtime::evaluated::EvaluatedValue;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
+use crate::runtime::{ExecutionError, InvariantError};
 use num_bigint::BigInt;
 
 pub(in crate::runtime) fn eval_int_expr(
@@ -37,10 +37,12 @@ pub(in crate::runtime) fn eval_int_expr(
         IntExprKind::TupleIndex { tuple, index } => {
             match project_tuple_expr(plan, state, frame, tuple, *index, ValueType::Int)? {
                 EvaluatedValue::Int(value) => Ok(value),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::Int,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::Int,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         IntExprKind::CustomField(access) => {
@@ -49,13 +51,15 @@ pub(in crate::runtime) fn eval_int_expr(
                 EvaluatedValue::Int(value) => Ok(value),
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected: ValueType::Int,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected: ValueType::Int,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }

--- a/src/runtime/expression/list.rs
+++ b/src/runtime/expression/list.rs
@@ -16,7 +16,6 @@ use crate::plan::execution::{
     UtfCodepointListItem,
 };
 use crate::plan::{FunctionType, ValueType};
-use crate::runtime::ExecutionError;
 use crate::runtime::evaluated::{
     EvaluatedBitArray, EvaluatedCustomValue, EvaluatedFunctionValue, EvaluatedValue,
 };
@@ -28,6 +27,7 @@ use crate::runtime::state::{
     ListValueId, NilListValueId, ParameterListListValueId, ParameterListValueId, RuntimeState,
     StoredListValueId, StringListValueId, TupleListValueId, UtfCodepointListValueId,
 };
+use crate::runtime::{ExecutionError, InvariantError};
 
 pub(in crate::runtime) fn eval_list_expr(
     plan: &ExecutionPlan,
@@ -169,14 +169,18 @@ fn eval_parameter_list_expr_kind(
             let expected = plan.list_value_type(item.type_id().list_type());
             match project_tuple_expr(plan, state, frame, tuple, *index, expected.clone())? {
                 EvaluatedValue::List(ListValueId::Parameter(value)) => Ok(value),
-                EvaluatedValue::List(value) => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected,
-                    actual: plan.list_value_type(value.list_type()),
-                }),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected,
-                    actual: other.value_type(plan),
-                }),
+                EvaluatedValue::List(value) => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected,
+                        actual: plan.list_value_type(value.list_type()),
+                    },
+                )),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         ParameterListExprKind::CustomField(access) => {
@@ -186,13 +190,15 @@ fn eval_parameter_list_expr_kind(
                 EvaluatedValue::List(ListValueId::Parameter(value)) => Ok(value),
                 value => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: value.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: value.value_type(plan),
+                        },
+                    ))
                 }
             }
         }
@@ -202,11 +208,13 @@ fn eval_parameter_list_expr_kind(
             if source.index() < length {
                 Ok(ParameterListValueId::new(item.type_id()))
             } else {
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: plan.list_value_type(item.type_id().list_type()),
-                    index: source.index(),
-                    length,
-                })
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: plan.list_value_type(item.type_id().list_type()),
+                        index: source.index(),
+                        length,
+                    },
+                ))
             }
         }
         ParameterListExprKind::Panic(panic) => {
@@ -424,13 +432,18 @@ fn eval_typed_list_expr_kind<Item: RuntimeListItem>(
                 EvaluatedValue::List(value) => {
                     let actual = plan.list_value_type(value.list_type());
                     Item::from_tuple_value(value).ok_or_else(|| {
-                        ExecutionError::TupleIndexFamilyMismatch { expected, actual }
+                        ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
+                            expected,
+                            actual,
+                        })
                     })
                 }
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         TypedListExprKind::CustomField(access) => {
@@ -441,24 +454,26 @@ fn eval_typed_list_expr_kind<Item: RuntimeListItem>(
                     let actual = plan.list_value_type(value.list_type());
                     Item::from_tuple_value(value).ok_or_else(|| {
                         let descriptor = plan.custom_constructor(constructor);
-                        ExecutionError::CustomFieldFamilyMismatch {
+                        ExecutionError::Invariant(InvariantError::CustomFieldFamilyMismatch {
                             custom_type: plan.custom_value_type(constructor.type_id()),
                             constructor: descriptor.name().clone(),
                             field_index: access.index(),
                             expected,
                             actual,
-                        }
+                        })
                     })
                 }
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }
@@ -469,10 +484,12 @@ fn eval_typed_list_expr_kind<Item: RuntimeListItem>(
                 .get(source.index())
                 .cloned()
                 .map(|value| Item::from_core(item, value.into_core()))
-                .ok_or_else(|| ExecutionError::ListIndexOutOfBounds {
-                    item_type: plan.list_value_type(item.list_type()),
-                    index: source.index(),
-                    length: values.len(),
+                .ok_or_else(|| {
+                    ExecutionError::Invariant(InvariantError::ListIndexOutOfBounds {
+                        item_type: plan.list_value_type(item.list_type()),
+                        index: source.index(),
+                        length: values.len(),
+                    })
                 })
         }
         TypedListExprKind::DropFirst { list, count } => {
@@ -1257,14 +1274,13 @@ macro_rules! project_primitive_list {
         ) -> Result<$value, ExecutionError> {
             let list = $eval(plan, state, frame, list)?;
             let values = state.$values(&list);
-            values
-                .get(index)
-                .$get()
-                .ok_or_else(|| ExecutionError::ListIndexOutOfBounds {
+            values.get(index).$get().ok_or_else(|| {
+                ExecutionError::Invariant(InvariantError::ListIndexOutOfBounds {
                     item_type: $expected,
                     index,
                     length: values.len(),
                 })
+            })
         }
     };
 }
@@ -1334,14 +1350,13 @@ pub(in crate::runtime) fn project_custom_list_expr(
 ) -> Result<EvaluatedCustomValue, ExecutionError> {
     let list = eval_custom_list_expr(plan, state, frame, list)?;
     let values = state.custom_values(&list);
-    values
-        .get(index)
-        .cloned()
-        .ok_or_else(|| ExecutionError::ListIndexOutOfBounds {
+    values.get(index).cloned().ok_or_else(|| {
+        ExecutionError::Invariant(InvariantError::ListIndexOutOfBounds {
             item_type: ValueType::Custom(plan.custom_value_type(item_type)),
             index,
             length: values.len(),
         })
+    })
 }
 
 pub(in crate::runtime) fn project_nil_list_expr(
@@ -1356,11 +1371,13 @@ pub(in crate::runtime) fn project_nil_list_expr(
     if index < len {
         Ok(())
     } else {
-        Err(ExecutionError::ListIndexOutOfBounds {
-            item_type: ValueType::Nil,
-            index,
-            length: len,
-        })
+        Err(ExecutionError::Invariant(
+            InvariantError::ListIndexOutOfBounds {
+                item_type: ValueType::Nil,
+                index,
+                length: len,
+            },
+        ))
     }
 }
 
@@ -1374,14 +1391,13 @@ pub(in crate::runtime) fn project_tuple_list_expr(
 ) -> Result<Vec<EvaluatedValue>, ExecutionError> {
     let list = eval_tuple_list_expr(plan, state, frame, list)?;
     let values = state.tuple_values(&list);
-    values
-        .get(index)
-        .cloned()
-        .ok_or_else(|| ExecutionError::ListIndexOutOfBounds {
+    values.get(index).cloned().ok_or_else(|| {
+        ExecutionError::Invariant(InvariantError::ListIndexOutOfBounds {
             item_type: ValueType::Tuple(item_type.to_vec()),
             index,
             length: values.len(),
         })
+    })
 }
 
 pub(in crate::runtime) fn project_function_list_expr(
@@ -1394,14 +1410,13 @@ pub(in crate::runtime) fn project_function_list_expr(
 ) -> Result<EvaluatedFunctionValue, ExecutionError> {
     let list = eval_function_list_expr(plan, state, frame, list)?;
     let values = state.function_values(&list);
-    values
-        .get(index)
-        .cloned()
-        .ok_or_else(|| ExecutionError::ListIndexOutOfBounds {
+    values.get(index).cloned().ok_or_else(|| {
+        ExecutionError::Invariant(InvariantError::ListIndexOutOfBounds {
             item_type: ValueType::Function(Box::new(item_type.clone())),
             index,
             length: values.len(),
         })
+    })
 }
 
 #[cfg(test)]
@@ -1430,7 +1445,7 @@ mod tests {
     };
     use crate::runtime::frame::Frame;
     use crate::runtime::{EvaluatedCustomValue, EvaluatedValue};
-    use crate::runtime::{ExecutionError, ListValue, RuntimeState, Value};
+    use crate::runtime::{ExecutionError, InvariantError, ListValue, RuntimeState, Value};
 
     #[test]
     fn source_bool_cases_select_false_branches_for_every_list_storage_family() {
@@ -1530,10 +1545,12 @@ pub fn main() {
 
         assert_eq!(
             crate::run_main(&generic_list_plan(expression)),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: expected.clone(),
-                actual: ValueType::List(Box::new(ValueType::Int)),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: expected.clone(),
+                    actual: ValueType::List(Box::new(ValueType::Int)),
+                }
+            )),
         );
 
         let expression = ModuleListExpr::tuple_index(
@@ -1548,10 +1565,12 @@ pub fn main() {
         .expect("parameter list tuple projection should retain its generic item");
         assert_eq!(
             crate::run_main(&generic_list_plan(expression)),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected,
-                actual: ValueType::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected,
+                    actual: ValueType::Int,
+                }
+            )),
         );
     }
 
@@ -1570,11 +1589,13 @@ pub fn main() {
 
         assert_eq!(
             crate::run_main(&generic_list_plan(expression)),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::List(Box::new(ValueType::Parameter(parameter))),
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::List(Box::new(ValueType::Parameter(parameter))),
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
     }
 
@@ -1620,13 +1641,15 @@ pub fn main() {
 
         assert_eq!(
             super::eval_parameter_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: plan.custom_value_type(construction.constructor().type_id()),
-                constructor: descriptor.name().clone(),
-                field_index: access.index(),
-                expected: plan.list_value_type(expression.item().type_id().list_type()),
-                actual: ValueType::List(Box::new(ValueType::Int)),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: plan.custom_value_type(construction.constructor().type_id()),
+                    constructor: descriptor.name().clone(),
+                    field_index: access.index(),
+                    expected: plan.list_value_type(expression.item().type_id().list_type()),
+                    actual: ValueType::List(Box::new(ValueType::Int)),
+                }
+            )),
         );
     }
 
@@ -1782,11 +1805,13 @@ pub fn main() {
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             project_int_list_expr(&plan, &mut state, &mut frame, expression, 0),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::Int,
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::Int,
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
 
         let function = plan.string_list_function(plan.string_list_function_id(0));
@@ -1794,11 +1819,13 @@ pub fn main() {
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             project_string_list_expr(&plan, &mut state, &mut frame, expression, 0),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::String,
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::String,
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
 
         let function = plan.bit_array_list_function(plan.bit_array_list_function_id(0));
@@ -1806,11 +1833,13 @@ pub fn main() {
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             project_bit_array_list_expr(&plan, &mut state, &mut frame, expression, 0),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::BitArray,
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::BitArray,
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
 
         let function = plan.utf_codepoint_list_function(plan.utf_codepoint_list_function_id(0));
@@ -1818,11 +1847,13 @@ pub fn main() {
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             project_utf_codepoint_list_expr(&plan, &mut state, &mut frame, expression, 0),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::UtfCodepoint,
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::UtfCodepoint,
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
 
         let function = plan.custom_list_function(plan.custom_list_function_id(0));
@@ -1831,11 +1862,13 @@ pub fn main() {
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             project_custom_list_expr(&plan, &mut state, &mut frame, expression, 0, item_type,),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::Custom(plan.custom_value_type(item_type)),
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::Custom(plan.custom_value_type(item_type)),
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
 
         let function = plan.float_list_function(plan.float_list_function_id(0));
@@ -1843,11 +1876,13 @@ pub fn main() {
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             project_float_list_expr(&plan, &mut state, &mut frame, expression, 0),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::Float,
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::Float,
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
 
         let function = plan.bool_list_function(plan.bool_list_function_id(0));
@@ -1855,11 +1890,13 @@ pub fn main() {
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             project_bool_list_expr(&plan, &mut state, &mut frame, expression, 0),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::Bool,
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::Bool,
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
 
         let function = plan.nil_list_function(plan.nil_list_function_id(0));
@@ -1867,11 +1904,13 @@ pub fn main() {
         let mut frame = Frame::new(function.frame_layout(), &mut state);
         assert_eq!(
             project_nil_list_expr(&plan, &mut state, &mut frame, expression, 0),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::Nil,
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::Nil,
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
 
         let function = plan.tuple_list_function(plan.tuple_list_function_id(0));
@@ -1886,11 +1925,13 @@ pub fn main() {
                 0,
                 &[ValueType::Int],
             ),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::Tuple(vec![ValueType::Int]),
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::Tuple(vec![ValueType::Int]),
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
 
         let function = plan.function_list_function(plan.function_list_function_id(0));
@@ -1906,11 +1947,13 @@ pub fn main() {
                 0,
                 &function_type,
             ),
-            Err(ExecutionError::ListIndexOutOfBounds {
-                item_type: ValueType::Function(Box::new(function_type)),
-                index: 0,
-                length: 0,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::ListIndexOutOfBounds {
+                    item_type: ValueType::Function(Box::new(function_type)),
+                    index: 0,
+                    length: 0,
+                }
+            )),
         );
     }
 
@@ -2095,10 +2138,12 @@ pub fn main() {
 
         assert_eq!(
             super::eval_int_list_expr(&plan, &mut state, &mut frame, expression),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::List(Box::new(ValueType::Int)),
-                actual: ValueType::List(Box::new(ValueType::String)),
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::List(Box::new(ValueType::Int)),
+                    actual: ValueType::List(Box::new(ValueType::String)),
+                }
+            )),
         );
     }
 
@@ -2643,115 +2688,145 @@ pub fn main() {
         match expression {
             crate::plan::execution::ListLocalExpr::Parameter { value, .. } => assert_eq!(
                 super::eval_parameter_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::Parameter(
-                        value.item().type_id().item(),
-                    ))),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::Parameter(
+                            value.item().type_id().item(),
+                        ))),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::Int { value, .. } => assert_eq!(
                 super::eval_int_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::Int)),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::Int)),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::String { value, .. } => assert_eq!(
                 super::eval_string_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::String)),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::String)),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::BitArray { value, .. } => assert_eq!(
                 super::eval_bit_array_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::BitArray)),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::BitArray)),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::UtfCodepoint { value, .. } => assert_eq!(
                 super::eval_utf_codepoint_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::UtfCodepoint)),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::UtfCodepoint)),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::Custom { value, .. } => assert_eq!(
                 super::eval_custom_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::Custom(
-                        plan.custom_value_type(value.item().type_id().item_type()),
-                    ))),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::Custom(
+                            plan.custom_value_type(value.item().type_id().item_type()),
+                        ))),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::Float { value, .. } => assert_eq!(
                 super::eval_float_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::Float)),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::Float)),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::Bool { value, .. } => assert_eq!(
                 super::eval_bool_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::Bool)),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::Bool)),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::Nil { value, .. } => assert_eq!(
                 super::eval_nil_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::Nil)),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::Nil)),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::Tuple { value, .. } => assert_eq!(
                 super::eval_tuple_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::Tuple(vec![ValueType::Int]))),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::Tuple(vec![
+                            ValueType::Int
+                        ]))),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::ParameterList { value, .. } => assert_eq!(
                 super::eval_parameter_list_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::List(Box::new(
-                        ValueType::Parameter(value.item().type_id().item_type().item()),
-                    )))),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::List(Box::new(
+                            ValueType::Parameter(value.item().type_id().item_type().item()),
+                        )))),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::List { value, .. } => assert_eq!(
                 super::eval_list_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::List(Box::new(ValueType::Int)))),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::List(Box::new(
+                            ValueType::Int
+                        )))),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
             crate::plan::execution::ListLocalExpr::Function { value, .. } => assert_eq!(
                 super::eval_function_list_expr(plan, state, frame, value),
-                Err(ExecutionError::ListIndexOutOfBounds {
-                    item_type: ValueType::List(Box::new(ValueType::Function(Box::new(
-                        FunctionType::new(Vec::new(), ValueType::Int),
-                    )))),
-                    index: 0,
-                    length: 0,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::ListIndexOutOfBounds {
+                        item_type: ValueType::List(Box::new(ValueType::Function(Box::new(
+                            FunctionType::new(Vec::new(), ValueType::Int),
+                        )))),
+                        index: 0,
+                        length: 0,
+                    }
+                )),
             ),
         }
     }

--- a/src/runtime/expression/nil.rs
+++ b/src/runtime/expression/nil.rs
@@ -5,11 +5,11 @@ use super::{
 use crate::plan::ValueType;
 use crate::plan::execution::ExecutionPlan;
 use crate::plan::execution::{NilExpr, NilExprKind};
-use crate::runtime::ExecutionError;
 use crate::runtime::evaluated::EvaluatedValue;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
+use crate::runtime::{ExecutionError, InvariantError};
 
 pub(in crate::runtime) fn eval_nil_expr(
     plan: &ExecutionPlan,
@@ -39,10 +39,12 @@ pub(in crate::runtime) fn eval_nil_expr(
         NilExprKind::TupleIndex { tuple, index } => {
             match project_tuple_expr(plan, state, frame, tuple, *index, ValueType::Nil)? {
                 EvaluatedValue::Nil => Ok(()),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::Nil,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::Nil,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         NilExprKind::CustomField(access) => {
@@ -51,13 +53,15 @@ pub(in crate::runtime) fn eval_nil_expr(
                 EvaluatedValue::Nil => Ok(()),
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected: ValueType::Nil,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected: ValueType::Nil,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }

--- a/src/runtime/expression/string.rs
+++ b/src/runtime/expression/string.rs
@@ -5,11 +5,11 @@ use super::{
 use crate::plan::ValueType;
 use crate::plan::execution::ExecutionPlan;
 use crate::plan::execution::{StringExpr, StringExprKind};
-use crate::runtime::ExecutionError;
 use crate::runtime::evaluated::EvaluatedValue;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
+use crate::runtime::{ExecutionError, InvariantError};
 use ecow::EcoString;
 
 pub(in crate::runtime) fn eval_string_expr(
@@ -37,10 +37,12 @@ pub(in crate::runtime) fn eval_string_expr(
         StringExprKind::TupleIndex { tuple, index } => {
             match project_tuple_expr(plan, state, frame, tuple, *index, ValueType::String)? {
                 EvaluatedValue::String(value) => Ok(value),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::String,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::String,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         StringExprKind::CustomField(access) => {
@@ -49,13 +51,15 @@ pub(in crate::runtime) fn eval_string_expr(
                 EvaluatedValue::String(value) => Ok(value),
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected: ValueType::String,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected: ValueType::String,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }

--- a/src/runtime/expression/tuple.rs
+++ b/src/runtime/expression/tuple.rs
@@ -5,11 +5,11 @@ use super::{
 use crate::plan::ValueType;
 use crate::plan::execution::ExecutionPlan;
 use crate::plan::execution::{TupleExpr, TupleExprKind};
-use crate::runtime::ExecutionError;
 use crate::runtime::evaluated::EvaluatedValue;
 use crate::runtime::frame::Frame;
 use crate::runtime::function;
 use crate::runtime::state::RuntimeState;
+use crate::runtime::{ExecutionError, InvariantError};
 
 pub(in crate::runtime) fn eval_tuple_expr(
     plan: &ExecutionPlan,
@@ -53,10 +53,12 @@ pub(in crate::runtime) fn eval_tuple_expr(
             );
             match project_tuple_expr(plan, state, frame, tuple, *index, expected.clone())? {
                 EvaluatedValue::Tuple(values) => Ok(values),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         TupleExprKind::CustomField(access) => {
@@ -72,13 +74,15 @@ pub(in crate::runtime) fn eval_tuple_expr(
                 EvaluatedValue::Tuple(value) => Ok(value),
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }
@@ -160,10 +164,14 @@ pub(in crate::runtime) fn project_tuple_expr(
 ) -> Result<EvaluatedValue, ExecutionError> {
     let values = eval_tuple_expr(plan, state, frame, tuple)?;
     let Some(value) = values.get(index).cloned() else {
-        return Err(ExecutionError::TupleIndexFamilyMismatch {
-            expected,
-            actual: ValueType::Tuple(values.iter().map(|value| value.value_type(plan)).collect()),
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::TupleIndexFamilyMismatch {
+                expected,
+                actual: ValueType::Tuple(
+                    values.iter().map(|value| value.value_type(plan)).collect(),
+                ),
+            },
+        ));
     };
     Ok(value)
 }
@@ -174,7 +182,7 @@ mod tests {
         BoolExpr, Expr, FloatExpr, FunctionTemplate, FunctionTemplateId, IntExpr, ModulePlan,
         PanicExpr, PanicSite, ReturnExpr, Step, StringExpr, TupleExpr, TupleFunctionId, ValueType,
     };
-    use crate::runtime::{ExecutionError, run_main};
+    use crate::runtime::{ExecutionError, InvariantError, run_main};
 
     #[test]
     fn source_tuple_expression_variants_evaluate_exact_values() {
@@ -296,10 +304,10 @@ pub fn main() -> #(Int) {{ {expression} }}
 
         assert_eq!(
             run_module_tuple_expression(expression),
-            ExecutionError::TupleIndexFamilyMismatch {
+            ExecutionError::Invariant(InvariantError::TupleIndexFamilyMismatch {
                 expected: ValueType::Tuple(vec![ValueType::Int]),
                 actual: ValueType::Tuple(vec![ValueType::List(Box::new(ValueType::Int))]),
-            },
+            }),
         );
     }
 

--- a/src/runtime/expression/utf_codepoint.rs
+++ b/src/runtime/expression/utf_codepoint.rs
@@ -7,7 +7,7 @@ use crate::plan::execution::{ExecutionPlan, UtfCodepointExpr, UtfCodepointExprKi
 use crate::runtime::evaluated::EvaluatedValue;
 use crate::runtime::frame::Frame;
 use crate::runtime::state::RuntimeState;
-use crate::runtime::{ExecutionError, function};
+use crate::runtime::{ExecutionError, InvariantError, function};
 
 pub(in crate::runtime) fn eval_utf_codepoint_expr(
     plan: &ExecutionPlan,
@@ -36,10 +36,12 @@ pub(in crate::runtime) fn eval_utf_codepoint_expr(
         UtfCodepointExprKind::TupleIndex { tuple, index } => {
             match project_tuple_expr(plan, state, frame, tuple, *index, ValueType::UtfCodepoint)? {
                 EvaluatedValue::UtfCodepoint(value) => Ok(value),
-                other => Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::UtfCodepoint,
-                    actual: other.value_type(plan),
-                }),
+                other => Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::UtfCodepoint,
+                        actual: other.value_type(plan),
+                    },
+                )),
             }
         }
         UtfCodepointExprKind::CustomField(access) => {
@@ -48,13 +50,15 @@ pub(in crate::runtime) fn eval_utf_codepoint_expr(
                 EvaluatedValue::UtfCodepoint(value) => Ok(value),
                 other => {
                     let descriptor = plan.custom_constructor(constructor);
-                    Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index: access.index(),
-                        expected: ValueType::UtfCodepoint,
-                        actual: other.value_type(plan),
-                    })
+                    Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index: access.index(),
+                            expected: ValueType::UtfCodepoint,
+                            actual: other.value_type(plan),
+                        },
+                    ))
                 }
             }
         }

--- a/src/runtime/function.rs
+++ b/src/runtime/function.rs
@@ -37,7 +37,7 @@ use crate::runtime::{
     EvaluatedCustomValue, EvaluatedFloatFunction, EvaluatedFunctionFunction,
     EvaluatedFunctionValue, EvaluatedGenericFunction, EvaluatedIntFunction, EvaluatedListFunction,
     EvaluatedNeverFunction, EvaluatedNilFunction, EvaluatedStringFunction, EvaluatedTupleFunction,
-    EvaluatedUtfCodepointFunction, EvaluatedValue, ExecutionError, Value,
+    EvaluatedUtfCodepointFunction, EvaluatedValue, ExecutionError, InvariantError, Value,
 };
 use bind::{bind_arguments, bind_function_value_arguments};
 use ecow::EcoString;
@@ -746,10 +746,12 @@ pub(in crate::runtime) fn run_int_list_function_call(
 ) -> ExecutionResult<IntListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::Int(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -771,10 +773,12 @@ pub(in crate::runtime) fn run_parameter_list_function_call(
 ) -> ExecutionResult<ParameterListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::Parameter(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -796,10 +800,12 @@ pub(in crate::runtime) fn run_string_list_function_call(
 ) -> ExecutionResult<StringListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::String(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -821,10 +827,12 @@ pub(in crate::runtime) fn run_bit_array_list_function_call(
 ) -> ExecutionResult<BitArrayListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::BitArray(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -846,10 +854,12 @@ pub(in crate::runtime) fn run_utf_codepoint_list_function_call(
 ) -> ExecutionResult<UtfCodepointListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::UtfCodepoint(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -871,10 +881,12 @@ pub(in crate::runtime) fn run_custom_list_function_call(
 ) -> ExecutionResult<CustomListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::Custom(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -896,10 +908,12 @@ pub(in crate::runtime) fn run_float_list_function_call(
 ) -> ExecutionResult<FloatListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::Float(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -921,10 +935,12 @@ pub(in crate::runtime) fn run_bool_list_function_call(
 ) -> ExecutionResult<BoolListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::Bool(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -946,10 +962,12 @@ pub(in crate::runtime) fn run_nil_list_function_call(
 ) -> ExecutionResult<NilListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::Nil(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -971,10 +989,12 @@ pub(in crate::runtime) fn run_tuple_list_function_call(
 ) -> ExecutionResult<TupleListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::Tuple(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -996,10 +1016,12 @@ pub(in crate::runtime) fn run_list_list_function_call(
 ) -> ExecutionResult<ListListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::List(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -1021,10 +1043,12 @@ pub(in crate::runtime) fn run_parameter_list_list_function_call(
 ) -> ExecutionResult<ParameterListListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::ParameterList(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -1046,10 +1070,12 @@ pub(in crate::runtime) fn run_function_list_function_call(
 ) -> ExecutionResult<FunctionListValueId> {
     let function = eval_list_function_expr(plan, state, caller_frame, function)?;
     let ListFunctionId::Function(runtime_id) = function.runtime_id() else {
-        return Err(ExecutionError::FunctionReturnFamilyMismatch {
-            expected: FunctionReturnFamily::List,
-            actual: FunctionReturnFamily::List,
-        });
+        return Err(ExecutionError::Invariant(
+            InvariantError::FunctionReturnFamilyMismatch {
+                expected: FunctionReturnFamily::List,
+                actual: FunctionReturnFamily::List,
+            },
+        ));
     };
     let frame = bind_function_value_arguments(
         plan,
@@ -1314,12 +1340,12 @@ pub(in crate::runtime) fn run_int_function_function_call(
 ) -> ExecutionResult<EvaluatedIntFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .int()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.int().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::Int,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let runtime_function = plan.int_function_function(function_id);
     let frame_layout = runtime_function.frame_layout();
     let frame = bind_function_value_arguments(
@@ -1342,12 +1368,12 @@ pub(in crate::runtime) fn run_generic_function_function_call(
 ) -> ExecutionResult<EvaluatedGenericFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .generic()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.generic().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::Generic,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let frame_layout = plan.generic_function_function(&function_id).frame_layout();
     let frame = bind_function_value_arguments(
         plan,
@@ -1369,12 +1395,12 @@ pub(in crate::runtime) fn run_never_function_function_call(
 ) -> ExecutionResult<EvaluatedNeverFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .never()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.never().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::Never,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let frame_layout = plan.never_function_function(&function_id).frame_layout();
     let frame = bind_function_value_arguments(
         plan,
@@ -1396,12 +1422,12 @@ pub(in crate::runtime) fn run_float_function_function_call(
 ) -> ExecutionResult<EvaluatedFloatFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .float()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.float().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::Float,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let runtime_function = plan.float_function_function(function_id);
     let frame_layout = runtime_function.frame_layout();
     let frame = bind_function_value_arguments(
@@ -1424,12 +1450,12 @@ pub(in crate::runtime) fn run_string_function_function_call(
 ) -> ExecutionResult<EvaluatedStringFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .string()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.string().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::String,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let runtime_function = plan.string_function_function(function_id);
     let frame_layout = runtime_function.frame_layout();
     let frame = bind_function_value_arguments(
@@ -1452,13 +1478,12 @@ pub(in crate::runtime) fn run_bit_array_function_function_call(
 ) -> ExecutionResult<EvaluatedBitArrayFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id =
-        runtime_id
-            .bit_array()
-            .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::BitArray,
-                actual: runtime_id.family(),
-            })?;
+    let function_id = runtime_id.bit_array().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
+            expected: FunctionReturnFamily::BitArray,
+            actual: runtime_id.family(),
+        },
+    ))?;
     let runtime_function = plan.bit_array_function_function(function_id);
     let frame = bind_function_value_arguments(
         plan,
@@ -1480,13 +1505,12 @@ pub(in crate::runtime) fn run_utf_codepoint_function_function_call(
 ) -> ExecutionResult<EvaluatedUtfCodepointFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id =
-        runtime_id
-            .utf_codepoint()
-            .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::UtfCodepoint,
-                actual: runtime_id.family(),
-            })?;
+    let function_id = runtime_id.utf_codepoint().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
+            expected: FunctionReturnFamily::UtfCodepoint,
+            actual: runtime_id.family(),
+        },
+    ))?;
     let runtime_function = plan.utf_codepoint_function_function(function_id);
     let frame = bind_function_value_arguments(
         plan,
@@ -1508,12 +1532,12 @@ pub(in crate::runtime) fn run_custom_function_function_call(
 ) -> ExecutionResult<EvaluatedCustomFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .custom()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.custom().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::Custom,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let runtime_function = plan.custom_function_function(&function_id);
     let frame = bind_function_value_arguments(
         plan,
@@ -1535,12 +1559,12 @@ pub(in crate::runtime) fn run_bool_function_function_call(
 ) -> ExecutionResult<EvaluatedBoolFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .bool()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.bool().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::Bool,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let runtime_function = plan.bool_function_function(function_id);
     let frame_layout = runtime_function.frame_layout();
     let frame = bind_function_value_arguments(
@@ -1563,12 +1587,12 @@ pub(in crate::runtime) fn run_nil_function_function_call(
 ) -> ExecutionResult<EvaluatedNilFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .nil()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.nil().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::Nil,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let runtime_function = plan.nil_function_function(function_id);
     let frame_layout = runtime_function.frame_layout();
     let frame = bind_function_value_arguments(
@@ -1591,12 +1615,12 @@ pub(in crate::runtime) fn run_tuple_function_function_call(
 ) -> ExecutionResult<EvaluatedTupleFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .tuple()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.tuple().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::Tuple,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let runtime_function = plan.tuple_function_function(function_id);
     let frame_layout = runtime_function.frame_layout();
     let frame = bind_function_value_arguments(
@@ -1619,12 +1643,12 @@ pub(in crate::runtime) fn run_list_function_function_call(
 ) -> ExecutionResult<EvaluatedListFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id = runtime_id
-        .list()
-        .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
+    let function_id = runtime_id.list().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::List,
             actual: runtime_id.family(),
-        })?;
+        },
+    ))?;
     let runtime_function = plan.list_function_function(&function_id);
     let frame_layout = runtime_function.frame_layout();
     let frame = bind_function_value_arguments(
@@ -1647,13 +1671,12 @@ pub(in crate::runtime) fn run_function_function_function_call(
 ) -> ExecutionResult<EvaluatedFunctionFunction> {
     let function = eval_function_function_expr(plan, state, caller_frame, function)?;
     let runtime_id = function.runtime_id();
-    let function_id =
-        runtime_id
-            .function()
-            .ok_or(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Function,
-                actual: runtime_id.family(),
-            })?;
+    let function_id = runtime_id.function().ok_or(ExecutionError::Invariant(
+        InvariantError::FunctionReturnFamilyMismatch {
+            expected: FunctionReturnFamily::Function,
+            actual: runtime_id.family(),
+        },
+    ))?;
     let runtime_function = plan.function_function_function(&function_id);
     let frame_layout = runtime_function.frame_layout();
     let frame = bind_function_value_arguments(
@@ -1763,7 +1786,7 @@ mod tests {
     };
     use crate::runtime::FunctionValueKind;
     use crate::runtime::frame::Frame;
-    use crate::runtime::{ExecutionError, Value, run_main};
+    use crate::runtime::{ExecutionError, InvariantError, Value, run_main};
 
     #[test]
     fn source_utf_codepoint_list_function_calls_return_values_and_argument_errors() {
@@ -2127,10 +2150,10 @@ pub fn main() {
                 ),
             ),
         );
-        let expected = ExecutionError::FunctionReturnFamilyMismatch {
+        let expected = ExecutionError::Invariant(InvariantError::FunctionReturnFamilyMismatch {
             expected: FunctionReturnFamily::List,
             actual: FunctionReturnFamily::List,
-        };
+        });
 
         let function = plan.int_list_function(plan.int_list_function_id(0));
         let mut state = crate::runtime::RuntimeState::new();
@@ -2418,10 +2441,12 @@ pub fn main() {
         frame.set_function_function(&local, wrong_string);
         assert_eq!(
             run_int_function_loop(&plan, &mut state, IntFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Int,
-                actual: FunctionReturnFamily::String,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Int,
+                    actual: FunctionReturnFamily::String,
+                }
+            )),
         );
 
         let function = plan.string_function_function(StringFunctionFunctionId(0));
@@ -2431,10 +2456,12 @@ pub fn main() {
         frame.set_function_function(&local, wrong_int.clone());
         assert_eq!(
             run_string_function_loop(&plan, &mut state, StringFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::String,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::String,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function =
@@ -2450,10 +2477,12 @@ pub fn main() {
                 crate::plan::execution::BitArrayFunctionFunctionId(0),
                 frame,
             ),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::BitArray,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::BitArray,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.utf_codepoint_function_function(UtfCodepointFunctionFunctionId(0));
@@ -2468,10 +2497,12 @@ pub fn main() {
                 UtfCodepointFunctionFunctionId(0),
                 frame,
             ),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::UtfCodepoint,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::UtfCodepoint,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.custom_function_function(&custom_function_id);
@@ -2481,10 +2512,12 @@ pub fn main() {
         frame.set_function_function(&local, wrong_int.clone());
         assert_eq!(
             run_custom_function_loop(&plan, &mut state, custom_function_id.clone(), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Custom,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Custom,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.float_function_function(FloatFunctionFunctionId(0));
@@ -2494,10 +2527,12 @@ pub fn main() {
         frame.set_function_function(&local, wrong_int.clone());
         assert_eq!(
             run_float_function_loop(&plan, &mut state, FloatFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Float,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Float,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.bool_function_function(BoolFunctionFunctionId(0));
@@ -2507,10 +2542,12 @@ pub fn main() {
         frame.set_function_function(&local, wrong_int.clone());
         assert_eq!(
             run_bool_function_loop(&plan, &mut state, BoolFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Bool,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Bool,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.nil_function_function(NilFunctionFunctionId(0));
@@ -2520,10 +2557,12 @@ pub fn main() {
         frame.set_function_function(&local, wrong_int.clone());
         assert_eq!(
             run_nil_function_loop(&plan, &mut state, NilFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Nil,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Nil,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.tuple_function_function(TupleFunctionFunctionId(0));
@@ -2533,10 +2572,12 @@ pub fn main() {
         frame.set_function_function(&local, wrong_int.clone());
         assert_eq!(
             run_tuple_function_loop(&plan, &mut state, TupleFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Tuple,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Tuple,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.list_function_function(&list_function_id);
@@ -2546,10 +2587,12 @@ pub fn main() {
         frame.set_function_function(&local, wrong_int.clone());
         assert_eq!(
             run_list_function_loop(&plan, &mut state, list_function_id, frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::List,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::List,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.function_function_function(&function_function_id);
@@ -2559,10 +2602,12 @@ pub fn main() {
         frame.set_function_function(&local, wrong_int);
         assert_eq!(
             run_function_function_loop(&plan, &mut state, function_function_id.clone(), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Function,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Function,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
     }
 
@@ -2610,10 +2655,12 @@ pub fn main() { #(generic_function, never_function) }
         frame.set_function_function(&local, wrong_int.clone());
         assert_eq!(
             run_generic_function_loop(&plan, &mut state, generic_function_id, frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Generic,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Generic,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.never_function_function(&never_function_id);
@@ -2623,10 +2670,12 @@ pub fn main() { #(generic_function, never_function) }
         frame.set_function_function(&local, wrong_int);
         assert_eq!(
             run_never_function_loop(&plan, &mut state, never_function_id, frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Never,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Never,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
     }
 
@@ -2736,10 +2785,12 @@ pub fn main() {
         frame.set_function_list(FunctionListLocalId(0), value);
         assert_eq!(
             run_int_function_loop(&plan, &mut state, IntFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Int,
-                actual: FunctionReturnFamily::String,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Int,
+                    actual: FunctionReturnFamily::String,
+                }
+            )),
         );
 
         let function = plan.string_function_function(StringFunctionFunctionId(0));
@@ -2752,10 +2803,12 @@ pub fn main() {
         frame.set_function_list(FunctionListLocalId(0), value);
         assert_eq!(
             run_string_function_loop(&plan, &mut state, StringFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::String,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::String,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function =
@@ -2774,10 +2827,12 @@ pub fn main() {
                 crate::plan::execution::BitArrayFunctionFunctionId(0),
                 frame,
             ),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::BitArray,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::BitArray,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.utf_codepoint_function_function(UtfCodepointFunctionFunctionId(0));
@@ -2795,10 +2850,12 @@ pub fn main() {
                 UtfCodepointFunctionFunctionId(0),
                 frame,
             ),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::UtfCodepoint,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::UtfCodepoint,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.custom_function_function(&custom_function_id);
@@ -2811,10 +2868,12 @@ pub fn main() {
         frame.set_function_list(FunctionListLocalId(0), value);
         assert_eq!(
             run_custom_function_loop(&plan, &mut state, custom_function_id.clone(), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Custom,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Custom,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.float_function_function(FloatFunctionFunctionId(0));
@@ -2827,10 +2886,12 @@ pub fn main() {
         frame.set_function_list(FunctionListLocalId(0), value);
         assert_eq!(
             run_float_function_loop(&plan, &mut state, FloatFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Float,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Float,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.bool_function_function(BoolFunctionFunctionId(0));
@@ -2843,10 +2904,12 @@ pub fn main() {
         frame.set_function_list(FunctionListLocalId(0), value);
         assert_eq!(
             run_bool_function_loop(&plan, &mut state, BoolFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Bool,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Bool,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.nil_function_function(NilFunctionFunctionId(0));
@@ -2859,10 +2922,12 @@ pub fn main() {
         frame.set_function_list(FunctionListLocalId(0), value);
         assert_eq!(
             run_nil_function_loop(&plan, &mut state, NilFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Nil,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Nil,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.tuple_function_function(TupleFunctionFunctionId(0));
@@ -2875,10 +2940,12 @@ pub fn main() {
         frame.set_function_list(FunctionListLocalId(0), value);
         assert_eq!(
             run_tuple_function_loop(&plan, &mut state, TupleFunctionFunctionId(0), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Tuple,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Tuple,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.list_function_function(&list_function_id);
@@ -2891,10 +2958,12 @@ pub fn main() {
         frame.set_function_list(FunctionListLocalId(0), value);
         assert_eq!(
             run_list_function_loop(&plan, &mut state, list_function_id, frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::List,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::List,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
 
         let function = plan.function_function_function(&function_function_id);
@@ -2907,10 +2976,12 @@ pub fn main() {
         frame.set_function_list(FunctionListLocalId(0), value);
         assert_eq!(
             run_function_function_loop(&plan, &mut state, function_function_id.clone(), frame),
-            Err(ExecutionError::FunctionReturnFamilyMismatch {
-                expected: FunctionReturnFamily::Function,
-                actual: FunctionReturnFamily::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::FunctionReturnFamilyMismatch {
+                    expected: FunctionReturnFamily::Function,
+                    actual: FunctionReturnFamily::Int,
+                }
+            )),
         );
     }
 

--- a/src/runtime/function/bind.rs
+++ b/src/runtime/function/bind.rs
@@ -799,7 +799,7 @@ mod tests {
         UtfCodepointListLocalId, UtfCodepointLocalId, ValueShape, ValueType,
     };
     use crate::runtime::frame::Frame;
-    use crate::runtime::{EvaluatedValue, ExecutionError, run_main};
+    use crate::runtime::{EvaluatedValue, ExecutionError, InvariantError, run_main};
 
     #[test]
     fn source_arguments_and_captures_preserve_every_value_family() {
@@ -1081,10 +1081,12 @@ pub fn main() { caller }
 
             assert_eq!(
                 super::super::return_body::run_nil_loop(&plan, &mut state, function_id, frame,),
-                Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::Function(Box::new(expected_function_type)),
-                    actual: ValueType::Int,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::Function(Box::new(expected_function_type)),
+                        actual: ValueType::Int,
+                    }
+                )),
             );
         }
     }
@@ -1131,10 +1133,12 @@ pub fn main() { caller }
 
             assert_eq!(
                 super::super::return_body::run_nil_loop(&plan, &mut state, function_id, frame,),
-                Err(ExecutionError::TupleIndexFamilyMismatch {
-                    expected: ValueType::Function(Box::new(expected_function_type)),
-                    actual: ValueType::Int,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::TupleIndexFamilyMismatch {
+                        expected: ValueType::Function(Box::new(expected_function_type)),
+                        actual: ValueType::Int,
+                    }
+                )),
             );
         }
     }

--- a/src/runtime/function/steps.rs
+++ b/src/runtime/function/steps.rs
@@ -33,7 +33,7 @@ use crate::runtime::{
     EvaluatedNilFunction, EvaluatedStringFunction, EvaluatedTupleFunction,
     EvaluatedUtfCodepointFunction, EvaluatedValue,
 };
-use crate::runtime::{ExecutionError, PanicKind};
+use crate::runtime::{ExecutionError, InvariantError, PanicKind};
 use ecow::EcoString;
 use num_bigint::BigInt;
 use std::convert::Infallible;
@@ -542,13 +542,15 @@ fn append_total_bindings(
         crate::plan::execution::TotalBindingPatternKind::Bind(binding) => {
             let Some(binding) = pending_binding(plan, binding, field_value) else {
                 let descriptor = plan.custom_constructor(constructor);
-                return Err(ExecutionError::CustomFieldFamilyMismatch {
-                    custom_type: plan.custom_value_type(constructor.type_id()),
-                    constructor: descriptor.name().clone(),
-                    field_index,
-                    expected: plan.value_type(pattern.type_()),
-                    actual: field_value.value_type(plan),
-                });
+                return Err(ExecutionError::Invariant(
+                    InvariantError::CustomFieldFamilyMismatch {
+                        custom_type: plan.custom_value_type(constructor.type_id()),
+                        constructor: descriptor.name().clone(),
+                        field_index,
+                        expected: plan.value_type(pattern.type_()),
+                        actual: field_value.value_type(plan),
+                    },
+                ));
             };
             bindings.push(binding);
         }
@@ -556,13 +558,15 @@ fn append_total_bindings(
         crate::plan::execution::TotalBindingPatternKind::Tuple(patterns) => {
             let EvaluatedValue::Tuple(values) = field_value else {
                 let descriptor = plan.custom_constructor(constructor);
-                return Err(ExecutionError::CustomFieldFamilyMismatch {
-                    custom_type: plan.custom_value_type(constructor.type_id()),
-                    constructor: descriptor.name().clone(),
-                    field_index,
-                    expected: plan.value_type(pattern.type_()),
-                    actual: field_value.value_type(plan),
-                });
+                return Err(ExecutionError::Invariant(
+                    InvariantError::CustomFieldFamilyMismatch {
+                        custom_type: plan.custom_value_type(constructor.type_id()),
+                        constructor: descriptor.name().clone(),
+                        field_index,
+                        expected: plan.value_type(pattern.type_()),
+                        actual: field_value.value_type(plan),
+                    },
+                ));
             };
             for (pattern, value) in patterns.iter().zip(values) {
                 append_total_bindings(plan, constructor, field_index, value, pattern, bindings)?;
@@ -572,24 +576,28 @@ fn append_total_bindings(
             if let ListAssertTail::Bind(binding) = tail {
                 let EvaluatedValue::List(value) = field_value else {
                     let descriptor = plan.custom_constructor(constructor);
-                    return Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index,
-                        expected: plan.value_type(pattern.type_()),
-                        actual: field_value.value_type(plan),
-                    });
+                    return Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index,
+                            expected: plan.value_type(pattern.type_()),
+                            actual: field_value.value_type(plan),
+                        },
+                    ));
                 };
                 let Some(binding) = pending_list_binding(binding.local().clone(), value.clone())
                 else {
                     let descriptor = plan.custom_constructor(constructor);
-                    return Err(ExecutionError::CustomFieldFamilyMismatch {
-                        custom_type: plan.custom_value_type(constructor.type_id()),
-                        constructor: descriptor.name().clone(),
-                        field_index,
-                        expected: plan.value_type(pattern.type_()),
-                        actual: field_value.value_type(plan),
-                    });
+                    return Err(ExecutionError::Invariant(
+                        InvariantError::CustomFieldFamilyMismatch {
+                            custom_type: plan.custom_value_type(constructor.type_id()),
+                            constructor: descriptor.name().clone(),
+                            field_index,
+                            expected: plan.value_type(pattern.type_()),
+                            actual: field_value.value_type(plan),
+                        },
+                    ));
                 };
                 bindings.push(PendingBinding::List(binding));
             }
@@ -597,13 +605,15 @@ fn append_total_bindings(
         crate::plan::execution::TotalBindingPatternKind::Custom(custom_pattern) => {
             let EvaluatedValue::Custom(value) = field_value else {
                 let descriptor = plan.custom_constructor(constructor);
-                return Err(ExecutionError::CustomFieldFamilyMismatch {
-                    custom_type: plan.custom_value_type(constructor.type_id()),
-                    constructor: descriptor.name().clone(),
-                    field_index,
-                    expected: plan.value_type(pattern.type_()),
-                    actual: field_value.value_type(plan),
-                });
+                return Err(ExecutionError::Invariant(
+                    InvariantError::CustomFieldFamilyMismatch {
+                        custom_type: plan.custom_value_type(constructor.type_id()),
+                        constructor: descriptor.name().clone(),
+                        field_index,
+                        expected: plan.value_type(pattern.type_()),
+                        actual: field_value.value_type(plan),
+                    },
+                ));
             };
             append_custom_field_bindings(plan, custom_pattern, value, bindings)?;
         }
@@ -614,13 +624,15 @@ fn append_total_bindings(
             append_total_bindings(plan, constructor, field_index, field_value, inner, bindings)?;
             let Some(binding) = pending_binding(plan, binding, field_value) else {
                 let descriptor = plan.custom_constructor(constructor);
-                return Err(ExecutionError::CustomFieldFamilyMismatch {
-                    custom_type: plan.custom_value_type(constructor.type_id()),
-                    constructor: descriptor.name().clone(),
-                    field_index,
-                    expected: plan.value_type(pattern.type_()),
-                    actual: field_value.value_type(plan),
-                });
+                return Err(ExecutionError::Invariant(
+                    InvariantError::CustomFieldFamilyMismatch {
+                        custom_type: plan.custom_value_type(constructor.type_id()),
+                        constructor: descriptor.name().clone(),
+                        field_index,
+                        expected: plan.value_type(pattern.type_()),
+                        actual: field_value.value_type(plan),
+                    },
+                ));
             };
             bindings.push(binding);
         }
@@ -639,13 +651,15 @@ fn ensure_custom_field_type(
         Ok(())
     } else {
         let descriptor = plan.custom_constructor(constructor);
-        Err(ExecutionError::CustomFieldFamilyMismatch {
-            custom_type: plan.custom_value_type(constructor.type_id()),
-            constructor: descriptor.name().clone(),
-            field_index,
-            expected: plan.value_type(expected),
-            actual: value.value_type(plan),
-        })
+        Err(ExecutionError::Invariant(
+            InvariantError::CustomFieldFamilyMismatch {
+                custom_type: plan.custom_value_type(constructor.type_id()),
+                constructor: descriptor.name().clone(),
+                field_index,
+                expected: plan.value_type(expected),
+                actual: value.value_type(plan),
+            },
+        ))
     }
 }
 
@@ -939,7 +953,7 @@ mod tests {
     use crate::runtime::state::{IntListValueId, ListValueId};
     use crate::runtime::{
         EvaluatedCustomValue, EvaluatedFunctionFunction, EvaluatedFunctionValue,
-        EvaluatedListCapture, EvaluatedValue, ExecutionError, ListValue,
+        EvaluatedListCapture, EvaluatedValue, ExecutionError, InvariantError, ListValue,
     };
 
     #[test]
@@ -1735,13 +1749,15 @@ pub fn main() {
                 &function.steps()[assert_index..=assert_index],
                 &mut frame,
             ),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: custom_plan.custom_value_type(constructor_id.type_id()),
-                constructor: "Boxed".into(),
-                field_index: 0,
-                expected: ValueType::Int,
-                actual: ValueType::String,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: custom_plan.custom_value_type(constructor_id.type_id()),
+                    constructor: "Boxed".into(),
+                    field_index: 0,
+                    expected: ValueType::Int,
+                    actual: ValueType::String,
+                }
+            )),
         );
 
         let tuple_list_plan = crate::runtime::plan_src(
@@ -1792,13 +1808,15 @@ pub fn main() {
                 &function.steps()[assert_index..=assert_index],
                 &mut frame,
             ),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: tuple_list_plan.custom_value_type(constructor_id.type_id()),
-                constructor: "Boxed".into(),
-                field_index: 0,
-                expected: ValueType::Int,
-                actual: ValueType::String,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: tuple_list_plan.custom_value_type(constructor_id.type_id()),
+                    constructor: "Boxed".into(),
+                    field_index: 0,
+                    expected: ValueType::Int,
+                    actual: ValueType::String,
+                }
+            )),
         );
     }
 
@@ -1865,13 +1883,15 @@ pub fn main() {
                 &mut bindings,
             )
             .map(|_| ()),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: plan.custom_value_type(constructor_id.type_id()),
-                constructor: constructor.name().clone(),
-                field_index: 0,
-                expected: crate::plan::ValueType::Int,
-                actual: crate::plan::ValueType::String,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: plan.custom_value_type(constructor_id.type_id()),
+                    constructor: constructor.name().clone(),
+                    field_index: 0,
+                    expected: crate::plan::ValueType::Int,
+                    actual: crate::plan::ValueType::String,
+                }
+            )),
         );
         assert_eq!(bindings, Vec::new());
     }
@@ -1916,13 +1936,13 @@ pub fn main() {
         .expect("nested custom setup should execute");
         let outer = frame.get_custom(custom_local);
         let inner = expect_custom_value(&outer.fields()[0]);
-        let expected = ExecutionError::CustomFieldFamilyMismatch {
+        let expected = ExecutionError::Invariant(InvariantError::CustomFieldFamilyMismatch {
             custom_type: plan.custom_value_type(inner.constructor().type_id()),
             constructor: plan.custom_constructor(inner.constructor()).name().clone(),
             field_index: 0,
             expected: ValueType::Int,
             actual: ValueType::String,
-        };
+        });
         let tuple_pattern = &list_pattern.elements()[0];
 
         let malformed_inner = EvaluatedCustomValue::from_fields(
@@ -2086,13 +2106,15 @@ pub fn main() {
                 EvaluatedCustomValue::from_fields(constructor_id, fields.into_boxed_slice());
             assert_eq!(
                 bind_custom_fields(&plan, pattern, &mutated),
-                Err(ExecutionError::CustomFieldFamilyMismatch {
-                    custom_type: plan.custom_value_type(constructor_id.type_id()),
-                    constructor: constructor.name().clone(),
-                    field_index,
-                    expected,
-                    actual,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::CustomFieldFamilyMismatch {
+                        custom_type: plan.custom_value_type(constructor_id.type_id()),
+                        constructor: constructor.name().clone(),
+                        field_index,
+                        expected,
+                        actual,
+                    }
+                )),
             );
         }
 
@@ -2107,13 +2129,15 @@ pub fn main() {
                 &steps[bind_index..=bind_index],
                 &mut frame,
             ),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: plan.custom_value_type(constructor_id.type_id()),
-                constructor: constructor.name().clone(),
-                field_index: 0,
-                expected: ValueType::Int,
-                actual: ValueType::String,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: plan.custom_value_type(constructor_id.type_id()),
+                    constructor: constructor.name().clone(),
+                    field_index: 0,
+                    expected: ValueType::Int,
+                    actual: ValueType::String,
+                }
+            )),
         );
     }
 
@@ -2145,10 +2169,12 @@ pub fn main() {
         let ok = tuple_plan.custom_constructor_id(0, 0);
         assert_eq!(
             execute_steps(&tuple_plan, &mut state, tuple_function.steps(), &mut frame,),
-            Err(ExecutionError::TupleIndexFamilyMismatch {
-                expected: ValueType::Custom(tuple_plan.custom_value_type(ok.type_id())),
-                actual: ValueType::Int,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::TupleIndexFamilyMismatch {
+                    expected: ValueType::Custom(tuple_plan.custom_value_type(ok.type_id())),
+                    actual: ValueType::Int,
+                }
+            )),
         );
 
         let custom_plan = crate::runtime::plan_src(
@@ -2189,13 +2215,15 @@ pub fn main() {
                 custom_function.steps(),
                 &mut frame,
             ),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: custom_plan.custom_value_type(constructor.type_id()),
-                constructor: custom_plan.custom_constructor(constructor).name().clone(),
-                field_index: 0,
-                expected: ValueType::Int,
-                actual: ValueType::String,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: custom_plan.custom_value_type(constructor.type_id()),
+                    constructor: custom_plan.custom_constructor(constructor).name().clone(),
+                    field_index: 0,
+                    expected: ValueType::Int,
+                    actual: ValueType::String,
+                }
+            )),
         );
     }
 
@@ -2254,13 +2282,15 @@ pub fn main() {
         let mutated = EvaluatedCustomValue::from_fields(constructor_id, fields.into_boxed_slice());
         assert_eq!(
             bind_custom_fields(&plan, pattern, &mutated),
-            Err(ExecutionError::CustomFieldFamilyMismatch {
-                custom_type: plan.custom_value_type(inner.constructor().type_id()),
-                constructor: plan.custom_constructor(inner.constructor()).name().clone(),
-                field_index: 0,
-                expected: ValueType::Int,
-                actual: ValueType::String,
-            }),
+            Err(ExecutionError::Invariant(
+                InvariantError::CustomFieldFamilyMismatch {
+                    custom_type: plan.custom_value_type(inner.constructor().type_id()),
+                    constructor: plan.custom_constructor(inner.constructor()).name().clone(),
+                    field_index: 0,
+                    expected: ValueType::Int,
+                    actual: ValueType::String,
+                }
+            )),
         );
         let replacements = vec![
             (
@@ -2322,13 +2352,15 @@ pub fn main() {
                 EvaluatedCustomValue::from_fields(constructor_id, fields.into_boxed_slice());
             assert_eq!(
                 bind_custom_fields(&plan, pattern, &mutated),
-                Err(ExecutionError::CustomFieldFamilyMismatch {
-                    custom_type: plan.custom_value_type(error_constructor.type_id()),
-                    constructor: plan.custom_constructor(error_constructor).name().clone(),
-                    field_index,
-                    expected,
-                    actual,
-                }),
+                Err(ExecutionError::Invariant(
+                    InvariantError::CustomFieldFamilyMismatch {
+                        custom_type: plan.custom_value_type(error_constructor.type_id()),
+                        constructor: plan.custom_constructor(error_constructor).name().clone(),
+                        field_index,
+                        expected,
+                        actual,
+                    }
+                )),
             );
         }
     }


### PR DESCRIPTION
- Separate source-reachable panics from runtime invariant failures.
- Move invariant variants and diagnostics under a dedicated error domain.
- Keep every invariant construction explicit at its runtime boundary.
