### PR TITLE
Support remaining provider-free Gleam stdlib modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ equally, while collisions are resolved by equality. Their public runtime
 values remain opaque and self-contained. The `geam::gleam_stdlib` module
 provides an explicitly composed host-provider bundle for unchanged official
 `gleam_stdlib` `v1.0.3` modules that require externals; it is not injected by
-project loading. The verified module set is `gleam/bool`, `gleam/option`,
-`gleam/order`, `gleam/dict`, `gleam/dynamic`, `gleam/float`, `gleam/int`,
-`gleam/list`, `gleam/string_tree`, `gleam/string`, `gleam/bit_array`, and
-`gleam/dynamic/decode`.
+project loading. The verified module set is `gleam/bit_array`, `gleam/bool`,
+`gleam/bytes_tree`, `gleam/dict`, `gleam/dynamic`, `gleam/dynamic/decode`,
+`gleam/float`, `gleam/function`, `gleam/int`, `gleam/list`, `gleam/option`,
+`gleam/order`, `gleam/pair`, `gleam/result`, `gleam/set`, `gleam/string`, and
+`gleam/string_tree`.
 
 The main public entry points are:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -70,12 +70,13 @@ CI prepares this fixture with Gleam `v1.17.0`. Provider-free roots run through
 run_main`; roots whose selected closure uses registered externals run through
 `compile_typed_host_project -> plan_host_program ->
 HostedExecution::try_from_module_plan -> run_main` with the explicit
-`geam::gleam_stdlib` provider bundle. The tracked set covers `gleam/bool`,
-`gleam/option`, `gleam/order`, `gleam/dict`, `gleam/dynamic`, `gleam/float`,
-`gleam/int`, `gleam/list`, `gleam/string_tree`, `gleam/string`,
-`gleam/bit_array`, and `gleam/dynamic/decode`. Each module fixes its analyzed
-public surface and executes grouped source behavior. This integration suite
-does not replace hermetic synthetic owner coverage for the loader or
+`geam::gleam_stdlib` provider bundle. The tracked set covers `gleam/bit_array`,
+`gleam/bool`, `gleam/bytes_tree`, `gleam/dict`, `gleam/dynamic`,
+`gleam/dynamic/decode`, `gleam/float`, `gleam/function`, `gleam/int`,
+`gleam/list`, `gleam/option`, `gleam/order`, `gleam/pair`, `gleam/result`,
+`gleam/set`, `gleam/string`, and `gleam/string_tree`. Each module fixes its
+analyzed public surface and executes grouped source behavior. This integration
+suite does not replace hermetic synthetic owner coverage for the loader or
 providers.
 
 Source-level rejection fixtures live under categorized

--- a/docs/upstream-gleam.md
+++ b/docs/upstream-gleam.md
@@ -181,16 +181,46 @@ Private transient-style external APIs can be represented by returning new
 persistent payload versions that share immutable retained entries. This does
 not add a general mutable external-value model or cyclic runtime graph support.
 
+### Gleam Stdlib v1.0.3 Compatibility
+
+Checked modules have exact public-surface coverage and execute unchanged
+official source through the upstream integration suite. An unchecked module is
+not necessarily rejected; it has not yet been verified end to end.
+
+#### No Module-Specific Provider
+
+- [x] `gleam/bool`
+- [x] `gleam/bytes_tree`
+- [x] `gleam/function`
+- [x] `gleam/list`
+- [x] `gleam/option`
+- [x] `gleam/order`
+- [x] `gleam/pair`
+- [x] `gleam/result`
+- [x] `gleam/set`
+
+#### Explicit Rust Provider
+
+- [x] `gleam/bit_array`
+- [x] `gleam/dict`
+- [x] `gleam/dynamic`
+- [x] `gleam/dynamic/decode`
+- [x] `gleam/float`
+- [x] `gleam/int`
+- [x] `gleam/string`
+- [x] `gleam/string_tree`
+
+#### Not Yet Verified
+
+- [ ] `gleam/io`: requires a caller-owned output boundary.
+- [ ] `gleam/uri`: requires implementations for bodyless externals.
+
 `geam::gleam_stdlib::host_providers` supplies the explicit provider bundle for
-the verified `gleam_stdlib` `v1.0.3` modules. Callers compose that bundle into a
-`HostProviderSet`; project loading selects only providers in the resolved
-source closure and does not infer or inject the bundle. The verified set is
-`gleam/bit_array`, `gleam/bool`, `gleam/bytes_tree`, `gleam/dict`,
-`gleam/dynamic`, `gleam/dynamic/decode`, `gleam/float`, `gleam/function`,
-`gleam/int`, `gleam/list`, `gleam/option`, `gleam/order`, `gleam/pair`,
-`gleam/result`, `gleam/set`, `gleam/string`, and `gleam/string_tree`. Functions
-with valid Gleam fallback bodies, including the annotated `gleam/bytes_tree`
-operations, continue to compile and execute from the unchanged package source.
+provider-backed modules. Callers compose that bundle into a `HostProviderSet`;
+project loading selects only providers in the resolved source closure and does
+not infer or inject the bundle. Functions with valid Gleam fallback bodies,
+including the annotated `gleam/bytes_tree` operations, continue to compile and
+execute from the unchanged package source.
 
 The provider-backed modules retain their source-facing value distinctions.
 Dictionary lookup uses source hashing followed by source equality within a

--- a/docs/upstream-gleam.md
+++ b/docs/upstream-gleam.md
@@ -185,11 +185,12 @@ not add a general mutable external-value model or cyclic runtime graph support.
 the verified `gleam_stdlib` `v1.0.3` modules. Callers compose that bundle into a
 `HostProviderSet`; project loading selects only providers in the resolved
 source closure and does not infer or inject the bundle. The verified set is
-`gleam/bool`, `gleam/option`, `gleam/order`, `gleam/dict`, `gleam/dynamic`,
-`gleam/float`, `gleam/int`, `gleam/list`, `gleam/string_tree`, `gleam/string`,
-`gleam/bit_array`, and `gleam/dynamic/decode`. Functions with valid Gleam
-fallback bodies continue to compile and execute from the unchanged package
-source.
+`gleam/bit_array`, `gleam/bool`, `gleam/bytes_tree`, `gleam/dict`,
+`gleam/dynamic`, `gleam/dynamic/decode`, `gleam/float`, `gleam/function`,
+`gleam/int`, `gleam/list`, `gleam/option`, `gleam/order`, `gleam/pair`,
+`gleam/result`, `gleam/set`, `gleam/string`, and `gleam/string_tree`. Functions
+with valid Gleam fallback bodies, including the annotated `gleam/bytes_tree`
+operations, continue to compile and execute from the unchanged package source.
 
 The provider-backed modules retain their source-facing value distinctions.
 Dictionary lookup uses source hashing followed by source equality within a

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_bytes_tree_basics.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_bytes_tree_basics.gleam
@@ -1,0 +1,28 @@
+import gleam/bytes_tree
+import gleam/string_tree
+
+pub fn main() {
+  let empty = bytes_tree.new()
+  assert bytes_tree.to_bit_array(empty) == <<>>
+  assert bytes_tree.byte_size(empty) == 0
+
+  let text = bytes_tree.from_string("hello")
+  assert bytes_tree.to_bit_array(text) == <<"hello":utf8>>
+  assert bytes_tree.byte_size(text) == 5
+
+  let text_tree = string_tree.from_strings(["hel", "lo"])
+  let from_text_tree = bytes_tree.from_string_tree(text_tree)
+  assert bytes_tree.to_bit_array(from_text_tree) == <<"hello":utf8>>
+  assert bytes_tree.byte_size(from_text_tree) == 5
+
+  let bytes = bytes_tree.from_bit_array(<<1, 2, 3>>)
+  assert bytes_tree.to_bit_array(bytes) == <<1, 2, 3>>
+  assert bytes_tree.byte_size(bytes) == 3
+
+  let padded = bytes_tree.from_bit_array(<<5:size(3)>>)
+  assert bytes_tree.to_bit_array(padded) == <<5:size(3), 0:size(5)>>
+  assert bytes_tree.byte_size(padded) == 1
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_bytes_tree_structure.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_bytes_tree_structure.gleam
@@ -1,0 +1,56 @@
+import gleam/bit_array
+import gleam/bytes_tree
+import gleam/list
+import gleam/string
+
+pub fn main() {
+  let base = bytes_tree.from_string("middle")
+  let left = bytes_tree.prepend_string(base, "left-")
+  let right = bytes_tree.append_string(base, "-right")
+
+  assert bytes_tree.to_bit_array(base) == <<"middle":utf8>>
+  assert bytes_tree.to_bit_array(left) == <<"left-middle":utf8>>
+  assert bytes_tree.to_bit_array(right) == <<"middle-right":utf8>>
+
+  let with_bytes =
+    bytes_tree.prepend(base, <<"[":utf8>>)
+    |> bytes_tree.append(<<"]":utf8>>)
+  assert bytes_tree.to_bit_array(with_bytes) == <<"[middle]":utf8>>
+
+  let with_trees =
+    bytes_tree.prepend_tree(base, bytes_tree.from_string("before-"))
+    |> bytes_tree.append_tree(bytes_tree.from_string("-after"))
+  assert bytes_tree.to_bit_array(with_trees) == <<"before-middle-after":utf8>>
+
+  let concatenated = bytes_tree.concat([
+    bytes_tree.from_string("one"),
+    bytes_tree.from_string("-"),
+    bytes_tree.from_string("two"),
+  ])
+  assert bytes_tree.to_bit_array(concatenated) == <<"one-two":utf8>>
+
+  let concatenated_bits = bytes_tree.concat_bit_arrays([
+    <<5:size(3)>>,
+    <<3:size(2)>>,
+  ])
+  assert bytes_tree.to_bit_array(concatenated_bits)
+    == <<5:size(3), 0:size(5), 3:size(2), 0:size(6)>>
+
+  let flat = bytes_tree.from_string("ab")
+  let segmented = bytes_tree.concat([
+    bytes_tree.from_string("a"),
+    bytes_tree.from_string("b"),
+  ])
+  assert flat != segmented
+  assert bytes_tree.to_bit_array(flat) == bytes_tree.to_bit_array(segmented)
+
+  let deep =
+    list.repeat(bytes_tree.from_string("x"), times: 512)
+    |> list.fold(from: bytes_tree.new(), with: bytes_tree.append_tree)
+  let deep_bits = bytes_tree.to_bit_array(deep)
+  assert bytes_tree.byte_size(deep) == 512
+  assert bit_array.to_string(deep_bits) == Ok(string.repeat("x", times: 512))
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_function.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_function.gleam
@@ -1,0 +1,18 @@
+import gleam/function
+
+type Boxed(value) {
+  Boxed(value)
+}
+
+pub fn main() {
+  assert function.identity(1) == 1
+  assert function.identity(#("one", True)) == #("one", True)
+  assert function.identity([1, 2, 3]) == [1, 2, 3]
+  assert function.identity(Boxed("value")) == Boxed("value")
+
+  let increment = function.identity(fn(value) { value + 1 })
+  assert increment(1) == 2
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_pair.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_pair.gleam
@@ -1,0 +1,22 @@
+import gleam/pair
+
+pub fn main() {
+  let value = pair.new(1, "one")
+
+  assert pair.first(value) == 1
+  assert pair.second(value) == "one"
+  assert pair.swap(value) == #("one", 1)
+  assert pair.map_first(of: #(1, False), with: int_name) == #("one", False)
+  assert pair.map_second(of: #(1, "one"), with: fn(value) { value == "one" })
+    == #(1, True)
+
+  Nil
+}
+
+fn int_name(value: Int) -> String {
+  case value {
+    1 -> "one"
+    _ -> "other"
+  }
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_result_basics.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_result_basics.gleam
@@ -1,0 +1,42 @@
+import gleam/result
+
+pub fn main() {
+  let ok: Result(Int, String) = Ok(1)
+  let error: Result(Int, String) = Error("error")
+
+  assert result.is_ok(ok)
+  assert !result.is_ok(error)
+  assert result.is_error(error)
+  assert !result.is_error(ok)
+
+  assert result.map(over: ok, with: fn(value) { value + 1 }) == Ok(2)
+  assert result.map(over: error, with: fn(value) { value + 1 }) == error
+  assert result.map_error(over: ok, with: fn(value) { value <> "!" }) == ok
+  assert result.map_error(over: error, with: fn(value) { value <> "!" })
+    == Error("error!")
+
+  assert result.flatten(Ok(Ok(1))) == Ok(1)
+  assert result.flatten(Ok(Error("inner"))) == Error("inner")
+  assert result.flatten(Error("outer")) == Error("outer")
+
+  assert result.unwrap(ok, or: 0) == 1
+  assert result.unwrap(error, or: 0) == 0
+  assert result.lazy_unwrap(ok, or: fn() { panic as "unselected lazy default" })
+    == 1
+  assert result.lazy_unwrap(error, or: fn() { 0 }) == 0
+  assert result.unwrap_error(error, or: "default") == "error"
+  assert result.unwrap_error(ok, or: "default") == "default"
+
+  assert result.or(ok, Ok(2)) == ok
+  assert result.or(error, Ok(2)) == Ok(2)
+  assert result.lazy_or(ok, fn() { panic as "unselected lazy result" }) == ok
+  assert result.lazy_or(error, fn() { Ok(2) }) == Ok(2)
+
+  assert result.replace(ok, "one") == Ok("one")
+  assert result.replace(error, "one") == Error("error")
+  assert result.replace_error(ok, Nil) == Ok(1)
+  assert result.replace_error(error, Nil) == Error(Nil)
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_result_combinators.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_result_combinators.gleam
@@ -1,0 +1,30 @@
+import gleam/result
+
+pub fn main() {
+  let ok: Result(Int, String) = Ok(1)
+  let error: Result(Int, String) = Error("first")
+
+  assert result.try(ok, fn(value) { Ok(value + 1) }) == Ok(2)
+  assert result.try(ok, fn(_) { Error("next") }) == Error("next")
+  assert result.try(error, fn(_) { panic as "unselected try callback" }) == error
+
+  assert result.all([Ok(1), Ok(2), Ok(3)]) == Ok([1, 2, 3])
+  assert result.all([Ok(1), Error("first"), Error("second")])
+    == Error("first")
+  assert result.partition([Ok(1), Error("a"), Error("b"), Ok(2)])
+    == #([2, 1], ["b", "a"])
+  assert result.values([Ok(1), Error("ignored"), Ok(3)]) == [1, 3]
+
+  assert result.try_recover(ok, with: fn(_) {
+    panic as "unselected recovery callback"
+  }) == ok
+  assert result.try_recover(error, with: fn(value) {
+    assert value == "first"
+    Ok(2)
+  }) == Ok(2)
+  assert result.try_recover(error, with: fn(_) { Error("failed") })
+    == Error("failed")
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_set_basics.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_set_basics.gleam
@@ -1,0 +1,42 @@
+import gleam/list
+import gleam/set
+
+pub fn main() {
+  let empty = set.new()
+  let one = set.insert(empty, 1)
+  let two = set.insert(one, 2)
+  let duplicate = set.insert(two, 2)
+
+  assert set.is_empty(empty)
+  assert set.size(empty) == 0
+  assert set.size(one) == 1
+  assert set.size(two) == 2
+  assert set.size(duplicate) == 2
+  assert !set.contains(empty, 1)
+  assert set.contains(one, 1)
+  assert !set.contains(one, 2)
+  assert set.contains(two, 2)
+
+  assert set.delete(two, 2) == one
+  assert set.delete(two, 3) == two
+
+  let values = set.from_list([3, 1, 3, 2, 1])
+  let members = set.to_list(values)
+  assert set.size(values) == 3
+  assert list.length(members) == 3
+  assert list.contains(members, 1)
+  assert list.contains(members, 2)
+  assert list.contains(members, 3)
+  assert set.fold(over: values, from: 0, with: fn(total, value) {
+    total + value
+  }) == 6
+
+  assert set.from_list([1, 2, 3]) == set.from_list([3, 2, 1, 2])
+  assert set.each(set.from_list([7]), fn(value) {
+    assert value == 7
+    "ignored"
+  }) == Nil
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_set_operations.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_set_operations.gleam
@@ -1,0 +1,30 @@
+import gleam/set
+
+pub fn main() {
+  let base = set.from_list([1, 2, 3, 4])
+  let other = set.from_list([3, 4, 5])
+
+  assert set.filter(in: base, keeping: fn(value) { value % 2 == 0 })
+    == set.from_list([2, 4])
+  let mapped = set.map(base, with: fn(value) { value % 2 })
+  assert mapped == set.from_list([0, 1])
+  assert set.size(mapped) == 2
+  assert set.drop(from: base, drop: [1, 3, 8]) == set.from_list([2, 4])
+  assert set.take(from: base, keeping: [1, 3, 8]) == set.from_list([1, 3])
+
+  assert set.union(of: base, and: other) == set.from_list([1, 2, 3, 4, 5])
+  assert set.intersection(of: base, and: other) == set.from_list([3, 4])
+  assert set.difference(from: base, minus: other) == set.from_list([1, 2])
+  assert set.is_subset(set.from_list([1, 2]), of: base)
+  assert !set.is_subset(set.from_list([1, 5]), of: base)
+  assert set.is_disjoint(set.from_list([1, 2]), from: set.from_list([3, 4]))
+  assert !set.is_disjoint(base, from: other)
+  assert set.symmetric_difference(of: base, and: other)
+    == set.from_list([1, 2, 5])
+
+  assert base == set.from_list([4, 3, 2, 1])
+  assert other == set.from_list([5, 4, 3])
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/gleam_stdlib.rs
+++ b/tests/gleam_stdlib.rs
@@ -31,6 +31,8 @@ mod gleam_order;
 mod gleam_pair;
 #[path = "gleam_stdlib/gleam_result.rs"]
 mod gleam_result;
+#[path = "gleam_stdlib/gleam_set.rs"]
+mod gleam_set;
 #[path = "gleam_stdlib/gleam_string.rs"]
 mod gleam_string;
 #[path = "gleam_stdlib/gleam_string_tree.rs"]
@@ -87,9 +89,12 @@ fn assert_surface(
 
     let mut type_aliases = module
         .type_info
-        .type_aliases
-        .keys()
-        .map(|name| name.as_str())
+        .types
+        .iter()
+        .filter(|(name, type_)| {
+            type_.publicity.is_public() && module.type_info.type_aliases.contains_key(*name)
+        })
+        .map(|(name, _)| name.as_str())
         .collect::<Vec<_>>();
     type_aliases.sort_unstable();
     assert_eq!(type_aliases.as_slice(), expected.type_aliases);

--- a/tests/gleam_stdlib.rs
+++ b/tests/gleam_stdlib.rs
@@ -17,6 +17,8 @@ mod gleam_dynamic;
 mod gleam_dynamic_decode;
 #[path = "gleam_stdlib/gleam_float.rs"]
 mod gleam_float;
+#[path = "gleam_stdlib/gleam_function.rs"]
+mod gleam_function;
 #[path = "gleam_stdlib/gleam_int.rs"]
 mod gleam_int;
 #[path = "gleam_stdlib/gleam_list.rs"]
@@ -25,6 +27,8 @@ mod gleam_list;
 mod gleam_option;
 #[path = "gleam_stdlib/gleam_order.rs"]
 mod gleam_order;
+#[path = "gleam_stdlib/gleam_pair.rs"]
+mod gleam_pair;
 #[path = "gleam_stdlib/gleam_string.rs"]
 mod gleam_string;
 #[path = "gleam_stdlib/gleam_string_tree.rs"]

--- a/tests/gleam_stdlib.rs
+++ b/tests/gleam_stdlib.rs
@@ -29,6 +29,8 @@ mod gleam_option;
 mod gleam_order;
 #[path = "gleam_stdlib/gleam_pair.rs"]
 mod gleam_pair;
+#[path = "gleam_stdlib/gleam_result.rs"]
+mod gleam_result;
 #[path = "gleam_stdlib/gleam_string.rs"]
 mod gleam_string;
 #[path = "gleam_stdlib/gleam_string_tree.rs"]

--- a/tests/gleam_stdlib.rs
+++ b/tests/gleam_stdlib.rs
@@ -9,6 +9,8 @@ use gleam_core::type_::printer::Printer;
 mod gleam_bit_array;
 #[path = "gleam_stdlib/gleam_bool.rs"]
 mod gleam_bool;
+#[path = "gleam_stdlib/gleam_bytes_tree.rs"]
+mod gleam_bytes_tree;
 #[path = "gleam_stdlib/gleam_dict.rs"]
 mod gleam_dict;
 #[path = "gleam_stdlib/gleam_dynamic.rs"]

--- a/tests/gleam_stdlib/gleam_bytes_tree.rs
+++ b/tests/gleam_stdlib/gleam_bytes_tree.rs
@@ -1,0 +1,101 @@
+use geam::gleam_stdlib::{GleamStdlibProfile, GleamStdlibRunState, host_providers};
+use geam::{HostModule, HostProviderSet, Value};
+
+use super::{ExpectedSurface, assert_surface, run_hosted_fixture};
+
+const DEPENDENCIES: &[&str] = &[
+    "gleam/order",
+    "gleam/float",
+    "gleam/int",
+    "gleam/option",
+    "gleam/dict",
+    "gleam/list",
+    "gleam/string_tree",
+    "gleam/string",
+    "gleam/bit_array",
+    "gleam/bytes_tree",
+];
+
+const SURFACE: ExpectedSurface = ExpectedSurface {
+    values: &[
+        "append",
+        "append_string",
+        "append_tree",
+        "byte_size",
+        "concat",
+        "concat_bit_arrays",
+        "from_bit_array",
+        "from_string",
+        "from_string_tree",
+        "new",
+        "prepend",
+        "prepend_string",
+        "prepend_tree",
+        "to_bit_array",
+    ],
+    types: &[("BytesTree", 0)],
+    type_aliases: &[],
+    constructors: &[],
+    functions: r#"
+append: fn(to: BytesTree, suffix: BitArray) -> BytesTree
+append_string: fn(to: BytesTree, suffix: String) -> BytesTree
+append_tree: fn(to: BytesTree, suffix: BytesTree) -> BytesTree
+byte_size: fn(BytesTree) -> Int
+concat: fn(List(BytesTree)) -> BytesTree
+concat_bit_arrays: fn(List(BitArray)) -> BytesTree
+from_bit_array: fn(BitArray) -> BytesTree
+from_string: fn(String) -> BytesTree
+from_string_tree: fn(StringTree) -> BytesTree
+new: fn() -> BytesTree
+prepend: fn(to: BytesTree, prefix: BitArray) -> BytesTree
+prepend_string: fn(to: BytesTree, prefix: String) -> BytesTree
+prepend_tree: fn(to: BytesTree, prefix: BytesTree) -> BytesTree
+to_bit_array: fn(BytesTree) -> BitArray
+"#,
+};
+
+fn hosts() -> HostProviderSet<GleamStdlibProfile> {
+    let providers =
+        host_providers::<GleamStdlibProfile>().expect("official stdlib providers should register");
+    HostProviderSet::with_providers(Vec::<HostModule<GleamStdlibProfile>>::new(), providers)
+        .expect("official stdlib provider modules should be unique")
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn tracks_official_gleam_bytes_tree_public_surface() {
+    assert_surface(
+        "gleam_bytes_tree_basics",
+        "gleam/bytes_tree",
+        DEPENDENCIES,
+        &SURFACE,
+    );
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_bytes_tree_basics() {
+    assert_eq!(
+        run_hosted_fixture(
+            "gleam_bytes_tree_basics",
+            DEPENDENCIES,
+            hosts(),
+            &mut GleamStdlibRunState::from_seed([0; 32]),
+        ),
+        Value::Nil,
+    );
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_bytes_tree_structure() {
+    assert_eq!(
+        run_hosted_fixture(
+            "gleam_bytes_tree_structure",
+            DEPENDENCIES,
+            hosts(),
+            &mut GleamStdlibRunState::from_seed([1; 32]),
+        ),
+        Value::Nil,
+    );
+}

--- a/tests/gleam_stdlib/gleam_function.rs
+++ b/tests/gleam_stdlib/gleam_function.rs
@@ -1,0 +1,33 @@
+use geam::Value;
+
+use super::{ExpectedSurface, assert_surface, run_fixture};
+
+const SURFACE: ExpectedSurface = ExpectedSurface {
+    values: &["identity"],
+    types: &[],
+    type_aliases: &[],
+    constructors: &[],
+    functions: r#"
+identity: fn(a) -> a
+"#,
+};
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn tracks_official_gleam_function_public_surface() {
+    assert_surface(
+        "gleam_function",
+        "gleam/function",
+        &["gleam/function"],
+        &SURFACE,
+    );
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_function_behavior() {
+    assert_eq!(
+        run_fixture("gleam_function", &["gleam/function"]),
+        Value::Nil,
+    );
+}

--- a/tests/gleam_stdlib/gleam_pair.rs
+++ b/tests/gleam_stdlib/gleam_pair.rs
@@ -1,0 +1,30 @@
+use geam::Value;
+
+use super::{ExpectedSurface, assert_surface, run_fixture};
+
+const SURFACE: ExpectedSurface = ExpectedSurface {
+    values: &["first", "map_first", "map_second", "new", "second", "swap"],
+    types: &[],
+    type_aliases: &[],
+    constructors: &[],
+    functions: r#"
+first: fn(#(a, b)) -> a
+map_first: fn(of: #(a, b), with: fn(a) -> c) -> #(c, b)
+map_second: fn(of: #(a, b), with: fn(b) -> c) -> #(a, c)
+new: fn(a, b) -> #(a, b)
+second: fn(#(a, b)) -> b
+swap: fn(#(a, b)) -> #(b, a)
+"#,
+};
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn tracks_official_gleam_pair_public_surface() {
+    assert_surface("gleam_pair", "gleam/pair", &["gleam/pair"], &SURFACE);
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_pair_behavior() {
+    assert_eq!(run_fixture("gleam_pair", &["gleam/pair"]), Value::Nil);
+}

--- a/tests/gleam_stdlib/gleam_result.rs
+++ b/tests/gleam_stdlib/gleam_result.rs
@@ -1,0 +1,104 @@
+use geam::gleam_stdlib::{GleamStdlibProfile, GleamStdlibRunState, host_providers};
+use geam::{HostModule, HostProviderSet, Value};
+
+use super::{ExpectedSurface, assert_surface, run_hosted_fixture};
+
+const DEPENDENCIES: &[&str] = &[
+    "gleam/option",
+    "gleam/dict",
+    "gleam/order",
+    "gleam/float",
+    "gleam/int",
+    "gleam/list",
+    "gleam/result",
+];
+
+const SURFACE: ExpectedSurface = ExpectedSurface {
+    values: &[
+        "all",
+        "flatten",
+        "is_error",
+        "is_ok",
+        "lazy_or",
+        "lazy_unwrap",
+        "map",
+        "map_error",
+        "or",
+        "partition",
+        "replace",
+        "replace_error",
+        "try",
+        "try_recover",
+        "unwrap",
+        "unwrap_error",
+        "values",
+    ],
+    types: &[],
+    type_aliases: &[],
+    constructors: &[],
+    functions: r#"
+all: fn(List(Result(a, e))) -> Result(List(a), e)
+flatten: fn(Result(Result(a, e), e)) -> Result(a, e)
+is_error: fn(Result(a, e)) -> Bool
+is_ok: fn(Result(a, e)) -> Bool
+lazy_or: fn(Result(a, e), fn() -> Result(a, e)) -> Result(a, e)
+lazy_unwrap: fn(Result(a, e), or: fn() -> a) -> a
+map: fn(over: Result(a, e), with: fn(a) -> b) -> Result(b, e)
+map_error: fn(over: Result(a, e), with: fn(e) -> f) -> Result(a, f)
+or: fn(Result(a, e), Result(a, e)) -> Result(a, e)
+partition: fn(List(Result(a, e))) -> #(List(a), List(e))
+replace: fn(Result(a, e), b) -> Result(b, e)
+replace_error: fn(Result(a, e), f) -> Result(a, f)
+try: fn(Result(a, e), apply: fn(a) -> Result(b, e)) -> Result(b, e)
+try_recover: fn(Result(a, e), with: fn(e) -> Result(a, f)) -> Result(a, f)
+unwrap: fn(Result(a, e), or: a) -> a
+unwrap_error: fn(Result(a, e), or: e) -> e
+values: fn(List(Result(a, e))) -> List(a)
+"#,
+};
+
+fn hosts() -> HostProviderSet<GleamStdlibProfile> {
+    let providers =
+        host_providers::<GleamStdlibProfile>().expect("official stdlib providers should register");
+    HostProviderSet::with_providers(Vec::<HostModule<GleamStdlibProfile>>::new(), providers)
+        .expect("official stdlib provider modules should be unique")
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn tracks_official_gleam_result_public_surface() {
+    assert_surface(
+        "gleam_result_basics",
+        "gleam/result",
+        DEPENDENCIES,
+        &SURFACE,
+    );
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_result_basics() {
+    assert_eq!(
+        run_hosted_fixture(
+            "gleam_result_basics",
+            DEPENDENCIES,
+            hosts(),
+            &mut GleamStdlibRunState::from_seed([0; 32]),
+        ),
+        Value::Nil,
+    );
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_result_combinators() {
+    assert_eq!(
+        run_hosted_fixture(
+            "gleam_result_combinators",
+            DEPENDENCIES,
+            hosts(),
+            &mut GleamStdlibRunState::from_seed([1; 32]),
+        ),
+        Value::Nil,
+    );
+}

--- a/tests/gleam_stdlib/gleam_set.rs
+++ b/tests/gleam_stdlib/gleam_set.rs
@@ -1,0 +1,106 @@
+use geam::gleam_stdlib::{GleamStdlibProfile, GleamStdlibRunState, host_providers};
+use geam::{HostModule, HostProviderSet, Value};
+
+use super::{ExpectedSurface, assert_surface, run_hosted_fixture};
+
+const DEPENDENCIES: &[&str] = &[
+    "gleam/option",
+    "gleam/dict",
+    "gleam/order",
+    "gleam/float",
+    "gleam/int",
+    "gleam/list",
+    "gleam/result",
+    "gleam/set",
+];
+
+const SURFACE: ExpectedSurface = ExpectedSurface {
+    values: &[
+        "contains",
+        "delete",
+        "difference",
+        "drop",
+        "each",
+        "filter",
+        "fold",
+        "from_list",
+        "insert",
+        "intersection",
+        "is_disjoint",
+        "is_empty",
+        "is_subset",
+        "map",
+        "new",
+        "size",
+        "symmetric_difference",
+        "take",
+        "to_list",
+        "union",
+    ],
+    types: &[("Set", 1)],
+    type_aliases: &[],
+    constructors: &[],
+    functions: r#"
+contains: fn(in: Set(member), this: member) -> Bool
+delete: fn(from: Set(member), this: member) -> Set(member)
+difference: fn(from: Set(member), minus: Set(member)) -> Set(member)
+drop: fn(from: Set(member), drop: List(member)) -> Set(member)
+each: fn(Set(member), fn(member) -> a) -> Nil
+filter: fn(in: Set(member), keeping: fn(member) -> Bool) -> Set(member)
+fold: fn(over: Set(member), from: acc, with: fn(acc, member) -> acc) -> acc
+from_list: fn(List(member)) -> Set(member)
+insert: fn(into: Set(member), this: member) -> Set(member)
+intersection: fn(of: Set(member), and: Set(member)) -> Set(member)
+is_disjoint: fn(Set(member), from: Set(member)) -> Bool
+is_empty: fn(Set(member)) -> Bool
+is_subset: fn(Set(member), of: Set(member)) -> Bool
+map: fn(Set(member), with: fn(member) -> mapped) -> Set(mapped)
+new: fn() -> Set(member)
+size: fn(Set(member)) -> Int
+symmetric_difference: fn(of: Set(member), and: Set(member)) -> Set(member)
+take: fn(from: Set(member), keeping: List(member)) -> Set(member)
+to_list: fn(Set(member)) -> List(member)
+union: fn(of: Set(member), and: Set(member)) -> Set(member)
+"#,
+};
+
+fn hosts() -> HostProviderSet<GleamStdlibProfile> {
+    let providers =
+        host_providers::<GleamStdlibProfile>().expect("official stdlib providers should register");
+    HostProviderSet::with_providers(Vec::<HostModule<GleamStdlibProfile>>::new(), providers)
+        .expect("official stdlib provider modules should be unique")
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn tracks_official_gleam_set_public_surface() {
+    assert_surface("gleam_set_basics", "gleam/set", DEPENDENCIES, &SURFACE);
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_set_basics() {
+    assert_eq!(
+        run_hosted_fixture(
+            "gleam_set_basics",
+            DEPENDENCIES,
+            hosts(),
+            &mut GleamStdlibRunState::from_seed([0; 32]),
+        ),
+        Value::Nil,
+    );
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_set_operations() {
+    assert_eq!(
+        run_hosted_fixture(
+            "gleam_set_operations",
+            DEPENDENCIES,
+            hosts(),
+            &mut GleamStdlibRunState::from_seed([1; 32]),
+        ),
+        Value::Nil,
+    );
+}


### PR DESCRIPTION
## Summary

- verify unchanged official `gleam/function`, `gleam/pair`, `gleam/result`, `gleam/set`, and `gleam/bytes_tree` sources
- execute every public function with exact v1.0.3 surface and dependency-order snapshots
- document the provider-aware stdlib compatibility status as a 17-of-19 checklist

## Details

`gleam/function` and `gleam/pair` use the plain project pipeline. `gleam/result`, `gleam/set`, and `gleam/bytes_tree` use the hosted pipeline only for existing transitive providers.

No module-specific provider or new runtime representation is added for these modules. BytesTree executes its official Gleam fallback bodies unchanged, Set assertions remain independent of dictionary iteration order, and the integration suite covers persistent branches, byte padding, callbacks, and lazy behavior.

## Compatibility

The verified v1.0.3 set is now 17 of 19 modules. `gleam/io` and `gleam/uri` remain explicitly unverified because they require separate host-boundary or provider design.