### PR TITLE
Order production functions for reader flow

### DIFF
--- a/docs/review-policy.md
+++ b/docs/review-policy.md
@@ -106,6 +106,16 @@ actual callers before assigning a semantic role.
   contained or open structures.
 - Within an owner module, declare the representative owner or protocol before
   its variants, payloads, IDs, adapters, and other supporting types.
+- Arrange production functions in reader order. Put public or representative
+  entry points before the private functions they introduce, and order a private
+  implementation chain by first use so its primary path can be followed from
+  top to bottom. Do not place helpers before callers merely out of
+  declaration-before-use habit.
+- When the call graph does not provide the clearest reading order, use the
+  protocol or domain order instead. Trait implementations follow the trait, and
+  independent sibling operations keep a stable domain order. Shared helpers
+  follow the entry points that establish their purpose; mutually recursive
+  functions stay together with the conceptual entry point first.
 - Treat a one-caller type that mirrors a final type and is immediately consumed
   as a design smell. Make it a real final substructure or keep it phase-local
   behind a narrow constructor.

--- a/src/frontend/program.rs
+++ b/src/frontend/program.rs
@@ -518,6 +518,99 @@ impl HostedParsedModule {
     }
 }
 
+fn dependency_order(
+    modules: &[ParsedModule],
+    hosts: &[RegisteredHostModule],
+) -> Result<Vec<EcoString>, FrontendError> {
+    #[derive(Clone, Copy)]
+    enum Visit {
+        Visiting(usize),
+        Visited,
+    }
+
+    fn visit(
+        module: &EcoString,
+        dependencies: &BTreeMap<EcoString, BTreeSet<EcoString>>,
+        visits: &mut BTreeMap<EcoString, Visit>,
+        path: &mut Vec<EcoString>,
+        order: &mut Vec<EcoString>,
+    ) -> Result<(), FrontendError> {
+        match visits.get(module).copied() {
+            Some(Visit::Visited) => return Ok(()),
+            Some(Visit::Visiting(position)) => {
+                let mut modules = path[position..].to_vec();
+                modules.push(module.clone());
+                return Err(FrontendError::ImportCycle { modules });
+            }
+            None => {}
+        }
+
+        visits.insert(module.clone(), Visit::Visiting(path.len()));
+        path.push(module.clone());
+        for dependency in &dependencies[module] {
+            visit(dependency, dependencies, visits, path, order)?;
+        }
+        path.pop();
+        visits.insert(module.clone(), Visit::Visited);
+        order.push(module.clone());
+        Ok(())
+    }
+
+    let supplied = modules
+        .iter()
+        .map(|module| module.module.name.clone())
+        .chain(hosts.iter().map(|module| module.module().clone()))
+        .collect::<BTreeSet<_>>();
+    let package_modules = modules
+        .iter()
+        .map(|module| (&module.package, &module.module.name))
+        .chain(
+            hosts
+                .iter()
+                .map(|module| (module.package(), module.module())),
+        )
+        .fold(
+            BTreeMap::<EcoString, BTreeSet<EcoString>>::new(),
+            |mut packages, (package, module)| {
+                packages
+                    .entry(package.clone())
+                    .or_default()
+                    .insert(module.clone());
+                packages
+            },
+        );
+    let dependencies = modules
+        .iter()
+        .map(|module| {
+            let mut internal = module
+                .module
+                .dependencies(Target::Erlang)
+                .into_iter()
+                .map(|(dependency, _)| dependency)
+                .filter(|dependency| supplied.contains(dependency))
+                .collect::<BTreeSet<_>>();
+            for package in &module.direct_dependencies {
+                if let Some(dependencies) = package_modules.get(package) {
+                    internal.extend(dependencies.iter().cloned());
+                }
+            }
+            (module.module.name.clone(), internal)
+        })
+        .chain(
+            hosts
+                .iter()
+                .map(|module| (module.module().clone(), BTreeSet::new())),
+        )
+        .collect::<BTreeMap<_, _>>();
+    let mut order = Vec::with_capacity(modules.len());
+    let mut visits = BTreeMap::new();
+    let mut path = Vec::new();
+    for module in dependencies.keys() {
+        visit(module, &dependencies, &mut visits, &mut path, &mut order)?;
+    }
+    Ok(order)
+}
+
 fn host_module_interface(
     module: &RegisteredHostModule,
     prelude: &ModuleInterface,
@@ -614,99 +707,6 @@ fn host_type(type_: &HostTypeDescriptor) -> std::sync::Arc<gleam_core::type_::Ty
             arguments.iter().map(host_type).collect(),
         ),
     }
-}
-
-fn dependency_order(
-    modules: &[ParsedModule],
-    hosts: &[RegisteredHostModule],
-) -> Result<Vec<EcoString>, FrontendError> {
-    #[derive(Clone, Copy)]
-    enum Visit {
-        Visiting(usize),
-        Visited,
-    }
-
-    fn visit(
-        module: &EcoString,
-        dependencies: &BTreeMap<EcoString, BTreeSet<EcoString>>,
-        visits: &mut BTreeMap<EcoString, Visit>,
-        path: &mut Vec<EcoString>,
-        order: &mut Vec<EcoString>,
-    ) -> Result<(), FrontendError> {
-        match visits.get(module).copied() {
-            Some(Visit::Visited) => return Ok(()),
-            Some(Visit::Visiting(position)) => {
-                let mut modules = path[position..].to_vec();
-                modules.push(module.clone());
-                return Err(FrontendError::ImportCycle { modules });
-            }
-            None => {}
-        }
-
-        visits.insert(module.clone(), Visit::Visiting(path.len()));
-        path.push(module.clone());
-        for dependency in &dependencies[module] {
-            visit(dependency, dependencies, visits, path, order)?;
-        }
-        path.pop();
-        visits.insert(module.clone(), Visit::Visited);
-        order.push(module.clone());
-        Ok(())
-    }
-
-    let supplied = modules
-        .iter()
-        .map(|module| module.module.name.clone())
-        .chain(hosts.iter().map(|module| module.module().clone()))
-        .collect::<BTreeSet<_>>();
-    let package_modules = modules
-        .iter()
-        .map(|module| (&module.package, &module.module.name))
-        .chain(
-            hosts
-                .iter()
-                .map(|module| (module.package(), module.module())),
-        )
-        .fold(
-            BTreeMap::<EcoString, BTreeSet<EcoString>>::new(),
-            |mut packages, (package, module)| {
-                packages
-                    .entry(package.clone())
-                    .or_default()
-                    .insert(module.clone());
-                packages
-            },
-        );
-    let dependencies = modules
-        .iter()
-        .map(|module| {
-            let mut internal = module
-                .module
-                .dependencies(Target::Erlang)
-                .into_iter()
-                .map(|(dependency, _)| dependency)
-                .filter(|dependency| supplied.contains(dependency))
-                .collect::<BTreeSet<_>>();
-            for package in &module.direct_dependencies {
-                if let Some(dependencies) = package_modules.get(package) {
-                    internal.extend(dependencies.iter().cloned());
-                }
-            }
-            (module.module.name.clone(), internal)
-        })
-        .chain(
-            hosts
-                .iter()
-                .map(|module| (module.module().clone(), BTreeSet::new())),
-        )
-        .collect::<BTreeMap<_, _>>();
-    let mut order = Vec::with_capacity(modules.len());
-    let mut visits = BTreeMap::new();
-    let mut path = Vec::new();
-    for module in dependencies.keys() {
-        visit(module, &dependencies, &mut visits, &mut path, &mut order)?;
-    }
-    Ok(order)
 }
 
 #[cfg(test)]

--- a/src/gleam_stdlib/bit_array/function/codec.rs
+++ b/src/gleam_stdlib/bit_array/function/codec.rs
@@ -39,14 +39,6 @@ where
     })
 }
 
-fn decode_base64(value: &str) -> Result<Vec<u8>, base64::DecodeError> {
-    let encoded = value
-        .bytes()
-        .filter(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
-        .collect::<Vec<_>>();
-    ERLANG_BASE64.decode(encoded)
-}
-
 pub(in crate::gleam_stdlib::bit_array) fn base16_encode(value: BitArrayValue) -> EcoString {
     hex::encode_upper(value.pad_to_bytes().bytes()).into()
 }
@@ -62,6 +54,14 @@ where
         Ok(bytes) => call.return_custom::<BitArrayOk>((BitArrayValue::from_bytes(bytes), ())),
         Err(_) => call.return_custom::<BitArrayError>(((), ())),
     })
+}
+
+fn decode_base64(value: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    let encoded = value
+        .bytes()
+        .filter(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
+        .collect::<Vec<_>>();
+    ERLANG_BASE64.decode(encoded)
 }
 
 #[cfg(test)]

--- a/src/gleam_stdlib/dict/function.rs
+++ b/src/gleam_stdlib/dict/function.rs
@@ -29,28 +29,6 @@ where
     }
 }
 
-fn matching_entry<'call, Profile, Provider, Return, Payload, Arguments>(
-    call: &mut HostCall<'call, Profile, Provider, Return>,
-    payload: &HostExternalPayloadView<'call, Payload, Arguments>,
-    key_hash: u64,
-    key: <<Arguments as HostTypeAt<KeyIndex>>::Type as HostType>::Value<'call>,
-) -> Option<usize>
-where
-    Profile: HostProfile,
-    Provider: HostProvider<Profile>,
-    Return: HostType,
-    Payload: DictPayloadStorage,
-    Arguments: HostTypeSequence + HostTypeAt<KeyIndex>,
-{
-    payload.storage().matching_index(key_hash, &mut |index| {
-        let candidate = payload
-            .restore_argument::<Profile, Provider, Return, KeyIndex>(call, |payload| {
-                &payload.storage().buckets[&key_hash][index].key
-            });
-        call.equal::<<Arguments as HostTypeAt<KeyIndex>>::Type>(candidate, key.clone())
-    })
-}
-
 pub(in crate::gleam_stdlib) fn lookup<'call, Profile, Provider, Return, KeyType, ValueType>(
     call: &mut HostCall<'call, Profile, Provider, Return>,
     dict: HostExternal<'call, super::schema::DictOf<KeyType, ValueType>>,
@@ -71,23 +49,6 @@ where
             &payload.storage.buckets[&key_hash][index].value
         }),
     )
-}
-
-fn create_entry<'call, Profile, Arguments>(
-    builder: &mut HostExternalPayloadBuilder<'_, Profile, Arguments>,
-    key_hash: u64,
-    key: <<Arguments as HostTypeAt<KeyIndex>>::Type as HostType>::Value<'call>,
-    value: <<Arguments as HostTypeAt<ItemIndex>>::Type as HostType>::Value<'call>,
-) -> Rc<DictEntry>
-where
-    Profile: HostProfile,
-    Arguments: HostTypeSequence + HostTypeAt<KeyIndex> + HostTypeAt<ItemIndex>,
-{
-    Rc::new(DictEntry {
-        key_hash,
-        key: builder.store_argument::<KeyIndex>(key),
-        value: builder.store_argument::<ItemIndex>(value),
-    })
 }
 
 pub(super) fn to_transient<'call, Profile>(
@@ -329,6 +290,45 @@ where
         storage: storage.with_entry(key_hash, index, create_entry(builder, key_hash, key, value)),
     });
     Ok(call.return_value(transient))
+}
+
+fn matching_entry<'call, Profile, Provider, Return, Payload, Arguments>(
+    call: &mut HostCall<'call, Profile, Provider, Return>,
+    payload: &HostExternalPayloadView<'call, Payload, Arguments>,
+    key_hash: u64,
+    key: <<Arguments as HostTypeAt<KeyIndex>>::Type as HostType>::Value<'call>,
+) -> Option<usize>
+where
+    Profile: HostProfile,
+    Provider: HostProvider<Profile>,
+    Return: HostType,
+    Payload: DictPayloadStorage,
+    Arguments: HostTypeSequence + HostTypeAt<KeyIndex>,
+{
+    payload.storage().matching_index(key_hash, &mut |index| {
+        let candidate = payload
+            .restore_argument::<Profile, Provider, Return, KeyIndex>(call, |payload| {
+                &payload.storage().buckets[&key_hash][index].key
+            });
+        call.equal::<<Arguments as HostTypeAt<KeyIndex>>::Type>(candidate, key.clone())
+    })
+}
+
+fn create_entry<'call, Profile, Arguments>(
+    builder: &mut HostExternalPayloadBuilder<'_, Profile, Arguments>,
+    key_hash: u64,
+    key: <<Arguments as HostTypeAt<KeyIndex>>::Type as HostType>::Value<'call>,
+    value: <<Arguments as HostTypeAt<ItemIndex>>::Type as HostType>::Value<'call>,
+) -> Rc<DictEntry>
+where
+    Profile: HostProfile,
+    Arguments: HostTypeSequence + HostTypeAt<KeyIndex> + HostTypeAt<ItemIndex>,
+{
+    Rc::new(DictEntry {
+        key_hash,
+        key: builder.store_argument::<KeyIndex>(key),
+        value: builder.store_argument::<ItemIndex>(value),
+    })
 }
 
 #[cfg(test)]

--- a/src/gleam_stdlib/dict/storage.rs
+++ b/src/gleam_stdlib/dict/storage.rs
@@ -157,10 +157,6 @@ fn inspect_storage(context: &HostExternalInspection<'_>, storage: &DictStorage) 
 }
 
 impl DictStorage {
-    fn entries(&self) -> impl Iterator<Item = &Rc<DictEntry>> {
-        self.buckets.values().flat_map(Vector::iter)
-    }
-
     pub(super) fn with_entry(
         &self,
         key_hash: u64,
@@ -206,6 +202,10 @@ impl DictStorage {
     ) -> Option<usize> {
         let bucket = self.buckets.get(&key_hash)?;
         (0..bucket.len()).find(|index| is_equal(*index))
+    }
+
+    fn entries(&self) -> impl Iterator<Item = &Rc<DictEntry>> {
+        self.buckets.values().flat_map(Vector::iter)
     }
 }
 

--- a/src/gleam_stdlib/dynamic/function.rs
+++ b/src/gleam_stdlib/dynamic/function.rs
@@ -32,18 +32,6 @@ where
     Ok(call.return_value(name))
 }
 
-pub(in crate::gleam_stdlib) fn classification<'call, Profile, Provider, Return>(
-    call: &HostCall<'call, Profile, Provider, Return>,
-    value: HostExternal<'call, Dynamic>,
-) -> EcoString
-where
-    Profile: GleamStdlibHostProfile,
-    Provider: HostProvider<Profile>,
-    Return: HostType,
-{
-    call.external_payload(value).representation().name().into()
-}
-
 pub(super) fn cast<'call, Profile, Type>(
     mut call: HostCall<'call, Profile, DynamicProvider<Profile>, Dynamic>,
     value: Type::Value<'call>,
@@ -55,6 +43,41 @@ where
     let dynamic =
         create_value::<Profile, DynamicProvider<Profile>, Dynamic, Type>(&mut call, value);
     Ok(call.return_value(dynamic))
+}
+
+pub(super) fn array<'call, Profile>(
+    mut call: HostCall<'call, Profile, DynamicProvider<Profile>, Dynamic>,
+    values: HostList<'call, Dynamic>,
+) -> Result<HostCallCompletion<'call, Dynamic>, HostCallError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    let mut index = 0;
+    let mut sequence = Vec::new();
+    while let Some(value) = call.list_item(values, index) {
+        sequence.push(value);
+        index += 1;
+    }
+    let dynamic = call.create_external_with(move |builder| DynamicPayload::Array {
+        value: builder.store_dynamic::<DynamicList>(values),
+        elements: sequence
+            .into_iter()
+            .map(|value| builder.store_dynamic::<Dynamic>(value))
+            .collect(),
+    });
+    Ok(call.return_value(dynamic))
+}
+
+pub(in crate::gleam_stdlib) fn classification<'call, Profile, Provider, Return>(
+    call: &HostCall<'call, Profile, Provider, Return>,
+    value: HostExternal<'call, Dynamic>,
+) -> EcoString
+where
+    Profile: GleamStdlibHostProfile,
+    Provider: HostProvider<Profile>,
+    Return: HostType,
+{
+    call.external_payload(value).representation().name().into()
 }
 
 pub(in crate::gleam_stdlib) fn create_value<'call, Profile, Provider, Return, Type>(
@@ -108,29 +131,6 @@ where
     payload
         .decode::<Profile, Provider, Return, DynamicList>(call, DynamicPayload::value)
         .map(sequence)
-}
-
-pub(super) fn array<'call, Profile>(
-    mut call: HostCall<'call, Profile, DynamicProvider<Profile>, Dynamic>,
-    values: HostList<'call, Dynamic>,
-) -> Result<HostCallCompletion<'call, Dynamic>, HostCallError>
-where
-    Profile: GleamStdlibHostProfile,
-{
-    let mut index = 0;
-    let mut sequence = Vec::new();
-    while let Some(value) = call.list_item(values, index) {
-        sequence.push(value);
-        index += 1;
-    }
-    let dynamic = call.create_external_with(move |builder| DynamicPayload::Array {
-        value: builder.store_dynamic::<DynamicList>(values),
-        elements: sequence
-            .into_iter()
-            .map(|value| builder.store_dynamic::<Dynamic>(value))
-            .collect(),
-    });
-    Ok(call.return_value(dynamic))
 }
 
 #[cfg(test)]

--- a/src/gleam_stdlib/dynamic/storage.rs
+++ b/src/gleam_stdlib/dynamic/storage.rs
@@ -47,6 +47,24 @@ impl DynamicRepresentation {
         Self::from_family(value.value_family(), value.value_type())
     }
 
+    pub(super) fn name(self) -> &'static str {
+        match self {
+            Self::Bool => "Bool",
+            Self::String => "String",
+            Self::Float => "Float",
+            Self::Int => "Int",
+            Self::BitArray => "BitArray",
+            Self::UtfCodepoint => "UtfCodepoint",
+            Self::List => "List",
+            Self::Array => "Array",
+            Self::Dict => "Dict",
+            Self::Nil => "Nil",
+            Self::Function => "Function",
+            Self::Custom => "Custom",
+            Self::External => "External",
+        }
+    }
+
     fn from_family(family: HostStoredValueFamily, type_: &crate::ValueType) -> Self {
         if let crate::ValueType::External(type_) = type_
             && type_.type_name().package() == "gleam_stdlib"
@@ -69,24 +87,6 @@ impl DynamicRepresentation {
             HostStoredValueFamily::Custom => Self::Custom,
             HostStoredValueFamily::External => Self::External,
             HostStoredValueFamily::Function => Self::Function,
-        }
-    }
-
-    pub(super) fn name(self) -> &'static str {
-        match self {
-            Self::Bool => "Bool",
-            Self::String => "String",
-            Self::Float => "Float",
-            Self::Int => "Int",
-            Self::BitArray => "BitArray",
-            Self::UtfCodepoint => "UtfCodepoint",
-            Self::List => "List",
-            Self::Array => "Array",
-            Self::Dict => "Dict",
-            Self::Nil => "Nil",
-            Self::Function => "Function",
-            Self::Custom => "Custom",
-            Self::External => "External",
         }
     }
 }

--- a/src/gleam_stdlib/run_state.rs
+++ b/src/gleam_stdlib/run_state.rs
@@ -27,6 +27,12 @@ impl GleamStdlibRunState {
         Self::try_from_seed_source(|seed| SysRng.try_fill_bytes(seed))
     }
 
+    pub(super) fn random_float(&mut self) -> f64 {
+        const SCALE: f64 = 1.0 / ((1u64 << 53) as f64);
+
+        ((self.random.next_u64() >> 11) as f64) * SCALE
+    }
+
     fn try_from_seed_source<Error>(
         fill: impl FnOnce(&mut [u8; 32]) -> Result<(), Error>,
     ) -> Result<Self, GleamStdlibRunStateError>
@@ -39,12 +45,6 @@ impl GleamStdlibRunState {
             .map_err(|error| GleamStdlibRunStateError {
                 reason: error.to_string().into(),
             })
-    }
-
-    pub(super) fn random_float(&mut self) -> f64 {
-        const SCALE: f64 = 1.0 / ((1u64 << 53) as f64);
-
-        ((self.random.next_u64() >> 11) as f64) * SCALE
     }
 }
 

--- a/src/host/external/dynamic.rs
+++ b/src/host/external/dynamic.rs
@@ -59,10 +59,6 @@ impl HostStoredDynamic {
         Self { value }
     }
 
-    fn has_type(&self, type_: &crate::plan::ValueType) -> bool {
-        self.value.type_() == type_
-    }
-
     pub(crate) fn value_type(&self) -> &crate::plan::ValueType {
         self.value.type_()
     }
@@ -90,6 +86,10 @@ impl HostStoredDynamic {
             return None;
         }
         Some(call.restore_runtime_value::<Type>(&self.value))
+    }
+
+    fn has_type(&self, type_: &crate::plan::ValueType) -> bool {
+        self.value.type_() == type_
     }
 }
 

--- a/src/host/function/return_.rs
+++ b/src/host/function/return_.rs
@@ -54,6 +54,17 @@ type HostScopedCallback<Profile> = dyn Fn(&mut dyn HostCallRuntime<Profile>) -> 
     + Send
     + Sync;
 
+pub(super) trait HostReturn: Sized {
+    fn descriptor() -> crate::host::HostTypeDescriptor;
+
+    fn implementation<Profile: HostProfile>(
+        function: impl Fn(&mut Profile::RunState, &dyn HostCallArguments) -> Result<Self, HostCallError>
+        + Send
+        + Sync
+        + 'static,
+    ) -> HostFunctionImplementation<Profile>;
+}
+
 impl<Profile: HostProfile> Clone for HostValueFunction<Profile> {
     fn clone(&self) -> Self {
         Self {
@@ -191,17 +202,6 @@ pub(crate) fn expect_value_implementation<Profile: HostProfile>(
         panic!("host callback should produce a value");
     };
     implementation
-}
-
-pub(super) trait HostReturn: Sized {
-    fn descriptor() -> crate::host::HostTypeDescriptor;
-
-    fn implementation<Profile: HostProfile>(
-        function: impl Fn(&mut Profile::RunState, &dyn HostCallArguments) -> Result<Self, HostCallError>
-        + Send
-        + Sync
-        + 'static,
-    ) -> HostFunctionImplementation<Profile>;
 }
 
 #[cfg(test)]

--- a/src/host/module.rs
+++ b/src/host/module.rs
@@ -346,6 +346,28 @@ impl HostModuleIdentity {
     }
 }
 
+fn validate_module_name(module: &EcoString) -> Result<(), HostRegistrationError> {
+    let valid = module != PRELUDE_MODULE_NAME
+        && !module.is_empty()
+        && module.split('/').all(|segment| {
+            !segment.is_empty()
+                && string_to_keyword(segment).is_none()
+                && check_name_case(
+                    SrcSpan::new(0, 0),
+                    &EcoString::from(segment),
+                    Named::Function,
+                )
+                .is_ok()
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(HostRegistrationError::InvalidModuleName {
+            module: module.clone(),
+        })
+    }
+}
+
 fn validate_module_identities(
     identities: &[(&EcoString, &EcoString)],
 ) -> Result<(), HostRegistrationError> {
@@ -525,28 +547,6 @@ impl<Profile: HostProfile> RegisteredHostImplementations<Profile> {
         id: RegisteredHostImplementationId,
     ) -> Arc<HostFunctionImplementation<Profile>> {
         Arc::clone(&self.functions[id.0])
-    }
-}
-
-fn validate_module_name(module: &EcoString) -> Result<(), HostRegistrationError> {
-    let valid = module != PRELUDE_MODULE_NAME
-        && !module.is_empty()
-        && module.split('/').all(|segment| {
-            !segment.is_empty()
-                && string_to_keyword(segment).is_none()
-                && check_name_case(
-                    SrcSpan::new(0, 0),
-                    &EcoString::from(segment),
-                    Named::Function,
-                )
-                .is_ok()
-        });
-    if valid {
-        Ok(())
-    } else {
-        Err(HostRegistrationError::InvalidModuleName {
-            module: module.clone(),
-        })
     }
 }
 

--- a/src/host/profile.rs
+++ b/src/host/profile.rs
@@ -144,6 +144,22 @@ where
             .map(|token| crate::host::type_::from_token::<Item, Profile>(self.runtime, token))
     }
 
+    pub(crate) fn create_list<Item: HostType>(
+        &mut self,
+        values: impl IntoIterator<Item = Item::Value<'call>>,
+    ) -> HostList<'call, Item> {
+        let values = values
+            .into_iter()
+            .map(crate::host::type_::into_scoped::<Item>)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let value = self.runtime.build_list(
+            &crate::host::HostTypeDescriptor::of::<HostListType<Item>>(),
+            values,
+        );
+        HostList::new(self.runtime.list_token(value))
+    }
+
     pub fn tuple_len<Elements>(&self, value: HostTuple<'call, Elements>) -> usize {
         self.runtime.tuple_len(value.token)
     }
