### PR TITLE
Cache external provider SDK builds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -218,6 +218,8 @@ jobs:
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "tests/fixtures/provider_sdk -> target"
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary

- Point the External Provider SDK Rust cache at the independent fixture workspace target.
- Preserve normal, Clippy, and coverage dependency artifacts across workflow runs.
- Keep the root and provider SDK workspace build outputs isolated.