### PR TITLE
Prepare Geam 0.1.1 publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: "Geam: Publish crate"
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Authenticate and verify without publishing
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: geam-crates-io-publish
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  publish:
+    name: crate to crates.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Require the main branch
+        env:
+          SELECTED_REF: ${{ github.ref }}
+        run: test "$SELECTED_REF" = refs/heads/main
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: "1.96"
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: geam-publish
+
+      - name: Package and verify
+        run: cargo publish --dry-run --locked
+
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish to crates.io
+        if: ${{ inputs.dry_run == false }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-core"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd35326343c72724b8070f856a09ee1ea28ac781df6e9499dd6585e1749f5162"
+checksum = "cd5b88b6c9781859113bda2bbfe191c8fd2159affb21efdc7b5f074368dc9a0c"
 dependencies = [
  "age",
  "askama",
@@ -1068,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-erlang-generation"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7666b902941502bb11a47097b193746d2059f68b2f021fd299baf122bfa2171b"
+checksum = "01a90ab8770e7a08091f45ed1876ebcbb166ffde47b5e58349e2afb5d4deb056"
 dependencies = [
  "ecow",
  "geam-gleam-erlang-term-format",
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-erlang-term-format"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c3f64360516f3bf999ac12631c345d7779f45984b334917d34625c8675881b"
+checksum = "3d92b21dc62910f10d818b611e6d9832034ace2b2f133ac494ee37b29334df9c"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-hexpm"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34c3fdb1c94e1226671c20c64723a363db5b69d54a8881a43f67ebb70c34c72"
+checksum = "37cfd616f9fcf56d9f8f79688df79108af1da14d243c7258a3d6ab9429ef7cc4"
 dependencies = [
  "base16",
  "bytes",
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-pretty-arena"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b97f422f4e6812310550a53063f741cf8f480d9ff9d626b871521ed0cf61cb8"
+checksum = "b704b2930fd62e13e41294862decd0c177c435369920c215db15d8fa7540e3ab"
 dependencies = [
  "ecow",
  "im",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geam"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.96"
 description = "Experimental Rust-embedded execution runtime for typed Gleam programs"
@@ -25,7 +25,7 @@ camino = "1"
 # Keep this aligned with the Gleam v1.18.1 dependency graph. geam-gleam-core
 # does not compile against ecow 0.3.0.
 ecow = "=0.2.6"
-gleam-core = { package = "geam-gleam-core", version = "=1.18.1-geam.1" }
+gleam-core = { package = "geam-gleam-core", version = "=1.18.1-geam.2" }
 half = { version = "2.7.1", default-features = false }
 hex = "0.4"
 im = "15"

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,31 @@
+# Publishing
+
+Geam is published as one crate. The manual `Geam: Publish crate` workflow uses
+the same `cargo publish --locked` path for every release; it does not create a
+Git tag or GitHub release.
+
+## Authentication
+
+The workflow runs in the repository's `crates-io` environment and uses this
+crates.io Trusted Publisher identity:
+
+- repository owner: `panarch`
+- repository: `geam`
+- workflow: `publish.yml`
+- environment: `crates-io`
+
+The environment restricts deployment branches to `main`. The workflow requests
+a short-lived crates.io token through OIDC, so no long-lived registry token is
+stored in GitHub.
+
+## Release
+
+1. Merge the version and dependency update into `main` and wait for Checks.
+2. Run `Geam: Publish crate` from `main` and leave `dry_run` enabled. This
+   verifies the package and Trusted Publisher authentication without uploading
+   it.
+3. Run the workflow again with `dry_run` disabled. It repeats the package
+   verification and then runs `cargo publish --locked`.
+
+The published version comes directly from the `geam` package in `Cargo.toml`.
+Concurrent publish runs are serialized, and only `main` can publish.

--- a/tests/fixtures/provider_sdk/Cargo.lock
+++ b/tests/fixtures/provider_sdk/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1010,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-core"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd35326343c72724b8070f856a09ee1ea28ac781df6e9499dd6585e1749f5162"
+checksum = "cd5b88b6c9781859113bda2bbfe191c8fd2159affb21efdc7b5f074368dc9a0c"
 dependencies = [
  "age",
  "askama",
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-erlang-generation"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7666b902941502bb11a47097b193746d2059f68b2f021fd299baf122bfa2171b"
+checksum = "01a90ab8770e7a08091f45ed1876ebcbb166ffde47b5e58349e2afb5d4deb056"
 dependencies = [
  "ecow",
  "geam-gleam-erlang-term-format",
@@ -1081,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-erlang-term-format"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c3f64360516f3bf999ac12631c345d7779f45984b334917d34625c8675881b"
+checksum = "3d92b21dc62910f10d818b611e6d9832034ace2b2f133ac494ee37b29334df9c"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-hexpm"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34c3fdb1c94e1226671c20c64723a363db5b69d54a8881a43f67ebb70c34c72"
+checksum = "37cfd616f9fcf56d9f8f79688df79108af1da14d243c7258a3d6ab9429ef7cc4"
 dependencies = [
  "base16",
  "bytes",
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "geam-gleam-pretty-arena"
-version = "1.18.1-geam.1"
+version = "1.18.1-geam.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b97f422f4e6812310550a53063f741cf8f480d9ff9d626b871521ed0cf61cb8"
+checksum = "b704b2930fd62e13e41294862decd0c177c435369920c215db15d8fa7540e3ab"
 dependencies = [
  "ecow",
  "im",


### PR DESCRIPTION
## Summary

- bump Geam to `0.1.1` and use all five `1.18.1-geam.2` compiler mirror crates
- add one manual, single-crate crates.io publishing workflow
- document the stable Trusted Publishing and release boundary

## Release flow

The workflow runs only from `main` in the branch-restricted `crates-io`
environment. It defaults to a dry run that packages the crate and validates
Trusted Publisher authentication. Disabling `dry_run` repeats the verification
and runs `cargo publish --locked`.

This intentionally does not reproduce the compiler mirror's multi-crate
archive reconciliation, polling, Git tag, or GitHub Release machinery.

## Verification

- `cargo fmt --check`
- `cargo test --locked --quiet` (2,545 passed)
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo llvm-cov --summary-only --fail-under-lines 100 --fail-under-regions 100 --quiet`
- `cargo test --manifest-path tests/fixtures/provider_sdk/Cargo.toml --workspace --locked --quiet`
- `cargo clippy --manifest-path tests/fixtures/provider_sdk/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo llvm-cov --manifest-path tests/fixtures/provider_sdk/Cargo.toml --workspace --summary-only --fail-under-lines 100 --fail-under-regions 100 --quiet`
- `cargo publish --dry-run --locked --allow-dirty`
- workflow YAML parse and `git diff --check`