@@ -164,40 +180,6 @@ where
         crate::host::type_::into_scoped_values::<Elements>(values, &mut output);
         let value = self.runtime.build_tuple(output.into_boxed_slice());
         HostTuple::new(self.runtime.tuple_token(value))
-    }
-
-    pub(crate) fn create_list<Item: HostType>(
-        &mut self,
-        values: impl IntoIterator<Item = Item::Value<'call>>,
-    ) -> HostList<'call, Item> {
-        let values = values
-            .into_iter()
-            .map(crate::host::type_::into_scoped::<Item>)
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        let value = self.runtime.build_list(
-            &crate::host::HostTypeDescriptor::of::<HostListType<Item>>(),
-            values,
-        );
-        HostList::new(self.runtime.list_token(value))
-    }
-
-    pub(crate) fn create_custom<Constructor>(
-        &mut self,
-        fields: <Constructor::Fields as HostTypeSequence>::Values<'call>,
-    ) -> HostCustom<'call, Constructor::Custom>
-    where
-        Constructor: HostCustomConstructor,
-        Constructor::Fields: HostTypeSequence,
-    {
-        let mut output = Vec::new();
-        crate::host::type_::into_scoped_values::<Constructor::Fields>(fields, &mut output);
-        let value = self.runtime.build_custom(
-            &crate::host::HostTypeDescriptor::of::<Constructor::Custom>(),
-            crate::host::type_::custom_constructor_index::<Constructor>(),
-            output.into_boxed_slice(),
-        );
-        HostCustom::new(self.runtime.custom_token(value))
     }
 
     pub fn custom_constructor<Custom>(&self, value: HostCustom<'call, Custom>) -> usize {
@@ -232,6 +214,24 @@ where
     {
         let fields = self.runtime.custom_fields(value.token);
         crate::host::type_::from_tokens::<Constructor::Fields, Profile>(self.runtime, &fields)
+    }
+
+    pub(crate) fn create_custom<Constructor>(
+        &mut self,
+        fields: <Constructor::Fields as HostTypeSequence>::Values<'call>,
+    ) -> HostCustom<'call, Constructor::Custom>
+    where
+        Constructor: HostCustomConstructor,
+        Constructor::Fields: HostTypeSequence,
+    {
+        let mut output = Vec::new();
+        crate::host::type_::into_scoped_values::<Constructor::Fields>(fields, &mut output);
+        let value = self.runtime.build_custom(
+            &crate::host::HostTypeDescriptor::of::<Constructor::Custom>(),
+            crate::host::type_::custom_constructor_index::<Constructor>(),
+            output.into_boxed_slice(),
+        );
+        HostCustom::new(self.runtime.custom_token(value))
     }
 
     /// Borrows the Rust payload behind one typed external value.

--- a/src/plan/execution.rs
+++ b/src/plan/execution.rs
@@ -158,6 +158,55 @@ impl ExecutionPlan {
     }
 }
 
+impl<Profile: HostProfile> HostedExecution<Profile> {
+    /// Seals all entry-reachable host specializations into executable storage.
+    ///
+    /// A linked but unused provider does not participate in sealing.
+    pub fn try_from_module_plan(
+        module_plan: HostedModulePlan<Profile>,
+    ) -> Result<Self, HostSpecializationError> {
+        let (program, host_functions) = lowering::lower_hosted(module_plan)?;
+        Ok(Self {
+            program,
+            host_functions,
+            external_stores: Profile::ExternalStores::default(),
+        })
+    }
+
+    pub fn run_main(
+        &self,
+        state: &mut Profile::RunState,
+        echo: &mut dyn crate::EchoSink,
+    ) -> Result<crate::Value, crate::ExecutionError> {
+        crate::runtime::run_hosted_main(self, state, echo)
+    }
+
+    pub fn explain(&self) -> ExecutionPlanExplanation<'_> {
+        ExecutionPlanExplanation::new_hosted(self)
+    }
+
+    pub(crate) fn host_value_function<Body>(
+        &self,
+        id: &host::HostFunctionId<Body>,
+    ) -> &host::HostedValueFunction<Profile>
+    where
+        Body: function::ExecutionFunctionBody,
+    {
+        self.host_functions.value(id)
+    }
+
+    pub(crate) fn host_never_function(
+        &self,
+        id: host::HostNeverFunctionId,
+    ) -> &host::HostedNeverFunction<Profile> {
+        self.host_functions.never(id)
+    }
+
+    pub(crate) fn external_stores(&self) -> &Profile::ExternalStores {
+        &self.external_stores
+    }
+}
+
 #[cfg(test)]
 impl ExecutionPlan {
     pub(crate) fn main_runtime(&self) -> self::function::RuntimeFunctionId {
@@ -500,55 +549,6 @@ impl ExecutionPlan {
     #[cfg(test)]
     pub(crate) fn function_function_function_id(&self, index: usize) -> FunctionFunctionFunctionId {
         self.program.functions.function_function_function_id(index)
-    }
-}
-
-impl<Profile: HostProfile> HostedExecution<Profile> {
-    /// Seals all entry-reachable host specializations into executable storage.
-    ///
-    /// A linked but unused provider does not participate in sealing.
-    pub fn try_from_module_plan(
-        module_plan: HostedModulePlan<Profile>,
-    ) -> Result<Self, HostSpecializationError> {
-        let (program, host_functions) = lowering::lower_hosted(module_plan)?;
-        Ok(Self {
-            program,
-            host_functions,
-            external_stores: Profile::ExternalStores::default(),
-        })
-    }
-
-    pub fn run_main(
-        &self,
-        state: &mut Profile::RunState,
-        echo: &mut dyn crate::EchoSink,
-    ) -> Result<crate::Value, crate::ExecutionError> {
-        crate::runtime::run_hosted_main(self, state, echo)
-    }
-
-    pub fn explain(&self) -> ExecutionPlanExplanation<'_> {
-        ExecutionPlanExplanation::new_hosted(self)
-    }
-
-    pub(crate) fn host_value_function<Body>(
-        &self,
-        id: &host::HostFunctionId<Body>,
-    ) -> &host::HostedValueFunction<Profile>
-    where
-        Body: function::ExecutionFunctionBody,
-    {
-        self.host_functions.value(id)
-    }
-
-    pub(crate) fn host_never_function(
-        &self,
-        id: host::HostNeverFunctionId,
-    ) -> &host::HostedNeverFunction<Profile> {
-        self.host_functions.never(id)
-    }
-
-    pub(crate) fn external_stores(&self) -> &Profile::ExternalStores {
-        &self.external_stores
     }
 }
 

--- a/src/plan/execution/function/body.rs
+++ b/src/plan/execution/function/body.rs
@@ -144,6 +144,14 @@ impl TailCallLabelIndex for usize {
     }
 }
 
+impl<Function: TailCallLabelIndex> TailCallLabelIndex
+    for crate::plan::FunctionCallTarget<Function>
+{
+    fn tail_call_label_index(&self) -> usize {
+        self.function().tail_call_label_index()
+    }
+}
+
 impl TailCallLabelIndex for NeverFunctionId {
     fn tail_call_label_index(&self) -> usize {
         self.0
@@ -153,14 +161,6 @@ impl TailCallLabelIndex for NeverFunctionId {
 impl TailCallLabelIndex for IntFunctionId {
     fn tail_call_label_index(&self) -> usize {
         self.0
-    }
-}
-
-impl<Function: TailCallLabelIndex> TailCallLabelIndex
-    for crate::plan::FunctionCallTarget<Function>
-{
-    fn tail_call_label_index(&self) -> usize {
-        self.function().tail_call_label_index()
     }
 }
 

--- a/src/plan/execution/function/profile.rs
+++ b/src/plan/execution/function/profile.rs
@@ -322,34 +322,6 @@ impl ExecutionGraphProfile for HostedExecutionGraph {
     }
 }
 
-#[cfg(test)]
-pub(super) fn plain_core_runtime_function_id(
-    id: &ProfiledCoreRuntimeFunctionId<Infallible>,
-) -> CoreRuntimeFunctionId {
-    use ProfiledCoreRuntimeFunctionId as F;
-
-    match id {
-        F::Never(id) => CoreRuntimeFunctionId::Never(*id),
-        F::Int(id) => CoreRuntimeFunctionId::Int(*id),
-        F::Float(id) => CoreRuntimeFunctionId::Float(*id),
-        F::String(id) => CoreRuntimeFunctionId::String(*id),
-        F::BitArray(id) => CoreRuntimeFunctionId::BitArray(*id),
-        F::UtfCodepoint(id) => CoreRuntimeFunctionId::UtfCodepoint(*id),
-        F::Custom(id) => CoreRuntimeFunctionId::Custom(*id),
-        F::Bool(id) => CoreRuntimeFunctionId::Bool(*id),
-        F::Nil(id) => CoreRuntimeFunctionId::Nil(*id),
-        F::Tuple { id, return_type } => CoreRuntimeFunctionId::Tuple {
-            id: *id,
-            return_type: return_type.clone(),
-        },
-        F::List(id) => CoreRuntimeFunctionId::List(Infallible::list_function(id)),
-        F::Function { id, return_type } => CoreRuntimeFunctionId::Function {
-            id: RuntimeFunctionFunctionTarget::Core(id.clone()),
-            return_type: return_type.clone(),
-        },
-    }
-}
-
 impl FunctionLabelSource for Infallible {
     fn function_label(&self) -> crate::plan::execution::explain::FunctionLabel {
         match *self {}
@@ -378,6 +350,34 @@ impl<Body, HostTarget> ExecutionFunctionEntry<Body> for ValueFunctionEntry<Body,
             ValueFunctionEntry::Graph(function) => ExecutionFunctionRef::Graph(function),
             ValueFunctionEntry::Host(target) => ExecutionFunctionRef::Host(target),
         }
+    }
+}
+
+#[cfg(test)]
+pub(super) fn plain_core_runtime_function_id(
+    id: &ProfiledCoreRuntimeFunctionId<Infallible>,
+) -> CoreRuntimeFunctionId {
+    use ProfiledCoreRuntimeFunctionId as F;
+
+    match id {
+        F::Never(id) => CoreRuntimeFunctionId::Never(*id),
+        F::Int(id) => CoreRuntimeFunctionId::Int(*id),
+        F::Float(id) => CoreRuntimeFunctionId::Float(*id),
+        F::String(id) => CoreRuntimeFunctionId::String(*id),
+        F::BitArray(id) => CoreRuntimeFunctionId::BitArray(*id),
+        F::UtfCodepoint(id) => CoreRuntimeFunctionId::UtfCodepoint(*id),
+        F::Custom(id) => CoreRuntimeFunctionId::Custom(*id),
+        F::Bool(id) => CoreRuntimeFunctionId::Bool(*id),
+        F::Nil(id) => CoreRuntimeFunctionId::Nil(*id),
+        F::Tuple { id, return_type } => CoreRuntimeFunctionId::Tuple {
+            id: *id,
+            return_type: return_type.clone(),
+        },
+        F::List(id) => CoreRuntimeFunctionId::List(Infallible::list_function(id)),
+        F::Function { id, return_type } => CoreRuntimeFunctionId::Function {
+            id: RuntimeFunctionFunctionTarget::Core(id.clone()),
+            return_type: return_type.clone(),
+        },
     }
 }
 #[cfg(test)]

--- a/src/plan/execution/function/table.rs
+++ b/src/plan/execution/function/table.rs
@@ -122,63 +122,6 @@ fn write_function<Body>(
     );
 }
 
-#[cfg(test)]
-mod explain_tests {
-    use crate::plan::execution::explain;
-
-    #[test]
-    fn writes_value_list_and_function_return_groups_in_order() {
-        let source = r#"
-fn ints() -> List(Int) { [] }
-fn callable() -> fn() -> Int { fn() { 1 } }
-
-pub fn main() {
-  let _ = #(ints(), callable())
-  0
-}
-"#;
-        let expected = concat!(
-            "\nfunction int#0\n",
-            "  entry b0 params=[] captures=[]\n",
-            "  block b0 params=[]\n",
-            "    %list.int#0:shape#1(list_type#0) = list.int[type#0] call ",
-            "list.int#0 args=[]\n",
-            "    %function.int#0:shape#2(fn() -> Int) = function[Int] call ",
-            "function.int#0 args=[]\n",
-            "    %tuple#0:shape#3(#(list_type#0, fn() -> Int)) = tuple.value ",
-            "elements=[%list.int#0, %function.int#0]\n",
-            "    %int#0:shape#0(Int) = int.value 0\n",
-            "    return %int#0\n",
-            "\nfunction int#1\n",
-            "  entry b0 params=[] captures=[]\n",
-            "  block b0 params=[]\n",
-            "    %int#0:shape#0(Int) = int.value 1\n",
-            "    return %int#0\n",
-            "\nfunction list.int#0\n",
-            "  entry b0 params=[] captures=[]\n",
-            "  block b0 params=[]\n",
-            "    %list.int#0:shape#1(list_type#0) = list.int[type#0] value ",
-            "elements=[]\n",
-            "    return %list.int#0\n",
-            "\nfunction function.int#0\n",
-            "  entry b0 params=[] captures=[]\n",
-            "  block b0 params=[]\n",
-            "    %function.int#0:shape#2(fn() -> Int) = function[Int] closure ",
-            "target=int#1 captures=[]\n",
-            "    return %function.int#0\n",
-        );
-
-        assert_explanation(source, expected);
-    }
-
-    fn assert_explanation(source: &str, expected: &str) {
-        explain::assert_rendered(source, expected, |plan, output| {
-            let mut context = explain::ExplainContext::new(plan, output);
-            context.write(&plan.program.functions);
-        });
-    }
-}
-
 impl<Profile: ExecutionProfile> FunctionTables<Profile> {
     pub(in crate::plan::execution) fn never_function(
         &self,
@@ -603,6 +546,63 @@ impl<Profile: ExecutionProfile> FunctionTables<Profile> {
         id: &FunctionFunctionFunctionId,
     ) -> &ExecutionFunction<Profile, ExecutionFunctionFunctionFunctionBody<Profile>> {
         &self.function_returns.function_function_functions[id.index()]
+    }
+}
+
+#[cfg(test)]
+mod explain_tests {
+    use crate::plan::execution::explain;
+
+    #[test]
+    fn writes_value_list_and_function_return_groups_in_order() {
+        let source = r#"
+fn ints() -> List(Int) { [] }
+fn callable() -> fn() -> Int { fn() { 1 } }
+
+pub fn main() {
+  let _ = #(ints(), callable())
+  0
+}
+"#;
+        let expected = concat!(
+            "\nfunction int#0\n",
+            "  entry b0 params=[] captures=[]\n",
+            "  block b0 params=[]\n",
+            "    %list.int#0:shape#1(list_type#0) = list.int[type#0] call ",
+            "list.int#0 args=[]\n",
+            "    %function.int#0:shape#2(fn() -> Int) = function[Int] call ",
+            "function.int#0 args=[]\n",
+            "    %tuple#0:shape#3(#(list_type#0, fn() -> Int)) = tuple.value ",
+            "elements=[%list.int#0, %function.int#0]\n",
+            "    %int#0:shape#0(Int) = int.value 0\n",
+            "    return %int#0\n",
+            "\nfunction int#1\n",
+            "  entry b0 params=[] captures=[]\n",
+            "  block b0 params=[]\n",
+            "    %int#0:shape#0(Int) = int.value 1\n",
+            "    return %int#0\n",
+            "\nfunction list.int#0\n",
+            "  entry b0 params=[] captures=[]\n",
+            "  block b0 params=[]\n",
+            "    %list.int#0:shape#1(list_type#0) = list.int[type#0] value ",
+            "elements=[]\n",
+            "    return %list.int#0\n",
+            "\nfunction function.int#0\n",
+            "  entry b0 params=[] captures=[]\n",
+            "  block b0 params=[]\n",
+            "    %function.int#0:shape#2(fn() -> Int) = function[Int] closure ",
+            "target=int#1 captures=[]\n",
+            "    return %function.int#0\n",
+        );
+
+        assert_explanation(source, expected);
+    }
+
+    fn assert_explanation(source: &str, expected: &str) {
+        explain::assert_rendered(source, expected, |plan, output| {
+            let mut context = explain::ExplainContext::new(plan, output);
+            context.write(&plan.program.functions);
+        });
     }
 }
 

--- a/src/plan/execution/graph/bit_array.rs
+++ b/src/plan/execution/graph/bit_array.rs
@@ -5,6 +5,13 @@ pub(crate) enum Endianness {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FloatBitSize {
+    Sixteen,
+    ThirtyTwo,
+    SixtyFour,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StringEncoding {
     Utf8,
     Utf16(Endianness),
@@ -65,11 +72,4 @@ mod explain_tests {
             "utf32.little",
         );
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum FloatBitSize {
-    Sixteen,
-    ThirtyTwo,
-    SixtyFour,
 }

--- a/src/plan/execution/graph/block/instruction.rs
+++ b/src/plan/execution/graph/block/instruction.rs
@@ -128,6 +128,97 @@ where
     }
 }
 
+pub(super) fn write_binary<Value: LocalLabel>(
+    output: &mut String,
+    opcode: &str,
+    left: &Value,
+    right: &Value,
+) {
+    output.push_str(opcode);
+    output.push(' ');
+    left.write_local_label(output);
+    output.push(' ');
+    right.write_local_label(output);
+}
+
+pub(super) fn write_call<Function: FunctionLabelSource>(
+    output: &mut String,
+    opcode: &str,
+    function: &Function,
+    args: &[ParamLocal],
+) {
+    output.push_str(opcode);
+    output.push(' ');
+    function.function_label().write(output);
+    write_args(output, args);
+}
+
+pub(super) fn write_function_call<Function: LocalLabel>(
+    output: &mut String,
+    opcode: &str,
+    function: &Function,
+    args: &[ParamLocal],
+) {
+    output.push_str(opcode);
+    output.push(' ');
+    function.write_local_label(output);
+    write_args(output, args);
+}
+
+pub(super) fn write_args(output: &mut String, args: &[ParamLocal]) {
+    output.push_str(" args=");
+    write_local_labels(output, args);
+}
+
+pub(super) fn write_constant<Value>(
+    output: &mut String,
+    family: &str,
+    id: crate::plan::execution::constant::ConstantId<Value>,
+) {
+    output.push_str("constant.");
+    output.push_str(family);
+    output.push('#');
+    output.push_str(&id.index().to_string());
+}
+
+pub(super) fn write_length<Value: LocalLabel>(
+    output: &mut String,
+    opcode: &str,
+    value: &Value,
+    length: usize,
+) {
+    output.push_str(opcode);
+    output.push(' ');
+    value.write_local_label(output);
+    output.push_str(" length=");
+    output.push_str(&length.to_string());
+}
+
+pub(super) fn write_literal(output: &mut String, opcode: &str, value: &str) {
+    output.push_str(opcode);
+    output.push(' ');
+    output.push_str(value);
+}
+
+pub(super) fn write_projection<Source: LocalLabel>(
+    output: &mut String,
+    opcode: &str,
+    source: &Source,
+    index: usize,
+) {
+    output.push_str(opcode);
+    output.push(' ');
+    source.write_local_label(output);
+    output.push_str(" index=");
+    output.push_str(&index.to_string());
+}
+
+pub(super) fn write_unary<Value: LocalLabel>(output: &mut String, opcode: &str, value: &Value) {
+    output.push_str(opcode);
+    output.push(' ');
+    value.write_local_label(output);
+}
+
 #[cfg(test)]
 mod instruction_explain_tests {
     use crate::plan::execution::explain;
@@ -233,95 +324,4 @@ pub fn main() { #(Boxed) }
             context.write(instruction.kind());
         });
     }
-}
-
-pub(super) fn write_binary<Value: LocalLabel>(
-    output: &mut String,
-    opcode: &str,
-    left: &Value,
-    right: &Value,
-) {
-    output.push_str(opcode);
-    output.push(' ');
-    left.write_local_label(output);
-    output.push(' ');
-    right.write_local_label(output);
-}
-
-pub(super) fn write_call<Function: FunctionLabelSource>(
-    output: &mut String,
-    opcode: &str,
-    function: &Function,
-    args: &[ParamLocal],
-) {
-    output.push_str(opcode);
-    output.push(' ');
-    function.function_label().write(output);
-    write_args(output, args);
-}
-
-pub(super) fn write_function_call<Function: LocalLabel>(
-    output: &mut String,
-    opcode: &str,
-    function: &Function,
-    args: &[ParamLocal],
-) {
-    output.push_str(opcode);
-    output.push(' ');
-    function.write_local_label(output);
-    write_args(output, args);
-}
-
-pub(super) fn write_args(output: &mut String, args: &[ParamLocal]) {
-    output.push_str(" args=");
-    write_local_labels(output, args);
-}
-
-pub(super) fn write_constant<Value>(
-    output: &mut String,
-    family: &str,
-    id: crate::plan::execution::constant::ConstantId<Value>,
-) {
-    output.push_str("constant.");
-    output.push_str(family);
-    output.push('#');
-    output.push_str(&id.index().to_string());
-}
-
-pub(super) fn write_length<Value: LocalLabel>(
-    output: &mut String,
-    opcode: &str,
-    value: &Value,
-    length: usize,
-) {
-    output.push_str(opcode);
-    output.push(' ');
-    value.write_local_label(output);
-    output.push_str(" length=");
-    output.push_str(&length.to_string());
-}
-
-pub(super) fn write_literal(output: &mut String, opcode: &str, value: &str) {
-    output.push_str(opcode);
-    output.push(' ');
-    output.push_str(value);
-}
-
-pub(super) fn write_projection<Source: LocalLabel>(
-    output: &mut String,
-    opcode: &str,
-    source: &Source,
-    index: usize,
-) {
-    output.push_str(opcode);
-    output.push(' ');
-    source.write_local_label(output);
-    output.push_str(" index=");
-    output.push_str(&index.to_string());
-}
-
-pub(super) fn write_unary<Value: LocalLabel>(output: &mut String, opcode: &str, value: &Value) {
-    output.push_str(opcode);
-    output.push(' ');
-    value.write_local_label(output);
 }

--- a/src/plan/execution/graph/value.rs
+++ b/src/plan/execution/graph/value.rs
@@ -32,6 +32,10 @@ pub(crate) use param::{ParamLocal, ParamSlot};
 use crate::plan::execution::explain::{Explain, ExplainContext};
 use std::convert::Infallible;
 
+pub(in crate::plan::execution) trait LocalLabel {
+    fn write_local_label(&self, output: &mut String);
+}
+
 impl<Value> Explain for Value
 where
     Value: LocalLabel,
@@ -39,6 +43,12 @@ where
     fn write_explanation(&self, context: &mut ExplainContext<'_, '_>) {
         self.write_local_label(context.output());
     }
