### PR TITLE
Support official Gleam IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ provides an explicitly composed host-provider bundle for unchanged official
 `gleam_stdlib` `v1.0.3` modules that require externals; it is not injected by
 project loading. The verified module set is `gleam/bit_array`, `gleam/bool`,
 `gleam/bytes_tree`, `gleam/dict`, `gleam/dynamic`, `gleam/dynamic/decode`,
-`gleam/float`, `gleam/function`, `gleam/int`, `gleam/list`, `gleam/option`,
-`gleam/order`, `gleam/pair`, `gleam/result`, `gleam/set`, `gleam/string`, and
-`gleam/string_tree`.
+`gleam/float`, `gleam/function`, `gleam/int`, `gleam/io`, `gleam/list`,
+`gleam/option`, `gleam/order`, `gleam/pair`, `gleam/result`, `gleam/set`,
+`gleam/string`, and `gleam/string_tree`.
 
 The main public entry points are:
 
@@ -85,9 +85,13 @@ The main public entry points are:
 - `run_main`
 - `HostedExecution::run_main`
 
-`run_main` takes a caller-owned `EchoSink`; Geam never selects stdout, stderr,
-or a hidden output destination for the host. Ordinary and pipeline Echo both
-emit through that boundary and continue with their original value.
+`run_main` takes a caller-owned `EchoSink`; language Echo does not select
+stdout, stderr, or a hidden output destination. Ordinary and pipeline Echo
+both emit through that boundary and continue with their original value.
+Official `gleam/io` functions use a separate caller-owned
+`geam::gleam_stdlib::IoSink`. The default stdlib run state collects owned
+stdout and stderr events, while custom profiles can project another concrete
+sink without changing the hosted execution boundary.
 
 The existing `TypedProgram -> ModulePlan -> ExecutionPlan -> run_main` path is
 host-free. Rust callbacks enter only through

--- a/docs/runtime-semantics.md
+++ b/docs/runtime-semantics.md
@@ -292,6 +292,25 @@ global output queue, or default stdout/stderr destination, and sink failures
 are not part of `ExecutionError`. A future build profile that omits source
 metadata is a separate design concern.
 
+## Standard-Library IO
+
+Official `gleam/io` functions emit through the `IoSink` projected by the
+caller's `GleamStdlibHostProfile`. Each owned `IoOutput` records either stdout
+or stderr and one exact text chunk. `print` operations preserve their input;
+`println` operations append exactly one newline before emitting. All four
+operations emit before returning `Nil`, so output remains caller-owned if a
+later source expression panics.
+
+The default `GleamStdlibRunState` collects events in cross-stream source order.
+A custom profile may project another concrete sink, including an adapter that
+streams to an outer host. Delivery is infallible at the Geam boundary: writer
+failure policy belongs to that adapter and does not become an `ExecutionError`
+or `HostFailure`.
+
+Stdlib IO and language Echo remain separate capabilities. They do not share a
+global queue or select a process output destination. A host that needs one
+combined transcript can compose both adapters over its own shared recorder.
+
 ## Execution Graph
 
 An executable function owns its entry bindings and a `FunctionBody`. The body

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -72,7 +72,7 @@ run_main`; roots whose selected closure uses registered externals run through
 HostedExecution::try_from_module_plan -> run_main` with the explicit
 `geam::gleam_stdlib` provider bundle. The tracked set covers `gleam/bit_array`,
 `gleam/bool`, `gleam/bytes_tree`, `gleam/dict`, `gleam/dynamic`,
-`gleam/dynamic/decode`, `gleam/float`, `gleam/function`, `gleam/int`,
+`gleam/dynamic/decode`, `gleam/float`, `gleam/function`, `gleam/int`, `gleam/io`,
 `gleam/list`, `gleam/option`, `gleam/order`, `gleam/pair`, `gleam/result`,
 `gleam/set`, `gleam/string`, and `gleam/string_tree`. Each module fixes its
 analyzed public surface and executes grouped source behavior. This integration

--- a/docs/upstream-gleam.md
+++ b/docs/upstream-gleam.md
@@ -186,6 +186,7 @@ not add a general mutable external-value model or cyclic runtime graph support.
 Checked modules have exact public-surface coverage and execute unchanged
 official source through the upstream integration suite. An unchecked module is
 not necessarily rejected; it has not yet been verified end to end.
