### PR TITLE
Support official Gleam URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ project loading. The verified module set is `gleam/bit_array`, `gleam/bool`,
 `gleam/bytes_tree`, `gleam/dict`, `gleam/dynamic`, `gleam/dynamic/decode`,
 `gleam/float`, `gleam/function`, `gleam/int`, `gleam/io`, `gleam/list`,
 `gleam/option`, `gleam/order`, `gleam/pair`, `gleam/result`, `gleam/set`,
-`gleam/string`, and `gleam/string_tree`.
+`gleam/string`, `gleam/string_tree`, and `gleam/uri`.
 
 The main public entry points are:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,10 +74,10 @@ HostedExecution::try_from_module_plan -> run_main` with the explicit
 `gleam/bool`, `gleam/bytes_tree`, `gleam/dict`, `gleam/dynamic`,
 `gleam/dynamic/decode`, `gleam/float`, `gleam/function`, `gleam/int`, `gleam/io`,
 `gleam/list`, `gleam/option`, `gleam/order`, `gleam/pair`, `gleam/result`,
-`gleam/set`, `gleam/string`, and `gleam/string_tree`. Each module fixes its
-analyzed public surface and executes grouped source behavior. This integration
-suite does not replace hermetic synthetic owner coverage for the loader or
-providers.
+`gleam/set`, `gleam/string`, `gleam/string_tree`, and `gleam/uri`. Each module
+fixes its analyzed public surface and executes grouped source behavior. This
+integration suite does not replace hermetic synthetic owner coverage for the
+loader or providers.
 
 Source-level rejection fixtures live under categorized
 `tests/fixtures/rejection/**/*.gleam` paths. They are reserved for public

--- a/docs/upstream-gleam.md
+++ b/docs/upstream-gleam.md
@@ -186,7 +186,7 @@ not add a general mutable external-value model or cyclic runtime graph support.
 Checked modules have exact public-surface coverage and execute unchanged
 official source through the upstream integration suite. An unchecked module is
 not necessarily rejected; it has not yet been verified end to end.
-Geam currently verifies 18 of the 19 public modules in this baseline.
+Geam currently verifies all 19 public modules in this baseline.
 
 #### No Module-Specific Provider
 
@@ -211,17 +211,15 @@ Geam currently verifies 18 of the 19 public modules in this baseline.
 - [x] `gleam/io`
 - [x] `gleam/string`
 - [x] `gleam/string_tree`
-
-#### Not Yet Verified
-
-- [ ] `gleam/uri`: requires implementations for bodyless externals.
+- [x] `gleam/uri`
 
 `geam::gleam_stdlib::host_providers` supplies the explicit provider bundle for
 provider-backed modules. Callers compose that bundle into a `HostProviderSet`;
 project loading selects only providers in the resolved source closure and does
 not infer or inject the bundle. Functions with valid Gleam fallback bodies,
-including the annotated `gleam/bytes_tree` operations, continue to compile and
-execute from the unchanged package source.
+including the annotated `gleam/bytes_tree` operations and `gleam/uri.parse`,
+continue to compile and execute from the unchanged package source. The URI
+provider binds only its five bodyless string and percent-codec externals.
 
 The provider-backed modules retain their source-facing value distinctions.
 Dictionary lookup uses source hashing followed by source equality within a

--- a/src/gleam_stdlib.rs
+++ b/src/gleam_stdlib.rs
@@ -12,6 +12,7 @@ mod result;
 mod run_state;
 mod string;
 mod string_tree;
+mod uri;
 
 pub use io::{IoOutput, IoSink, IoStream};
 pub use run_state::{GleamStdlibRunState, GleamStdlibRunStateError};
@@ -69,7 +70,7 @@ pub fn host_providers<Profile>() -> Result<Vec<HostProviderModule<Profile>>, Hos
 where
     Profile: GleamStdlibHostProfile,
 {
-    let registrations: [ProviderRegistration<Profile>; 9] = [
+    let registrations: [ProviderRegistration<Profile>; 10] = [
         dict::host_provider::<Profile>,
         dynamic::host_provider::<Profile>,
         float::host_provider::<Profile>,
@@ -79,6 +80,7 @@ where
         bit_array::host_provider::<Profile>,
         dynamic_decode::host_provider::<Profile>,
         io::host_provider::<Profile>,
+        uri::host_provider::<Profile>,
     ];
 
     registrations
@@ -162,6 +164,7 @@ mod tests {
                 "gleam/bit_array",
                 "gleam/dynamic/decode",
                 "gleam/io",
+                "gleam/uri",
             ],
         );
         let provider = &providers[0];

--- a/src/gleam_stdlib/uri.rs
+++ b/src/gleam_stdlib/uri.rs
@@ -1,0 +1,110 @@
+mod function;
+mod schema;
+
+use self::function::{
+    UriProvider, codeunit_slice, parse_query, percent_decode, percent_encode, pop_codeunit,
+};
+use self::schema::{CodeunitPair, PercentDecodeResult, QueryResult};
+use super::GleamStdlibHostProfile;
+use crate::{HostProviderModule, HostRegistrationError};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+pub(super) fn host_provider<Profile>() -> Result<HostProviderModule<Profile>, HostRegistrationError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    HostProviderModule::new("gleam_stdlib", "gleam/uri")
+        .and_then(|provider| {
+            provider.with_scoped_function::<UriProvider<Profile>, (EcoString,), CodeunitPair, _>(
+                "pop_codeunit",
+                pop_codeunit::<Profile>,
+            )
+        })
+        .and_then(|provider| {
+            provider.with_fallible_function::<(EcoString, BigInt, BigInt), EcoString, _>(
+                "codeunit_slice",
+                codeunit_slice,
+            )
+        })
+        .and_then(|provider| {
+            provider.with_scoped_function::<UriProvider<Profile>, (EcoString,), QueryResult, _>(
+                "parse_query",
+                parse_query::<Profile>,
+            )
+        })
+        .and_then(|provider| provider.with_function("percent_encode", percent_encode))
+        .and_then(|provider| {
+            provider
+                .with_scoped_function::<UriProvider<Profile>, (EcoString,), PercentDecodeResult, _>(
+                    "percent_decode",
+                    percent_decode::<Profile>,
+                )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_provider;
+    use crate::ValueType;
+    use crate::gleam_stdlib::GleamStdlibProfile;
+    use crate::plan::{CustomType, CustomTypeName, FunctionType};
+
+    #[test]
+    fn registers_only_the_bodyless_official_uri_externals() {
+        let provider =
+            host_provider::<GleamStdlibProfile>().expect("official URI provider should register");
+
+        assert_eq!(provider.package(), "gleam_stdlib");
+        assert_eq!(provider.module(), "gleam/uri");
+        assert_eq!(provider.external_types().count(), 0);
+        let result = |success| {
+            ValueType::Custom(CustomType::new(
+                CustomTypeName::new("".into(), "gleam".into(), "Result".into()),
+                vec![success, ValueType::Nil],
+            ))
+        };
+        let expected = [
+            (
+                "pop_codeunit",
+                FunctionType::new(
+                    vec![ValueType::String],
+                    ValueType::Tuple(vec![ValueType::Int, ValueType::String]),
+                ),
+            ),
+            (
+                "codeunit_slice",
+                FunctionType::new(
+                    vec![ValueType::String, ValueType::Int, ValueType::Int],
+                    ValueType::String,
+                ),
+            ),
+            (
+                "parse_query",
+                FunctionType::new(
+                    vec![ValueType::String],
+                    result(ValueType::List(Box::new(ValueType::Tuple(vec![
+                        ValueType::String,
+                        ValueType::String,
+                    ])))),
+                ),
+            ),
+            (
+                "percent_encode",
+                FunctionType::new(vec![ValueType::String], ValueType::String),
+            ),
+            (
+                "percent_decode",
+                FunctionType::new(vec![ValueType::String], result(ValueType::String)),
+            ),
+        ];
+        let functions = provider.functions().collect::<Vec<_>>();
+
+        assert_eq!(functions.len(), expected.len());
+        for (function, (name, type_)) in functions.into_iter().zip(expected) {
+            assert_eq!(function.name(), name);
+            assert!(function.scheme().is_monomorphic());
+            assert_eq!(function.type_(), &type_);
+        }
+    }
+}

--- a/src/gleam_stdlib/uri/function.rs
+++ b/src/gleam_stdlib/uri/function.rs
@@ -1,0 +1,257 @@
+mod codec;
+
+use super::schema::{
+    CodeunitPair, PercentDecodeError, PercentDecodeOk, PercentDecodeResult, QueryError, QueryOk,
+    QueryPair, QueryPairElements, QueryResult,
+};
+use crate::gleam_stdlib::GleamStdlibHostProfile;
+use crate::{HostCall, HostCallCompletion, HostCallError, HostFailure, HostProvider};
+use ecow::EcoString;
+use num_bigint::BigInt;
+use num_traits::ToPrimitive;
+use std::marker::PhantomData;
+
+pub(super) struct UriProvider<Profile>(PhantomData<Profile>);
+
+impl<Profile> HostProvider<Profile> for UriProvider<Profile>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    type State = Profile::RunState;
+
+    fn project(state: &mut Profile::RunState) -> &mut Self::State {
+        state
+    }
+}
+
+pub(super) fn pop_codeunit<'call, Profile>(
+    call: HostCall<'call, Profile, UriProvider<Profile>, CodeunitPair>,
+    string: EcoString,
+) -> Result<HostCallCompletion<'call, CodeunitPair>, HostCallError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    let Some(value) = string.chars().next() else {
+        return Ok(call.return_tuple((BigInt::from(0), (string, ()))));
+    };
+    let rest = EcoString::from(&string[value.len_utf8()..]);
+
+    Ok(call.return_tuple((BigInt::from(u32::from(value)), (rest, ()))))
+}
+
+pub(super) fn codeunit_slice(
+    string: EcoString,
+    from: BigInt,
+    length: BigInt,
+) -> Result<EcoString, HostFailure> {
+    let from = from
+        .to_usize()
+        .ok_or_else(|| HostFailure::new("URI string slice index is not representable"))?;
+    let length = length
+        .to_usize()
+        .ok_or_else(|| HostFailure::new("URI string slice length is not representable"))?;
+    let end = from
+        .checked_add(length)
+        .ok_or_else(|| HostFailure::new("URI string slice range is not representable"))?;
+    let from = scalar_byte_index(&string, from)
+        .ok_or_else(|| HostFailure::new("URI string slice starts outside the string"))?;
+    let end = scalar_byte_index(&string, end)
+        .ok_or_else(|| HostFailure::new("URI string slice ends outside the string"))?;
+
+    Ok(EcoString::from(&string[from..end]))
+}
+
+pub(super) fn parse_query<'call, Profile>(
+    mut call: HostCall<'call, Profile, UriProvider<Profile>, QueryResult>,
+    query: EcoString,
+) -> Result<HostCallCompletion<'call, QueryResult>, HostCallError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    let Some(pairs) = codec::parse_query(&query) else {
+        return Ok(call.return_custom::<QueryError>(((), ())));
+    };
+    let pairs = pairs
+        .into_iter()
+        .map(|(key, value)| call.create_tuple::<QueryPairElements>((key, (value, ()))))
+        .collect::<Vec<_>>();
+    let pairs = call.create_list::<QueryPair>(pairs);
+
+    Ok(call.return_custom::<QueryOk>((pairs, ())))
+}
+
+pub(super) fn percent_encode(value: EcoString) -> EcoString {
+    codec::percent_encode(&value)
+}
+
+pub(super) fn percent_decode<'call, Profile>(
+    call: HostCall<'call, Profile, UriProvider<Profile>, PercentDecodeResult>,
+    value: EcoString,
+) -> Result<HostCallCompletion<'call, PercentDecodeResult>, HostCallError>
+where
+    Profile: GleamStdlibHostProfile,
+{
+    Ok(match codec::percent_decode(&value) {
+        Some(value) => call.return_custom::<PercentDecodeOk>((value, ())),
+        None => call.return_custom::<PercentDecodeError>(((), ())),
+    })
+}
+
+fn scalar_byte_index(string: &str, index: usize) -> Option<usize> {
+    if index == string.chars().count() {
+        return Some(string.len());
+    }
+
+    string.char_indices().nth(index).map(|(index, _)| index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UriProvider, codeunit_slice, scalar_byte_index};
+    use crate::gleam_stdlib::{GleamStdlibProfile, GleamStdlibRunState};
+    use crate::{
+        HostModule, HostProvider, HostProviderSet, HostedExecution, ModuleSource, PackageSource,
+        Value, compile_typed_host_program, plan_host_program,
+    };
+    use ecow::EcoString;
+    use num_bigint::BigInt;
+
+    const URI_SOURCE: &str = r#"
+@external(erlang, "gleam_stdlib", "string_pop_codeunit")
+fn pop_codeunit(string: String) -> #(Int, String)
+
+@external(erlang, "binary", "part")
+fn codeunit_slice(string: String, from: Int, length: Int) -> String
+
+@external(erlang, "gleam_stdlib", "parse_query")
+pub fn parse_query(query: String) -> Result(List(#(String, String)), Nil)
+
+@external(erlang, "gleam_stdlib", "percent_encode")
+pub fn percent_encode(value: String) -> String
+
+@external(erlang, "gleam_stdlib", "percent_decode")
+pub fn percent_decode(value: String) -> Result(String, Nil)
+
+pub fn main() {
+  let #(codepoint, rest) = pop_codeunit("ñrest")
+  assert codepoint == 241
+  assert rest == "rest"
+
+  let #(empty_codepoint, empty_rest) = pop_codeunit("")
+  assert empty_codepoint == 0
+  assert empty_rest == ""
+  assert codeunit_slice("año", 1, 2) == "ño"
+  assert parse_query("a+b=1&a+b=2") == Ok([#("a b", "1"), #("a b", "2")])
+  assert parse_query("%C2") == Error(Nil)
+  assert percent_encode("ñ +") == "%C3%B1%20+"
+  assert percent_decode("%C3%B1%20+") == Ok("ñ +")
+  assert percent_decode("%C2") == Error(Nil)
+}
+"#;
+
+    #[test]
+    fn uri_provider_projects_the_caller_owned_run_state() {
+        let mut state = GleamStdlibRunState::from_seed([3; 32]);
+        let expected = std::ptr::from_mut(&mut state);
+        let projected =
+            <UriProvider<GleamStdlibProfile> as HostProvider<GleamStdlibProfile>>::project(
+                &mut state,
+            );
+
+        assert!(std::ptr::eq(projected, expected));
+    }
+
+    #[test]
+    fn slices_uri_strings_by_unicode_scalar_index() {
+        assert_eq!(
+            codeunit_slice("año".into(), 1.into(), 1.into()),
+            Ok("ñ".into())
+        );
+        assert_eq!(
+            codeunit_slice("año".into(), 1.into(), 2.into()),
+            Ok("ño".into())
+        );
+        assert_eq!(
+            codeunit_slice("año".into(), 3.into(), 0.into()),
+            Ok("".into())
+        );
+    }
+
+    #[test]
+    fn rejects_unrepresentable_or_out_of_bounds_uri_slices() {
+        for (from, length, message) in [
+            (
+                BigInt::from(-1),
+                BigInt::from(1),
+                "URI string slice index is not representable",
+            ),
+            (
+                BigInt::from(0),
+                BigInt::from(-1),
+                "URI string slice length is not representable",
+            ),
+            (
+                BigInt::from(usize::MAX),
+                BigInt::from(1),
+                "URI string slice range is not representable",
+            ),
+            (
+                BigInt::from(4),
+                BigInt::from(0),
+                "URI string slice starts outside the string",
+            ),
+            (
+                BigInt::from(2),
+                BigInt::from(2),
+                "URI string slice ends outside the string",
+            ),
+        ] {
+            assert_eq!(
+                codeunit_slice("año".into(), from, length)
+                    .expect_err("invalid URI string slice should fail")
+                    .message(),
+                message,
+            );
+        }
+
+        assert_eq!(scalar_byte_index("año", usize::MAX), None);
+    }
+
+    #[test]
+    fn executes_every_uri_provider_through_the_typed_hosted_pipeline() {
+        let provider = super::super::host_provider::<GleamStdlibProfile>()
+            .expect("synthetic URI provider should register");
+        let typed = compile_typed_host_program(
+            "gleam_stdlib",
+            "gleam/uri",
+            [PackageSource::new(
+                "gleam_stdlib",
+                Vec::<EcoString>::new(),
+                [ModuleSource::new(
+                    "gleam/uri",
+                    "src/gleam/uri.gleam",
+                    URI_SOURCE,
+                )],
+            )],
+            HostProviderSet::with_providers(
+                Vec::<HostModule<GleamStdlibProfile>>::new(),
+                [provider],
+            )
+            .expect("synthetic URI provider module should be unique"),
+        )
+        .expect("synthetic URI source should compile");
+        let plan = plan_host_program(typed).expect("synthetic URI source should plan");
+        let execution =
+            HostedExecution::try_from_module_plan(plan).expect("synthetic URI source should seal");
+
+        assert_eq!(
+            execution
+                .run_main(
+                    &mut GleamStdlibRunState::from_seed([5; 32]),
+                    &mut Vec::new(),
+                )
+                .expect("synthetic URI source should run"),
+            Value::Nil,
+        );
+    }
+}

--- a/src/gleam_stdlib/uri/function/codec.rs
+++ b/src/gleam_stdlib/uri/function/codec.rs
@@ -1,0 +1,136 @@
+use ecow::EcoString;
+
+const HEX_DIGITS: &[u8; 16] = b"0123456789ABCDEF";
+
+pub(super) fn parse_query(query: &str) -> Option<Vec<(EcoString, EcoString)>> {
+    if query.is_empty() {
+        return Some(Vec::new());
+    }
+
+    query
+        .split('&')
+        .map(|section| {
+            let (key, value) = section.split_once('=').unwrap_or((section, ""));
+            Some((decode(key, true)?, decode(value, true)?))
+        })
+        .collect()
+}
+
+pub(super) fn percent_encode(value: &str) -> EcoString {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if is_unescaped(byte) {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(HEX_DIGITS[usize::from(byte >> 4)]));
+            encoded.push(char::from(HEX_DIGITS[usize::from(byte & 0x0f)]));
+        }
+    }
+    encoded.into()
+}
+
+pub(super) fn percent_decode(value: &str) -> Option<EcoString> {
+    decode(value, false)
+}
+
+fn decode(value: &str, plus_as_space: bool) -> Option<EcoString> {
+    let input = value.as_bytes();
+    let mut decoded = Vec::with_capacity(input.len());
+    let mut index = 0;
+    while index < input.len() {
+        match input[index] {
+            b'+' if plus_as_space => decoded.push(b' '),
+            b'%' => {
+                let high = hex_value(*input.get(index + 1)?)?;
+                let low = hex_value(*input.get(index + 2)?)?;
+                decoded.push((high << 4) | low);
+                index += 2;
+            }
+            byte => decoded.push(byte),
+        }
+        index += 1;
+    }
+
+    String::from_utf8(decoded).ok().map(Into::into)
+}
+
+fn is_unescaped(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+        || matches!(
+            byte,
+            b'!' | b'$' | b'\'' | b'(' | b')' | b'*' | b'+' | b'-' | b'.' | b'_' | b'~'
+        )
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_query, percent_decode, percent_encode};
+
+    #[test]
+    fn matches_the_official_erlang_percent_codec() {
+        for (decoded, encoded) in [
+            (
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+            ),
+            ("!$'()*+-._~", "!$'()*+-._~"),
+            (" ,;:?[]@/\\&#=", "%20%2C%3B%3A%3F%5B%5D%40%2F%5C%26%23%3D"),
+            ("ñ", "%C3%B1"),
+            ("100% great+fun", "100%25%20great+fun"),
+        ] {
+            assert_eq!(percent_encode(decoded), encoded);
+            assert_eq!(percent_decode(encoded).as_deref(), Some(decoded));
+        }
+        assert_eq!(percent_decode("%c3%b1").as_deref(), Some("ñ"));
+        assert_eq!(percent_decode("+").as_deref(), Some("+"));
+    }
+
+    #[test]
+    fn rejects_malformed_percent_encoding_and_invalid_utf8() {
+        for invalid in ["%", "%0", "%GG", "%0G", "%C2", "%FF"] {
+            assert_eq!(percent_decode(invalid), None, "{invalid:?}");
+        }
+    }
+
+    #[test]
+    fn parses_official_erlang_query_segments_in_source_order() {
+        for (query, expected) in [
+            ("", vec![]),
+            ("a", vec![("a", "")]),
+            ("=x", vec![("", "x")]),
+            ("a=", vec![("a", "")]),
+            ("a=b=c", vec![("a", "b=c")]),
+            ("&&", vec![("", ""), ("", ""), ("", "")]),
+            ("a[]=1&a[]=2", vec![("a[]", "1"), ("a[]", "2")]),
+            ("one+two=three+four", vec![("one two", "three four")]),
+        ] {
+            assert_eq!(
+                parse_query(query),
+                Some(
+                    expected
+                        .into_iter()
+                        .map(|(key, value)| (key.into(), value.into()))
+                        .collect(),
+                ),
+                "{query:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_query_when_any_component_is_invalid() {
+        for invalid in ["%C2=value", "key=%", "ok=1&bad=%GG"] {
+            assert_eq!(parse_query(invalid), None, "{invalid:?}");
+        }
+    }
+}

--- a/src/gleam_stdlib/uri/schema.rs
+++ b/src/gleam_stdlib/uri/schema.rs
@@ -1,0 +1,20 @@
+use super::super::result::{GleamError, GleamOk, GleamResult};
+use crate::{HostListType, HostTupleType, HostTypeList, HostTypeListEnd};
+use ecow::EcoString;
+use num_bigint::BigInt;
+
+pub(super) type CodeunitPairElements =
+    HostTypeList<BigInt, HostTypeList<EcoString, HostTypeListEnd>>;
+pub(super) type CodeunitPair = HostTupleType<CodeunitPairElements>;
+
+pub(super) type QueryPairElements =
+    HostTypeList<EcoString, HostTypeList<EcoString, HostTypeListEnd>>;
+pub(super) type QueryPair = HostTupleType<QueryPairElements>;
+pub(super) type QueryPairs = HostListType<QueryPair>;
+pub(super) type QueryResult = GleamResult<QueryPairs, ()>;
+pub(super) type QueryOk = GleamOk<QueryPairs, ()>;
+pub(super) type QueryError = GleamError<QueryPairs, ()>;
+
+pub(super) type PercentDecodeResult = GleamResult<EcoString, ()>;
+pub(super) type PercentDecodeOk = GleamOk<EcoString, ()>;
+pub(super) type PercentDecodeError = GleamError<EcoString, ()>;

--- a/src/plan/value_shape.rs
+++ b/src/plan/value_shape.rs
@@ -126,7 +126,7 @@ impl CustomValueShape {
         ))
     }
 
-    fn refine(&self, other: &Self) -> Option<Self> {
+    pub(crate) fn refine(&self, other: &Self) -> Option<Self> {
         if self.type_ != other.type_ {
             return None;
         }

--- a/src/planner/context.rs
+++ b/src/planner/context.rs
@@ -201,11 +201,16 @@ impl FunctionParam {
 pub(super) struct ResolvedCustomConstructor {
     constructor: CustomConstructor,
     constructor_count: usize,
+    source_shape: CustomValueShape,
 }
 
 impl ResolvedCustomConstructor {
     pub(super) fn constructor_count(&self) -> usize {
         self.constructor_count
+    }
+
+    pub(super) fn source_shape(&self) -> &CustomValueShape {
+        &self.source_shape
     }
 
     pub(super) fn into_constructor(self) -> CustomConstructor {
@@ -2538,11 +2543,11 @@ impl<'a> PlanContext<'a> {
         field_types: Vec<ValueType>,
     ) -> Result<ResolvedCustomConstructor, PlanError> {
         let mut type_parameters = self.type_parameters.clone();
-        let type_ =
+        let source_shape =
             match ValueShape::from_gleam_in_with_external(type_, &mut type_parameters, &|name| {
                 self.registry.is_external_type(name)
             }) {
-                ValueShape::Custom(shape) => shape.type_().clone(),
+                ValueShape::Custom(shape) => shape,
                 _ => {
                     return Err(PlanError::InvalidTypedAst {
                         reason: InvalidTypedAstReason::CustomType {
@@ -2552,13 +2557,15 @@ impl<'a> PlanContext<'a> {
                     });
                 }
             };
-        self.custom_constructor_from_parts(
-            type_,
+        let mut constructor = self.custom_constructor_from_parts(
+            source_shape.type_().clone(),
             constructor.name.clone(),
             &constructor.module,
             usize::from(constructor.constructor_index),
             field_types,
-        )
+        )?;
+        constructor.source_shape = source_shape;
+        Ok(constructor)
     }
 
     pub(super) fn custom_field_access(
@@ -2728,9 +2735,11 @@ impl<'a> PlanContext<'a> {
             .map(|(label, type_)| CustomConstructorField::new(label, type_))
             .collect();
 
+        let source_shape = CustomValueShape::any(type_.clone());
         Ok(ResolvedCustomConstructor {
             constructor: CustomConstructor::new(type_, name, variant_index, fields),
             constructor_count,
+            source_shape,
         })
     }
 
@@ -4287,6 +4296,7 @@ mod tests {
                     )],
                 ),
                 constructor_count: 1,
+                source_shape: CustomValueShape::any(generic_int.clone()),
             }),
         );
         assert_eq!(
@@ -4413,6 +4423,7 @@ mod tests {
                     vec![CustomConstructorField::new(None, ValueType::String)],
                 ),
                 constructor_count: 2,
+                source_shape: CustomValueShape::any(result_type.clone()),
             }),
         );
         assert_eq!(

--- a/src/planner/pattern.rs
+++ b/src/planner/pattern.rs
@@ -4,5 +4,5 @@ mod runtime;
 pub(in crate::planner) use bit_array::plan_bit_array_pattern;
 pub(in crate::planner) use runtime::{
     PlannedCustomBinding, pattern_value_type, pattern_value_type_in_context,
-    plan_custom_subject_pattern, plan_runtime_pattern,
+    plan_custom_subject_pattern, plan_runtime_pattern_with_source_shape,
 };

--- a/src/planner/pattern/runtime.rs
+++ b/src/planner/pattern/runtime.rs
@@ -57,26 +57,6 @@ impl PlannedCustomBinding {
         self.constructor_count
     }
 
-    pub(in crate::planner) fn intrinsic_binding(&self) -> Option<CustomBindingPattern> {
-        match self.source_shape.constructor() {
-            CustomConstructorRefinement::Exact(index) if index == self.constructor.index() => {
-                Some(CustomBindingPattern::exact(
-                    self.source_shape.clone(),
-                    self.constructor.clone(),
-                    self.fields.clone(),
-                ))
-            }
-            CustomConstructorRefinement::Any if self.constructor_count == 1 => {
-                Some(CustomBindingPattern::only_constructor(
-                    self.source_shape.clone(),
-                    self.constructor.clone(),
-                    self.fields.clone(),
-                ))
-            }
-            CustomConstructorRefinement::Any | CustomConstructorRefinement::Exact(_) => None,
-        }
-    }
-
     pub(in crate::planner) fn into_intrinsic_binding(self) -> Option<CustomBindingPattern> {
         match self.source_shape.constructor() {
             CustomConstructorRefinement::Exact(index) if index == self.constructor.index() => Some(
@@ -114,8 +94,18 @@ impl PlannedCustomBinding {
     }
 }
 
-pub(in crate::planner) fn plan_runtime_pattern(
+#[cfg(test)]
+fn plan_runtime_pattern(
     pattern: TypedPattern,
+    context: &mut PlanContext<'_>,
+) -> Result<PlannedRuntimePattern, PlanError> {
+    let source_shape = pattern_value_shape(&pattern, context)?;
+    plan_runtime_pattern_with_source_shape(pattern, source_shape, context)
+}
+
+pub(in crate::planner) fn plan_runtime_pattern_with_source_shape(
+    pattern: TypedPattern,
+    source_shape: ValueShape,
     context: &mut PlanContext<'_>,
 ) -> Result<PlannedRuntimePattern, PlanError> {
     match pattern {
@@ -156,11 +146,18 @@ pub(in crate::planner) fn plan_runtime_pattern(
             custom_binding: None,
         }),
         Pattern::Tuple { elements, .. } => {
+            let ValueShape::Tuple(source_shapes) = source_shape else {
+                return Err(invalid_pattern());
+            };
+            if elements.len() != source_shapes.len() {
+                return Err(invalid_pattern());
+            }
             let mut patterns = Vec::with_capacity(elements.len());
             let mut bindings = Vec::with_capacity(elements.len());
             let mut is_total = true;
-            for element in elements {
-                let element = plan_runtime_pattern(element, context)?;
+            for (element, source_shape) in elements.into_iter().zip(source_shapes) {
+                let element =
+                    plan_runtime_pattern_with_source_shape(element, source_shape, context)?;
                 is_total &= element.is_total;
                 if let Some(binding) = element.total_binding {
                     bindings.push(binding);
@@ -174,12 +171,9 @@ pub(in crate::planner) fn plan_runtime_pattern(
                 custom_binding: None,
             })
         }
-        Pattern::List {
-            elements,
-            tail,
-            type_,
-            ..
-        } => plan_list_pattern(elements, tail.map(|tail| *tail), type_, context),
+        Pattern::List { elements, tail, .. } => {
+            plan_list_pattern(elements, tail.map(|tail| *tail), source_shape, context)
+        }
         Pattern::BitArray { segments, .. } => {
             let (pattern, is_total) = super::plan_bit_array_pattern(segments, context)?;
             Ok(PlannedRuntimePattern {
@@ -211,7 +205,7 @@ pub(in crate::planner) fn plan_runtime_pattern(
             type_,
             ..
         } => {
-            let ValueShape::Custom(source_shape) = context.value_shape(type_.as_ref()) else {
+            let ValueShape::Custom(source_shape) = source_shape else {
                 return Err(invalid_pattern());
             };
             plan_custom_pattern(arguments, constructor, type_, source_shape, context)
@@ -240,9 +234,9 @@ pub(in crate::planner) fn plan_runtime_pattern(
             })
         }
         Pattern::Assign { name, pattern, .. } => {
-            let shape = pattern_value_shape(&pattern, context)?;
-            let planned = plan_runtime_pattern(*pattern, context)?;
-            let binding = define_value_binding(name, shape, context);
+            let planned =
+                plan_runtime_pattern_with_source_shape(*pattern, source_shape.clone(), context)?;
+            let binding = define_value_binding(name, source_shape, context);
             Ok(PlannedRuntimePattern {
                 pattern: AssertPattern::alias(planned.pattern, binding.clone()),
                 is_total: planned.is_total,
@@ -289,6 +283,7 @@ pub(in crate::planner) fn pattern_value_type_in_context(
     pattern_value_shape_with(pattern, &mut value_shape).map(|shape| shape.value_type())
 }
 
+#[cfg(test)]
 fn pattern_value_shape(
     pattern: &TypedPattern,
     context: &mut PlanContext<'_>,
@@ -327,17 +322,20 @@ fn pattern_value_shape_with(
 fn plan_list_pattern(
     elements: Vec<TypedPattern>,
     tail: Option<TailPattern<Arc<Type>>>,
-    type_: Arc<Type>,
+    source_shape: ValueShape,
     context: &mut PlanContext<'_>,
 ) -> Result<PlannedRuntimePattern, PlanError> {
-    let ValueShape::List(item_shape) = context.value_shape(type_.as_ref()) else {
+    let ValueShape::List(item_shape) = source_shape else {
         return Err(invalid_pattern());
     };
     let element_type = item_shape.value_type();
     let has_no_elements = elements.is_empty();
     let mut patterns = Vec::with_capacity(elements.len());
     for element in elements {
-        patterns.push(plan_runtime_pattern(element, context)?.pattern);
+        patterns.push(
+            plan_runtime_pattern_with_source_shape(element, item_shape.as_ref().clone(), context)?
+                .pattern,
+        );
     }
     let tail = tail
         .map(|tail| plan_list_tail(tail, item_shape.as_ref(), context))
@@ -364,8 +362,8 @@ fn plan_list_tail(
 ) -> Result<ListAssertTail, PlanError> {
     match tail.pattern {
         Pattern::Variable { name, type_, .. }
-            if context.value_shape(type_.as_ref())
-                == ValueShape::List(Box::new(item_shape.clone())) =>
+            if context.value_type(type_.as_ref())
+                == ValueType::List(Box::new(item_shape.value_type())) =>
         {
             Ok(ListAssertTail::bind(
                 context.define_list_local_shape(name.clone(), item_shape.clone()),
@@ -373,8 +371,8 @@ fn plan_list_tail(
             ))
         }
         Pattern::Discard { type_, .. }
-            if context.value_shape(type_.as_ref())
-                == ValueShape::List(Box::new(item_shape.clone())) =>
+            if context.value_type(type_.as_ref())
+                == ValueType::List(Box::new(item_shape.value_type())) =>
         {
             Ok(ListAssertTail::Ignore)
         }
@@ -439,42 +437,51 @@ fn plan_custom_pattern(
         .collect::<Result<Vec<_>, _>>()?;
     let resolved_constructor =
         context.custom_pattern_constructor(type_.as_ref(), &constructor, field_types)?;
+    let pattern_source_shape = resolved_constructor.source_shape().clone();
     let constructor_count = resolved_constructor.constructor_count();
     let custom_constructor = resolved_constructor.into_constructor();
     let mut fields = Vec::with_capacity(arguments.len());
-    let mut total_fields = Vec::with_capacity(arguments.len());
-    for argument in arguments {
-        let field = plan_runtime_pattern(argument.value, context)?;
+    let mut binding_fields = Vec::with_capacity(arguments.len());
+    let mut fields_are_total = true;
+    for (argument, source_field) in arguments.into_iter().zip(custom_constructor.fields()) {
+        let source_shape = ValueShape::from_value_type(source_field.type_().clone());
+        let field = plan_runtime_pattern_with_source_shape(argument.value, source_shape, context)?;
+        fields_are_total &= field.is_total;
         if let Some(binding) = field.total_binding {
-            total_fields.push(binding);
+            binding_fields.push(binding);
         }
         fields.push(field.pattern);
     }
-    let fields_are_total = total_fields.len() == fields.len();
+    let fields_are_bindable = binding_fields.len() == fields.len();
     let matches_exact_constructor = source_shape.constructor()
         == CustomConstructorRefinement::Exact(usize::from(constructor.constructor_index));
     let is_total = fields_are_total && (constructor_count == 1 || matches_exact_constructor);
-    let custom_binding = fields_are_total.then(|| PlannedCustomBinding {
-        constructor: custom_constructor.clone(),
-        fields: total_fields.clone(),
-        source_shape,
-        constructor_count,
-    });
+    let binding_source_shape = source_shape.refine(&pattern_source_shape);
+    let custom_binding =
+        (fields_are_bindable && binding_source_shape.is_some()).then(|| PlannedCustomBinding {
+            constructor: custom_constructor.clone(),
+            fields: binding_fields.clone(),
+            source_shape: source_shape.clone(),
+            constructor_count,
+        });
+    let total_binding = binding_source_shape
+        .filter(|_| fields_are_bindable)
+        .map(|binding_source_shape| PlannedCustomBinding {
+            constructor: custom_constructor.clone(),
+            fields: binding_fields.clone(),
+            source_shape: binding_source_shape,
+            constructor_count,
+        })
+        .and_then(PlannedCustomBinding::into_intrinsic_binding)
+        .map(TotalBindingPattern::custom);
     Ok(PlannedCustomPattern {
         pattern: CustomPattern::new(
             custom_constructor,
             fields,
-            fields_are_total.then_some(total_fields),
+            fields_are_total.then_some(binding_fields),
         ),
         is_total,
-        total_binding: if is_total {
-            custom_binding
-                .as_ref()
-                .and_then(PlannedCustomBinding::intrinsic_binding)
-                .map(TotalBindingPattern::custom)
-        } else {
-            None
-        },
+        total_binding,
         custom_binding,
     })
 }
@@ -552,7 +559,7 @@ mod tests {
     use super::{
         invalid_pattern, pattern_value_shape, pattern_value_type, pattern_value_type_in_context,
         plan_bool_pattern, plan_custom_pattern, plan_list_tail, plan_nil_pattern,
-        plan_runtime_pattern, total_bit_array_binding,
+        plan_runtime_pattern, plan_runtime_pattern_with_source_shape, total_bit_array_binding,
     };
     use crate::plan::{
         AssertBinding, AssertPattern, BitArrayBindingPattern, BitArrayLocalId, BitArrayPattern,
@@ -849,6 +856,35 @@ mod tests {
             },
             &mut context,
         ));
+        let tuple = Pattern::Tuple {
+            location: span,
+            elements: vec![Pattern::Discard {
+                name: "_".into(),
+                location: span,
+                type_: type_::int(),
+            }],
+        };
+        assert_invalid(plan_runtime_pattern_with_source_shape(
+            tuple.clone(),
+            ValueShape::Int,
+            &mut context,
+        ));
+        assert_invalid(plan_runtime_pattern_with_source_shape(
+            tuple,
+            ValueShape::Tuple(Vec::new().into_boxed_slice()),
+            &mut context,
+        ));
+        assert_invalid(plan_runtime_pattern_with_source_shape(
+            Pattern::Tuple {
+                location: span,
+                elements: vec![Pattern::Invalid {
+                    location: span,
+                    type_: type_::int(),
+                }],
+            },
+            ValueShape::Tuple(vec![ValueShape::Int].into_boxed_slice()),
+            &mut context,
+        ));
         assert_invalid(plan_runtime_pattern(
             Pattern::Assign {
                 location: span,
@@ -1119,13 +1155,6 @@ mod tests {
             &mut context,
         )
         .expect("non-inferred Result variant should plan");
-        assert_eq!(
-            any.custom_binding
-                .as_ref()
-                .expect("total fields should preserve the custom binding")
-                .intrinsic_binding(),
-            None,
-        );
         assert_eq!(
             any.custom_binding
                 .clone()

--- a/src/planner/statement/assignment/assert.rs
+++ b/src/planner/statement/assignment/assert.rs
@@ -110,7 +110,7 @@ fn binding_pattern_accepts_shape(
             source_shape,
             constructor_count,
             constructor,
-            ..
+            fields,
         } => {
             let crate::plan::ValueShape::Custom(actual) = shape else {
                 return false;
@@ -119,6 +119,16 @@ fn binding_pattern_accepts_shape(
                 && (*constructor_count == 1
                     || actual.constructor()
                         == crate::plan::CustomConstructorRefinement::Exact(constructor.index()))
+                && fields.len() == constructor.fields().len()
+                && fields
+                    .iter()
+                    .zip(constructor.fields())
+                    .all(|(pattern, field)| {
+                        binding_pattern_accepts_shape(
+                            pattern,
+                            &crate::plan::ValueShape::from_value_type(field.type_().clone()),
+                        )
+                    })
         }
         BindingPattern::Alias { pattern, .. } => binding_pattern_accepts_shape(pattern, shape),
     }
@@ -143,13 +153,19 @@ fn plan_refutable_assert_assignment_from_expr(
     context: &mut PlanContext<'_>,
 ) -> Result<PlannedAssignment, PlanError> {
     validate_pattern_value_type(&pattern, value.value_type(), context)?;
+    let source_shape = value.shape().clone();
     let message = message
         .map(|message| plan_assert_message(message, context))
         .transpose()?;
     let (let_step, subject, local_value) = plan_assert_subject(value, context)?;
     let site = context.panic_site(location);
     let pattern_span = pattern.location().into();
-    let pattern = crate::planner::pattern::plan_runtime_pattern(pattern, context)?.pattern;
+    let pattern = crate::planner::pattern::plan_runtime_pattern_with_source_shape(
+        pattern,
+        source_shape,
+        context,
+    )?
+    .pattern;
 
     Ok(PlannedAssignment {
         steps: vec![

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -316,6 +316,7 @@ mod control_flow {
             tuple_pattern_fallthrough,
             custom_pattern,
             custom_pattern_combinations,
+            nested_custom_field_fallthrough,
             result_subject,
             tuple_pattern_closure_capture,
             list_case_return_families,
@@ -819,6 +820,7 @@ mod execution_errors {
             let_assert_bool_pattern,
             let_assert_string_prefix_pattern,
             let_assert_nested_compound_pattern,
+            let_assert_nested_custom_field,
             let_assert_message_failure,
         );
     }

--- a/tests/fixtures/execution/control_flow/case/list_pattern_element_families.gleam
+++ b/tests/fixtures/execution/control_flow/case/list_pattern_element_families.gleam
@@ -30,6 +30,13 @@ fn function_identity(value: fn(Int) -> Int) {
   value
 }
 
+fn first_ok(values: List(Result(Int, Nil))) {
+  case values {
+    [Ok(value)] -> value
+    _ -> 0
+  }
+}
+
 pub fn main() {
   let string_ok = case ["one"] {
     ["one"] -> True
@@ -91,11 +98,12 @@ pub fn main() {
     [f] -> f(add_one)(41) == 42
     _ -> False
   }
+  let custom_ok = first_ok([Ok(1)]) == 1
 
   string_ok && float_ok && bool_ok && bool_true_ok && nil_ok && nested_list_ok
   && tuple_ok && int_function_ok && string_function_ok && float_function_ok
   && bool_function_ok && nil_function_ok && tuple_function_ok && list_function_ok
-  && function_function_ok
+  && function_function_ok && custom_ok
 }
 
 // @geam:expect Bool(true)

--- a/tests/fixtures/execution/control_flow/case/nested_custom_field_fallthrough.gleam
+++ b/tests/fixtures/execution/control_flow/case/nested_custom_field_fallthrough.gleam
@@ -1,0 +1,20 @@
+type Maybe(value) {
+  Some(value)
+  None
+}
+
+type Envelope {
+  Envelope(value: Maybe(Int))
+}
+
+fn classify(envelope: Envelope) {
+  case envelope {
+    Envelope(value: Some(_)) -> 1
+    _ -> 0
+  }
+}
+
+pub fn main() {
+  #(classify(Envelope(None)), classify(Envelope(Some(1))))
+}
+// @geam:expect Tuple([Int(0), Int(1)])

--- a/tests/fixtures/execution_errors/patterns/let_assert_nested_custom_field.gleam
+++ b/tests/fixtures/execution_errors/patterns/let_assert_nested_custom_field.gleam
@@ -1,0 +1,27 @@
+type Maybe(value) {
+  Some(value)
+  None
+}
+
+type Envelope {
+  Envelope(value: Maybe(Int))
+}
+
+pub fn main() {
+  let assert Envelope(value: Some(_)) = Envelope(None)
+  Nil
+}
+
+// @geam:expect-error
+// geam::let_assert
+//
+//   x let_assert: Pattern match failed, no pattern matched the value.
+//     ,-[tests/fixtures/execution_errors/patterns/let_assert_nested_custom_field.gleam:11:3]
+//  10 | pub fn main() {
+//  11 |   let assert Envelope(value: Some(_)) = Envelope(None)
+//     :   ^^^^^|^^^^ ^^^^^^^^^^^^|^^^^^^^^^^^
+//     :        |                 `-- pattern
+//     :        `-- let assert in main.main
+//  12 |   Nil
+//     `----
+//   help: failed value: geam/main/Envelope::Envelope(geam/main/Maybe(Int)::None())

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_uri_operations.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_uri_operations.gleam
@@ -1,0 +1,94 @@
+import gleam/option.{None, Some}
+import gleam/uri
+
+fn parsed(source: String) -> uri.Uri {
+  let assert Ok(value) = uri.parse(source)
+  value
+}
+
+pub fn main() {
+  assert uri.path_segments("/") == []
+  assert uri.path_segments("/weebl//bob") == ["weebl", "bob"]
+  assert uri.path_segments("/weebl/../bob") == ["bob"]
+  assert uri.path_segments("../bob") == ["bob"]
+
+  assert uri.to_string(uri.Uri(None, None, None, None, "/teapot", None, None))
+    == "/teapot"
+  assert uri.to_string(uri.Uri(Some("ftp"), None, None, None, "thing.txt", None, None))
+    == "ftp:thing.txt"
+  assert uri.to_string(uri.Uri(None, None, Some("example.com"), None, "", None, None))
+    == "//example.com/"
+  assert uri.to_string(uri.Uri(None, None, Some("example.com"), Some(81), "noslash", None, None))
+    == "//example.com:81/noslash"
+  assert uri.to_string(uri.Uri(None, Some("ignored"), None, Some(81), "noslash", None, Some("frag")))
+    == "noslash#frag"
+
+  assert uri.origin(parsed("http://example.test/path?weebl#bob"))
+    == Ok("http://example.test")
+  assert uri.origin(parsed("http://example.test:8080"))
+    == Ok("http://example.test:8080")
+  assert uri.origin(parsed("https://mozilla.org:443/"))
+    == Ok("https://mozilla.org")
+  assert uri.origin(parsed("http://localhost:80/")) == Ok("http://localhost")
+  assert uri.origin(parsed("/path")) == Error(Nil)
+  assert uri.origin(parsed("file:///dev/null")) == Error(Nil)
+
+  let relative_base = parsed("/relative")
+  assert relative_base.scheme == None
+  assert relative_base.host == None
+  assert relative_base.path == "/relative"
+  assert uri.merge(relative_base, parsed("")) == Error(Nil)
+  assert uri.merge(
+      parsed("http://google.com/weebl"),
+      parsed("http://example.com/baz"),
+    )
+    == uri.parse("http://example.com/baz")
+  assert uri.merge(
+      parsed("http://google.com/weebl"),
+      parsed("http://example.com/.././bob/../../baz"),
+    )
+    == uri.parse("http://example.com/baz")
+  assert uri.merge(
+      parsed("http://google.com/weebl"),
+      parsed("//example.com/.././bob/../../../baz"),
+    )
+    == uri.parse("http://example.com/baz")
+  assert uri.merge(parsed("http://example.com/weebl/bob"), parsed("/baz"))
+    == uri.parse("http://example.com/baz")
+  assert uri.merge(parsed("http://example.com/weebl/bob"), parsed("baz"))
+    == uri.parse("http://example.com/weebl/baz")
+  assert uri.merge(parsed("http://example.com/weebl/"), parsed("baz"))
+    == uri.parse("http://example.com/weebl/baz")
+  assert uri.merge(parsed("http://example.com"), parsed("baz"))
+    == uri.parse("http://example.com/baz")
+  assert uri.merge(
+      parsed("http://example.com"),
+      parsed("/.././bob/../../../baz"),
+    )
+    == uri.parse("http://example.com/baz")
+  assert uri.merge(parsed("http://example.com/weebl/bob"), parsed(""))
+    == uri.parse("http://example.com/weebl/bob")
+  assert uri.merge(
+      parsed("http://example.com/weebl/bob"),
+      parsed("#fragment"),
+    )
+    == uri.parse("http://example.com/weebl/bob#fragment")
+  assert uri.merge(
+      parsed("http://example.com/weebl/bob"),
+      parsed("?query"),
+    )
+    == uri.parse("http://example.com/weebl/bob?query")
+  assert uri.merge(
+      parsed("http://example.com/weebl/bob?query1"),
+      parsed("?query2"),
+    )
+    == uri.parse("http://example.com/weebl/bob?query2")
+  assert uri.merge(
+      parsed("http://example.com/weebl/bob?query"),
+      parsed(""),
+    )
+    == uri.parse("http://example.com/weebl/bob?query")
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_uri_parse.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_uri_parse.gleam
@@ -1,0 +1,51 @@
+import gleam/option.{None, Some}
+import gleam/uri
+
+pub fn main() {
+  assert uri.empty
+    == uri.Uri(
+      scheme: None,
+      userinfo: None,
+      host: None,
+      port: None,
+      path: "",
+      query: None,
+      fragment: None,
+    )
+
+  let assert Ok(full) =
+    uri.parse("https://weebl:bob@example.com:1234/path?query=true#fragment")
+  assert full
+    == uri.Uri(
+      scheme: Some("https"),
+      userinfo: Some("weebl:bob"),
+      host: Some("example.com"),
+      port: Some(1234),
+      path: "/path",
+      query: Some("query=true"),
+      fragment: Some("fragment"),
+    )
+
+  let assert Ok(empty) = uri.parse("")
+  assert empty == uri.empty
+
+  let assert Ok(empty_host) = uri.parse("//:")
+  assert empty_host.host == Some("")
+  assert empty_host.port == None
+
+  let unicode_source =
+    "HTTPS://EXAMPLE.COM/경로/가나다라마바사아자차카타파하/🙂🙂🙂?도시=서울#조각"
+  let assert Ok(unicode) = uri.parse(unicode_source)
+  assert unicode.scheme == Some("https")
+  assert unicode.host == Some("EXAMPLE.COM")
+  assert unicode.path == "/경로/가나다라마바사아자차카타파하/🙂🙂🙂"
+  assert unicode.query == Some("도시=서울")
+  assert unicode.fragment == Some("조각")
+  assert uri.to_string(unicode)
+    == "https://EXAMPLE.COM/경로/가나다라마바사아자차카타파하/🙂🙂🙂?도시=서울#조각"
+
+  assert uri.parse(":https") == Error(Nil)
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/fixtures/projects/gleam_stdlib/src/gleam_uri_query.gleam
+++ b/tests/fixtures/projects/gleam_stdlib/src/gleam_uri_query.gleam
@@ -1,0 +1,36 @@
+import gleam/uri
+
+pub fn main() {
+  assert uri.parse_query("weebl+bob=1&city=%C3%B6rebro")
+    == Ok([#("weebl bob", "1"), #("city", "örebro")])
+  assert uri.parse_query("") == Ok([])
+  assert uri.parse_query("a") == Ok([#("a", "")])
+  assert uri.parse_query("=x") == Ok([#("", "x")])
+  assert uri.parse_query("a=") == Ok([#("a", "")])
+  assert uri.parse_query("a=b=c") == Ok([#("a", "b=c")])
+  assert uri.parse_query("&&") == Ok([#("", ""), #("", ""), #("", "")])
+  assert uri.parse_query("a[]=1&a[]=2")
+    == Ok([#("a[]", "1"), #("a[]", "2")])
+  assert uri.parse_query("%C2") == Error(Nil)
+
+  let query = [
+    #("weebl bob", "1+1-1*1.1~1!1'1(1);%"),
+    #("city", "örebro"),
+  ]
+  let encoded_query = uri.query_to_string(query)
+  assert encoded_query
+    == "weebl%20bob=1%2B1-1*1.1~1!1'1(1)%3B%25&city=%C3%B6rebro"
+  assert uri.parse_query(encoded_query) == Ok(query)
+
+  assert uri.percent_encode("!$'()*+-._~") == "!$'()*+-._~"
+  assert uri.percent_encode(" ,;:?[]@/\\&#=")
+    == "%20%2C%3B%3A%3F%5B%5D%40%2F%5C%26%23%3D"
+  assert uri.percent_encode("ñ") == "%C3%B1"
+  assert uri.percent_decode("%c3%b1") == Ok("ñ")
+  assert uri.percent_decode("+") == Ok("+")
+  assert uri.percent_decode("%") == Error(Nil)
+  assert uri.percent_decode("%FF") == Error(Nil)
+
+  Nil
+}
+// @geam:expect Nil

--- a/tests/gleam_stdlib.rs
+++ b/tests/gleam_stdlib.rs
@@ -41,6 +41,8 @@ mod gleam_set;
 mod gleam_string;
 #[path = "gleam_stdlib/gleam_string_tree.rs"]
 mod gleam_string_tree;
+#[path = "gleam_stdlib/gleam_uri.rs"]
+mod gleam_uri;
 
 struct ExpectedSurface {
     values: &'static [&'static str],

--- a/tests/gleam_stdlib/gleam_uri.rs
+++ b/tests/gleam_stdlib/gleam_uri.rs
@@ -1,0 +1,86 @@
+use geam::gleam_stdlib::{GleamStdlibProfile, GleamStdlibRunState, host_providers};
+use geam::{HostModule, HostProviderSet};
+
+use super::{ExpectedSurface, assert_surface, run_hosted_fixture};
+
+const DEPENDENCIES: &[&str] = &[
+    "gleam/option",
+    "gleam/dict",
+    "gleam/order",
+    "gleam/float",
+    "gleam/int",
+    "gleam/list",
+    "gleam/string_tree",
+    "gleam/string",
+    "gleam/uri",
+];
+
+const SURFACE: ExpectedSurface = ExpectedSurface {
+    values: &[
+        "Uri",
+        "empty",
+        "merge",
+        "origin",
+        "parse",
+        "parse_query",
+        "path_segments",
+        "percent_decode",
+        "percent_encode",
+        "query_to_string",
+        "to_string",
+    ],
+    types: &[("Uri", 0)],
+    type_aliases: &[],
+    constructors: &[("Uri", "Uri", 7)],
+    functions: r#"
+merge: fn(Uri, Uri) -> Result(Uri, Nil)
+origin: fn(Uri) -> Result(String, Nil)
+parse: fn(String) -> Result(Uri, Nil)
+parse_query: fn(String) -> Result(List(#(String, String)), Nil)
+path_segments: fn(String) -> List(String)
+percent_decode: fn(String) -> Result(String, Nil)
+percent_encode: fn(String) -> String
+query_to_string: fn(List(#(String, String))) -> String
+to_string: fn(Uri) -> String
+"#,
+};
+
+fn hosts() -> HostProviderSet<GleamStdlibProfile> {
+    let providers =
+        host_providers::<GleamStdlibProfile>().expect("official stdlib providers should register");
+    HostProviderSet::with_providers(Vec::<HostModule<GleamStdlibProfile>>::new(), providers)
+        .expect("official stdlib provider modules should be unique")
+}
+
+fn run(root_module: &str) {
+    run_hosted_fixture(
+        root_module,
+        DEPENDENCIES,
+        hosts(),
+        &mut GleamStdlibRunState::from_seed([0; 32]),
+    );
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn tracks_official_gleam_uri_public_surface() {
+    assert_surface("gleam_uri_parse", "gleam/uri", DEPENDENCIES, &SURFACE);
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_the_unchanged_official_gleam_uri_parser() {
+    run("gleam_uri_parse");
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_uri_query_and_percent_codecs() {
+    run("gleam_uri_query");
+}
+
+#[test]
+#[ignore = "requires `gleam deps download` in the gleam_stdlib fixture"]
+fn runs_official_gleam_uri_operations() {
+    run("gleam_uri_operations");
+}


### PR DESCRIPTION
## Summary

- Bind the five bodyless `gleam/uri` externals through the explicit stdlib host-provider bundle.
- Execute the unchanged official Gleam parser, URI operations, query handling, and percent codecs.
- Complete end-to-end verification of all 19 public `gleam_stdlib` v1.0.3 modules.

## Planner correction

Official `uri.merge` exposed a general nested custom-pattern issue. Runtime pattern planning now carries the actual subject shape through tuple, list, and custom fields, while keeping the pattern's inferred constructor shape separate. This preserves refutable matching without losing bindings that become valid after a successful match.

Source-backed regressions cover nested custom case fallthrough, `let assert` failure, and custom values inside list patterns.

## Boundaries

- `gleam/uri.parse` remains the unchanged official Gleam fallback.
- Only `pop_codeunit`, `codeunit_slice`, `parse_query`, `percent_encode`, and `percent_decode` are registered as providers.
- No public Rust API, runtime representation, Cargo dependency, automatic provider injection, or URI-specific planner/runtime branch is added.
- Query and percent-codec behavior follows the existing Erlang-target compatibility rule.