+}
+
+pub(in crate::plan::execution) fn write_local_labels(output: &mut String, locals: &[ParamLocal]) {
+    write_list(output, locals, |output, local| {
+        local.write_local_label(output)
+    });
 }
 
 fn write_list<Value>(
@@ -54,16 +64,6 @@ fn write_list<Value>(
         write_value(output, value);
     }
     output.push(']');
-}
-
-pub(in crate::plan::execution) trait LocalLabel {
-    fn write_local_label(&self, output: &mut String);
-}
-
-pub(in crate::plan::execution) fn write_local_labels(output: &mut String, locals: &[ParamLocal]) {
-    write_list(output, locals, |output, local| {
-        local.write_local_label(output)
-    });
 }
 
 impl LocalLabel for IntLocalId {

--- a/src/plan/execution/lowering.rs
+++ b/src/plan/execution/lowering.rs
@@ -62,6 +62,121 @@ type PlainLoweredExecution = LoweredExecution<Infallible>;
 
 pub(super) use host::lower_hosted;
 
+pub(super) fn lower(module_plan: ModulePlan) -> ExecutionProgram<Infallible> {
+    let parts = module_plan.into_parts();
+    let root = parts.root;
+    let entry = parts.entry;
+    let mut module_contexts = Vec::with_capacity(parts.modules.len());
+    let mut module_templates = Vec::with_capacity(parts.modules.len());
+    let mut constant_templates = Vec::with_capacity(parts.modules.len());
+    let mut custom_types = Vec::new();
+
+    for module in parts.modules {
+        let parts = module.into_parts();
+        module_contexts.push(super::ExecutionModuleContext::new(
+            parts.module,
+            parts.source_context,
+        ));
+        custom_types.extend(parts.custom_types);
+        constant_templates.push(parts.constants);
+        let mut templates = parts.functions;
+        templates.extend(parts.anonymous_functions);
+        templates.sort_by_key(|template| template.id().index());
+        module_templates.push(templates);
+    }
+
+    let templates = FunctionTemplates::new(module_templates);
+    let main_return_shape = templates
+        .get(entry)
+        .signature()
+        .shape()
+        .return_shape()
+        .clone();
+    let main_key = SpecializationKey::monomorphic(entry);
+    let initial = SpecializationState {
+        constant_templates: ProgramConstantTemplates {
+            modules: constant_templates,
+        },
+        representations: RepresentationContext::new(custom_types),
+        erased_specializations: HashSet::new(),
+    };
+
+    // Function indices remain provisional until a pass produces no new erasures.
+    let (main, lowered) = resolve_specialization_fixed_point(initial, |state| {
+        let SpecializationState {
+            constant_templates,
+            representations,
+            erased_specializations,
+        } = state;
+        let main_value_shape = specialization::SpecializedValueShape::instantiate(
+            &main_return_shape,
+            main_key.substitution(),
+        );
+        let main_return_shape = representations.inhabitation(&main_value_shape);
+        let mut context = LoweringContext::new(
+            templates.entry_templates(),
+            representations,
+            constant_templates,
+            main_key.clone(),
+            erased_specializations,
+        );
+
+        let main = context.reserve_main(main_key.clone(), main_return_shape);
+
+        while let Some(key) = context.pending.pop_front() {
+            context.begin(&key);
+            function::lower_specialized(templates.get(key.template()), &key, &mut context);
+        }
+
+        let (constant_templates, representations, lowered) = context.finish();
+        let outcome = SpecializationOutcome::from_representability(
+            graph::seal_plain_runtime_function_id(main),
+            main_key.clone(),
+        )
+        .zip_with(lowered, |main, lowered| (main, lowered));
+        let erased_specializations = outcome.erased_specializations();
+        outcome.into_fixed_point(SpecializationState {
+            constant_templates,
+            representations,
+            erased_specializations,
+        })
+    });
+
+    ExecutionProgram {
+        common: ExecutionProgramCommon {
+            root,
+            modules: module_contexts.into_boxed_slice(),
+            main,
+            constants: lowered.constants,
+            list_types: lowered.list_types,
+            custom_types: lowered.custom_types,
+            external_types: lowered.external_types,
+            value_shapes: lowered.value_shapes,
+        },
+        functions: lowered.functions,
+    }
+}
+
+impl FunctionTemplates {
+    fn new(templates: Vec<Vec<crate::plan::FunctionTemplate>>) -> Self {
+        Self { templates }
+    }
+
+    fn get(&self, id: crate::plan::FunctionTemplateId) -> &crate::plan::FunctionTemplate {
+        &self.templates[id.module().index()][id.index()]
+    }
+
+    fn entry_templates(
+        &self,
+    ) -> HashMap<crate::plan::FunctionTemplateId, local::FunctionEntryTemplate> {
+        self.templates
+            .iter()
+            .flatten()
+            .map(|template| (template.id(), local::FunctionEntryTemplate::new(template)))
+            .collect()
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum FixedPointStep<State, Output> {
     Complete(Output),
@@ -1220,121 +1335,6 @@ impl LoweringContext {
             })
             .include_prior_erasure(erased_specializations);
         (constant_templates, representations, outcome)
-    }
-}
-
-pub(super) fn lower(module_plan: ModulePlan) -> ExecutionProgram<Infallible> {
-    let parts = module_plan.into_parts();
-    let root = parts.root;
-    let entry = parts.entry;
-    let mut module_contexts = Vec::with_capacity(parts.modules.len());
-    let mut module_templates = Vec::with_capacity(parts.modules.len());
-    let mut constant_templates = Vec::with_capacity(parts.modules.len());
-    let mut custom_types = Vec::new();
-
-    for module in parts.modules {
-        let parts = module.into_parts();
-        module_contexts.push(super::ExecutionModuleContext::new(
-            parts.module,
-            parts.source_context,
-        ));
-        custom_types.extend(parts.custom_types);
-        constant_templates.push(parts.constants);
-        let mut templates = parts.functions;
-        templates.extend(parts.anonymous_functions);
-        templates.sort_by_key(|template| template.id().index());
-        module_templates.push(templates);
-    }
-
-    let templates = FunctionTemplates::new(module_templates);
-    let main_return_shape = templates
-        .get(entry)
-        .signature()
-        .shape()
-        .return_shape()
-        .clone();
-    let main_key = SpecializationKey::monomorphic(entry);
-    let initial = SpecializationState {
-        constant_templates: ProgramConstantTemplates {
-            modules: constant_templates,
-        },
-        representations: RepresentationContext::new(custom_types),
-        erased_specializations: HashSet::new(),
-    };
-
-    // Function indices remain provisional until a pass produces no new erasures.
-    let (main, lowered) = resolve_specialization_fixed_point(initial, |state| {
-        let SpecializationState {
-            constant_templates,
-            representations,
-            erased_specializations,
-        } = state;
-        let main_value_shape = specialization::SpecializedValueShape::instantiate(
-            &main_return_shape,
-            main_key.substitution(),
-        );
-        let main_return_shape = representations.inhabitation(&main_value_shape);
-        let mut context = LoweringContext::new(
-            templates.entry_templates(),
-            representations,
-            constant_templates,
-            main_key.clone(),
-            erased_specializations,
-        );
-
-        let main = context.reserve_main(main_key.clone(), main_return_shape);
-
-        while let Some(key) = context.pending.pop_front() {
-            context.begin(&key);
-            function::lower_specialized(templates.get(key.template()), &key, &mut context);
-        }
-
-        let (constant_templates, representations, lowered) = context.finish();
-        let outcome = SpecializationOutcome::from_representability(
-            graph::seal_plain_runtime_function_id(main),
-            main_key.clone(),
-        )
-        .zip_with(lowered, |main, lowered| (main, lowered));
-        let erased_specializations = outcome.erased_specializations();
-        outcome.into_fixed_point(SpecializationState {
-            constant_templates,
-            representations,
-            erased_specializations,
-        })
-    });
-
-    ExecutionProgram {
-        common: ExecutionProgramCommon {
-            root,
-            modules: module_contexts.into_boxed_slice(),
-            main,
-            constants: lowered.constants,
-            list_types: lowered.list_types,
-            custom_types: lowered.custom_types,
-            external_types: lowered.external_types,
-            value_shapes: lowered.value_shapes,
-        },
-        functions: lowered.functions,
-    }
-}
-
-impl FunctionTemplates {
-    fn new(templates: Vec<Vec<crate::plan::FunctionTemplate>>) -> Self {
-        Self { templates }
-    }
-
-    fn get(&self, id: crate::plan::FunctionTemplateId) -> &crate::plan::FunctionTemplate {
-        &self.templates[id.module().index()][id.index()]
-    }
-
-    fn entry_templates(
-        &self,
-    ) -> HashMap<crate::plan::FunctionTemplateId, local::FunctionEntryTemplate> {
-        self.templates
-            .iter()
-            .flatten()
-            .map(|template| (template.id(), local::FunctionEntryTemplate::new(template)))
-            .collect()
     }
 }
 

--- a/src/plan/execution/lowering/graph/build/expression/function/generic.rs
+++ b/src/plan/execution/lowering/graph/build/expression/function/generic.rs
@@ -451,6 +451,148 @@ generic_primitive_function!(
     tuple_function_function_id
 );
 
+pub(super) fn symbolic_function_expr(
+    expression: &module::FunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftFunction>> {
+    symbolic_kind_from_function(expression, shape, cursor, graph, context)
+        .map(|flow| flow.map(|value| value.value().clone()))
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_int_function_expr(
+    expression: &module::IntFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_int_kind(expression.kind(), shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_float_function_expr(
+    expression: &module::FloatFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_float_kind(expression.kind(), shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_string_function_expr(
+    expression: &module::StringFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_string_kind(expression.kind(), shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_bit_array_function_expr(
+    expression: &module::BitArrayFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_bit_array_kind(expression.kind(), shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_utf_codepoint_function_expr(
+    expression: &module::UtfCodepointFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_utf_codepoint_kind(expression.kind(), shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_custom_function_expr_kind(
+    kind: &module::CustomFunctionExprKind,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_custom_kind(kind, shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_external_function_expr_kind(
+    kind: &module::ExternalFunctionExprKind,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_external_kind(kind, shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_bool_function_expr(
+    expression: &module::BoolFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_bool_kind(expression.kind(), shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_nil_function_expr(
+    expression: &module::NilFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_nil_kind(expression.kind(), shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_tuple_function_expr(
+    expression: &module::TupleFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_tuple_kind(expression.kind(), shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_list_function_expr(
+    expression: &module::ListFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_list_kind(expression.kind(), shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_function_function_expr_kind(
+    kind: &module::FunctionFunctionExprKind,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftGenericFunction>> {
+    symbolic_returning_function_kind(kind, shape, cursor, graph, context)
+}
+
+pub(in crate::plan::execution::lowering) fn symbolic_generic_function_expr(
+    expression: &module::GenericFunctionExpr,
+    shape: &SpecializedFunctionShape,
+    cursor: DraftCursor,
+    graph: &mut DraftGraph,
+    context: &mut super::super::super::LoweringContext,
+) -> Representability<DraftFlow<DraftFunction>> {
+    symbolic_generic_kind(expression.kind(), shape, cursor, graph, context)
+        .map(|flow| flow.map(|value| value.value().clone()))
+}
+
 macro_rules! define_symbolic_fixed_function {
     ($name:ident, $module_kind:ident, $constant:ident, $local_kind:ident) => {
         fn $name(
@@ -1582,148 +1724,6 @@ fn symbolic_returning_function_kind(
             })
         }
     }
-}
-
-pub(super) fn symbolic_function_expr(
-    expression: &module::FunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftFunction>> {
-    symbolic_kind_from_function(expression, shape, cursor, graph, context)
-        .map(|flow| flow.map(|value| value.value().clone()))
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_int_function_expr(
-    expression: &module::IntFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_int_kind(expression.kind(), shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_float_function_expr(
-    expression: &module::FloatFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_float_kind(expression.kind(), shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_string_function_expr(
-    expression: &module::StringFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_string_kind(expression.kind(), shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_bit_array_function_expr(
-    expression: &module::BitArrayFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_bit_array_kind(expression.kind(), shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_utf_codepoint_function_expr(
-    expression: &module::UtfCodepointFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_utf_codepoint_kind(expression.kind(), shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_custom_function_expr_kind(
-    kind: &module::CustomFunctionExprKind,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_custom_kind(kind, shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_external_function_expr_kind(
-    kind: &module::ExternalFunctionExprKind,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_external_kind(kind, shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_bool_function_expr(
-    expression: &module::BoolFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_bool_kind(expression.kind(), shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_nil_function_expr(
-    expression: &module::NilFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_nil_kind(expression.kind(), shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_tuple_function_expr(
-    expression: &module::TupleFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_tuple_kind(expression.kind(), shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_list_function_expr(
-    expression: &module::ListFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_list_kind(expression.kind(), shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_function_function_expr_kind(
-    kind: &module::FunctionFunctionExprKind,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftGenericFunction>> {
-    symbolic_returning_function_kind(kind, shape, cursor, graph, context)
-}
-
-pub(in crate::plan::execution::lowering) fn symbolic_generic_function_expr(
-    expression: &module::GenericFunctionExpr,
-    shape: &SpecializedFunctionShape,
-    cursor: DraftCursor,
-    graph: &mut DraftGraph,
-    context: &mut super::super::super::LoweringContext,
-) -> Representability<DraftFlow<DraftFunction>> {
-    symbolic_generic_kind(expression.kind(), shape, cursor, graph, context)
-        .map(|flow| flow.map(|value| value.value().clone()))
 }
 
 fn symbolic_kind_from_function(

--- a/src/plan/execution/lowering/graph/draft.rs
+++ b/src/plan/execution/lowering/graph/draft.rs
@@ -703,6 +703,12 @@ impl<Return, TailCall> DraftGraphBuilder<Return, TailCall> {
     }
 }
 
+impl<Return, TailCall> DraftGraphBuilder<Return, TailCall> {
+    pub(in crate::plan::execution::lowering) fn graph(&self) -> &DraftGraph {
+        &self.graph
+    }
+}
+
 impl<Return, TailCall> std::ops::Deref for DraftGraphBuilder<Return, TailCall> {
     type Target = DraftGraph;
 
@@ -714,12 +720,6 @@ impl<Return, TailCall> std::ops::Deref for DraftGraphBuilder<Return, TailCall> {
 impl<Return, TailCall> std::ops::DerefMut for DraftGraphBuilder<Return, TailCall> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.graph
-    }
-}
-
-impl<Return, TailCall> DraftGraphBuilder<Return, TailCall> {
-    pub(in crate::plan::execution::lowering) fn graph(&self) -> &DraftGraph {
-        &self.graph
     }
 }
 

--- a/src/plan/execution/type_/custom.rs
+++ b/src/plan/execution/type_/custom.rs
@@ -69,17 +69,17 @@ impl CustomTypeTable {
         &self.types[id.type_id().index()].constructors[&id.index()]
     }
 
-    #[cfg(test)]
-    pub(crate) fn len(&self) -> usize {
-        self.types.len()
-    }
-
     pub(crate) fn constructor_id_for_type(
         &self,
         type_id: CustomTypeId,
         constructor_index: usize,
     ) -> CustomConstructorId {
         self.types[type_id.index()].constructors[&constructor_index].id()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.types.len()
     }
 
     #[cfg(test)]

--- a/src/plan/execution/type_/function.rs
+++ b/src/plan/execution/type_/function.rs
@@ -42,12 +42,12 @@ impl FunctionType {
         }
     }
 
-    pub(crate) fn return_(&self) -> &ValueType {
-        &self.return_
-    }
-
     pub(crate) fn argument_types(&self) -> &[ValueType] {
         &self.arguments
+    }
+
+    pub(crate) fn return_(&self) -> &ValueType {
+        &self.return_
     }
 }
 

--- a/src/plan/execution/type_/list.rs
+++ b/src/plan/execution/type_/list.rs
@@ -325,6 +325,14 @@ impl ListTypeTable {
         }
     }
 
+    pub(crate) fn storage_type(&self, id: ListTypeId) -> ListStorageTypeId {
+        self.get(id)
+    }
+
+    fn get(&self, id: ListTypeId) -> ListStorageTypeId {
+        self.types[id.index()]
+    }
+
     #[cfg(test)]
     pub(in crate::plan::execution) fn entries(
         &self,
@@ -334,14 +342,6 @@ impl ListTypeTable {
             .copied()
             .enumerate()
             .map(|(index, type_)| (ListTypeId(index), type_))
-    }
-
-    fn get(&self, id: ListTypeId) -> ListStorageTypeId {
-        self.types[id.index()]
-    }
-
-    pub(crate) fn storage_type(&self, id: ListTypeId) -> ListStorageTypeId {
-        self.get(id)
     }
 
     pub(crate) fn value_type(

--- a/src/plan/execution/type_/shape.rs
+++ b/src/plan/execution/type_/shape.rs
@@ -119,13 +119,13 @@ impl ValueShapeTable {
         }
     }
 
+    pub(crate) fn value_type(&self, id: ValueShapeId) -> &super::ValueType {
+        &self.shape_types[id.index()]
+    }
+
     #[cfg(test)]
     pub(crate) fn get(&self, id: ValueShapeId) -> &ValueShapeDescriptor {
         &self.shapes[id.index()]
-    }
-
-    pub(crate) fn value_type(&self, id: ValueShapeId) -> &super::ValueType {
-        &self.shape_types[id.index()]
     }
 
     #[cfg(test)]

--- a/src/plan/module.rs
+++ b/src/plan/module.rs
@@ -243,6 +243,18 @@ impl ModulePlan {
         self
     }
 
+    pub fn root(&self) -> ModuleId {
+        self.root
+    }
+
+    pub fn entry(&self) -> FunctionTemplateId {
+        self.entry
+    }
+
+    pub fn modules(&self) -> &[PlannedModule] {
+        &self.modules
+    }
+
     pub fn module(&self) -> &EcoString {
         self.root_module().module()
     }
@@ -265,18 +277,6 @@ impl ModulePlan {
 
     pub fn functions(&self) -> &[FunctionTemplate] {
         &self.root_module().functions[1..]
-    }
-
-    pub fn root(&self) -> ModuleId {
-        self.root
-    }
-
-    pub fn entry(&self) -> FunctionTemplateId {
-        self.entry
-    }
-
-    pub fn modules(&self) -> &[PlannedModule] {
-        &self.modules
     }
 
     #[cfg(test)]

--- a/src/plan/module/constant.rs
+++ b/src/plan/module/constant.rs
@@ -302,21 +302,6 @@ impl ConstantNilReference {
 }
 
 impl ConstantInstantiation {
-    pub(crate) fn module(&self) -> crate::plan::ModuleId {
-        match &self.kind {
-            ConstantInstantiationKind::Int(value) => value.module(),
-            ConstantInstantiationKind::String(value) => value.module(),
-            ConstantInstantiationKind::BitArray(value) => value.module(),
-            ConstantInstantiationKind::Custom(value) => value.module(),
-            ConstantInstantiationKind::Float(value) => value.module(),
-            ConstantInstantiationKind::Bool(value) => value.module(),
-            ConstantInstantiationKind::Nil(value) => value.module(),
-            ConstantInstantiationKind::Tuple(value) => value.module(),
-            ConstantInstantiationKind::List(value) => value.module(),
-            ConstantInstantiationKind::Function(value) => value.module(),
-        }
-    }
-
     pub(crate) fn from_int(value: ConstantIntInstantiation) -> Self {
         Self {
             kind: ConstantInstantiationKind::Int(value),
@@ -374,6 +359,21 @@ impl ConstantInstantiation {
     pub(crate) fn from_function(value: ConstantFunctionInstantiation) -> Self {
         Self {
             kind: ConstantInstantiationKind::Function(value),
+        }
+    }
+
+    pub(crate) fn module(&self) -> crate::plan::ModuleId {
+        match &self.kind {
+            ConstantInstantiationKind::Int(value) => value.module(),
+            ConstantInstantiationKind::String(value) => value.module(),
+            ConstantInstantiationKind::BitArray(value) => value.module(),
+            ConstantInstantiationKind::Custom(value) => value.module(),
+            ConstantInstantiationKind::Float(value) => value.module(),
+            ConstantInstantiationKind::Bool(value) => value.module(),
+            ConstantInstantiationKind::Nil(value) => value.module(),
+            ConstantInstantiationKind::Tuple(value) => value.module(),
+            ConstantInstantiationKind::List(value) => value.module(),
+            ConstantInstantiationKind::Function(value) => value.module(),
         }
     }
 
@@ -640,6 +640,52 @@ impl ConstantTemplates {
         templates
     }
 
+    fn push_value(&mut self, value: ConstantValue) {
+        match value.kind {
+            ConstantValueKind::Int(value) => self.ints.push(value),
+            ConstantValueKind::Float(value) => self.floats.push(value),
+            ConstantValueKind::String(value) => self.strings.push(value),
+            ConstantValueKind::Bool(value) => self.bools.push(value),
+            ConstantValueKind::Nil(value) => self.nils.push(value),
+            ConstantValueKind::Tuple(value) => self.tuples.push(value),
+            ConstantValueKind::List(value) => match value {
+                ConstantListValue::Generic(value) => self.generic_lists.push(value),
+                ConstantListValue::ParameterList(value) => self.parameter_list_lists.push(value),
+                ConstantListValue::Int(value) => self.int_lists.push(value),
+                ConstantListValue::String(value) => self.string_lists.push(value),
+                ConstantListValue::BitArray(value) => self.bit_array_lists.push(value),
+                ConstantListValue::UtfCodepoint(value) => self.utf_codepoint_lists.push(value),
+                ConstantListValue::Custom(value) => self.custom_lists.push(value),
+                ConstantListValue::External(value) => self.external_lists.push(value),
+                ConstantListValue::Float(value) => self.float_lists.push(value),
+                ConstantListValue::Bool(value) => self.bool_lists.push(value),
+                ConstantListValue::Nil(value) => self.nil_lists.push(value),
+                ConstantListValue::Tuple(value) => self.tuple_lists.push(value),
+                ConstantListValue::List(value) => self.list_lists.push(value),
+                ConstantListValue::Function(value) => self.function_lists.push(value),
+            },
+            ConstantValueKind::BitArray(value) => self.bit_arrays.push(value),
+            ConstantValueKind::Custom(value) => self.custom_values.push(value),
+            ConstantValueKind::Function(value) => match value {
+                ConstantFunctionValue::Generic(value) => self.generic_functions.push(value),
+                ConstantFunctionValue::Int(value) => self.int_functions.push(value),
+                ConstantFunctionValue::String(value) => self.string_functions.push(value),
+                ConstantFunctionValue::BitArray(value) => self.bit_array_functions.push(value),
+                ConstantFunctionValue::UtfCodepoint(value) => {
+                    self.utf_codepoint_functions.push(value)
+                }
+                ConstantFunctionValue::Custom(value) => self.custom_functions.push(value),
+                ConstantFunctionValue::External(value) => self.external_functions.push(value),
+                ConstantFunctionValue::Float(value) => self.float_functions.push(value),
+                ConstantFunctionValue::Bool(value) => self.bool_functions.push(value),
+                ConstantFunctionValue::Nil(value) => self.nil_functions.push(value),
+                ConstantFunctionValue::Tuple(value) => self.tuple_functions.push(value),
+                ConstantFunctionValue::List(value) => self.list_functions.push(value),
+                ConstantFunctionValue::Function(value) => self.function_functions.push(value),
+            },
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn from_entries(entries: Vec<(ConstantTemplate, ConstantValue)>) -> Self {
         Self::from_module_entries(crate::plan::ModuleId::root(), entries)
@@ -828,52 +874,6 @@ impl ConstantTemplates {
         id: ConstantFunctionFunctionTemplateId,
     ) -> &ConstantFunctionFunctionValue {
         &self.function_functions[id.0]
-    }
-
-    fn push_value(&mut self, value: ConstantValue) {
-        match value.kind {
-            ConstantValueKind::Int(value) => self.ints.push(value),
-            ConstantValueKind::Float(value) => self.floats.push(value),
-            ConstantValueKind::String(value) => self.strings.push(value),
-            ConstantValueKind::Bool(value) => self.bools.push(value),
-            ConstantValueKind::Nil(value) => self.nils.push(value),
-            ConstantValueKind::Tuple(value) => self.tuples.push(value),
-            ConstantValueKind::List(value) => match value {
-                ConstantListValue::Generic(value) => self.generic_lists.push(value),
-                ConstantListValue::ParameterList(value) => self.parameter_list_lists.push(value),
-                ConstantListValue::Int(value) => self.int_lists.push(value),
-                ConstantListValue::String(value) => self.string_lists.push(value),
-                ConstantListValue::BitArray(value) => self.bit_array_lists.push(value),
-                ConstantListValue::UtfCodepoint(value) => self.utf_codepoint_lists.push(value),
-                ConstantListValue::Custom(value) => self.custom_lists.push(value),
-                ConstantListValue::External(value) => self.external_lists.push(value),
-                ConstantListValue::Float(value) => self.float_lists.push(value),
-                ConstantListValue::Bool(value) => self.bool_lists.push(value),
-                ConstantListValue::Nil(value) => self.nil_lists.push(value),
-                ConstantListValue::Tuple(value) => self.tuple_lists.push(value),
-                ConstantListValue::List(value) => self.list_lists.push(value),
-                ConstantListValue::Function(value) => self.function_lists.push(value),
-            },
-            ConstantValueKind::BitArray(value) => self.bit_arrays.push(value),
-            ConstantValueKind::Custom(value) => self.custom_values.push(value),
-            ConstantValueKind::Function(value) => match value {
-                ConstantFunctionValue::Generic(value) => self.generic_functions.push(value),
-                ConstantFunctionValue::Int(value) => self.int_functions.push(value),
-                ConstantFunctionValue::String(value) => self.string_functions.push(value),
-                ConstantFunctionValue::BitArray(value) => self.bit_array_functions.push(value),
-                ConstantFunctionValue::UtfCodepoint(value) => {
-                    self.utf_codepoint_functions.push(value)
-                }
-                ConstantFunctionValue::Custom(value) => self.custom_functions.push(value),
-                ConstantFunctionValue::External(value) => self.external_functions.push(value),
-                ConstantFunctionValue::Float(value) => self.float_functions.push(value),
-                ConstantFunctionValue::Bool(value) => self.bool_functions.push(value),
-                ConstantFunctionValue::Nil(value) => self.nil_functions.push(value),
-                ConstantFunctionValue::Tuple(value) => self.tuple_functions.push(value),
-                ConstantFunctionValue::List(value) => self.list_functions.push(value),
-                ConstantFunctionValue::Function(value) => self.function_functions.push(value),
-            },
-        }
     }
 
     pub(crate) fn reference(instantiation: ConstantInstantiation) -> Expr {

--- a/src/plan/module/constant/function.rs
+++ b/src/plan/module/constant/function.rs
@@ -561,6 +561,29 @@ impl ConstantFunctionInstantiation {
         }
     }
 
+    pub(super) fn substitute(&self, outer: &TypeSubstitution) -> Self {
+        match self {
+            Self::Generic(value) => Self::from_generic_source(
+                value.module(),
+                *value.source(),
+                value.substitution().substitute(outer),
+                value.shape().substitute(outer),
+            ),
+            Self::Int(value) => Self::Int(value.substitute(outer)),
+            Self::String(value) => Self::String(value.substitute(outer)),
+            Self::BitArray(value) => Self::BitArray(value.substitute(outer)),
+            Self::UtfCodepoint(value) => Self::UtfCodepoint(value.substitute(outer)),
+            Self::Custom(value) => Self::Custom(value.substitute(outer)),
+            Self::External(value) => Self::External(value.substitute(outer)),
+            Self::Float(value) => Self::Float(value.substitute(outer)),
+            Self::Bool(value) => Self::Bool(value.substitute(outer)),
+            Self::Nil(value) => Self::Nil(value.substitute(outer)),
+            Self::Tuple(value) => Self::Tuple(value.substitute(outer)),
+            Self::List(value) => Self::List(value.substitute(outer)),
+            Self::Function(value) => Self::Function(value.substitute(outer)),
+        }
+    }
+
     fn from_generic_source(
         module: crate::plan::ModuleId,
         source: ConstantGenericFunctionTemplateId,
@@ -671,29 +694,6 @@ impl ConstantFunctionInstantiation {
                     return_,
                 ))
             }
-        }
-    }
-
-    pub(super) fn substitute(&self, outer: &TypeSubstitution) -> Self {
-        match self {
-            Self::Generic(value) => Self::from_generic_source(
-                value.module(),
-                *value.source(),
-                value.substitution().substitute(outer),
-                value.shape().substitute(outer),
-            ),
-            Self::Int(value) => Self::Int(value.substitute(outer)),
-            Self::String(value) => Self::String(value.substitute(outer)),
-            Self::BitArray(value) => Self::BitArray(value.substitute(outer)),
-            Self::UtfCodepoint(value) => Self::UtfCodepoint(value.substitute(outer)),
-            Self::Custom(value) => Self::Custom(value.substitute(outer)),
-            Self::External(value) => Self::External(value.substitute(outer)),
-            Self::Float(value) => Self::Float(value.substitute(outer)),
-            Self::Bool(value) => Self::Bool(value.substitute(outer)),
-            Self::Nil(value) => Self::Nil(value.substitute(outer)),
-            Self::Tuple(value) => Self::Tuple(value.substitute(outer)),
-            Self::List(value) => Self::List(value.substitute(outer)),
-            Self::Function(value) => Self::Function(value.substitute(outer)),
         }
     }
 }

--- a/src/plan/module/expression/custom.rs
+++ b/src/plan/module/expression/custom.rs
@@ -424,12 +424,12 @@ impl CustomConstruction {
         })
     }
 
-    pub(crate) fn fields(&self) -> &[super::Expr] {
-        &self.fields
-    }
-
     pub(crate) fn constructor(&self) -> &CustomConstructor {
         &self.constructor
+    }
+
+    pub(crate) fn fields(&self) -> &[super::Expr] {
+        &self.fields
     }
 }
 

--- a/src/plan/module/expression/function.rs
+++ b/src/plan/module/expression/function.rs
@@ -172,64 +172,6 @@ impl FunctionExpr {
         }
     }
 
-    fn new(kind: FunctionExprKind) -> Self {
-        let shape = match &kind {
-            FunctionExprKind::Generic(expression) => expression.shape(),
-            FunctionExprKind::Int(expression) => {
-                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
-            }
-            FunctionExprKind::String(expression) => {
-                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
-            }
-            FunctionExprKind::BitArray(expression) => {
-                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
-            }
-            FunctionExprKind::UtfCodepoint(expression) => {
-                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
-            }
-            FunctionExprKind::Custom(expression) => crate::plan::FunctionShape::new(
-                expression.custom_function_type().argument_shapes().to_vec(),
-                crate::plan::ValueShape::Custom(
-                    expression.custom_function_type().return_().clone(),
-                ),
-            ),
-            FunctionExprKind::External(expression) => crate::plan::FunctionShape::new(
-                expression
-                    .external_function_type()
-                    .argument_shapes()
-                    .to_vec(),
-                crate::plan::ValueShape::External(
-                    expression.external_function_type().return_().clone(),
-                ),
-            ),
-            FunctionExprKind::Float(expression) => {
-                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
-            }
-            FunctionExprKind::Bool(expression) => {
-                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
-            }
-            FunctionExprKind::Nil(expression) => {
-                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
-            }
-            FunctionExprKind::Tuple(expression) => {
-                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
-            }
-            FunctionExprKind::List(expression) => {
-                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
-            }
-            FunctionExprKind::Function(expression) => crate::plan::FunctionShape::new(
-                expression
-                    .function_function_type()
-                    .argument_shapes()
-                    .to_vec(),
-                crate::plan::ValueShape::Function(Box::new(
-                    expression.function_function_type().return_shape().clone(),
-                )),
-            ),
-        };
-        Self { shape, kind }
-    }
-
     pub(crate) fn custom_field_shape(access: CustomFieldAccess, shape: FunctionShape) -> Self {
         let type_ = shape.type_();
         match shape.return_shape().clone() {
@@ -671,6 +613,64 @@ impl FunctionExpr {
     }
 
     fn with_typed_shape(kind: FunctionExprKind, shape: crate::plan::FunctionShape) -> Self {
+        Self { shape, kind }
+    }
+
+    fn new(kind: FunctionExprKind) -> Self {
+        let shape = match &kind {
+            FunctionExprKind::Generic(expression) => expression.shape(),
+            FunctionExprKind::Int(expression) => {
+                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
+            }
+            FunctionExprKind::String(expression) => {
+                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
+            }
+            FunctionExprKind::BitArray(expression) => {
+                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
+            }
+            FunctionExprKind::UtfCodepoint(expression) => {
+                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
+            }
+            FunctionExprKind::Custom(expression) => crate::plan::FunctionShape::new(
+                expression.custom_function_type().argument_shapes().to_vec(),
+                crate::plan::ValueShape::Custom(
+                    expression.custom_function_type().return_().clone(),
+                ),
+            ),
+            FunctionExprKind::External(expression) => crate::plan::FunctionShape::new(
+                expression
+                    .external_function_type()
+                    .argument_shapes()
+                    .to_vec(),
+                crate::plan::ValueShape::External(
+                    expression.external_function_type().return_().clone(),
+                ),
+            ),
+            FunctionExprKind::Float(expression) => {
+                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
+            }
+            FunctionExprKind::Bool(expression) => {
+                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
+            }
+            FunctionExprKind::Nil(expression) => {
+                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
+            }
+            FunctionExprKind::Tuple(expression) => {
+                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
+            }
+            FunctionExprKind::List(expression) => {
+                crate::plan::FunctionShape::from_function_type(expression.type_().clone())
+            }
+            FunctionExprKind::Function(expression) => crate::plan::FunctionShape::new(
+                expression
+                    .function_function_type()
+                    .argument_shapes()
+                    .to_vec(),
+                crate::plan::ValueShape::Function(Box::new(
+                    expression.function_function_type().return_shape().clone(),
+                )),
+            ),
+        };
         Self { shape, kind }
     }
 

--- a/src/plan/module/expression/function/custom.rs
+++ b/src/plan/module/expression/function/custom.rs
@@ -313,6 +313,9 @@ impl CustomFunctionExpr {
         }
     }
 
+    pub fn type_(&self) -> FunctionType {
+        self.type_.to_function_type()
+    }
     pub(crate) fn custom_function_type(&self) -> &CustomFunctionType {
         &self.type_
     }
@@ -322,9 +325,6 @@ impl CustomFunctionExpr {
         self
     }
 
-    pub fn type_(&self) -> FunctionType {
-        self.type_.to_function_type()
-    }
     pub(crate) fn kind(&self) -> &CustomFunctionExprKind {
         &self.kind
     }

--- a/src/plan/module/expression/function/external.rs
+++ b/src/plan/module/expression/function/external.rs
@@ -279,6 +279,10 @@ impl ExternalFunctionExpr {
         }
     }
 
+    pub fn type_(&self) -> FunctionType {
+        self.type_.to_function_type()
+    }
+
     pub(crate) fn external_function_type(&self) -> &ExternalFunctionType {
         &self.type_
     }
@@ -286,10 +290,6 @@ impl ExternalFunctionExpr {
     pub(super) fn with_type(mut self, type_: ExternalFunctionType) -> Self {
         self.type_ = type_;
         self
-    }
-
-    pub fn type_(&self) -> FunctionType {
-        self.type_.to_function_type()
     }
 
     pub(crate) fn kind(&self) -> &ExternalFunctionExprKind {

--- a/src/plan/module/expression/function/returning_function.rs
+++ b/src/plan/module/expression/function/returning_function.rs
@@ -88,11 +88,6 @@ impl FunctionFunctionExpr {
         }
     }
 
-    pub(crate) fn with_type(mut self, type_: FunctionFunctionType) -> Self {
-        self.type_ = type_;
-        self
-    }
-
     pub(crate) fn reference(value: FunctionFunctionReference, return_type: FunctionType) -> Self {
         let type_ = FunctionFunctionType::new(
             value
@@ -320,11 +315,16 @@ impl FunctionFunctionExpr {
         }
     }
 
+    pub fn type_(&self) -> FunctionType {
+        self.type_.to_function_type()
+    }
     pub(crate) fn function_function_type(&self) -> &FunctionFunctionType {
         &self.type_
     }
-    pub fn type_(&self) -> FunctionType {
-        self.type_.to_function_type()
+
+    pub(crate) fn with_type(mut self, type_: FunctionFunctionType) -> Self {
+        self.type_ = type_;
+        self
     }
 
     pub(crate) fn kind(&self) -> &FunctionFunctionExprKind {

--- a/src/plan/module/expression/list/typed.rs
+++ b/src/plan/module/expression/list/typed.rs
@@ -134,27 +134,6 @@ impl<Item: ListItem> ListIndexSource<Item> {
 }
 
 impl<Item: ListItem> TypedListExpr<Item> {
-    fn new(item: Item, kind: TypedListExprKind<Item>) -> Self {
-        let item_shape = crate::plan::ValueShape::from_value_type(item.value_type());
-        Self {
-            item_shape,
-            item,
-            kind,
-        }
-    }
-
-    fn from_shape_item_and_kind(
-        item_shape: crate::plan::ValueShape,
-        item: Item,
-        kind: TypedListExprKind<Item>,
-    ) -> Self {
-        Self {
-            item_shape,
-            item,
-            kind,
-        }
-    }
-
     pub(in crate::plan::module) fn constant(
         item_shape: crate::plan::ValueShape,
         item: Item,
@@ -501,6 +480,27 @@ impl<Item: ListItem> TypedListExpr<Item> {
                 return_: Box::new(return_),
             },
         )
+    }
+
+    fn new(item: Item, kind: TypedListExprKind<Item>) -> Self {
+        let item_shape = crate::plan::ValueShape::from_value_type(item.value_type());
+        Self {
+            item_shape,
+            item,
+            kind,
+        }
+    }
+
+    fn from_shape_item_and_kind(
+        item_shape: crate::plan::ValueShape,
+        item: Item,
+        kind: TypedListExprKind<Item>,
+    ) -> Self {
+        Self {
+            item_shape,
+            item,
+            kind,
+        }
     }
 }
 

--- a/src/plan/module/expression/tuple.rs
+++ b/src/plan/module/expression/tuple.rs
@@ -68,16 +68,6 @@ pub(crate) enum TupleExprKind {
 }
 
 impl TupleExpr {
-    fn new(type_: Vec<ValueType>, kind: TupleExprKind) -> Self {
-        let shape = type_
-            .iter()
-            .cloned()
-            .map(crate::plan::ValueShape::from_value_type)
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        Self { type_, shape, kind }
-    }
-
     pub(crate) fn value(elements: Vec<super::Expr>, type_: Vec<ValueType>) -> Self {
         let shape = elements
             .iter()
@@ -272,6 +262,16 @@ impl TupleExpr {
     pub(crate) fn with_shape(mut self, shape: Box<[crate::plan::ValueShape]>) -> Self {
         self.shape = shape;
         self
+    }
+
+    fn new(type_: Vec<ValueType>, kind: TupleExprKind) -> Self {
+        let shape = type_
+            .iter()
+            .cloned()
+            .map(crate::plan::ValueShape::from_value_type)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self { type_, shape, kind }
     }
 }
 

--- a/src/plan/module/function.rs
+++ b/src/plan/module/function.rs
@@ -1318,10 +1318,6 @@ impl FunctionTemplate {
         self.signature.scheme()
     }
 
-    pub(crate) fn signature(&self) -> &FunctionTemplateSignature {
-        &self.signature
-    }
-
     pub fn name(&self) -> &EcoString {
         &self.name
     }
@@ -1330,16 +1326,20 @@ impl FunctionTemplate {
         self.entry.params()
     }
 
-    pub(crate) fn entry(&self) -> &FunctionEntry {
-        &self.entry
-    }
-
     pub fn steps(&self) -> &[Step] {
         &self.steps
     }
 
     pub fn return_(&self) -> &ReturnExpr {
         &self.return_
+    }
+
+    pub(crate) fn signature(&self) -> &FunctionTemplateSignature {
+        &self.signature
+    }
+
+    pub(crate) fn entry(&self) -> &FunctionEntry {
+        &self.entry
     }
 }
 
@@ -1423,12 +1423,6 @@ impl ReturnExpr {
         }
     }
 
-    pub(crate) fn int_list_body(body: IntListReturn) -> Self {
-        Self {
-            kind: ReturnExprKind::IntList { body },
-        }
-    }
-
     pub(crate) fn generic_list_body(
         parameter: crate::plan::TypeParameterId,
         body: GenericListReturn,
@@ -1444,6 +1438,12 @@ impl ReturnExpr {
     ) -> Self {
         Self {
             kind: ReturnExprKind::ParameterListList { parameter, body },
+        }
+    }
+
+    pub(crate) fn int_list_body(body: IntListReturn) -> Self {
+        Self {
+            kind: ReturnExprKind::IntList { body },
         }
     }
 
@@ -1513,21 +1513,21 @@ impl ReturnExpr {
         }
     }
 
-    pub(crate) fn int_function_shape_body(
-        shape: crate::plan::FunctionShape,
-        body: IntFunctionReturn,
-    ) -> Self {
-        Self {
-            kind: ReturnExprKind::IntFunction { shape, body },
-        }
-    }
-
     pub(crate) fn generic_function_shape_body(
         shape: crate::plan::FunctionShape,
         body: GenericFunctionReturn,
     ) -> Self {
         Self {
             kind: ReturnExprKind::GenericFunction { shape, body },
+        }
+    }
+
+    pub(crate) fn int_function_shape_body(
+        shape: crate::plan::FunctionShape,
+        body: IntFunctionReturn,
+    ) -> Self {
+        Self {
+            kind: ReturnExprKind::IntFunction { shape, body },
         }
     }
 
@@ -1635,10 +1635,6 @@ impl ReturnExpr {
         }
     }
 
-    pub(crate) fn kind(&self) -> &ReturnExprKind {
-        &self.kind
-    }
-
     pub fn value_type(&self) -> ValueType {
         match self.kind() {
             ReturnExprKind::Generic { parameter, .. } => ValueType::Parameter(*parameter),
@@ -1698,6 +1694,10 @@ impl ReturnExpr {
                 ValueType::Function(Box::new(shape.type_()))
             }
         }
+    }
+
+    pub(crate) fn kind(&self) -> &ReturnExprKind {
+        &self.kind
     }
 }
 

--- a/src/plan/module/pattern/custom.rs
+++ b/src/plan/module/pattern/custom.rs
@@ -20,12 +20,12 @@ impl CustomPattern {
         }
     }
 
-    pub(crate) fn fields(&self) -> &[AssertPattern] {
-        &self.fields
-    }
-
     pub(crate) fn constructor(&self) -> &CustomConstructor {
         &self.constructor
+    }
+
+    pub(crate) fn fields(&self) -> &[AssertPattern] {
+        &self.fields
     }
 
     pub(crate) fn total_fields(&self) -> Option<&[TotalBindingPattern]> {

--- a/src/plan/module/step.rs
+++ b/src/plan/module/step.rs
@@ -374,19 +374,19 @@ impl AssertPattern {
         Self::List(pattern)
     }
 
-    pub(crate) fn alias(pattern: AssertPattern, binding: AssertBinding) -> Self {
-        Self::Alias {
-            pattern: Box::new(pattern),
-            binding,
-        }
-    }
-
     pub(crate) fn bit_array(pattern: BitArrayPattern) -> Self {
         Self::BitArray(pattern)
     }
 
     pub(crate) fn custom(pattern: crate::plan::CustomPattern) -> Self {
         Self::Custom(pattern)
+    }
+
+    pub(crate) fn alias(pattern: AssertPattern, binding: AssertBinding) -> Self {
+        Self::Alias {
+            pattern: Box::new(pattern),
+            binding,
+        }
     }
 }
 
@@ -403,12 +403,12 @@ impl ListAssertPattern {
         }
     }
 
-    pub(crate) fn elements(&self) -> &[AssertPattern] {
-        &self.elements
-    }
-
     pub(crate) fn element_type(&self) -> &ValueType {
         &self.element_type
+    }
+
+    pub(crate) fn elements(&self) -> &[AssertPattern] {
+        &self.elements
     }
 
     pub(crate) fn tail(&self) -> Option<&ListAssertTail> {
@@ -432,16 +432,6 @@ impl Step {
     pub(crate) fn let_generic(local: GenericLocal, name: EcoString, value: GenericExpr) -> Self {
         Self {
             kind: StepKind::LetGeneric { local, name, value },
-        }
-    }
-
-    pub(crate) fn echo(subject: EchoSubject, message: Option<StringExpr>, site: EchoSite) -> Self {
-        Self {
-            kind: StepKind::Echo(Echo {
-                subject,
-                message,
-                site,
-            }),
         }
     }
 
@@ -658,6 +648,16 @@ impl Step {
         }
     }
 
+    pub(crate) fn echo(subject: EchoSubject, message: Option<StringExpr>, site: EchoSite) -> Self {
+        Self {
+            kind: StepKind::Echo(Echo {
+                subject,
+                message,
+                site,
+            }),
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn let_int_function(
         local: IntFunctionLocalId,
@@ -771,26 +771,6 @@ impl Step {
         Self::let_function_function_expr(local, name, TypedFunctionExpr::new(shape, value))
     }
 
-    pub(crate) fn evaluate(value: Expr) -> Self {
-        Self {
-            kind: StepKind::Evaluate(value),
-        }
-    }
-
-    pub(crate) fn assert_bool_at(
-        condition: BoolExpr,
-        message: Option<StringExpr>,
-        site: PanicSite,
-    ) -> Self {
-        Self {
-            kind: StepKind::AssertBool {
-                condition,
-                message,
-                site,
-            },
-        }
-    }
-
     pub(crate) fn assert_pattern_at(
         subject: AssertSubject,
         pattern: AssertPattern,
@@ -813,6 +793,26 @@ impl Step {
         let local = CustomLocal::from_shape(local, pattern.source_shape().clone());
         Self {
             kind: StepKind::BindCustomFields { local, pattern },
+        }
+    }
+
+    pub(crate) fn assert_bool_at(
+        condition: BoolExpr,
+        message: Option<StringExpr>,
+        site: PanicSite,
+    ) -> Self {
+        Self {
+            kind: StepKind::AssertBool {
+                condition,
+                message,
+                site,
+            },
+        }
+    }
+
+    pub(crate) fn evaluate(value: Expr) -> Self {
+        Self {
+            kind: StepKind::Evaluate(value),
         }
     }
 

--- a/src/plan/value_type.rs
+++ b/src/plan/value_type.rs
@@ -95,12 +95,12 @@ impl FunctionType {
         }
     }
 
-    pub fn return_(&self) -> &ValueType {
-        &self.return_
-    }
-
     pub fn argument_types(&self) -> &[ValueType] {
         &self.arguments
+    }
+
+    pub fn return_(&self) -> &ValueType {
+        &self.return_
     }
 }
 
@@ -120,16 +120,16 @@ impl CustomFunctionType {
         Self { arguments, return_ }
     }
 
-    pub(crate) fn return_(&self) -> &CustomValueShape {
-        &self.return_
-    }
-
     pub(crate) fn argument_shapes(&self) -> &[ValueShape] {
         &self.arguments
     }
 
     pub(crate) fn argument_types(&self) -> Vec<ValueType> {
         self.arguments.iter().map(ValueShape::value_type).collect()
+    }
+
+    pub(crate) fn return_(&self) -> &CustomValueShape {
+        &self.return_
     }
 
     pub(crate) fn to_function_type(&self) -> FunctionType {
@@ -145,16 +145,16 @@ impl ExternalFunctionType {
         Self { arguments, return_ }
     }
 
-    pub(crate) fn return_(&self) -> &ExternalValueShape {
-        &self.return_
-    }
-
     pub(crate) fn argument_shapes(&self) -> &[ValueShape] {
         &self.arguments
     }
 
     pub(crate) fn argument_types(&self) -> Vec<ValueType> {
         self.arguments.iter().map(ValueShape::value_type).collect()
+    }
+
+    pub(crate) fn return_(&self) -> &ExternalValueShape {
+        &self.return_
     }
 
     pub(crate) fn to_function_type(&self) -> FunctionType {
@@ -183,16 +183,16 @@ impl FunctionFunctionType {
         }
     }
 
-    pub(crate) fn return_shape(&self) -> &super::FunctionShape {
-        &self.return_
-    }
-
     pub(crate) fn argument_shapes(&self) -> &[ValueShape] {
         &self.arguments
     }
 
     pub(crate) fn argument_types(&self) -> Vec<ValueType> {
         self.arguments.iter().map(ValueShape::value_type).collect()
+    }
+
+    pub(crate) fn return_shape(&self) -> &super::FunctionShape {
+        &self.return_
     }
 
     pub(crate) fn return_type(&self) -> FunctionType {

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -617,14 +617,6 @@ pub(super) enum FunctionLocalBinding {
 }
 
 impl<'a> PlanContext<'a> {
-    fn executable_external(&self, module: &EcoString, name: &EcoString) -> bool {
-        match self.registry {
-            RegistryAccess::Program { registry } => registry.executable_external(module, name),
-            #[cfg(test)]
-            RegistryAccess::Local { .. } => false,
-        }
-    }
-
     #[cfg(test)]
     pub(super) fn new(
         module_name: &'a EcoString,
@@ -2334,6 +2326,14 @@ impl<'a> PlanContext<'a> {
                 },
             }
         })
+    }
+
+    fn executable_external(&self, module: &EcoString, name: &EcoString) -> bool {
+        match self.registry {
+            RegistryAccess::Program { registry } => registry.executable_external(module, name),
+            #[cfg(test)]
+            RegistryAccess::Local { .. } => false,
+        }
     }
 
     fn validate_constructor_arity(

--- a/src/planner/expression.rs
+++ b/src/planner/expression.rs
@@ -182,92 +182,6 @@ pub(super) fn plan_expr(
     Ok(expression)
 }
 
-fn plan_panic_expr(
-    location: gleam_core::ast::SrcSpan,
-    message: Option<TypedExpr>,
-    type_: std::sync::Arc<gleam_core::type_::Type>,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    let return_shape = context.value_shape(type_.as_ref());
-
-    let site = context.panic_site(location);
-    plan_panic_expr_with_shape(message, return_shape, site, context)
-}
-
-fn plan_todo_expr(
-    location: gleam_core::ast::SrcSpan,
-    kind: TodoKind,
-    message: Option<TypedExpr>,
-    type_: std::sync::Arc<gleam_core::type_::Type>,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    let return_shape = context.value_shape(type_.as_ref());
-
-    plan_todo_expr_with_shape(location, kind, message, return_shape, context)
-}
-
-fn plan_panic_expr_with_shape(
-    message: Option<TypedExpr>,
-    return_shape: ValueShape,
-    site: crate::plan::PanicSite,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    let message = plan_panic_message(message, context)?;
-
-    Ok(panic_expr(PanicExpr::panic_at(message, site), return_shape))
-}
-
-fn plan_todo_expr_with_shape(
-    location: gleam_core::ast::SrcSpan,
-    kind: TodoKind,
-    message: Option<TypedExpr>,
-    return_shape: ValueShape,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    let site = match &kind {
-        TodoKind::EmptyFunction { function_location } => context.panic_site(*function_location),
-        TodoKind::Keyword | TodoKind::EmptyBlock | TodoKind::IncompleteUse => {
-            context.panic_site(location)
-        }
-    };
-    let panic = match kind {
-        TodoKind::Keyword => PanicExpr::todo_at(plan_panic_message(message, context)?, site),
-        TodoKind::EmptyFunction { .. } => {
-            generated_todo_expr(message, PanicExpr::empty_function_at(site))?
-        }
-        TodoKind::EmptyBlock => generated_todo_expr(message, PanicExpr::empty_block_at(site))?,
-        TodoKind::IncompleteUse => {
-            generated_todo_expr(message, PanicExpr::incomplete_use_at(site))?
-        }
-    };
-
-    Ok(panic_expr(panic, return_shape))
-}
-
-fn plan_panic_message(
-    message: Option<TypedExpr>,
-    context: &mut PlanContext<'_>,
-) -> Result<Option<StringExpr>, PlanError> {
-    message
-        .map(|message| plan_string_expr(message, context))
-        .transpose()
-}
-
-fn generated_todo_expr(
-    message: Option<TypedExpr>,
-    expression: PanicExpr,
-) -> Result<PanicExpr, PlanError> {
-    if message.is_some() {
-        return Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::ExpressionShape {
-                kind: InvalidExpressionShapeKind::Invalid,
-            },
-        });
-    }
-
-    Ok(expression)
-}
-
 pub(super) fn plan_expr_with_expected_source_stop_type(
     expression: TypedExpr,
     expected: ValueType,
@@ -309,6 +223,100 @@ pub(super) fn plan_expr_with_expected_source_stop_shape(
         }
         expression => plan_expr(expression, context),
     }
+}
+
+pub(super) fn plan_use_call(
+    call: TypedExpr,
+    use_assignment_count: usize,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    call::plan_use_call(call, use_assignment_count, context)
+}
+
+fn plan_todo_expr(
+    location: gleam_core::ast::SrcSpan,
+    kind: TodoKind,
+    message: Option<TypedExpr>,
+    type_: std::sync::Arc<gleam_core::type_::Type>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let return_shape = context.value_shape(type_.as_ref());
+
+    plan_todo_expr_with_shape(location, kind, message, return_shape, context)
+}
+
+fn plan_panic_expr(
+    location: gleam_core::ast::SrcSpan,
+    message: Option<TypedExpr>,
+    type_: std::sync::Arc<gleam_core::type_::Type>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let return_shape = context.value_shape(type_.as_ref());
+
+    let site = context.panic_site(location);
+    plan_panic_expr_with_shape(message, return_shape, site, context)
+}
+
+fn plan_todo_expr_with_shape(
+    location: gleam_core::ast::SrcSpan,
+    kind: TodoKind,
+    message: Option<TypedExpr>,
+    return_shape: ValueShape,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let site = match &kind {
+        TodoKind::EmptyFunction { function_location } => context.panic_site(*function_location),
+        TodoKind::Keyword | TodoKind::EmptyBlock | TodoKind::IncompleteUse => {
+            context.panic_site(location)
+        }
+    };
+    let panic = match kind {
+        TodoKind::Keyword => PanicExpr::todo_at(plan_panic_message(message, context)?, site),
+        TodoKind::EmptyFunction { .. } => {
+            generated_todo_expr(message, PanicExpr::empty_function_at(site))?
+        }
+        TodoKind::EmptyBlock => generated_todo_expr(message, PanicExpr::empty_block_at(site))?,
+        TodoKind::IncompleteUse => {
+            generated_todo_expr(message, PanicExpr::incomplete_use_at(site))?
+        }
+    };
+
+    Ok(panic_expr(panic, return_shape))
+}
+
+fn plan_panic_expr_with_shape(
+    message: Option<TypedExpr>,
+    return_shape: ValueShape,
+    site: crate::plan::PanicSite,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    let message = plan_panic_message(message, context)?;
+
+    Ok(panic_expr(PanicExpr::panic_at(message, site), return_shape))
+}
+
+fn plan_panic_message(
+    message: Option<TypedExpr>,
+    context: &mut PlanContext<'_>,
+) -> Result<Option<StringExpr>, PlanError> {
+    message
+        .map(|message| plan_string_expr(message, context))
+        .transpose()
+}
+
+fn generated_todo_expr(
+    message: Option<TypedExpr>,
+    expression: PanicExpr,
+) -> Result<PanicExpr, PlanError> {
+    if message.is_some() {
+        return Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::ExpressionShape {
+                kind: InvalidExpressionShapeKind::Invalid,
+            },
+        });
+    }
+
+    Ok(expression)
 }
 
 fn panic_expr(panic: PanicExpr, return_shape: ValueShape) -> Expr {
@@ -805,14 +813,6 @@ fn list_index_function_expr(
             ))
         }
     }
-}
-
-pub(super) fn plan_use_call(
-    call: TypedExpr,
-    use_assignment_count: usize,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    call::plan_use_call(call, use_assignment_count, context)
 }
 
 fn plan_int_expr(

--- a/src/planner/expression/call/argument.rs
+++ b/src/planner/expression/call/argument.rs
@@ -98,6 +98,21 @@ pub(super) fn plan_custom_constructor_args(
         .collect()
 }
 
+fn plan_argument_value(
+    argument: GleamCallArg<TypedExpr>,
+    expected: ValueShape,
+    capture: Option<&CaptureSubstitution>,
+    context: &mut PlanContext<'_>,
+) -> Result<Expr, PlanError> {
+    if let Some(capture) = capture
+        && super::is_capture_local(&argument.value, &capture.name)
+    {
+        return Ok(capture.value.clone());
+    }
+
+    super::super::plan_expr_with_expected_source_stop_shape(argument.value, expected, context)
+}
+
 fn call_arg_type_mismatch(expected: ValueType, actual: ValueType) -> PlanError {
     if matches!(expected, ValueType::Function(_)) && matches!(actual, ValueType::Function(_)) {
         PlanError::InvalidTypedAst {
@@ -121,21 +136,6 @@ fn call_arg_shape_mismatch() -> PlanError {
             reason: InvalidCallShapeReason::FunctionCallArgumentTypeMismatch,
         },
     }
-}
-
-fn plan_argument_value(
-    argument: GleamCallArg<TypedExpr>,
-    expected: ValueShape,
-    capture: Option<&CaptureSubstitution>,
-    context: &mut PlanContext<'_>,
-) -> Result<Expr, PlanError> {
-    if let Some(capture) = capture
-        && super::is_capture_local(&argument.value, &capture.name)
-    {
-        return Ok(capture.value.clone());
-    }
-
-    super::super::plan_expr_with_expected_source_stop_shape(argument.value, expected, context)
 }
 
 #[cfg(test)]

--- a/src/planner/expression/call/implicit.rs
+++ b/src/planner/expression/call/implicit.rs
@@ -31,6 +31,101 @@ pub(super) fn plan_use_call(
     }
 }
 
+fn normalize_use_call_arguments(
+    mut arguments: Vec<GleamCallArg<TypedExpr>>,
+    use_assignment_count: usize,
+) -> Result<Vec<GleamCallArg<TypedExpr>>, PlanError> {
+    let mut callback_index = None;
+    for (index, argument) in arguments.iter().enumerate() {
+        match argument.implicit {
+            None => {}
+            Some(ImplicitCallArgOrigin::Use) => {
+                if callback_index.replace(index).is_some() {
+                    return Err(super::invalid_use_shape(
+                        InvalidUseShapeReason::MultipleCallbacks,
+                    ));
+                }
+            }
+            Some(
+                ImplicitCallArgOrigin::Pipe
+                | ImplicitCallArgOrigin::PatternFieldSpread
+                | ImplicitCallArgOrigin::IncorrectArityUse
+                | ImplicitCallArgOrigin::RecordUpdate,
+            ) => {
+                return Err(super::invalid_use_shape(
+                    InvalidUseShapeReason::UnsupportedImplicitArgument,
+                ));
+            }
+        }
+    }
+
+    let callback_index = match callback_index {
+        Some(index) if index + 1 == arguments.len() => index,
+        Some(_) => Err(super::invalid_use_shape(
+            InvalidUseShapeReason::CallbackNotLast,
+        ))?,
+        None => Err(super::invalid_use_shape(
+            InvalidUseShapeReason::MissingCallback,
+        ))?,
+    };
+
+    let callback = &mut arguments[callback_index];
+    callback.implicit = None;
+    normalize_use_callback(&mut callback.value, use_assignment_count)?;
+
+    Ok(arguments)
+}
+
+fn normalize_use_callback(
+    callback: &mut TypedExpr,
+    use_assignment_count: usize,
+) -> Result<(), PlanError> {
+    match callback {
+        TypedExpr::Fn { kind, body, .. } => match kind {
+            FunctionLiteralKind::Use { location } => {
+                normalize_use_generated_assignments(body, use_assignment_count)?;
+                *kind = FunctionLiteralKind::Anonymous { head: *location };
+                Ok(())
+            }
+            FunctionLiteralKind::Anonymous { .. } | FunctionLiteralKind::Capture { .. } => Err(
+                super::invalid_use_shape(InvalidUseShapeReason::CallbackLiteralKindNotUse),
+            ),
+        },
+        _ => Err(super::invalid_use_shape(
+            InvalidUseShapeReason::CallbackNotFunctionLiteral,
+        )),
+    }
+}
+
+fn normalize_use_generated_assignments(
+    body: &mut Vec1<TypedStatement>,
+    use_assignment_count: usize,
+) -> Result<(), PlanError> {
+    let statements = body.as_mut_slice();
+    if statements.len() < use_assignment_count {
+        return Err(super::invalid_use_shape(
+            InvalidUseShapeReason::InvalidGeneratedAssignment,
+        ));
+    }
+
+    for statement in &mut statements[..use_assignment_count] {
+        match statement {
+            Statement::Assignment(assignment)
+                if matches!(assignment.kind, AssignmentKind::Generated) =>
+            {
+                assignment.kind = AssignmentKind::Let;
+            }
+            _ => {
+                return Err(super::invalid_use_shape(
+                    InvalidUseShapeReason::InvalidGeneratedAssignment,
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub(super) fn plan_pipeline_direct_call(
     location: gleam_core::ast::SrcSpan,
     type_: std::sync::Arc<gleam_core::type_::Type>,
@@ -41,6 +136,45 @@ pub(super) fn plan_pipeline_direct_call(
     pipe_argument(&arguments)?;
 
     super::plan_call_expression(location, type_, fun, arguments, context, None)
+}
+
+fn pipe_argument(arguments: &[GleamCallArg<TypedExpr>]) -> Result<&TypedExpr, PlanError> {
+    let mut pipe_argument = None;
+    for argument in arguments {
+        match argument.implicit {
+            None => {}
+            Some(ImplicitCallArgOrigin::Pipe) => {
+                if pipe_argument.replace(&argument.value).is_some() {
+                    return Err(PlanError::InvalidTypedAst {
+                        reason: InvalidTypedAstReason::PipelineShape {
+                            reason: InvalidPipelineShapeReason::MultiplePipeArguments,
+                        },
+                    });
+                }
+            }
+            Some(
+                ImplicitCallArgOrigin::Use
+                | ImplicitCallArgOrigin::PatternFieldSpread
+                | ImplicitCallArgOrigin::IncorrectArityUse
+                | ImplicitCallArgOrigin::RecordUpdate,
+            ) => {
+                return Err(PlanError::InvalidTypedAst {
+                    reason: InvalidTypedAstReason::PipelineShape {
+                        reason: InvalidPipelineShapeReason::UnsupportedImplicitArgument,
+                    },
+                });
+            }
+        }
+    }
+
+    match pipe_argument {
+        Some(pipe_argument) => Ok(pipe_argument),
+        None => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::PipelineShape {
+                reason: InvalidPipelineShapeReason::MissingPipeArgument,
+            },
+        }),
+    }
 }
 
 pub(super) fn plan_pipeline_hole_call(
@@ -145,101 +279,6 @@ fn pipeline_hole_body_call(
     }
 }
 
-fn normalize_use_call_arguments(
-    mut arguments: Vec<GleamCallArg<TypedExpr>>,
-    use_assignment_count: usize,
-) -> Result<Vec<GleamCallArg<TypedExpr>>, PlanError> {
-    let mut callback_index = None;
-    for (index, argument) in arguments.iter().enumerate() {
-        match argument.implicit {
-            None => {}
-            Some(ImplicitCallArgOrigin::Use) => {
-                if callback_index.replace(index).is_some() {
-                    return Err(super::invalid_use_shape(
-                        InvalidUseShapeReason::MultipleCallbacks,
-                    ));
-                }
-            }
-            Some(
-                ImplicitCallArgOrigin::Pipe
-                | ImplicitCallArgOrigin::PatternFieldSpread
-                | ImplicitCallArgOrigin::IncorrectArityUse
-                | ImplicitCallArgOrigin::RecordUpdate,
-            ) => {
-                return Err(super::invalid_use_shape(
-                    InvalidUseShapeReason::UnsupportedImplicitArgument,
-                ));
-            }
-        }
-    }
-
-    let callback_index = match callback_index {
-        Some(index) if index + 1 == arguments.len() => index,
-        Some(_) => Err(super::invalid_use_shape(
-            InvalidUseShapeReason::CallbackNotLast,
-        ))?,
-        None => Err(super::invalid_use_shape(
-            InvalidUseShapeReason::MissingCallback,
-        ))?,
-    };
-
-    let callback = &mut arguments[callback_index];
-    callback.implicit = None;
-    normalize_use_callback(&mut callback.value, use_assignment_count)?;
-
-    Ok(arguments)
-}
-
-fn normalize_use_callback(
-    callback: &mut TypedExpr,
-    use_assignment_count: usize,
-) -> Result<(), PlanError> {
-    match callback {
-        TypedExpr::Fn { kind, body, .. } => match kind {
-            FunctionLiteralKind::Use { location } => {
-                normalize_use_generated_assignments(body, use_assignment_count)?;
-                *kind = FunctionLiteralKind::Anonymous { head: *location };
-                Ok(())
-            }
-            FunctionLiteralKind::Anonymous { .. } | FunctionLiteralKind::Capture { .. } => Err(
-                super::invalid_use_shape(InvalidUseShapeReason::CallbackLiteralKindNotUse),
-            ),
-        },
-        _ => Err(super::invalid_use_shape(
-            InvalidUseShapeReason::CallbackNotFunctionLiteral,
-        )),
-    }
-}
-
-fn normalize_use_generated_assignments(
-    body: &mut Vec1<TypedStatement>,
-    use_assignment_count: usize,
-) -> Result<(), PlanError> {
-    let statements = body.as_mut_slice();
-    if statements.len() < use_assignment_count {
-        return Err(super::invalid_use_shape(
-            InvalidUseShapeReason::InvalidGeneratedAssignment,
-        ));
-    }
-
-    for statement in &mut statements[..use_assignment_count] {
-        match statement {
-            Statement::Assignment(assignment)
-                if matches!(assignment.kind, AssignmentKind::Generated) =>
-            {
-                assignment.kind = AssignmentKind::Let;
-            }
-            _ => {
-                return Err(super::invalid_use_shape(
-                    InvalidUseShapeReason::InvalidGeneratedAssignment,
-                ));
-            }
-        }
-    }
-
-    Ok(())
-}
-
 fn count_capture_arguments(
     arguments: &[GleamCallArg<TypedExpr>],
     capture_name: &EcoString,
@@ -248,45 +287,6 @@ fn count_capture_arguments(
         .iter()
         .filter(|argument| super::is_capture_local(&argument.value, capture_name))
         .count()
-}
-
-fn pipe_argument(arguments: &[GleamCallArg<TypedExpr>]) -> Result<&TypedExpr, PlanError> {
-    let mut pipe_argument = None;
-    for argument in arguments {
-        match argument.implicit {
-            None => {}
-            Some(ImplicitCallArgOrigin::Pipe) => {
-                if pipe_argument.replace(&argument.value).is_some() {
-                    return Err(PlanError::InvalidTypedAst {
-                        reason: InvalidTypedAstReason::PipelineShape {
-                            reason: InvalidPipelineShapeReason::MultiplePipeArguments,
-                        },
-                    });
-                }
-            }
-            Some(
-                ImplicitCallArgOrigin::Use
-                | ImplicitCallArgOrigin::PatternFieldSpread
-                | ImplicitCallArgOrigin::IncorrectArityUse
-                | ImplicitCallArgOrigin::RecordUpdate,
-            ) => {
-                return Err(PlanError::InvalidTypedAst {
-                    reason: InvalidTypedAstReason::PipelineShape {
-                        reason: InvalidPipelineShapeReason::UnsupportedImplicitArgument,
-                    },
-                });
-            }
-        }
-    }
-
-    match pipe_argument {
-        Some(pipe_argument) => Ok(pipe_argument),
-        None => Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::PipelineShape {
-                reason: InvalidPipelineShapeReason::MissingPipeArgument,
-            },
-        }),
-    }
 }
 
 fn invalid_hole_capture() -> PlanError {

--- a/src/planner/expression/case/subject/function.rs
+++ b/src/planner/expression/case/subject/function.rs
@@ -295,14 +295,14 @@ fn bind_function_case_subject(
     (step, Expr::function(subject))
 }
 
-fn internal_int_function_case_subject_name(local: IntFunctionLocalId) -> EcoString {
-    format!("<case:int_function:{}>", local.0).into()
-}
-
 fn internal_generic_function_case_subject_name(
     local: &crate::plan::GenericFunctionLocal,
 ) -> EcoString {
     format!("<case:generic_function:{}>", local.id().0).into()
+}
+
+fn internal_int_function_case_subject_name(local: IntFunctionLocalId) -> EcoString {
+    format!("<case:int_function:{}>", local.0).into()
 }
 
 fn internal_string_function_case_subject_name(

--- a/src/planner/expression/case/subject/tuple.rs
+++ b/src/planner/expression/case/subject/tuple.rs
@@ -146,6 +146,28 @@ impl TupleCasePattern {
     }
 }
 
+impl TupleCasePattern {
+    fn from_list_pattern(pattern: super::list::ListCasePattern) -> Self {
+        let (match_condition, branch_bindings, total_branch_steps, is_total) = pattern.into_parts();
+        Self {
+            match_condition,
+            branch_bindings,
+            total_branch_steps,
+            is_total,
+        }
+    }
+
+    fn from_bit_array_pattern(pattern: super::bit_array::BitArrayCasePattern) -> Self {
+        let (match_condition, branch_bindings, is_total) = pattern.into_parts();
+        Self {
+            match_condition: Some(match_condition),
+            branch_bindings,
+            total_branch_steps: Vec::new(),
+            is_total,
+        }
+    }
+}
+
 fn plan_tuple_case_pattern_with_context(
     pattern: Pattern<Arc<Type>>,
     value: Expr,
@@ -394,28 +416,6 @@ fn combine_tuple_case_patterns(patterns: Vec<TupleCasePattern>) -> TupleCasePatt
     }
 
     combined
-}
-
-impl TupleCasePattern {
-    fn from_list_pattern(pattern: super::list::ListCasePattern) -> Self {
-        let (match_condition, branch_bindings, total_branch_steps, is_total) = pattern.into_parts();
-        Self {
-            match_condition,
-            branch_bindings,
-            total_branch_steps,
-            is_total,
-        }
-    }
-
-    fn from_bit_array_pattern(pattern: super::bit_array::BitArrayCasePattern) -> Self {
-        let (match_condition, branch_bindings, is_total) = pattern.into_parts();
-        Self {
-            match_condition: Some(match_condition),
-            branch_bindings,
-            total_branch_steps: Vec::new(),
-            is_total,
-        }
-    }
 }
 
 fn total_custom_binding_steps(

--- a/src/planner/expression/function.rs
+++ b/src/planner/expression/function.rs
@@ -57,6 +57,119 @@ pub(super) fn plan_anonymous(
     )
 }
 
+fn invalid_function_literal_kind_error() -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionShape {
+            kind: InvalidExpressionShapeKind::Invalid,
+        },
+    }
+}
+
+fn validate_capture_literal(
+    arguments: &[TypedArg],
+    body: &Vec1<TypedStatement>,
+) -> Result<(), PlanError> {
+    let [argument] = arguments else {
+        return Err(invalid_capture_literal_shape());
+    };
+
+    if argument.get_variable_name().map(|name| name.as_str()) != Some(CAPTURE_VARIABLE) {
+        return Err(invalid_capture_literal_shape());
+    }
+
+    let [Statement::Expression(TypedExpr::Call { arguments, .. })] = body.as_slice() else {
+        return Err(invalid_capture_literal_shape());
+    };
+
+    if count_capture_literal_arguments(arguments) == 1 {
+        Ok(())
+    } else {
+        Err(invalid_capture_literal_shape())
+    }
+}
+
+fn invalid_capture_literal_shape() -> PlanError {
+    PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionShape {
+            kind: InvalidExpressionShapeKind::FunctionCaptureLiteral,
+        },
+    }
+}
+
+fn count_capture_literal_arguments(arguments: &[GleamCallArg<TypedExpr>]) -> usize {
+    arguments
+        .iter()
+        .filter(|argument| is_capture_literal_local(&argument.value))
+        .count()
+}
+
+fn is_capture_literal_local(expression: &TypedExpr) -> bool {
+    matches!(
+        expression,
+        TypedExpr::Var {
+            name,
+            constructor,
+            ..
+        } if name.as_str() == CAPTURE_VARIABLE
+            && matches!(
+                constructor.variant,
+                ValueConstructorVariant::LocalVariable { .. }
+            )
+    )
+}
+
+fn anonymous_function_shape(shape: ValueShape) -> Result<FunctionShape, PlanError> {
+    let actual = match shape {
+        ValueShape::Function(shape) => return Ok(*shape),
+        ValueShape::Int => InvalidExpressionType::Int,
+        ValueShape::Float => InvalidExpressionType::Float,
+        ValueShape::String => InvalidExpressionType::String,
+        ValueShape::BitArray => InvalidExpressionType::BitArray,
+        ValueShape::UtfCodepoint => InvalidExpressionType::UtfCodepoint,
+        ValueShape::Custom(_) => InvalidExpressionType::Custom,
+        ValueShape::External(_) => InvalidExpressionType::External,
+        ValueShape::Bool => InvalidExpressionType::Bool,
+        ValueShape::Nil => InvalidExpressionType::Nil,
+        ValueShape::Tuple(_) => InvalidExpressionType::Tuple,
+        ValueShape::List(_) => InvalidExpressionType::List,
+        ValueShape::Parameter(_) => {
+            return Err(PlanError::InvalidTypedAst {
+                reason: InvalidTypedAstReason::ExpressionShape {
+                    kind: InvalidExpressionShapeKind::Invalid,
+                },
+            });
+        }
+    };
+    Err(PlanError::InvalidTypedAst {
+        reason: InvalidTypedAstReason::ExpressionType {
+            expected: InvalidExpressionType::Function,
+            actual,
+        },
+    })
+}
+
+fn validate_argument_types(
+    name: &ecow::EcoString,
+    type_: &FunctionType,
+    params: &[crate::planner::context::FunctionParam],
+) -> Result<(), PlanError> {
+    let actual = params
+        .iter()
+        .map(|param| param.local().value_type())
+        .collect::<Vec<_>>();
+
+    if actual == type_.argument_types() {
+        Ok(())
+    } else {
+        Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::FunctionShape {
+                name: name.clone(),
+                reason: InvalidFunctionShapeReason::ArgumentTypeMismatch,
+            },
+        })
+    }
+}
+
 fn plan_anonymous_with_valid_arguments(
     function_shape: FunctionShape,
     params: Vec<crate::planner::context::FunctionParam>,
@@ -115,67 +228,6 @@ fn plan_anonymous_with_captures(
         .with_resolved_shape(function_shape)
         .map(Expr::function)
         .ok_or_else(invalid_function_literal_kind_error)
-}
-
-fn validate_capture_literal(
-    arguments: &[TypedArg],
-    body: &Vec1<TypedStatement>,
-) -> Result<(), PlanError> {
-    let [argument] = arguments else {
-        return Err(invalid_capture_literal_shape());
-    };
-
-    if argument.get_variable_name().map(|name| name.as_str()) != Some(CAPTURE_VARIABLE) {
-        return Err(invalid_capture_literal_shape());
-    }
-
-    let [Statement::Expression(TypedExpr::Call { arguments, .. })] = body.as_slice() else {
-        return Err(invalid_capture_literal_shape());
-    };
-
-    if count_capture_literal_arguments(arguments) == 1 {
-        Ok(())
-    } else {
-        Err(invalid_capture_literal_shape())
-    }
-}
-
-fn count_capture_literal_arguments(arguments: &[GleamCallArg<TypedExpr>]) -> usize {
-    arguments
-        .iter()
-        .filter(|argument| is_capture_literal_local(&argument.value))
-        .count()
-}
-
-fn is_capture_literal_local(expression: &TypedExpr) -> bool {
-    matches!(
-        expression,
-        TypedExpr::Var {
-            name,
-            constructor,
-            ..
-        } if name.as_str() == CAPTURE_VARIABLE
-            && matches!(
-                constructor.variant,
-                ValueConstructorVariant::LocalVariable { .. }
-            )
-    )
-}
-
-fn invalid_function_literal_kind_error() -> PlanError {
-    PlanError::InvalidTypedAst {
-        reason: InvalidTypedAstReason::ExpressionShape {
-            kind: InvalidExpressionShapeKind::Invalid,
-        },
-    }
-}
-
-fn invalid_capture_literal_shape() -> PlanError {
-    PlanError::InvalidTypedAst {
-        reason: InvalidTypedAstReason::ExpressionShape {
-            kind: InvalidExpressionShapeKind::FunctionCaptureLiteral,
-        },
-    }
 }
 
 fn closure_expr(
@@ -256,58 +308,6 @@ fn closure_expr(
                 ),
             ))
         }
-    }
-}
-
-fn anonymous_function_shape(shape: ValueShape) -> Result<FunctionShape, PlanError> {
-    let actual = match shape {
-        ValueShape::Function(shape) => return Ok(*shape),
-        ValueShape::Int => InvalidExpressionType::Int,
-        ValueShape::Float => InvalidExpressionType::Float,
-        ValueShape::String => InvalidExpressionType::String,
-        ValueShape::BitArray => InvalidExpressionType::BitArray,
-        ValueShape::UtfCodepoint => InvalidExpressionType::UtfCodepoint,
-        ValueShape::Custom(_) => InvalidExpressionType::Custom,
-        ValueShape::External(_) => InvalidExpressionType::External,
-        ValueShape::Bool => InvalidExpressionType::Bool,
-        ValueShape::Nil => InvalidExpressionType::Nil,
-        ValueShape::Tuple(_) => InvalidExpressionType::Tuple,
-        ValueShape::List(_) => InvalidExpressionType::List,
-        ValueShape::Parameter(_) => {
-            return Err(PlanError::InvalidTypedAst {
-                reason: InvalidTypedAstReason::ExpressionShape {
-                    kind: InvalidExpressionShapeKind::Invalid,
-                },
-            });
-        }
-    };
-    Err(PlanError::InvalidTypedAst {
-        reason: InvalidTypedAstReason::ExpressionType {
-            expected: InvalidExpressionType::Function,
-            actual,
-        },
-    })
-}
-
-fn validate_argument_types(
-    name: &ecow::EcoString,
-    type_: &FunctionType,
-    params: &[crate::planner::context::FunctionParam],
-) -> Result<(), PlanError> {
-    let actual = params
-        .iter()
-        .map(|param| param.local().value_type())
-        .collect::<Vec<_>>();
-
-    if actual == type_.argument_types() {
-        Ok(())
-    } else {
-        Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::FunctionShape {
-                name: name.clone(),
-                reason: InvalidFunctionShapeReason::ArgumentTypeMismatch,
-            },
-        })
     }
 }
 

--- a/src/planner/expression/pipeline.rs
+++ b/src/planner/expression/pipeline.rs
@@ -59,24 +59,6 @@ fn plan_pipeline_value(
     }
 }
 
-fn plan_echo(expression: TypedExpr, context: &mut PlanContext<'_>) -> Result<Expr, PlanError> {
-    let TypedExpr::Echo {
-        location,
-        expression: None,
-        message,
-        type_,
-    } = expression
-    else {
-        return Err(invalid_pipeline_shape(InvalidPipelineShapeReason::EchoStep));
-    };
-    let shape = context.value_shape(&type_);
-    let constructor =
-        ValueConstructor::local_variable(location, VariableOrigin::generated(), type_);
-    let value = var::plan_var(PIPE_VARIABLE.into(), constructor, shape, context)?;
-
-    echo::plan_value(location, value, message.map(|message| *message), context)
-}
-
 fn plan_direct_call(
     expression: TypedExpr,
     context: &mut PlanContext<'_>,
@@ -112,6 +94,24 @@ fn plan_hole_call(expression: TypedExpr, context: &mut PlanContext<'_>) -> Resul
     };
 
     call::plan_pipeline_hole_call(location, type_, *fun, arguments, context)
+}
+
+fn plan_echo(expression: TypedExpr, context: &mut PlanContext<'_>) -> Result<Expr, PlanError> {
+    let TypedExpr::Echo {
+        location,
+        expression: None,
+        message,
+        type_,
+    } = expression
+    else {
+        return Err(invalid_pipeline_shape(InvalidPipelineShapeReason::EchoStep));
+    };
+    let shape = context.value_shape(&type_);
+    let constructor =
+        ValueConstructor::local_variable(location, VariableOrigin::generated(), type_);
+    let value = var::plan_var(PIPE_VARIABLE.into(), constructor, shape, context)?;
+
+    echo::plan_value(location, value, message.map(|message| *message), context)
 }
 
 fn invalid_pipeline_shape(reason: InvalidPipelineShapeReason) -> PlanError {

--- a/src/planner/function.rs
+++ b/src/planner/function.rs
@@ -46,6 +46,18 @@ pub(super) fn plan_selected_external_fallback(
     plan_selected_function(info, function, context, name)
 }
 
+pub(super) fn function_name(function: &TypedFunction) -> Result<EcoString, PlanError> {
+    match &function.name {
+        Some((_, name)) => Ok(name.clone()),
+        None => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::FunctionShape {
+                name: "<anonymous>".into(),
+                reason: InvalidFunctionShapeReason::Anonymous,
+            },
+        }),
+    }
+}
+
 fn plan_selected_function(
     info: FunctionInfo,
     function: TypedFunction,
@@ -148,18 +160,6 @@ fn define_params(
             )),
         })
         .collect()
-}
-
-pub(super) fn function_name(function: &TypedFunction) -> Result<EcoString, PlanError> {
-    match &function.name {
-        Some((_, name)) => Ok(name.clone()),
-        None => Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::FunctionShape {
-                name: "<anonymous>".into(),
-                reason: InvalidFunctionShapeReason::Anonymous,
-            },
-        }),
-    }
 }
 
 #[cfg(test)]

--- a/src/planner/function/return_body/function_value.rs
+++ b/src/planner/function/return_body/function_value.rs
@@ -119,14 +119,6 @@ fn generic_function_return(expression: GenericFunctionExpr) -> GenericFunctionRe
     }
 }
 
-fn custom_function_return(expression: CustomFunctionExpr) -> CustomFunctionReturn {
-    CustomFunctionReturn::expr(expression)
-}
-
-fn external_function_return(expression: ExternalFunctionExpr) -> ExternalFunctionReturn {
-    ExternalFunctionReturn::expr(expression)
-}
-
 fn int_function_return(expression: IntFunctionExpr) -> IntFunctionReturn {
     match expression.kind() {
         IntFunctionExprKind::Call {
@@ -385,6 +377,14 @@ fn utf_codepoint_function_return(
         ),
         _ => ReturnBody::expr(expression),
     }
+}
+
+fn custom_function_return(expression: CustomFunctionExpr) -> CustomFunctionReturn {
+    CustomFunctionReturn::expr(expression)
+}
+
+fn external_function_return(expression: ExternalFunctionExpr) -> ExternalFunctionReturn {
+    ExternalFunctionReturn::expr(expression)
 }
 
 fn float_function_return(expression: FloatFunctionExpr) -> FloatFunctionReturn {

--- a/src/planner/function/return_body/primitive.rs
+++ b/src/planner/function/return_body/primitive.rs
@@ -7,20 +7,6 @@ use crate::plan::{
     UtfCodepointExprKind, UtfCodepointReturn,
 };
 
-pub(super) fn custom_return(
-    signature_shape: crate::plan::CustomValueShape,
-    expression: CustomExpr,
-) -> CustomReturn {
-    CustomReturn::with_signature_shape(signature_shape, expression)
-}
-
-pub(super) fn external_return(
-    signature_shape: crate::plan::ExternalValueShape,
-    expression: ExternalExpr,
-) -> ExternalReturn {
-    ExternalReturn::with_signature_shape(signature_shape, expression)
-}
-
 pub(super) fn generic_return(expression: GenericExpr) -> GenericReturn {
     match expression.kind() {
         GenericExprKind::Call {
@@ -334,6 +320,82 @@ pub(super) fn utf_codepoint_return(expression: UtfCodepointExpr) -> UtfCodepoint
     }
 }
 
+pub(super) fn custom_return(
+    signature_shape: crate::plan::CustomValueShape,
+    expression: CustomExpr,
+) -> CustomReturn {
+    CustomReturn::with_signature_shape(signature_shape, expression)
+}
+
+pub(super) fn external_return(
+    signature_shape: crate::plan::ExternalValueShape,
+    expression: ExternalExpr,
+) -> ExternalReturn {
+    ExternalReturn::with_signature_shape(signature_shape, expression)
+}
+
+pub(super) fn float_return(expression: FloatExpr) -> FloatReturn {
+    match expression.kind() {
+        FloatExprKind::Call {
+            function,
+            args,
+            site,
+        } => ReturnBody::tail_call(
+            crate::plan::FunctionCallTarget::new(function.clone(), site.clone()),
+            args.clone(),
+        ),
+        FloatExprKind::BoolCase {
+            subject,
+            true_,
+            false_,
+        } => ReturnBody::bool_case(
+            (**subject).clone(),
+            float_return((**true_).clone()),
+            float_return((**false_).clone()),
+        ),
+        FloatExprKind::IntCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::int_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (value.clone(), float_return(branch.clone())))
+                .collect(),
+            float_return((**fallback).clone()),
+        ),
+        FloatExprKind::StringCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::string_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (value.clone(), float_return(branch.clone())))
+                .collect(),
+            float_return((**fallback).clone()),
+        ),
+        FloatExprKind::FloatCase {
+            subject,
+            clauses,
+            fallback,
+        } => ReturnBody::float_case(
+            (**subject).clone(),
+            clauses
+                .iter()
+                .map(|(value, branch)| (*value, float_return(branch.clone())))
+                .collect(),
+            float_return((**fallback).clone()),
+        ),
+        FloatExprKind::Block { steps, return_ } => {
+            ReturnBody::block(steps.clone(), float_return((**return_).clone()))
+        }
+        _ => ReturnBody::expr(expression),
+    }
+}
+
 pub(super) fn bool_return(expression: BoolExpr) -> BoolReturn {
     match expression.kind() {
         BoolExprKind::Call {
@@ -453,68 +515,6 @@ pub(super) fn nil_return(expression: NilExpr) -> NilReturn {
         ),
         NilExprKind::Block { steps, return_ } => {
             ReturnBody::block(steps.clone(), nil_return((**return_).clone()))
-        }
-        _ => ReturnBody::expr(expression),
-    }
-}
-
-pub(super) fn float_return(expression: FloatExpr) -> FloatReturn {
-    match expression.kind() {
-        FloatExprKind::Call {
-            function,
-            args,
-            site,
-        } => ReturnBody::tail_call(
-            crate::plan::FunctionCallTarget::new(function.clone(), site.clone()),
-            args.clone(),
-        ),
-        FloatExprKind::BoolCase {
-            subject,
-            true_,
-            false_,
-        } => ReturnBody::bool_case(
-            (**subject).clone(),
-            float_return((**true_).clone()),
-            float_return((**false_).clone()),
-        ),
-        FloatExprKind::IntCase {
-            subject,
-            clauses,
-            fallback,
-        } => ReturnBody::int_case(
-            (**subject).clone(),
-            clauses
-                .iter()
-                .map(|(value, branch)| (value.clone(), float_return(branch.clone())))
-                .collect(),
-            float_return((**fallback).clone()),
-        ),
-        FloatExprKind::StringCase {
-            subject,
-            clauses,
-            fallback,
-        } => ReturnBody::string_case(
-            (**subject).clone(),
-            clauses
-                .iter()
-                .map(|(value, branch)| (value.clone(), float_return(branch.clone())))
-                .collect(),
-            float_return((**fallback).clone()),
-        ),
-        FloatExprKind::FloatCase {
-            subject,
-            clauses,
-            fallback,
-        } => ReturnBody::float_case(
-            (**subject).clone(),
-            clauses
-                .iter()
-                .map(|(value, branch)| (*value, float_return(branch.clone())))
-                .collect(),
-            float_return((**fallback).clone()),
-        ),
-        FloatExprKind::Block { steps, return_ } => {
-            ReturnBody::block(steps.clone(), float_return((**return_).clone()))
         }
         _ => ReturnBody::expr(expression),
     }

--- a/src/planner/module.rs
+++ b/src/planner/module.rs
@@ -360,14 +360,6 @@ struct FunctionSeed {
     type_parameters: TypeParameterScope,
 }
 
-fn function_return_shape_in(
-    type_: &Type,
-    parameters: &mut TypeParameterScope,
-    is_external: &impl Fn(&crate::plan::ExternalTypeName) -> bool,
-) -> crate::plan::ValueShape {
-    crate::plan::ValueShape::from_gleam_in_with_external(type_, parameters, is_external)
-}
-
 pub(super) fn function_params_in(
     function_name: EcoString,
     arguments: &[gleam_core::ast::TypedArg],
@@ -393,6 +385,30 @@ pub(super) fn function_params_in(
         parameters,
         is_external,
     ))
+}
+
+pub(super) fn discarded_function_params(shapes: &[crate::plan::ValueShape]) -> Vec<FunctionParam> {
+    let mut locals = FunctionParamLocalCounters::default();
+    shapes
+        .iter()
+        .cloned()
+        .map(|shape| {
+            FunctionParam::new(
+                locals.next_value_shape(&shape),
+                shape,
+                ParamBinding::Discard,
+                None,
+            )
+        })
+        .collect()
+}
+
+fn function_return_shape_in(
+    type_: &Type,
+    parameters: &mut TypeParameterScope,
+    is_external: &impl Fn(&crate::plan::ExternalTypeName) -> bool,
+) -> crate::plan::ValueShape {
+    crate::plan::ValueShape::from_gleam_in_with_external(type_, parameters, is_external)
 }
 
 fn function_params_allowing_labels_in(
@@ -423,22 +439,6 @@ fn function_params_allowing_labels_in(
             );
             let local = locals.next_value_shape(&shape);
             FunctionParam::new(local, shape, binding, label)
-        })
-        .collect()
-}
-
-pub(super) fn discarded_function_params(shapes: &[crate::plan::ValueShape]) -> Vec<FunctionParam> {
-    let mut locals = FunctionParamLocalCounters::default();
-    shapes
-        .iter()
-        .cloned()
-        .map(|shape| {
-            FunctionParam::new(
-                locals.next_value_shape(&shape),
-                shape,
-                ParamBinding::Discard,
-                None,
-            )
         })
         .collect()
 }

--- a/src/planner/pattern/bit_array.rs
+++ b/src/planner/pattern/bit_array.rs
@@ -96,6 +96,56 @@ enum SegmentKind {
     UtfCodepoint(StringEncoding),
 }
 
+fn segment_kind(
+    segment: &BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>,
+) -> Result<SegmentKind, PlanError> {
+    let mut kind = None;
+    for option in &segment.options {
+        let next = match option {
+            BitArrayOption::Bytes { .. } | BitArrayOption::Bits { .. } => Some(SegmentKind::Bits),
+            BitArrayOption::Int { .. } => Some(SegmentKind::Int),
+            BitArrayOption::Float { .. } => Some(SegmentKind::Float),
+            BitArrayOption::Utf8 { .. } => Some(SegmentKind::String(StringEncoding::Utf8)),
+            BitArrayOption::Utf16 { .. } => Some(SegmentKind::String(StringEncoding::Utf16(
+                segment_endianness(segment),
+            ))),
+            BitArrayOption::Utf32 { .. } => Some(SegmentKind::String(StringEncoding::Utf32(
+                segment_endianness(segment),
+            ))),
+            BitArrayOption::Utf8Codepoint { .. } => {
+                Some(SegmentKind::UtfCodepoint(StringEncoding::Utf8))
+            }
+            BitArrayOption::Utf16Codepoint { .. } => Some(SegmentKind::UtfCodepoint(
+                StringEncoding::Utf16(segment_endianness(segment)),
+            )),
+            BitArrayOption::Utf32Codepoint { .. } => Some(SegmentKind::UtfCodepoint(
+                StringEncoding::Utf32(segment_endianness(segment)),
+            )),
+            BitArrayOption::Signed { .. }
+            | BitArrayOption::Unsigned { .. }
+            | BitArrayOption::Big { .. }
+            | BitArrayOption::Little { .. }
+            | BitArrayOption::Native { .. }
+            | BitArrayOption::Size { .. }
+            | BitArrayOption::Unit { .. } => None,
+        };
+        if let Some(next) = next {
+            if kind.is_some() {
+                return Err(invalid_pattern());
+            }
+            kind = Some(next);
+        }
+    }
+    if let Some(kind) = kind {
+        return Ok(kind);
+    }
+    if matches!(segment.value_unwrapping_assign(), Pattern::String { .. }) {
+        Ok(SegmentKind::String(StringEncoding::Utf8))
+    } else {
+        Ok(SegmentKind::Int)
+    }
+}
+
 fn validate_segment_options(
     segment: &BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>,
     kind: SegmentKind,
@@ -162,56 +212,6 @@ fn validate_segment_options(
         Err(invalid_pattern())
     } else {
         Ok(())
-    }
-}
-
-fn segment_kind(
-    segment: &BitArraySegment<Pattern<Arc<Type>>, Arc<Type>>,
-) -> Result<SegmentKind, PlanError> {
-    let mut kind = None;
-    for option in &segment.options {
-        let next = match option {
-            BitArrayOption::Bytes { .. } | BitArrayOption::Bits { .. } => Some(SegmentKind::Bits),
-            BitArrayOption::Int { .. } => Some(SegmentKind::Int),
-            BitArrayOption::Float { .. } => Some(SegmentKind::Float),
-            BitArrayOption::Utf8 { .. } => Some(SegmentKind::String(StringEncoding::Utf8)),
-            BitArrayOption::Utf16 { .. } => Some(SegmentKind::String(StringEncoding::Utf16(
-                segment_endianness(segment),
-            ))),
-            BitArrayOption::Utf32 { .. } => Some(SegmentKind::String(StringEncoding::Utf32(
-                segment_endianness(segment),
-            ))),
-            BitArrayOption::Utf8Codepoint { .. } => {
-                Some(SegmentKind::UtfCodepoint(StringEncoding::Utf8))
-            }
-            BitArrayOption::Utf16Codepoint { .. } => Some(SegmentKind::UtfCodepoint(
-                StringEncoding::Utf16(segment_endianness(segment)),
-            )),
-            BitArrayOption::Utf32Codepoint { .. } => Some(SegmentKind::UtfCodepoint(
-                StringEncoding::Utf32(segment_endianness(segment)),
-            )),
-            BitArrayOption::Signed { .. }
-            | BitArrayOption::Unsigned { .. }
-            | BitArrayOption::Big { .. }
-            | BitArrayOption::Little { .. }
-            | BitArrayOption::Native { .. }
-            | BitArrayOption::Size { .. }
-            | BitArrayOption::Unit { .. } => None,
-        };
-        if let Some(next) = next {
-            if kind.is_some() {
-                return Err(invalid_pattern());
-            }
-            kind = Some(next);
-        }
-    }
-    if let Some(kind) = kind {
-        return Ok(kind);
-    }
-    if matches!(segment.value_unwrapping_assign(), Pattern::String { .. }) {
-        Ok(SegmentKind::String(StringEncoding::Utf8))
-    } else {
-        Ok(SegmentKind::Int)
     }
 }
 

--- a/src/planner/pattern/runtime.rs
+++ b/src/planner/pattern/runtime.rs
@@ -273,6 +273,57 @@ pub(in crate::planner) fn plan_custom_subject_pattern(
     plan_custom_pattern(arguments, constructor, type_, source_shape, context)
 }
 
+pub(in crate::planner) fn pattern_value_type(
+    pattern: &TypedPattern,
+    context: &mut PlanContext<'_>,
+) -> Result<ValueType, PlanError> {
+    let mut value_shape = |type_: &Type| context.value_shape(type_);
+    pattern_value_shape_with(pattern, &mut value_shape).map(|shape| shape.value_type())
+}
+
+pub(in crate::planner) fn pattern_value_type_in_context(
+    pattern: &TypedPattern,
+    context: &PlanContext<'_>,
+) -> Result<ValueType, PlanError> {
+    let mut value_shape = |type_: &Type| context.value_shape_in_scope(type_);
+    pattern_value_shape_with(pattern, &mut value_shape).map(|shape| shape.value_type())
+}
+
+fn pattern_value_shape(
+    pattern: &TypedPattern,
+    context: &mut PlanContext<'_>,
+) -> Result<ValueShape, PlanError> {
+    let mut value_shape = |type_: &Type| context.value_shape(type_);
+    pattern_value_shape_with(pattern, &mut value_shape)
+}
+
+fn pattern_value_shape_with(
+    pattern: &TypedPattern,
+    value_shape: &mut impl FnMut(&Type) -> ValueShape,
+) -> Result<ValueShape, PlanError> {
+    let shape = match pattern {
+        Pattern::Int { .. } => ValueShape::Int,
+        Pattern::Float { .. } => ValueShape::Float,
+        Pattern::String { .. } | Pattern::StringPrefix { .. } => ValueShape::String,
+        Pattern::Variable { type_, .. }
+        | Pattern::Discard { type_, .. }
+        | Pattern::List { type_, .. }
+        | Pattern::Constructor { type_, .. }
+        | Pattern::Invalid { type_, .. } => value_shape(type_.as_ref()),
+        Pattern::Tuple { elements, .. } => ValueShape::Tuple(
+            elements
+                .iter()
+                .map(|element| pattern_value_shape_with(element, value_shape))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_boxed_slice(),
+        ),
+        Pattern::BitArray { .. } => ValueShape::BitArray,
+        Pattern::Assign { pattern, .. } => pattern_value_shape_with(pattern, value_shape)?,
+        Pattern::BitArraySize(_) => return Err(invalid_pattern()),
+    };
+    Ok(shape)
+}
+
 fn plan_list_pattern(
     elements: Vec<TypedPattern>,
     tail: Option<TailPattern<Arc<Type>>>,
@@ -487,57 +538,6 @@ fn define_string_binding(
     context: &mut PlanContext<'_>,
 ) -> crate::plan::StringAssertBinding {
     crate::plan::StringAssertBinding::new(context.define_string_local(name.clone()), name)
-}
-
-pub(in crate::planner) fn pattern_value_type(
-    pattern: &TypedPattern,
-    context: &mut PlanContext<'_>,
-) -> Result<ValueType, PlanError> {
-    let mut value_shape = |type_: &Type| context.value_shape(type_);
-    pattern_value_shape_with(pattern, &mut value_shape).map(|shape| shape.value_type())
-}
-
-fn pattern_value_shape(
-    pattern: &TypedPattern,
-    context: &mut PlanContext<'_>,
-) -> Result<ValueShape, PlanError> {
-    let mut value_shape = |type_: &Type| context.value_shape(type_);
-    pattern_value_shape_with(pattern, &mut value_shape)
-}
-
-pub(in crate::planner) fn pattern_value_type_in_context(
-    pattern: &TypedPattern,
-    context: &PlanContext<'_>,
-) -> Result<ValueType, PlanError> {
-    let mut value_shape = |type_: &Type| context.value_shape_in_scope(type_);
-    pattern_value_shape_with(pattern, &mut value_shape).map(|shape| shape.value_type())
-}
-
-fn pattern_value_shape_with(
-    pattern: &TypedPattern,
-    value_shape: &mut impl FnMut(&Type) -> ValueShape,
-) -> Result<ValueShape, PlanError> {
-    let shape = match pattern {
-        Pattern::Int { .. } => ValueShape::Int,
-        Pattern::Float { .. } => ValueShape::Float,
-        Pattern::String { .. } | Pattern::StringPrefix { .. } => ValueShape::String,
-        Pattern::Variable { type_, .. }
-        | Pattern::Discard { type_, .. }
-        | Pattern::List { type_, .. }
-        | Pattern::Constructor { type_, .. }
-        | Pattern::Invalid { type_, .. } => value_shape(type_.as_ref()),
-        Pattern::Tuple { elements, .. } => ValueShape::Tuple(
-            elements
-                .iter()
-                .map(|element| pattern_value_shape_with(element, value_shape))
-                .collect::<Result<Vec<_>, _>>()?
-                .into_boxed_slice(),
-        ),
-        Pattern::BitArray { .. } => ValueShape::BitArray,
-        Pattern::Assign { pattern, .. } => pattern_value_shape_with(pattern, value_shape)?,
-        Pattern::BitArraySize(_) => return Err(invalid_pattern()),
-    };
-    Ok(shape)
 }
 
 fn invalid_pattern() -> PlanError {

--- a/src/planner/statement.rs
+++ b/src/planner/statement.rs
@@ -40,6 +40,22 @@ pub(super) fn plan_non_empty_steps_and_return(
     plan_ordered_steps_and_return(statements, last_statement, context, expected_return_shape)
 }
 
+pub(super) fn plan_runtime_steps(
+    statement: gleam_core::ast::TypedStatement,
+    context: &mut PlanContext<'_>,
+) -> Result<Vec<Step>, PlanError> {
+    match statement {
+        Statement::Expression(expression) => Ok(vec![Step::evaluate(
+            plan_expr_with_expected_source_stop_shape(expression, ValueShape::Nil, context)?,
+        )]),
+        Statement::Assignment(assignment) => assignment::plan_assignment(*assignment, context),
+        Statement::Use(_) => Err(PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::UseStatement,
+        }),
+        Statement::Assert(assert) => Ok(vec![plan_assert_step(assert, context)?]),
+    }
+}
+
 fn plan_ordered_steps_and_return(
     statements: Vec<gleam_core::ast::TypedStatement>,
     last_statement: gleam_core::ast::TypedStatement,
@@ -71,22 +87,6 @@ fn plan_ordered_steps_and_return(
     };
 
     Ok(PlannedStatements { steps, return_ })
-}
-
-pub(super) fn plan_runtime_steps(
-    statement: gleam_core::ast::TypedStatement,
-    context: &mut PlanContext<'_>,
-) -> Result<Vec<Step>, PlanError> {
-    match statement {
-        Statement::Expression(expression) => Ok(vec![Step::evaluate(
-            plan_expr_with_expected_source_stop_shape(expression, ValueShape::Nil, context)?,
-        )]),
-        Statement::Assignment(assignment) => assignment::plan_assignment(*assignment, context),
-        Statement::Use(_) => Err(PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::UseStatement,
-        }),
-        Statement::Assert(assert) => Ok(vec![plan_assert_step(assert, context)?]),
-    }
 }
 
 fn plan_assert_step(assert: TypedAssert, context: &mut PlanContext<'_>) -> Result<Step, PlanError> {

--- a/src/planner/statement/assignment.rs
+++ b/src/planner/statement/assignment.rs
@@ -915,6 +915,28 @@ pub(super) fn plan_binding_pattern_in_context(
     }
 }
 
+pub(super) fn non_variable_pattern_error(pattern: &TypedPattern) -> PlanError {
+    match pattern {
+        Pattern::List { .. } => PlanError::UnsupportedPattern {
+            kind: UnsupportedPatternKind::List,
+        },
+        Pattern::Int { .. }
+        | Pattern::Float { .. }
+        | Pattern::String { .. }
+        | Pattern::BitArray { .. }
+        | Pattern::BitArraySize(_)
+        | Pattern::Constructor { .. }
+        | Pattern::StringPrefix { .. }
+        | Pattern::Invalid { .. }
+        | Pattern::Discard { .. }
+        | Pattern::Variable { .. }
+        | Pattern::Assign { .. }
+        | Pattern::Tuple { .. } => PlanError::InvalidTypedAst {
+            reason: InvalidTypedAstReason::InvalidPattern,
+        },
+    }
+}
+
 fn plan_total_bit_array_binding_pattern(
     segments: Vec<
         gleam_core::ast::BitArraySegment<TypedPattern, std::sync::Arc<gleam_core::type_::Type>>,
@@ -1055,28 +1077,6 @@ fn list_tail_type_matches(
         Err(PlanError::InvalidTypedAst {
             reason: InvalidTypedAstReason::InvalidPattern,
         })
-    }
-}
-
-pub(super) fn non_variable_pattern_error(pattern: &TypedPattern) -> PlanError {
-    match pattern {
-        Pattern::List { .. } => PlanError::UnsupportedPattern {
-            kind: UnsupportedPatternKind::List,
-        },
-        Pattern::Int { .. }
-        | Pattern::Float { .. }
-        | Pattern::String { .. }
-        | Pattern::BitArray { .. }
-        | Pattern::BitArraySize(_)
-        | Pattern::Constructor { .. }
-        | Pattern::StringPrefix { .. }
-        | Pattern::Invalid { .. }
-        | Pattern::Discard { .. }
-        | Pattern::Variable { .. }
-        | Pattern::Assign { .. }
-        | Pattern::Tuple { .. } => PlanError::InvalidTypedAst {
-            reason: InvalidTypedAstReason::InvalidPattern,
-        },
     }
 }
 

--- a/src/planner/type_parameter.rs
+++ b/src/planner/type_parameter.rs
@@ -17,6 +17,17 @@ pub(super) enum FunctionInstantiationMismatch {
     UnresolvedParameter,
 }
 
+impl TypeParameterScope {
+    pub(super) fn resolve(&mut self, source_id: u64) -> TypeParameterId {
+        let next = TypeParameterId(self.parameters.len());
+        *self.parameters.entry(source_id).or_insert(next)
+    }
+
+    pub(super) fn scheme(&self) -> TypeScheme {
+        TypeScheme::new(self.parameters.len())
+    }
+}
+
 pub(super) fn instantiate(
     signature: &FunctionTemplateSignature,
     actual: &crate::plan::FunctionShape,
@@ -149,17 +160,6 @@ fn match_shape(
             Some(())
         }
         _ => None,
-    }
-}
-
-impl TypeParameterScope {
-    pub(super) fn resolve(&mut self, source_id: u64) -> TypeParameterId {
-        let next = TypeParameterId(self.parameters.len());
-        *self.parameters.entry(source_id).or_insert(next)
-    }
-
-    pub(super) fn scheme(&self) -> TypeScheme {
-        TypeScheme::new(self.parameters.len())
     }
 }
 

--- a/src/runtime/error/diagnostic.rs
+++ b/src/runtime/error/diagnostic.rs
@@ -6,6 +6,40 @@ use crate::runtime::Value;
 use miette::{Diagnostic, LabeledSpan, SourceCode};
 use std::fmt;
 
+impl Diagnostic for ExecutionError {
+    fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        match self {
+            Self::Panic(panic) => panic.code(),
+            Self::Invariant(error) => error.code(),
+            Self::Host(error) => error.code(),
+        }
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        match self {
+            Self::Panic(panic) => panic.help(),
+            Self::Invariant(error) => error.help(),
+            Self::Host(error) => error.help(),
+        }
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        match self {
+            Self::Panic(panic) => panic.source_code(),
+            Self::Invariant(error) => error.source_code(),
+            Self::Host(error) => error.source_code(),
+        }
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        match self {
+            Self::Panic(panic) => panic.labels(),
+            Self::Invariant(error) => error.labels(),
+            Self::Host(error) => error.labels(),
+        }
+    }
+}
+
 impl Diagnostic for Panic {
     fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
         Some(Box::new(format!("geam::{}", self.kind().code())))
@@ -50,40 +84,6 @@ impl Diagnostic for Panic {
         }
 
         Some(Box::new(labels.into_iter()))
-    }
-}
-
-impl Diagnostic for ExecutionError {
-    fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
-        match self {
-            Self::Panic(panic) => panic.code(),
-            Self::Invariant(error) => error.code(),
-            Self::Host(error) => error.code(),
-        }
-    }
-
-    fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
-        match self {
-            Self::Panic(panic) => panic.help(),
-            Self::Invariant(error) => error.help(),
-            Self::Host(error) => error.help(),
-        }
-    }
-
-    fn source_code(&self) -> Option<&dyn SourceCode> {
-        match self {
-            Self::Panic(panic) => panic.source_code(),
-            Self::Invariant(error) => error.source_code(),
-            Self::Host(error) => error.source_code(),
-        }
-    }
-
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        match self {
-            Self::Panic(panic) => panic.labels(),
-            Self::Invariant(error) => error.labels(),
-            Self::Host(error) => error.labels(),
-        }
     }
 }
 

--- a/src/runtime/evaluated.rs
+++ b/src/runtime/evaluated.rs
@@ -39,6 +39,26 @@ pub(in crate::runtime) struct EvaluatedCustomValue {
     fields: Box<[EvaluatedValue]>,
 }
 
+impl EvaluatedBitArray {
+    pub(in crate::runtime) fn new(bits: BitVec<u8, Msb0>) -> Self {
+        Self {
+            value: crate::BitArrayValue::from_evaluated(bits),
+        }
+    }
+
+    pub(in crate::runtime) fn bits(&self) -> &bitvec::slice::BitSlice<u8, Msb0> {
+        self.value.bits()
+    }
+
+    pub(in crate::runtime) fn value(&self) -> crate::BitArrayValue {
+        self.value.clone()
+    }
+
+    pub(in crate::runtime) fn from_value(value: crate::BitArrayValue) -> Self {
+        Self { value }
+    }
+}
+
 impl EvaluatedCustomValue {
     pub(in crate::runtime) fn from_fields(
         constructor: CustomConstructorId,
@@ -60,26 +80,6 @@ impl EvaluatedCustomValue {
 
     pub(in crate::runtime) fn fields(&self) -> &[EvaluatedValue] {
         &self.fields
-    }
-}
-
-impl EvaluatedBitArray {
-    pub(in crate::runtime) fn new(bits: BitVec<u8, Msb0>) -> Self {
-        Self {
-            value: crate::BitArrayValue::from_evaluated(bits),
-        }
-    }
-
-    pub(in crate::runtime) fn bits(&self) -> &bitvec::slice::BitSlice<u8, Msb0> {
-        self.value.bits()
-    }
-
-    pub(in crate::runtime) fn value(&self) -> crate::BitArrayValue {
-        self.value.clone()
-    }
-
-    pub(in crate::runtime) fn from_value(value: crate::BitArrayValue) -> Self {
-        Self { value }
     }
 }
 

--- a/src/runtime/evaluated/capture.rs
+++ b/src/runtime/evaluated/capture.rs
@@ -247,20 +247,6 @@ impl EvaluatedCapture {
         Self::from_kind(EvaluatedCaptureKind::IntFunction { local, value })
     }
 
-    pub(in crate::runtime) fn generic_function(
-        local: GenericFunctionLocal,
-        value: EvaluatedGenericFunction,
-    ) -> Self {
-        Self::from_kind(EvaluatedCaptureKind::GenericFunction { local, value })
-    }
-
-    pub(in crate::runtime) fn never_function(
-        local: NeverFunctionLocal,
-        value: EvaluatedNeverFunction,
-    ) -> Self {
-        Self::from_kind(EvaluatedCaptureKind::NeverFunction { local, value })
-    }
-
     pub(in crate::runtime) fn float_function(
         local: FloatFunctionLocalId,
         value: EvaluatedFloatFunction,
@@ -336,6 +322,20 @@ impl EvaluatedCapture {
         value: EvaluatedFunctionFunction,
     ) -> Self {
         Self::from_kind(EvaluatedCaptureKind::FunctionFunction { local, value })
+    }
+
+    pub(in crate::runtime) fn generic_function(
+        local: GenericFunctionLocal,
+        value: EvaluatedGenericFunction,
+    ) -> Self {
+        Self::from_kind(EvaluatedCaptureKind::GenericFunction { local, value })
+    }
+
+    pub(in crate::runtime) fn never_function(
+        local: NeverFunctionLocal,
+        value: EvaluatedNeverFunction,
+    ) -> Self {
+        Self::from_kind(EvaluatedCaptureKind::NeverFunction { local, value })
     }
 }
 

--- a/src/runtime/evaluated/function.rs
+++ b/src/runtime/evaluated/function.rs
@@ -565,13 +565,6 @@ impl EvaluatedCustomFunction {
 }
 
 impl EvaluatedFunctionFunction {
-    pub(super) fn identity(&self) -> &EvaluatedFunctionIdentity {
-        match self {
-            Self::Core(value) => &value.identity,
-            Self::External(value) => &value.identity,
-        }
-    }
-
     pub(in crate::runtime) fn type_(&self) -> &FunctionType {
         match self {
             Self::Core(value) => value.type_(),
@@ -597,6 +590,13 @@ impl EvaluatedFunctionFunction {
         match self {
             Self::Core(value) => Self::Core(value.with_type(type_)),
             Self::External(value) => Self::External(value.with_type(type_)),
+        }
+    }
+
+    pub(super) fn identity(&self) -> &EvaluatedFunctionIdentity {
+        match self {
+            Self::Core(value) => &value.identity,
+            Self::External(value) => &value.identity,
         }
     }
 }

--- a/src/runtime/function.rs
+++ b/src/runtime/function.rs
@@ -37,32 +37,6 @@ pub(super) enum EvaluatedFunctionExit<Return, TailCall> {
     },
 }
 
-pub(super) fn evaluate<Plan, Return, TailCall>(
-    plan: &Plan,
-    state: &mut RuntimeStateFor<'_, Plan>,
-    function: &ProfiledFunctionBody<Return, TailCall, RuntimeGraph<Plan>>,
-    inputs: RetainedValues,
-) -> ExecutionResult<EvaluatedFunctionExit<Return::Evaluated, TailCall>>
-where
-    Plan: ExecutableRuntimePlan,
-    Return: GraphValue,
-    TailCall: Clone,
-{
-    graph::execute(plan, state, function.block_graph(), inputs).map(|completed| {
-        let exit = function.exit(completed.exit());
-        match exit {
-            FunctionExit::Return(value) => {
-                EvaluatedFunctionExit::Return(completed.into_value(state, value))
-            }
-            FunctionExit::TailCall { function, args } => {
-                let function = function.clone();
-                let args = completed.into_retained(state, args);
-                EvaluatedFunctionExit::TailCall { function, args }
-            }
-        }
-    })
-}
-
 pub(super) fn evaluate_entry<Plan, Body>(
     plan: &Plan,
     state: &mut RuntimeStateFor<'_, Plan>,
@@ -114,6 +88,32 @@ where
             .call_host_never(state, origin, target, inputs)
             .map(EvaluatedFunctionExit::Return),
     }
+}
+
+pub(super) fn evaluate<Plan, Return, TailCall>(
+    plan: &Plan,
+    state: &mut RuntimeStateFor<'_, Plan>,
+    function: &ProfiledFunctionBody<Return, TailCall, RuntimeGraph<Plan>>,
+    inputs: RetainedValues,
+) -> ExecutionResult<EvaluatedFunctionExit<Return::Evaluated, TailCall>>
+where
+    Plan: ExecutableRuntimePlan,
+    Return: GraphValue,
+    TailCall: Clone,
+{
+    graph::execute(plan, state, function.block_graph(), inputs).map(|completed| {
+        let exit = function.exit(completed.exit());
+        match exit {
+            FunctionExit::Return(value) => {
+                EvaluatedFunctionExit::Return(completed.into_value(state, value))
+            }
+            FunctionExit::TailCall { function, args } => {
+                let function = function.clone();
+                let args = completed.into_retained(state, args);
+                EvaluatedFunctionExit::TailCall { function, args }
+            }
+        }
+    })
 }
 
 pub(super) fn parameter_locals<Plan, Body>(

--- a/src/runtime/function/list.rs
+++ b/src/runtime/function/list.rs
@@ -16,6 +16,75 @@ use crate::runtime::state::list::{
     UtfCodepointListValueId,
 };
 
+pub(in crate::runtime) fn run_list<Plan: ExecutableRuntimePlan>(
+    plan: &Plan,
+    state: &mut RuntimeStateFor<'_, Plan>,
+    function: RuntimeListFunctionId,
+    origin: HostCallOrigin,
+    inputs: RetainedValues,
+) -> ExecutionResult<ListValueId> {
+    match function {
+        RuntimeListFunctionId::Core(function) => {
+            run_core_list(plan, state, function, origin, inputs)
+        }
+        RuntimeListFunctionId::External(function) => {
+            run_external_list(plan, state, function, origin, inputs).map(ListValueId::External)
+        }
+    }
+}
+
+pub(in crate::runtime) fn run_core_list<Plan: ExecutableRuntimePlan>(
+    plan: &Plan,
+    state: &mut RuntimeStateFor<'_, Plan>,
+    function: ListFunctionId,
+    origin: HostCallOrigin,
+    inputs: RetainedValues,
+) -> ExecutionResult<ListValueId> {
+    match function {
+        ListFunctionId::Parameter(function) => {
+            run_parameter_list(plan, state, function, origin, inputs).map(ListValueId::Parameter)
+        }
+        ListFunctionId::ParameterList(function) => {
+            run_parameter_list_list(plan, state, function, origin, inputs)
+                .map(ListValueId::ParameterList)
+        }
+        ListFunctionId::Int(function) => {
+            run_int_list(plan, state, function, origin, inputs).map(ListValueId::Int)
+        }
+        ListFunctionId::String(function) => {
+            run_string_list(plan, state, function, origin, inputs).map(ListValueId::String)
+        }
+        ListFunctionId::BitArray(function) => {
+            run_bit_array_list(plan, state, function, origin, inputs).map(ListValueId::BitArray)
+        }
+        ListFunctionId::UtfCodepoint(function) => {
+            run_utf_codepoint_list(plan, state, function, origin, inputs)
+                .map(ListValueId::UtfCodepoint)
+        }
+        ListFunctionId::Custom(function) => {
+            run_custom_list(plan, state, function, origin, inputs).map(ListValueId::Custom)
+        }
+        ListFunctionId::Float(function) => {
+            run_float_list(plan, state, function, origin, inputs).map(ListValueId::Float)
+        }
+        ListFunctionId::Bool(function) => {
+            run_bool_list(plan, state, function, origin, inputs).map(ListValueId::Bool)
+        }
+        ListFunctionId::Nil(function) => {
+            run_nil_list(plan, state, function, origin, inputs).map(ListValueId::Nil)
+        }
+        ListFunctionId::Tuple(function) => {
+            run_tuple_list(plan, state, function, origin, inputs).map(ListValueId::Tuple)
+        }
+        ListFunctionId::List(function) => {
+            run_list_list(plan, state, function, origin, inputs).map(ListValueId::List)
+        }
+        ListFunctionId::Function(function) => {
+            run_function_list(plan, state, function, origin, inputs).map(ListValueId::Function)
+        }
+    }
+}
+
 pub(in crate::runtime) fn run_parameter_list<Plan: ExecutableRuntimePlan>(
     plan: &Plan,
     state: &mut RuntimeStateFor<'_, Plan>,
@@ -448,73 +517,4 @@ pub(in crate::runtime) fn run_function_list<Plan: ExecutableRuntimePlan>(
             )
         },
     )
-}
-
-pub(in crate::runtime) fn run_list<Plan: ExecutableRuntimePlan>(
-    plan: &Plan,
-    state: &mut RuntimeStateFor<'_, Plan>,
-    function: RuntimeListFunctionId,
-    origin: HostCallOrigin,
-    inputs: RetainedValues,
-) -> ExecutionResult<ListValueId> {
-    match function {
-        RuntimeListFunctionId::Core(function) => {
-            run_core_list(plan, state, function, origin, inputs)
-        }
-        RuntimeListFunctionId::External(function) => {
-            run_external_list(plan, state, function, origin, inputs).map(ListValueId::External)
-        }
-    }
-}
-
-pub(in crate::runtime) fn run_core_list<Plan: ExecutableRuntimePlan>(
-    plan: &Plan,
-    state: &mut RuntimeStateFor<'_, Plan>,
-    function: ListFunctionId,
-    origin: HostCallOrigin,
-    inputs: RetainedValues,
-) -> ExecutionResult<ListValueId> {
-    match function {
-        ListFunctionId::Parameter(function) => {
-            run_parameter_list(plan, state, function, origin, inputs).map(ListValueId::Parameter)
-        }
-        ListFunctionId::ParameterList(function) => {
-            run_parameter_list_list(plan, state, function, origin, inputs)
-                .map(ListValueId::ParameterList)
-        }
-        ListFunctionId::Int(function) => {
-            run_int_list(plan, state, function, origin, inputs).map(ListValueId::Int)
-        }
-        ListFunctionId::String(function) => {
-            run_string_list(plan, state, function, origin, inputs).map(ListValueId::String)
-        }
-        ListFunctionId::BitArray(function) => {
-            run_bit_array_list(plan, state, function, origin, inputs).map(ListValueId::BitArray)
-        }
-        ListFunctionId::UtfCodepoint(function) => {
-            run_utf_codepoint_list(plan, state, function, origin, inputs)
-                .map(ListValueId::UtfCodepoint)
-        }
-        ListFunctionId::Custom(function) => {
-            run_custom_list(plan, state, function, origin, inputs).map(ListValueId::Custom)
-        }
-        ListFunctionId::Float(function) => {
-            run_float_list(plan, state, function, origin, inputs).map(ListValueId::Float)
-        }
-        ListFunctionId::Bool(function) => {
-            run_bool_list(plan, state, function, origin, inputs).map(ListValueId::Bool)
-        }
-        ListFunctionId::Nil(function) => {
-            run_nil_list(plan, state, function, origin, inputs).map(ListValueId::Nil)
-        }
-        ListFunctionId::Tuple(function) => {
-            run_tuple_list(plan, state, function, origin, inputs).map(ListValueId::Tuple)
-        }
-        ListFunctionId::List(function) => {
-            run_list_list(plan, state, function, origin, inputs).map(ListValueId::List)
-        }
-        ListFunctionId::Function(function) => {
-            run_function_list(plan, state, function, origin, inputs).map(ListValueId::Function)
-        }
-    }
 }

--- a/src/runtime/function/returning_function.rs
+++ b/src/runtime/function/returning_function.rs
@@ -21,6 +21,134 @@ use crate::runtime::graph::RetainedValues;
 use crate::runtime::state::RuntimeStateFor;
 use std::convert::Infallible;
 
+pub(in crate::runtime) fn run_core_function<Plan: ExecutableRuntimePlan>(
+    plan: &Plan,
+    state: &mut RuntimeStateFor<'_, Plan>,
+    function: ProfiledFunctionFunctionId<Infallible>,
+    origin: HostCallOrigin,
+    inputs: RetainedValues,
+) -> ExecutionResult<EvaluatedFunctionValue> {
+    use ProfiledFunctionFunctionId as F;
+
+    match function {
+        F::Generic(function) => {
+            run_generic_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::Never(function) => {
+            run_never_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::Int(function) => run_int_function(plan, state, function, origin, inputs).map(Into::into),
+        F::Float(function) => {
+            run_float_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::String(function) => {
+            run_string_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::BitArray(function) => {
+            run_bit_array_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::UtfCodepoint(function) => {
+            run_utf_codepoint_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::Custom(function) => {
+            run_custom_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::External(function) => match function {},
+        F::Bool(function) => {
+            run_bool_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::Nil(function) => run_nil_function(plan, state, function, origin, inputs).map(Into::into),
+        F::Tuple(function) => {
+            run_tuple_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::List(function) => {
+            run_core_list_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        F::Function(function) => {
+            run_function_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+    }
+}
+
+pub(in crate::runtime) fn run_external_function_function<Plan: ExecutableRuntimePlan>(
+    plan: &Plan,
+    state: &mut RuntimeStateFor<'_, Plan>,
+    function: ExternalFunctionCallTarget,
+    origin: HostCallOrigin,
+    inputs: RetainedValues,
+) -> ExecutionResult<EvaluatedFunctionValue> {
+    match function {
+        ExternalFunctionCallTarget::Function(function) => {
+            run_external_function(plan, state, function, origin, inputs).map(Into::into)
+        }
+        ExternalFunctionCallTarget::ListFunction { id, .. } => {
+            run_external_list_function(plan, state, id, origin, inputs).map(Into::into)
+        }
+    }
+}
+
+pub(in crate::runtime) fn run_generic_function<Plan: ExecutableRuntimePlan>(
+    plan: &Plan,
+    state: &mut RuntimeStateFor<'_, Plan>,
+    function: GenericFunctionFunctionId,
+    origin: HostCallOrigin,
+    inputs: RetainedValues,
+) -> ExecutionResult<EvaluatedGenericFunction> {
+    run_tail(
+        plan,
+        state,
+        function,
+        origin,
+        inputs,
+        |plan, state, function, origin, inputs| {
+            evaluate_entry(
+                plan,
+                state,
+                plan.generic_function_function(function),
+                origin,
+                inputs,
+            )
+        },
+        |_, _, target| {
+            (
+                target.function().clone(),
+                HostCallOrigin::source(target.site().clone()),
+            )
+        },
+    )
+}
+
+pub(in crate::runtime) fn run_never_function<Plan: ExecutableRuntimePlan>(
+    plan: &Plan,
+    state: &mut RuntimeStateFor<'_, Plan>,
+    function: NeverFunctionFunctionId,
+    origin: HostCallOrigin,
+    inputs: RetainedValues,
+) -> ExecutionResult<EvaluatedNeverFunction> {
+    run_tail(
+        plan,
+        state,
+        function,
+        origin,
+        inputs,
+        |plan, state, function, origin, inputs| {
+            evaluate_entry(
+                plan,
+                state,
+                plan.never_function_function(function),
+                origin,
+                inputs,
+            )
+        },
+        |_, _, target| {
+            (
+                target.function().clone(),
+                HostCallOrigin::source(target.site().clone()),
+            )
+        },
+    )
+}
+
 pub(in crate::runtime) fn run_int_function<Plan: ExecutableRuntimePlan>(
     plan: &Plan,
     state: &mut RuntimeStateFor<'_, Plan>,
@@ -170,68 +298,6 @@ pub(in crate::runtime) fn run_utf_codepoint_function<Plan: ExecutableRuntimePlan
         |_, _, target| {
             (
                 *target.function(),
-                HostCallOrigin::source(target.site().clone()),
-            )
-        },
-    )
-}
-
-pub(in crate::runtime) fn run_generic_function<Plan: ExecutableRuntimePlan>(
-    plan: &Plan,
-    state: &mut RuntimeStateFor<'_, Plan>,
-    function: GenericFunctionFunctionId,
-    origin: HostCallOrigin,
-    inputs: RetainedValues,
-) -> ExecutionResult<EvaluatedGenericFunction> {
-    run_tail(
-        plan,
-        state,
-        function,
-        origin,
-        inputs,
-        |plan, state, function, origin, inputs| {
-            evaluate_entry(
-                plan,
-                state,
-                plan.generic_function_function(function),
-                origin,
-                inputs,
-            )
-        },
-        |_, _, target| {
-            (
-                target.function().clone(),
-                HostCallOrigin::source(target.site().clone()),
-            )
-        },
-    )
-}
-
-pub(in crate::runtime) fn run_never_function<Plan: ExecutableRuntimePlan>(
-    plan: &Plan,
-    state: &mut RuntimeStateFor<'_, Plan>,
-    function: NeverFunctionFunctionId,
-    origin: HostCallOrigin,
-    inputs: RetainedValues,
-) -> ExecutionResult<EvaluatedNeverFunction> {
-    run_tail(
-        plan,
-        state,
-        function,
-        origin,
-        inputs,
-        |plan, state, function, origin, inputs| {
-            evaluate_entry(
-                plan,
-                state,
-                plan.never_function_function(function),
-                origin,
-                inputs,
-            )
-        },
-        |_, _, target| {
-            (
-                target.function().clone(),
                 HostCallOrigin::source(target.site().clone()),
             )
         },
@@ -484,70 +550,4 @@ pub(in crate::runtime) fn run_function_function<Plan: ExecutableRuntimePlan>(
             )
         },
     )
-}
-
-pub(in crate::runtime) fn run_core_function<Plan: ExecutableRuntimePlan>(
-    plan: &Plan,
-    state: &mut RuntimeStateFor<'_, Plan>,
-    function: ProfiledFunctionFunctionId<Infallible>,
-    origin: HostCallOrigin,
-    inputs: RetainedValues,
-) -> ExecutionResult<EvaluatedFunctionValue> {
-    use ProfiledFunctionFunctionId as F;
-
-    match function {
-        F::Generic(function) => {
-            run_generic_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::Never(function) => {
-            run_never_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::Int(function) => run_int_function(plan, state, function, origin, inputs).map(Into::into),
-        F::Float(function) => {
-            run_float_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::String(function) => {
-            run_string_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::BitArray(function) => {
-            run_bit_array_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::UtfCodepoint(function) => {
-            run_utf_codepoint_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::Custom(function) => {
-            run_custom_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::External(function) => match function {},
-        F::Bool(function) => {
-            run_bool_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::Nil(function) => run_nil_function(plan, state, function, origin, inputs).map(Into::into),
-        F::Tuple(function) => {
-            run_tuple_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::List(function) => {
-            run_core_list_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        F::Function(function) => {
-            run_function_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-    }
-}
-
-pub(in crate::runtime) fn run_external_function_function<Plan: ExecutableRuntimePlan>(
-    plan: &Plan,
-    state: &mut RuntimeStateFor<'_, Plan>,
-    function: ExternalFunctionCallTarget,
-    origin: HostCallOrigin,
-    inputs: RetainedValues,
-) -> ExecutionResult<EvaluatedFunctionValue> {
-    match function {
-        ExternalFunctionCallTarget::Function(function) => {
-            run_external_function(plan, state, function, origin, inputs).map(Into::into)
-        }
-        ExternalFunctionCallTarget::ListFunction { id, .. } => {
-            run_external_list_function(plan, state, id, origin, inputs).map(Into::into)
-        }
-    }
 }

--- a/src/runtime/graph.rs
+++ b/src/runtime/graph.rs
@@ -13,75 +13,6 @@ use self::terminator::{GraphAction, NeverCall, terminator_action};
 use crate::plan::execution::graph::{BlockGraphExitId, ParamLocal, ProfiledBlockGraph};
 use crate::runtime::{ExecutableRuntimePlan, RuntimeGraph};
 
-pub(in crate::runtime) fn execute_external_list_instruction<Plan>(
-    plan: &Plan,
-    state: &mut RuntimeStateFor<'_, Plan>,
-    environment: &mut BlockEnvironment,
-    instruction: &crate::plan::execution::graph::ExternalListInstruction,
-    expected: &crate::plan::ValueType,
-) -> ExecutionResult<()>
-where
-    Plan: ExecutableRuntimePlan
-        + crate::plan::execution::runtime::RuntimeExecutionPlan<
-            Profile = crate::plan::execution::host::HostedExecutionProfile,
-        >,
-{
-    instruction::execute_external_list(plan, state, environment, instruction, expected)
-}
-
-pub(in crate::runtime) fn execute_external_function_instruction<Plan>(
-    plan: &Plan,
-    state: &mut RuntimeStateFor<'_, Plan>,
-    environment: &mut BlockEnvironment,
-    instruction: &crate::plan::execution::graph::ExternalFunctionInstruction,
-) -> ExecutionResult<()>
-where
-    Plan: ExecutableRuntimePlan
-        + crate::plan::execution::runtime::RuntimeExecutionPlan<
-            Profile = crate::plan::execution::host::HostedExecutionProfile,
-        >,
-{
-    instruction::execute_external_function(plan, state, environment, instruction)
-}
-use crate::runtime::error::ExecutionResult;
-use crate::runtime::state::{RuntimeState, RuntimeStateFor};
-
-pub(super) struct CompletedGraph {
-    exit: BlockGraphExitId,
-    environment: BlockEnvironment,
-}
-
-impl CompletedGraph {
-    pub(super) fn exit(&self) -> BlockGraphExitId {
-        self.exit
-    }
-
-    pub(super) fn into_value<Value, State>(
-        self,
-        state: &mut RuntimeState<'_, State>,
-        value: &Value,
-    ) -> Value::Evaluated
-    where
-        Value: GraphValue,
-    {
-        let value = value.read(&self.environment);
-        drop(self.environment);
-        state.lists_mut().drain_releases();
-        value
-    }
-
-    pub(super) fn into_retained<State>(
-        self,
-        state: &mut RuntimeState<'_, State>,
-        values: &[ParamLocal],
-    ) -> RetainedValues {
-        let retained = self.environment.retain(values);
-        drop(self.environment);
-        state.lists_mut().drain_releases();
-        retained
-    }
-}
-
 pub(super) fn execute<Plan: ExecutableRuntimePlan>(
     plan: &Plan,
     state: &mut RuntimeStateFor<'_, Plan>,
@@ -126,6 +57,75 @@ pub(super) fn execute<Plan: ExecutableRuntimePlan>(
             }
         }
     }
+}
+use crate::runtime::error::ExecutionResult;
+use crate::runtime::state::{RuntimeState, RuntimeStateFor};
+
+pub(super) struct CompletedGraph {
+    exit: BlockGraphExitId,
+    environment: BlockEnvironment,
+}
+
+impl CompletedGraph {
+    pub(super) fn exit(&self) -> BlockGraphExitId {
+        self.exit
+    }
+
+    pub(super) fn into_value<Value, State>(
+        self,
+        state: &mut RuntimeState<'_, State>,
+        value: &Value,
+    ) -> Value::Evaluated
+    where
+        Value: GraphValue,
+    {
+        let value = value.read(&self.environment);
+        drop(self.environment);
+        state.lists_mut().drain_releases();
+        value
+    }
+
+    pub(super) fn into_retained<State>(
+        self,
+        state: &mut RuntimeState<'_, State>,
+        values: &[ParamLocal],
+    ) -> RetainedValues {
+        let retained = self.environment.retain(values);
+        drop(self.environment);
+        state.lists_mut().drain_releases();
+        retained
+    }
+}
+
+pub(in crate::runtime) fn execute_external_list_instruction<Plan>(
+    plan: &Plan,
+    state: &mut RuntimeStateFor<'_, Plan>,
+    environment: &mut BlockEnvironment,
+    instruction: &crate::plan::execution::graph::ExternalListInstruction,
+    expected: &crate::plan::ValueType,
+) -> ExecutionResult<()>
+where
+    Plan: ExecutableRuntimePlan
+        + crate::plan::execution::runtime::RuntimeExecutionPlan<
+            Profile = crate::plan::execution::host::HostedExecutionProfile,
+        >,
+{
+    instruction::execute_external_list(plan, state, environment, instruction, expected)
+}
+
+pub(in crate::runtime) fn execute_external_function_instruction<Plan>(
+    plan: &Plan,
+    state: &mut RuntimeStateFor<'_, Plan>,
+    environment: &mut BlockEnvironment,
+    instruction: &crate::plan::execution::graph::ExternalFunctionInstruction,
+) -> ExecutionResult<()>
+where
+    Plan: ExecutableRuntimePlan
+        + crate::plan::execution::runtime::RuntimeExecutionPlan<
+            Profile = crate::plan::execution::host::HostedExecutionProfile,
+        >,
+{
+    instruction::execute_external_function(plan, state, environment, instruction)
 }
 
 #[cfg(test)]

--- a/src/runtime/materialize.rs
+++ b/src/runtime/materialize.rs
@@ -44,6 +44,31 @@ pub(super) fn value(
     }
 }
 
+fn custom(
+    plan: RuntimeValueMetadata<'_>,
+    state: &RuntimeListStorage,
+    value: EvaluatedCustomValue,
+) -> CustomValue {
+    let constructor = plan.custom_constructor(value.constructor());
+    let fields = value
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            CustomFieldValue::from_evaluated(
+                constructor.fields()[index].label().cloned(),
+                self::value(plan, state, value.clone()),
+            )
+        })
+        .collect();
+    CustomValue::from_evaluated(
+        plan.custom_value_type(value.type_id()),
+        constructor.name().clone(),
+        constructor.id().index(),
+        fields,
+    )
+}
+
 fn external(
     plan: RuntimeValueMetadata<'_>,
     state: &RuntimeListStorage,
@@ -60,6 +85,10 @@ fn external(
         .inspection(&crate::host::HostExternalInspection::new(&inspect))
         .clone();
     ExternalValue::from_evaluated(plan.external_value_type(type_id), lease, inspection)
+}
+
+fn parameter_list(value: ParameterListValueId) -> ListValue {
+    ListValue::empty(crate::plan::ValueType::Parameter(value.type_id().item()))
 }
 
 fn list(
@@ -142,10 +171,6 @@ fn list(
     }
 }
 
-fn parameter_list(value: ParameterListValueId) -> ListValue {
-    ListValue::empty(crate::plan::ValueType::Parameter(value.type_id().item()))
-}
-
 fn function(
     plan: RuntimeValueMetadata<'_>,
     state: &RuntimeListStorage,
@@ -198,44 +223,6 @@ fn function(
     FunctionValue::from_kind(kind)
 }
 
-fn custom(
-    plan: RuntimeValueMetadata<'_>,
-    state: &RuntimeListStorage,
-    value: EvaluatedCustomValue,
-) -> CustomValue {
-    let constructor = plan.custom_constructor(value.constructor());
-    let fields = value
-        .fields()
-        .iter()
-        .enumerate()
-        .map(|(index, value)| {
-            CustomFieldValue::from_evaluated(
-                constructor.fields()[index].label().cloned(),
-                self::value(plan, state, value.clone()),
-            )
-        })
-        .collect();
-    CustomValue::from_evaluated(
-        plan.custom_value_type(value.type_id()),
-        constructor.name().clone(),
-        constructor.id().index(),
-        fields,
-    )
-}
-
-fn int_function(
-    plan: RuntimeValueMetadata<'_>,
-    state: &RuntimeListStorage,
-    value: &EvaluatedIntFunction,
-) -> IntFunctionValue {
-    IntFunctionValue::new_with_captures(
-        value.runtime_id(),
-        value.params().to_vec(),
-        captures(plan, state, value.captures()),
-        plan.function_type(value.type_()),
-    )
-}
-
 fn generic_function(
     plan: RuntimeValueMetadata<'_>,
     state: &RuntimeListStorage,
@@ -255,6 +242,19 @@ fn never_function(
     value: &EvaluatedNeverFunction,
 ) -> NeverFunctionValue {
     NeverFunctionValue::from_evaluated(
+        value.runtime_id(),
+        value.params().to_vec(),
+        captures(plan, state, value.captures()),
+        plan.function_type(value.type_()),
+    )
+}
+
+fn int_function(
+    plan: RuntimeValueMetadata<'_>,
+    state: &RuntimeListStorage,
+    value: &EvaluatedIntFunction,
+) -> IntFunctionValue {
+    IntFunctionValue::new_with_captures(
         value.runtime_id(),
         value.params().to_vec(),
         captures(plan, state, value.captures()),
@@ -419,18 +419,6 @@ fn function_function(
         captures(plan, state, value.captures()),
         plan.function_type(value.type_()),
     )
-}
-
-fn nested_list_values(
-    plan: RuntimeValueMetadata<'_>,
-    state: &RuntimeListStorage,
-    value: &super::state::list::ListListValueId,
-) -> Vec<ListValue> {
-    state
-        .list_values(value)
-        .iter()
-        .map(|value| list(plan, state, value))
-        .collect()
 }
 
 fn captures(
@@ -621,6 +609,18 @@ fn list_capture(
                 .collect(),
         },
     }
+}
+
+fn nested_list_values(
+    plan: RuntimeValueMetadata<'_>,
+    state: &RuntimeListStorage,
+    value: &super::state::list::ListListValueId,
+) -> Vec<ListValue> {
+    state
+        .list_values(value)
+        .iter()
+        .map(|value| list(plan, state, value))
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/runtime/value/function.rs
+++ b/src/runtime/value/function.rs
@@ -159,6 +159,25 @@ impl FunctionValue {
         Self { kind }
     }
 
+    pub fn type_(&self) -> FunctionType {
+        match &self.kind {
+            FunctionValueKind::Generic(value) => value.type_(),
+            FunctionValueKind::Never(value) => value.type_(),
+            FunctionValueKind::Int(value) => value.type_(),
+            FunctionValueKind::Float(value) => value.type_(),
+            FunctionValueKind::String(value) => value.type_(),
+            FunctionValueKind::BitArray(value) => value.type_(),
+            FunctionValueKind::UtfCodepoint(value) => value.type_(),
+            FunctionValueKind::Custom(value) => value.type_(),
+            FunctionValueKind::External(value) => value.type_(),
+            FunctionValueKind::Bool(value) => value.type_(),
+            FunctionValueKind::Nil(value) => value.type_(),
+            FunctionValueKind::Tuple(value) => value.type_(),
+            FunctionValueKind::List(value) => value.type_(),
+            FunctionValueKind::Function(value) => value.type_(),
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn new(
         runtime_id: RuntimeFunctionId,
@@ -232,25 +251,6 @@ impl FunctionValue {
         };
 
         Self { kind }
-    }
-
-    pub fn type_(&self) -> FunctionType {
-        match &self.kind {
-            FunctionValueKind::Generic(value) => value.type_(),
-            FunctionValueKind::Never(value) => value.type_(),
-            FunctionValueKind::Int(value) => value.type_(),
-            FunctionValueKind::Float(value) => value.type_(),
-            FunctionValueKind::String(value) => value.type_(),
-            FunctionValueKind::BitArray(value) => value.type_(),
-            FunctionValueKind::UtfCodepoint(value) => value.type_(),
-            FunctionValueKind::Custom(value) => value.type_(),
-            FunctionValueKind::External(value) => value.type_(),
-            FunctionValueKind::Bool(value) => value.type_(),
-            FunctionValueKind::Nil(value) => value.type_(),
-            FunctionValueKind::Tuple(value) => value.type_(),
-            FunctionValueKind::List(value) => value.type_(),
-            FunctionValueKind::Function(value) => value.type_(),
-        }
     }
 
     #[cfg(test)]
@@ -570,14 +570,6 @@ impl FunctionFunctionValue {
     }
 }
 
-impl From<IntFunctionValue> for FunctionValue {
-    fn from(value: IntFunctionValue) -> Self {
-        Self {
-            kind: FunctionValueKind::Int(value),
-        }
-    }
-}
-
 impl From<GenericFunctionValue> for FunctionValue {
     fn from(value: GenericFunctionValue) -> Self {
         Self {
@@ -590,6 +582,14 @@ impl From<NeverFunctionValue> for FunctionValue {
     fn from(value: NeverFunctionValue) -> Self {
         Self {
             kind: FunctionValueKind::Never(value),
+        }
+    }
+}
+
+impl From<IntFunctionValue> for FunctionValue {
+    fn from(value: IntFunctionValue) -> Self {
+        Self {
+            kind: FunctionValueKind::Int(value),
         }
     }
 }

--- a/src/runtime/value/list.rs
+++ b/src/runtime/value/list.rs
@@ -53,10 +53,6 @@ pub(super) enum ListValueKind {
 }
 
 impl ListValue {
-    pub(super) fn kind(&self) -> &ListValueKind {
-        &self.kind
-    }
-
     pub fn int(values: Vec<BigInt>) -> Self {
         Self {
             kind: ListValueKind::Int(values),
@@ -336,6 +332,10 @@ impl ListValue {
                 values.iter().cloned().map(Value::Function).collect()
             }
         }
+    }
+
+    pub(super) fn kind(&self) -> &ListValueKind {
+        &self.kind
     }
 }
 


### PR DESCRIPTION
## Summary

- Define reader-order guidance for production functions in the review policy.
- Audit every production Rust owner and place representative entries before the private chains they introduce.
- Preserve stable protocol and value-family ordering where call order is not the clearest reading order.
- Keep bit-array metadata declarations together before their formatters and tests.

## Review Notes

- The audit covers 413 production owners; the 24 test-only `planner::dsl` files are intentionally excluded.
- Production source changes are declaration moves only: added and removed source-line multisets are identical.
- Public APIs, function bodies, signatures, imports, visibility, tests, module ownership, Explain output, and runtime behavior are unchanged.
- Test modules, embedded Gleam source, and macro-generated families are not reordered.