+Geam currently verifies 18 of the 19 public modules in this baseline.
 
 #### No Module-Specific Provider
 
@@ -207,12 +208,12 @@ not necessarily rejected; it has not yet been verified end to end.
 - [x] `gleam/dynamic/decode`
 - [x] `gleam/float`
 - [x] `gleam/int`
+- [x] `gleam/io`
 - [x] `gleam/string`
 - [x] `gleam/string_tree`
 
 #### Not Yet Verified
 
-- [ ] `gleam/io`: requires a caller-owned output boundary.
 - [ ] `gleam/uri`: requires implementations for bodyless externals.
 
 `geam::gleam_stdlib::host_providers` supplies the explicit provider bundle for
@@ -228,7 +229,10 @@ collision bucket. Dynamic values retain their exact specialized shape for
 typed Decode operations. StringTree uses persistent acyclic structure, and
 BitArray values preserve logical bit ranges over shared immutable backing.
 Random operations use caller-owned `GleamStdlibRunState`; there is no hidden
-seed or global random state.
+seed or global random state. Official IO operations emit owned stdout and
+stderr events through the `IoSink` projected by `GleamStdlibHostProfile`. The
+default run state collects those events, and project loading does not select a
+terminal destination.
 
 The current public execution APIs are:
 
@@ -297,6 +301,8 @@ state remains owned by the caller and is borrowed only for
 The caller supplies the `EchoSink` used by `run_main`. Each emitted
 `EchoOutput` owns its materialized value, optional message, and compact source
 location; Geam does not select an output destination for the host.
+The official `gleam/io` provider uses a separate caller-owned `IoSink` for
+stdout and stderr text events. Echo and stdlib IO do not share a hidden queue.
 
 ## Intentionally Out Of Scope
 

--- a/src/gleam_stdlib.rs
+++ b/src/gleam_stdlib.rs
@@ -6,21 +6,29 @@ mod dynamic;
 mod dynamic_decode;
 mod float;
 mod int;
+mod io;
 mod option;
 mod result;
 mod run_state;
 mod string;
 mod string_tree;
 
+pub use io::{IoOutput, IoSink, IoStream};
 pub use run_state::{GleamStdlibRunState, GleamStdlibRunStateError};
 
-/// A host profile that exposes storage for the official Gleam standard library.
+/// A host profile that exposes state and storage for the official Gleam standard library.
 pub trait GleamStdlibHostProfile: HostProfile {
+    /// The concrete caller-owned sink used by official Gleam IO functions.
+    type Io: IoSink;
+
     /// Projects the standard-library external stores from this profile.
     fn gleam_stdlib_stores(stores: &Self::ExternalStores) -> &GleamStdlibStores;
 
     /// Projects caller-owned standard-library run state from this profile.
     fn gleam_stdlib_run_state(state: &mut Self::RunState) -> &mut GleamStdlibRunState;
+
+    /// Projects the caller-owned standard-library IO sink from this profile.
+    fn gleam_stdlib_io(state: &mut Self::RunState) -> &mut Self::Io;
 }
 
 /// External value stores used by the official Gleam standard library providers.
@@ -41,12 +49,18 @@ impl HostProfile for GleamStdlibProfile {
 }
 
 impl GleamStdlibHostProfile for GleamStdlibProfile {
+    type Io = Vec<IoOutput>;
+
     fn gleam_stdlib_stores(stores: &Self::ExternalStores) -> &GleamStdlibStores {
         stores
     }
 
     fn gleam_stdlib_run_state(state: &mut Self::RunState) -> &mut GleamStdlibRunState {
         state
+    }
+
+    fn gleam_stdlib_io(state: &mut Self::RunState) -> &mut Self::Io {
+        state.io_sink()
     }
 }
 
