### PR TITLE
Bump Geam to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geam"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.96"
 description = "Experimental Rust-embedded execution runtime for typed Gleam programs"

--- a/tests/fixtures/provider_sdk/Cargo.lock
+++ b/tests/fixtures/provider_sdk/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "bitvec",

--- a/tests/fixtures/standalone_cli/providers/Cargo.lock
+++ b/tests/fixtures/standalone_cli/providers/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "bitvec",

--- a/tests/fixtures/standalone_cli/providers/geam-catalog/Cargo.toml
+++ b/tests/fixtures/standalone_cli/providers/geam-catalog/Cargo.toml
@@ -13,6 +13,6 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.1"
+geam = "=0.1.2"
 num-bigint = "0.4"
 standalone-catalog-domain = { path = "../catalog-domain", version = "0.1.0" }

--- a/tests/fixtures/standalone_cli/providers/geam-counter/Cargo.toml
+++ b/tests/fixtures/standalone_cli/providers/geam-counter/Cargo.toml
@@ -13,4 +13,4 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.1"
+geam = "=0.1.2"


### PR DESCRIPTION
## Summary

- Bump the Geam package and locked workspace version to `0.1.2`.
- Align standalone provider fixture constraints and locks with the release version.

## Release

After merge and green Checks, run `Geam: Publish crate` from `main` first with `dry_run` enabled and then with it disabled.