### PR TITLE
Prepare Geam for crates.io publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,28 +768,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erlang-generation"
-version = "1.0.0"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "ecow",
- "erlang-term-format",
- "itertools",
- "num-bigint",
- "num-traits",
- "regex",
-]
-
-[[package]]
-name = "erlang-term-format"
-version = "1.0.0"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,7 +991,7 @@ dependencies = [
  "bitvec",
  "camino",
  "ecow",
- "gleam-core",
+ "geam-gleam-core",
  "half",
  "hex",
  "im",
@@ -1029,6 +1007,125 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "unicode-segmentation",
  "vec1",
+]
+
+[[package]]
+name = "geam-gleam-core"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd35326343c72724b8070f856a09ee1ea28ac781df6e9499dd6585e1749f5162"
+dependencies = [
+ "age",
+ "askama",
+ "async-trait",
+ "base16",
+ "bimap",
+ "bincode",
+ "bitvec",
+ "camino",
+ "clap",
+ "codespan-reporting",
+ "debug-ignore",
+ "dirs-next",
+ "ecow",
+ "flate2",
+ "futures",
+ "geam-gleam-erlang-generation",
+ "geam-gleam-hexpm",
+ "geam-gleam-pretty-arena",
+ "gen-lsp-types",
+ "globset",
+ "http",
+ "id-arena",
+ "im",
+ "indexmap",
+ "itertools",
+ "lsp-server",
+ "num-bigint",
+ "num-traits",
+ "pathdiff",
+ "petgraph",
+ "pubgrub",
+ "pulldown-cmark",
+ "radix_trie",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sourcemap",
+ "spdx",
+ "stacker",
+ "strum",
+ "tar",
+ "termcolor",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "unicode-segmentation",
+ "vec1",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "geam-gleam-erlang-generation"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7666b902941502bb11a47097b193746d2059f68b2f021fd299baf122bfa2171b"
+dependencies = [
+ "ecow",
+ "geam-gleam-erlang-term-format",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "regex",
+]
+
+[[package]]
+name = "geam-gleam-erlang-term-format"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c3f64360516f3bf999ac12631c345d7779f45984b334917d34625c8675881b"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "geam-gleam-hexpm"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34c3fdb1c94e1226671c20c64723a363db5b69d54a8881a43f67ebb70c34c72"
+dependencies = [
+ "base16",
+ "bytes",
+ "clap",
+ "ecow",
+ "flate2",
+ "http",
+ "http-auth-basic",
+ "prost 0.13.5",
+ "prost-build",
+ "pubgrub",
+ "regex",
+ "ring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+ "x509-parser",
+]
+
+[[package]]
+name = "geam-gleam-pretty-arena"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b97f422f4e6812310550a53063f741cf8f480d9ff9d626b871521ed0cf61cb8"
+dependencies = [
+ "ecow",
+ "im",
+ "num-bigint",
+ "typed-arena",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1088,62 +1185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gleam-core"
-version = "1.18.1"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "age",
- "askama",
- "async-trait",
- "base16",
- "bimap",
- "bincode",
- "bitvec",
- "camino",
- "clap",
- "codespan-reporting",
- "debug-ignore",
- "dirs-next",
- "ecow",
- "erlang-generation",
- "flate2",
- "futures",
- "gen-lsp-types",
- "globset",
- "hexpm",
- "http",
- "id-arena",
- "im",
- "indexmap",
- "itertools",
- "lsp-server",
- "num-bigint",
- "num-traits",
- "pathdiff",
- "petgraph",
- "pretty-arena",
- "pubgrub",
- "pulldown-cmark",
- "radix_trie",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "sourcemap",
- "spdx",
- "stacker",
- "strum",
- "tar",
- "termcolor",
- "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
- "tracing",
- "unicode-segmentation",
- "vec1",
- "xxhash-rust",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,30 +1241,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hexpm"
-version = "1.18.1"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "base16",
- "bytes",
- "clap",
- "ecow",
- "flate2",
- "http",
- "http-auth-basic",
- "prost 0.13.5",
- "prost-build",
- "pubgrub",
- "regex",
- "ring",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "url",
- "x509-parser",
-]
 
 [[package]]
 name = "hkdf"
@@ -1984,18 +2001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "pretty-arena"
-version = "1.0.0"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "ecow",
- "im",
- "num-bigint",
- "typed-arena",
- "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,30 @@
 name = "geam"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.96"
+description = "Experimental Rust-embedded execution runtime for typed Gleam programs"
+license = "Apache-2.0"
+repository = "https://github.com/panarch/geam"
+readme = "README.md"
+publish = ["crates-io"]
+keywords = ["gleam", "runtime", "interpreter", "embedded"]
+categories = ["compilers", "development-tools"]
+include = [
+    "/assets/geam-mascot.svg",
+    "/docs/**",
+    "/src/**",
+    "/LICENSE",
+    "/README.md",
+]
 
 [dependencies]
 base64 = "0.22"
 bitvec = "1.1.1"
 camino = "1"
-# Keep this aligned with the Gleam v1.18.1 dependency graph. gleam-core does not
-# compile against ecow 0.3.0.
+# Keep this aligned with the Gleam v1.18.1 dependency graph. geam-gleam-core
+# does not compile against ecow 0.3.0.
 ecow = "=0.2.6"
-gleam-core = { git = "https://github.com/gleam-lang/gleam", rev = "4a83802ca33a8a96227a1b332768725f232f9779", package = "gleam-core" }
+gleam-core = { package = "geam-gleam-core", version = "=1.18.1-geam.1" }
 half = { version = "2.7.1", default-features = false }
 hex = "0.4"
 im = "15"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -181,3 +181,7 @@ coverage commands, and validation expectations.
 
 See [docs/review-policy.md](docs/review-policy.md) for planner boundary, error,
 helper, and coverage review rules.
+
+## License
+
+Geam is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,9 +6,10 @@ milestones.
 For guidance on constructing owner tests, promoting diagnostic probes, and
 closing coverage gaps, see [test-development.md](test-development.md).
 
-The current compiler-boundary and runtime milestones depend on `gleam-core`
-pinned to the upstream baseline recorded in the README. `cargo test` compiles
-that Git dependency as part of the normal suite.
+The current compiler-boundary and runtime milestones depend on the exact
+`geam-gleam-core` package recorded in the upstream guide. `cargo test` resolves
+that published package and its compiler components from the locked crates.io
+dependency graph as part of the normal suite.
 
 Source-level execution tests live under categorized
 `tests/fixtures/execution/**/*.gleam` paths. Each fixture must end with an

--- a/docs/upstream-gleam.md
+++ b/docs/upstream-gleam.md
@@ -14,10 +14,15 @@ Repository: https://github.com/gleam-lang/gleam
 Release:    v1.18.1
 Commit:     4a83802ca33a8a96227a1b332768725f232f9779
 Published:  2026-08-01
+Cargo:      geam-gleam-core 1.18.1-geam.1
 ```
 
 The baseline is release-based rather than `main`-based so typed AST and
 compiler-boundary behavior are compared against a published Gleam toolchain.
+The `geam-gleam-core` package and its compiler-component dependencies are
+published from the release-tracking `panarch/gleam` mirror. Geam pins that
+package exactly so the crates.io dependency graph and this recorded upstream
+source identity advance together.
 
 The official standard library has an independent baseline:
 
@@ -74,8 +79,9 @@ the caller supplies both stdlib run state and the wall-clock source.
 
 ## Used Gleam Areas
 
-The first compiler-boundary milestone depends on `gleam-core` pinned to the
-baseline commit. The primary compiler areas used by Geam are:
+The first compiler-boundary milestone imports the `gleam_core` Rust library
+from the exact `geam-gleam-core` package recorded above. The primary compiler
+areas used by Geam are:
 
 ```text
 compiler-core/src/parse.rs
@@ -425,6 +431,7 @@ When updating Geam to a newer Gleam baseline, record:
 
 - Old and new Gleam release tags.
 - Old and new commit hashes.
+- Old and new `geam-gleam-core` package versions and mirror releases.
 - Old and new `gleam_stdlib` integration releases when that baseline changes.
 - Old and new `gleam_http` integration releases when that baseline changes.
 - Old and new `gleam_json` integration releases when that baseline changes.
@@ -434,6 +441,6 @@ When updating Geam to a newer Gleam baseline, record:
 - Profile/lowering fixture changes.
 - License or provenance changes, if any.
 
-The README keeps the current upstream release and commit hash visible. This
-document explains the practical differences between Geam and the referenced
-Gleam version.
+The README keeps the current upstream release visible. This document records
+the exact upstream commit and packaged compiler version, and explains the
+practical differences between Geam and the referenced Gleam version.

--- a/tests/fixtures/provider_sdk/Cargo.lock
+++ b/tests/fixtures/provider_sdk/Cargo.lock
@@ -768,28 +768,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erlang-generation"
-version = "1.0.0"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "ecow",
- "erlang-term-format",
- "itertools",
- "num-bigint",
- "num-traits",
- "regex",
-]
-
-[[package]]
-name = "erlang-term-format"
-version = "1.0.0"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,7 +991,7 @@ dependencies = [
  "bitvec",
  "camino",
  "ecow",
- "gleam-core",
+ "geam-gleam-core",
  "half",
  "hex",
  "im",
@@ -1028,6 +1006,125 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "unicode-segmentation",
  "vec1",
+]
+
+[[package]]
+name = "geam-gleam-core"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd35326343c72724b8070f856a09ee1ea28ac781df6e9499dd6585e1749f5162"
+dependencies = [
+ "age",
+ "askama",
+ "async-trait",
+ "base16",
+ "bimap",
+ "bincode",
+ "bitvec",
+ "camino",
+ "clap",
+ "codespan-reporting",
+ "debug-ignore",
+ "dirs-next",
+ "ecow",
+ "flate2",
+ "futures",
+ "geam-gleam-erlang-generation",
+ "geam-gleam-hexpm",
+ "geam-gleam-pretty-arena",
+ "gen-lsp-types",
+ "globset",
+ "http",
+ "id-arena",
+ "im",
+ "indexmap",
+ "itertools",
+ "lsp-server",
+ "num-bigint",
+ "num-traits",
+ "pathdiff",
+ "petgraph",
+ "pubgrub",
+ "pulldown-cmark",
+ "radix_trie",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sourcemap",
+ "spdx",
+ "stacker",
+ "strum",
+ "tar",
+ "termcolor",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "unicode-segmentation",
+ "vec1",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "geam-gleam-erlang-generation"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7666b902941502bb11a47097b193746d2059f68b2f021fd299baf122bfa2171b"
+dependencies = [
+ "ecow",
+ "geam-gleam-erlang-term-format",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "regex",
+]
+
+[[package]]
+name = "geam-gleam-erlang-term-format"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c3f64360516f3bf999ac12631c345d7779f45984b334917d34625c8675881b"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "geam-gleam-hexpm"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34c3fdb1c94e1226671c20c64723a363db5b69d54a8881a43f67ebb70c34c72"
+dependencies = [
+ "base16",
+ "bytes",
+ "clap",
+ "ecow",
+ "flate2",
+ "http",
+ "http-auth-basic",
+ "prost 0.13.5",
+ "prost-build",
+ "pubgrub",
+ "regex",
+ "ring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+ "x509-parser",
+]
+
+[[package]]
+name = "geam-gleam-pretty-arena"
+version = "1.18.1-geam.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b97f422f4e6812310550a53063f741cf8f480d9ff9d626b871521ed0cf61cb8"
+dependencies = [
+ "ecow",
+ "im",
+ "num-bigint",
+ "typed-arena",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1087,62 +1184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gleam-core"
-version = "1.18.1"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "age",
- "askama",
- "async-trait",
- "base16",
- "bimap",
- "bincode",
- "bitvec",
- "camino",
- "clap",
- "codespan-reporting",
- "debug-ignore",
- "dirs-next",
- "ecow",
- "erlang-generation",
- "flate2",
- "futures",
- "gen-lsp-types",
- "globset",
- "hexpm",
- "http",
- "id-arena",
- "im",
- "indexmap",
- "itertools",
- "lsp-server",
- "num-bigint",
- "num-traits",
- "pathdiff",
- "petgraph",
- "pretty-arena",
- "pubgrub",
- "pulldown-cmark",
- "radix_trie",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "sourcemap",
- "spdx",
- "stacker",
- "strum",
- "tar",
- "termcolor",
- "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
- "tracing",
- "unicode-segmentation",
- "vec1",
- "xxhash-rust",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,30 +1240,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hexpm"
-version = "1.18.1"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "base16",
- "bytes",
- "clap",
- "ecow",
- "flate2",
- "http",
- "http-auth-basic",
- "prost 0.13.5",
- "prost-build",
- "pubgrub",
- "regex",
- "ring",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "url",
- "x509-parser",
-]
 
 [[package]]
 name = "hkdf"
@@ -1965,18 +1982,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "pretty-arena"
-version = "1.0.0"
-source = "git+https://github.com/gleam-lang/gleam?rev=4a83802ca33a8a96227a1b332768725f232f9779#4a83802ca33a8a96227a1b332768725f232f9779"
-dependencies = [
- "ecow",
- "im",
- "num-bigint",
- "typed-arena",
- "unicode-segmentation",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- replace the upstream Git compiler dependency with the exact published `geam-gleam-core` package set
- add Apache-2.0 licensing and complete crates.io package metadata
- constrain the release archive to public source, documentation, README, license, and mascot assets
- update root and provider SDK lockfiles plus compiler-boundary documentation

## Release boundary

The crate remains at `0.1.0` and publication is restricted to crates.io. The actual upload remains a separate manual action after this PR is merged.

The locally built package and `cargo publish --dry-run` archives are byte-identical at 998,048 bytes with SHA-256 `bf3a43b46b6ed3b5d1c5d81d7f8ca12bb840e2a44f9e3d8b16620b79f06b6f3d`.