@@ -55,39 +69,32 @@ pub fn host_providers<Profile>() -> Result<Vec<HostProviderModule<Profile>>, Hos
 where
     Profile: GleamStdlibHostProfile,
 {
-    dict::host_provider::<Profile>().and_then(|dict| {
-        dynamic::host_provider::<Profile>().and_then(|dynamic| {
-            float::host_provider::<Profile>().and_then(|float| {
-                int::host_provider::<Profile>().and_then(|int| {
-                    string_tree::host_provider::<Profile>().and_then(|string_tree| {
-                        string::host_provider::<Profile>().and_then(|string| {
-                            bit_array::host_provider::<Profile>().and_then(|bit_array| {
-                                dynamic_decode::host_provider::<Profile>().map(|dynamic_decode| {
-                                    vec![
-                                        dict,
-                                        dynamic,
-                                        float,
-                                        int,
-                                        string_tree,
-                                        string,
-                                        bit_array,
-                                        dynamic_decode,
-                                    ]
-                                })
-                            })
-                        })
-                    })
-                })
-            })
-        })
-    })
+    let registrations: [ProviderRegistration<Profile>; 9] = [
+        dict::host_provider::<Profile>,
+        dynamic::host_provider::<Profile>,
+        float::host_provider::<Profile>,
+        int::host_provider::<Profile>,
+        string_tree::host_provider::<Profile>,
+        string::host_provider::<Profile>,
+        bit_array::host_provider::<Profile>,
+        dynamic_decode::host_provider::<Profile>,
+        io::host_provider::<Profile>,
+    ];
+
+    registrations
+        .into_iter()
+        .map(|register| register())
+        .collect()
 }
+
+type ProviderRegistration<Profile> =
+    fn() -> Result<HostProviderModule<Profile>, HostRegistrationError>;
 
 #[cfg(test)]
 mod tests {
     use super::{
         GleamStdlibHostProfile, GleamStdlibProfile, GleamStdlibRunState, GleamStdlibStores,
-        host_providers,
+        IoOutput, IoSink, IoStream, host_providers,
     };
     use crate::HostProfile;
 
@@ -100,6 +107,18 @@ mod tests {
 
     struct CustomRunState {
         stdlib: GleamStdlibRunState,
+        io: RecordingSink,
+    }
+
+    #[derive(Default)]
+    struct RecordingSink {
+        outputs: Vec<IoOutput>,
+    }
+
+    impl IoSink for RecordingSink {
+        fn emit(&mut self, output: IoOutput) {
+            self.outputs.push(output);
+        }
     }
 
     impl HostProfile for CustomProfile {
@@ -108,12 +127,18 @@ mod tests {
     }
 
     impl GleamStdlibHostProfile for CustomProfile {
+        type Io = RecordingSink;
+
         fn gleam_stdlib_stores(stores: &Self::ExternalStores) -> &GleamStdlibStores {
             &stores.stdlib
         }
 
         fn gleam_stdlib_run_state(state: &mut Self::RunState) -> &mut GleamStdlibRunState {
             &mut state.stdlib
+        }
+
+        fn gleam_stdlib_io(state: &mut Self::RunState) -> &mut Self::Io {
+            &mut state.io
         }
     }
 
@@ -136,6 +161,7 @@ mod tests {
                 "gleam/string",
                 "gleam/bit_array",
                 "gleam/dynamic/decode",
+                "gleam/io",
             ],
         );
         let provider = &providers[0];
@@ -181,12 +207,13 @@ mod tests {
     }
 
     #[test]
-    fn custom_profiles_project_their_stdlib_store_bundle() {
+    fn custom_profiles_project_stdlib_stores_state_and_io() {
         let default_stores = GleamStdlibStores::default();
         let stores = CustomStores::default();
         let mut default_state = GleamStdlibRunState::from_seed([1; 32]);
         let mut state = CustomRunState {
             stdlib: GleamStdlibRunState::from_seed([2; 32]),
+            io: RecordingSink::default(),
         };
 
         assert!(std::ptr::eq(
@@ -201,5 +228,14 @@ mod tests {
         assert!(std::ptr::eq(default_projected, &default_state));
         let projected = CustomProfile::gleam_stdlib_run_state(&mut state);
         assert!(std::ptr::eq(projected, &state.stdlib));
+
+        let default_io = GleamStdlibProfile::gleam_stdlib_io(&mut default_state);
+        default_io.emit(IoOutput::new(IoStream::Stdout, "default".into()));
+        assert_eq!(default_state.io_outputs()[0].text(), "default");
+
+        let custom_io = CustomProfile::gleam_stdlib_io(&mut state);
+        custom_io.emit(IoOutput::new(IoStream::Stderr, "custom".into()));
+        assert_eq!(state.io.outputs[0].stream(), IoStream::Stderr);
+        assert_eq!(state.io.outputs[0].text(), "custom");
     }
 }

--- a/src/gleam_stdlib/io.rs
+++ b/src/gleam_stdlib/io.rs
@@ -1,0 +1,136 @@
+mod function;
+
+use self::function::{IoProvider, print, print_error, println, println_error};
+use crate::gleam_stdlib::GleamStdlibHostProfile;
+use crate::{HostProviderModule, HostRegistrationError};
+use ecow::EcoString;
+
+/// A caller-owned destination for official Gleam standard-library IO events.
+pub trait IoSink {
+    /// Receives one owned standard-library IO event.
+    fn emit(&mut self, output: IoOutput);
+}
+
+/// One owned standard-library IO event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IoOutput {
+    stream: IoStream,
+    text: EcoString,
+}
+
+/// The standard stream selected by a Gleam IO operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IoStream {
+    /// Standard output.
+    Stdout,
+    /// Standard error.
+    Stderr,
+}
+
+impl IoOutput {
+    pub(super) fn new(stream: IoStream, text: EcoString) -> Self {
+        Self { stream, text }
+    }
+
+    /// Returns the selected standard stream.
+    pub fn stream(&self) -> IoStream {
+        self.stream
+    }
+
+    /// Returns the exact text emitted by the Gleam IO operation.
+    pub fn text(&self) -> &EcoString {
+        &self.text
+    }
+}
+
+impl IoSink for Vec<IoOutput> {
+    fn emit(&mut self, output: IoOutput) {
+        self.push(output);
+    }
+}
+
+pub(super) fn host_provider<Profile>() -> Result<HostProviderModule<Profile>, HostRegistrationError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    HostProviderModule::new("gleam_stdlib", "gleam/io")
+        .and_then(|provider| {
+            provider.with_scoped_function::<IoProvider<Profile>, (EcoString,), (), _>(
+                "print",
+                print::<Profile>,
+            )
+        })
+        .and_then(|provider| {
+            provider.with_scoped_function::<IoProvider<Profile>, (EcoString,), (), _>(
+                "print_error",
+                print_error::<Profile>,
+            )
+        })
+        .and_then(|provider| {
+            provider.with_scoped_function::<IoProvider<Profile>, (EcoString,), (), _>(
+                "println",
+                println::<Profile>,
+            )
+        })
+        .and_then(|provider| {
+            provider.with_scoped_function::<IoProvider<Profile>, (EcoString,), (), _>(
+                "println_error",
+                println_error::<Profile>,
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IoOutput, IoSink, IoStream, host_provider};
+    use crate::gleam_stdlib::GleamStdlibProfile;
+
+    #[test]
+    fn output_preserves_owned_stream_and_text() {
+        let output = IoOutput::new(IoStream::Stderr, "message".into());
+
+        assert_eq!(output.stream(), IoStream::Stderr);
+        assert_eq!(output.text(), "message");
+        assert_eq!(output.clone(), output);
+    }
+
+    #[test]
+    fn vector_sink_collects_outputs_in_order() {
+        let mut outputs = Vec::new();
+        outputs.emit(IoOutput::new(IoStream::Stdout, "first".into()));
+        outputs.emit(IoOutput::new(IoStream::Stderr, "second".into()));
+
+        assert_eq!(
+            outputs
+                .iter()
+                .map(|output| (output.stream(), output.text().as_str()))
+                .collect::<Vec<_>>(),
+            [(IoStream::Stdout, "first"), (IoStream::Stderr, "second")],
+        );
+    }
+
+    #[test]
+    fn registers_the_exact_official_io_provider_inventory() {
+        let provider =
+            host_provider::<GleamStdlibProfile>().expect("official IO provider should register");
+        let functions = provider.functions().collect::<Vec<_>>();
+
+        assert_eq!(provider.package(), "gleam_stdlib");
+        assert_eq!(provider.module(), "gleam/io");
+        assert_eq!(
+            functions
+                .iter()
+                .map(|function| function.name().as_str())
+                .collect::<Vec<_>>(),
+            ["print", "print_error", "println", "println_error"],
+        );
+        for function in functions {
+            assert!(function.scheme().is_monomorphic());
+            assert_eq!(
+                function.type_().argument_types(),
+                [crate::ValueType::String],
+            );
+            assert_eq!(function.type_().return_(), &crate::ValueType::Nil);
+        }
+    }
+}

--- a/src/gleam_stdlib/io/function.rs
+++ b/src/gleam_stdlib/io/function.rs
@@ -1,0 +1,152 @@
+use super::{IoOutput, IoSink, IoStream};
+use crate::gleam_stdlib::GleamStdlibHostProfile;
+use crate::{HostCall, HostCallCompletion, HostCallError, HostProvider};
+use ecow::EcoString;
+use std::marker::PhantomData;
+
+pub(super) struct IoProvider<Profile>(PhantomData<Profile>);
+
+impl<Profile> HostProvider<Profile> for IoProvider<Profile>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    type State = Profile::Io;
+
+    fn project(state: &mut Profile::RunState) -> &mut Self::State {
+        Profile::gleam_stdlib_io(state)
+    }
+}
+
+pub(super) fn print<'call, Profile>(
+    call: HostCall<'call, Profile, IoProvider<Profile>, ()>,
+    text: EcoString,
+) -> Result<HostCallCompletion<'call, ()>, HostCallError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    emit(call, IoStream::Stdout, text)
+}
+
+pub(super) fn print_error<'call, Profile>(
+    call: HostCall<'call, Profile, IoProvider<Profile>, ()>,
+    text: EcoString,
+) -> Result<HostCallCompletion<'call, ()>, HostCallError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    emit(call, IoStream::Stderr, text)
+}
+
+pub(super) fn println<'call, Profile>(
+    call: HostCall<'call, Profile, IoProvider<Profile>, ()>,
+    mut text: EcoString,
+) -> Result<HostCallCompletion<'call, ()>, HostCallError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    text.push('\n');
+    emit(call, IoStream::Stdout, text)
+}
+
+pub(super) fn println_error<'call, Profile>(
+    call: HostCall<'call, Profile, IoProvider<Profile>, ()>,
+    mut text: EcoString,
+) -> Result<HostCallCompletion<'call, ()>, HostCallError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    text.push('\n');
+    emit(call, IoStream::Stderr, text)
+}
+
+fn emit<'call, Profile>(
+    mut call: HostCall<'call, Profile, IoProvider<Profile>, ()>,
+    stream: IoStream,
+    text: EcoString,
+) -> Result<HostCallCompletion<'call, ()>, HostCallError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    call.state().emit(IoOutput::new(stream, text));
+    Ok(call.return_value(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gleam_stdlib::{GleamStdlibProfile, GleamStdlibRunState, IoStream};
+    use crate::{
+        HostModule, HostProviderSet, HostedExecution, ModuleSource, PackageSource, Value,
+        compile_typed_host_program, plan_host_program,
+    };
+    use ecow::EcoString;
+
+    const IO_SOURCE: &str = r#"
+@external(erlang, "gleam_stdlib", "print")
+pub fn print(string: String) -> Nil
+
+@external(erlang, "gleam_stdlib", "print_error")
+pub fn print_error(string: String) -> Nil
+
+@external(erlang, "gleam_stdlib", "println")
+pub fn println(string: String) -> Nil
+
+@external(erlang, "gleam_stdlib", "println_error")
+pub fn println_error(string: String) -> Nil
+
+pub fn main() {
+  print("first")
+  print_error("second")
+  println("third")
+  println_error("fourth")
+}
+"#;
+
+    #[test]
+    fn executes_all_io_callbacks_through_the_typed_provider() {
+        let provider = super::super::host_provider::<GleamStdlibProfile>()
+            .expect("synthetic IO provider should register");
+        let typed = compile_typed_host_program(
+            "gleam_stdlib",
+            "gleam/io",
+            [PackageSource::new(
+                "gleam_stdlib",
+                Vec::<EcoString>::new(),
+                [ModuleSource::new(
+                    "gleam/io",
+                    "src/gleam/io.gleam",
+                    IO_SOURCE,
+                )],
+            )],
+            HostProviderSet::with_providers(
+                Vec::<HostModule<GleamStdlibProfile>>::new(),
+                [provider],
+            )
+            .expect("synthetic IO provider module should be unique"),
+        )
+        .expect("synthetic IO source should compile");
+        let plan = plan_host_program(typed).expect("synthetic IO source should plan");
+        let execution =
+            HostedExecution::try_from_module_plan(plan).expect("synthetic IO source should seal");
+        let mut state = GleamStdlibRunState::from_seed([2; 32]);
+
+        assert_eq!(
+            execution
+                .run_main(&mut state, &mut Vec::new())
+                .expect("synthetic IO source should run"),
+            Value::Nil,
+        );
+        assert_eq!(
+            state
+                .io_outputs()
+                .iter()
+                .map(|output| (output.stream(), output.text().as_str()))
+                .collect::<Vec<_>>(),
+            [
+                (IoStream::Stdout, "first"),
+                (IoStream::Stderr, "second"),
+                (IoStream::Stdout, "third\n"),
+                (IoStream::Stderr, "fourth\n"),
+            ],
+        );
+    }
+}

--- a/src/gleam_stdlib/run_state.rs
+++ b/src/gleam_stdlib/run_state.rs
@@ -3,9 +3,12 @@ use rand::rngs::{ChaCha12Rng, SysRng};
 use rand::{Rng, SeedableRng, TryRng};
 use std::fmt::{self, Display, Formatter};
 
+use super::IoOutput;
+
 /// Caller-owned mutable state used by the official Gleam standard library.
 pub struct GleamStdlibRunState {
     random: ChaCha12Rng,
+    io_outputs: Vec<IoOutput>,
 }
 
 /// Failure to initialize standard-library run state from system entropy.
@@ -19,6 +22,7 @@ impl GleamStdlibRunState {
     pub fn from_seed(seed: [u8; 32]) -> Self {
         Self {
             random: ChaCha12Rng::from_seed(seed),
+            io_outputs: Vec::new(),
         }
     }
 
@@ -27,10 +31,24 @@ impl GleamStdlibRunState {
         Self::try_from_seed_source(|seed| SysRng.try_fill_bytes(seed))
     }
 
+    /// Returns the standard-library IO events collected by this run state.
+    pub fn io_outputs(&self) -> &[IoOutput] {
+        &self.io_outputs
+    }
+
+    /// Takes all collected standard-library IO events, leaving the state empty.
+    pub fn take_io_outputs(&mut self) -> Vec<IoOutput> {
+        std::mem::take(&mut self.io_outputs)
+    }
+
     pub(super) fn random_float(&mut self) -> f64 {
         const SCALE: f64 = 1.0 / ((1u64 << 53) as f64);
 
         ((self.random.next_u64() >> 11) as f64) * SCALE
+    }
+
+    pub(super) fn io_sink(&mut self) -> &mut Vec<IoOutput> {
+        &mut self.io_outputs
     }
 
     fn try_from_seed_source<Error>(
@@ -70,6 +88,7 @@ impl std::error::Error for GleamStdlibRunStateError {}
 #[cfg(test)]
 mod tests {
     use super::{GleamStdlibRunState, GleamStdlibRunStateError};
+    use crate::gleam_stdlib::{IoOutput, IoSink, IoStream};
     use std::fmt::{self, Display, Formatter};
 
     #[derive(Debug)]
@@ -94,6 +113,30 @@ mod tests {
         assert_ne!(first_next, first_value);
         assert_eq!(first_next, second.random_float());
         assert!((0.0..1.0).contains(&first_value));
+        assert!(first.io_outputs().is_empty());
+        assert!(second.io_outputs().is_empty());
+    }
+
+    #[test]
+    fn io_outputs_accumulate_and_can_be_taken() {
+        let mut state = GleamStdlibRunState::from_seed([8; 32]);
+        state
+            .io_sink()
+            .emit(IoOutput::new(IoStream::Stdout, "first".into()));
+        state
+            .io_sink()
+            .emit(IoOutput::new(IoStream::Stderr, "second".into()));
+
+        assert_eq!(
+            state
+                .io_outputs()
+                .iter()
+                .map(|output| (output.stream(), output.text().as_str()))
+                .collect::<Vec<_>>(),
+            [(IoStream::Stdout, "first"), (IoStream::Stderr, "second")],
+        );
+        assert_eq!(state.take_io_outputs().len(), 2);
+        assert!(state.io_outputs().is_empty());
     }
 
     #[test]
@@ -121,5 +164,6 @@ mod tests {
             .expect("system entropy should be available in the test environment");
 
         assert!((0.0..1.0).contains(&state.random_float()));
+        assert!(state.io_outputs().is_empty());
     }
 }

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_io.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_io.gleam
@@ -1,0 +1,16 @@
+import gleam/io
+
+pub fn main() {
+  assert io.print("stdout") == Nil
+  assert io.print_error("stderr") == Nil
+  assert io.println("stdout line") == Nil
+  assert io.println_error("stderr line") == Nil
+
+  assert io.print("") == Nil
+  assert io.println("") == Nil
+  assert io.print_error("embedded\n") == Nil
+  assert io.println_error("embedded\n") == Nil
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_io_order_and_panic.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_io_order_and_panic.gleam
@@ -1,0 +1,8 @@
+import gleam/io
+
+pub fn main() {
+  io.print("before")
+  echo Nil as "between"
+  io.print_error("after")
+  panic as "stop"
+}

--- a/tests/gleam_stdlib.rs
+++ b/tests/gleam_stdlib.rs
@@ -23,6 +23,8 @@ mod gleam_float;
 mod gleam_function;
 #[path = "gleam_stdlib/gleam_int.rs"]
 mod gleam_int;
+#[path = "gleam_stdlib/gleam_io.rs"]
+mod gleam_io;
 #[path = "gleam_stdlib/gleam_list.rs"]
 mod gleam_list;
 #[path = "gleam_stdlib/gleam_option.rs"]

--- a/tests/gleam_stdlib/gleam_io.rs
+++ b/tests/gleam_stdlib/gleam_io.rs
@@ -1,0 +1,232 @@
+use ecow::EcoString;
+use geam::gleam_stdlib::{
+    GleamStdlibHostProfile, GleamStdlibProfile, GleamStdlibRunState, GleamStdlibStores, IoOutput,
+    IoSink, IoStream, host_providers,
+};
+use geam::{
+    EchoOutput, EchoSink, ExecutionError, HostModule, HostProfile, HostProviderSet,
+    HostedExecution, PanicKind, PanicMessage, Value, compile_typed_host_project, plan_host_program,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use super::{ExpectedSurface, assert_surface, project_root};
+
+const DEPENDENCIES: &[&str] = &["gleam/io"];
+
+const SURFACE: ExpectedSurface = ExpectedSurface {
+    values: &["print", "print_error", "println", "println_error"],
+    types: &[],
+    type_aliases: &[],
+    constructors: &[],
+    functions: r#"
+print: fn(String) -> Nil
+print_error: fn(String) -> Nil
+println: fn(String) -> Nil
+println_error: fn(String) -> Nil
+"#,
+};
+
+const EXPECTED_OUTPUTS: &[(IoStream, &str)] = &[
+    (IoStream::Stdout, "stdout"),
+    (IoStream::Stderr, "stderr"),
+    (IoStream::Stdout, "stdout line\n"),
+    (IoStream::Stderr, "stderr line\n"),
+    (IoStream::Stdout, ""),
+    (IoStream::Stdout, "\n"),
+    (IoStream::Stderr, "embedded\n"),
+    (IoStream::Stderr, "embedded\n\n"),
+];
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn tracks_official_gleam_io_public_surface() {
+    assert_surface("gleam_io", "gleam/io", DEPENDENCIES, &SURFACE);
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_io_with_caller_owned_output() {
+    let execution = execution::<GleamStdlibProfile>("gleam_io");
+    let mut repeated_state = GleamStdlibRunState::from_seed([7; 32]);
+
+    for _ in 0..2 {
+        assert_eq!(
+            execution
+                .run_main(&mut repeated_state, &mut Vec::new())
+                .expect("official IO source should run"),
+            Value::Nil,
+        );
+    }
+
+    assert_outputs(
+        repeated_state.io_outputs(),
+        EXPECTED_OUTPUTS
+            .iter()
+            .copied()
+            .chain(EXPECTED_OUTPUTS.iter().copied()),
+    );
+    let taken = repeated_state.take_io_outputs();
+    assert_outputs(
+        &taken,
+        EXPECTED_OUTPUTS
+            .iter()
+            .copied()
+            .chain(EXPECTED_OUTPUTS.iter().copied()),
+    );
+    assert!(repeated_state.io_outputs().is_empty());
+
+    let mut independent_state = GleamStdlibRunState::from_seed([8; 32]);
+    assert_eq!(
+        execution
+            .run_main(&mut independent_state, &mut Vec::new())
+            .expect("official IO source should run with independent state"),
+        Value::Nil,
+    );
+    assert_outputs(
+        independent_state.io_outputs(),
+        EXPECTED_OUTPUTS.iter().copied(),
+    );
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn preserves_io_and_echo_order_before_a_later_panic() {
+    let execution = execution::<RecordingProfile>("gleam_io_order_and_panic");
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let mut state = RecordingRunState {
+        stdlib: GleamStdlibRunState::from_seed([9; 32]),
+        io: RecordingIoSink {
+            events: Rc::clone(&events),
+        },
+    };
+    let mut echo = RecordingEchoSink {
+        events: Rc::clone(&events),
+    };
+
+    let error = execution
+        .run_main(&mut state, &mut echo)
+        .expect_err("fixture should panic after emitting its events");
+    let ExecutionError::Panic(panic) = error else {
+        panic!("fixture should preserve its source panic");
+    };
+
+    assert_eq!(panic.kind(), PanicKind::Panic);
+    assert_eq!(panic.message(), &PanicMessage::Explicit("stop".into()));
+    assert_eq!(
+        events.borrow().as_slice(),
+        [
+            RecordedEvent::Io(IoStream::Stdout, "before".into()),
+            RecordedEvent::Echo {
+                message: Some("between".into()),
+                value: "Nil".into(),
+            },
+            RecordedEvent::Io(IoStream::Stderr, "after".into()),
+        ],
+    );
+}
+
+fn execution<Profile>(root_module: &str) -> HostedExecution<Profile>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    let providers = host_providers::<Profile>().expect("official stdlib providers should register");
+    let hosts = HostProviderSet::with_providers(Vec::<HostModule<Profile>>::new(), providers)
+        .expect("official stdlib provider modules should be unique");
+    let typed = compile_typed_host_project(project_root(), root_module, hosts)
+        .expect("official IO fixture should compile");
+    let plan = plan_host_program(typed).expect("official IO fixture should plan");
+
+    assert_eq!(
+        plan.modules()
+            .iter()
+            .map(|module| (module.package().as_str(), module.module().as_str()))
+            .collect::<Vec<_>>(),
+        [
+            ("gleam_stdlib", "gleam/io"),
+            ("geam_stdlib_test", root_module),
+        ],
+    );
+
+    HostedExecution::try_from_module_plan(plan).expect("official IO fixture should seal")
+}
+
+fn assert_outputs<'expected>(
+    outputs: &[IoOutput],
+    expected: impl IntoIterator<Item = (IoStream, &'expected str)>,
+) {
+    assert_eq!(
+        outputs
+            .iter()
+            .map(|output| (output.stream(), output.text().as_str()))
+            .collect::<Vec<_>>(),
+        expected.into_iter().collect::<Vec<_>>(),
+    );
+}
+
+struct RecordingProfile;
+
+struct RecordingRunState {
+    stdlib: GleamStdlibRunState,
+    io: RecordingIoSink,
+}
+
+#[derive(Default)]
+struct RecordingStores {
+    stdlib: GleamStdlibStores,
+}
+
+struct RecordingIoSink {
+    events: Rc<RefCell<Vec<RecordedEvent>>>,
+}
+
+struct RecordingEchoSink {
+    events: Rc<RefCell<Vec<RecordedEvent>>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RecordedEvent {
+    Io(IoStream, EcoString),
+    Echo {
+        message: Option<EcoString>,
+        value: EcoString,
+    },
+}
+
+impl HostProfile for RecordingProfile {
+    type RunState = RecordingRunState;
+    type ExternalStores = RecordingStores;
+}
+
+impl GleamStdlibHostProfile for RecordingProfile {
+    type Io = RecordingIoSink;
+
+    fn gleam_stdlib_stores(stores: &Self::ExternalStores) -> &GleamStdlibStores {
+        &stores.stdlib
+    }
+
+    fn gleam_stdlib_run_state(state: &mut Self::RunState) -> &mut GleamStdlibRunState {
+        &mut state.stdlib
+    }
+
+    fn gleam_stdlib_io(state: &mut Self::RunState) -> &mut Self::Io {
+        &mut state.io
+    }
+}
+
+impl IoSink for RecordingIoSink {
+    fn emit(&mut self, output: IoOutput) {
+        self.events
+            .borrow_mut()
+            .push(RecordedEvent::Io(output.stream(), output.text().clone()));
+    }
+}
+
+impl EchoSink for RecordingEchoSink {
+    fn emit(&mut self, output: EchoOutput) {
+        self.events.borrow_mut().push(RecordedEvent::Echo {
+            message: output.message().cloned(),
+            value: output.value().inspect().to_string().into(),
+        });
+    }
+}


### PR DESCRIPTION
- Route stdout and stderr writes through a caller-owned stdlib sink.
- Preserve ordered output chunks and Nil returns through typed host calls.
- Verify the complete unchanged v1.0.3 IO surface.