### PR TITLE
Bump Geam to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "ecow",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "ecow",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"
@@ -56,12 +56,12 @@ clap = { version = "4", features = ["derive"] }
 # does not compile against ecow 0.3.0.
 ecow = "=0.2.6"
 flate2 = "1"
-geam-core = { path = "core", version = "=0.1.2" }
-geam-cli = { path = "cli", version = "=0.1.2" }
-geam-json = { path = "builtins/json", version = "=0.1.2" }
-geam-macros = { path = "macros", version = "=0.1.2" }
-geam-stdlib = { path = "builtins/stdlib", version = "=0.1.2" }
-geam-time = { path = "builtins/time", version = "=0.1.2" }
+geam-core = { path = "core", version = "=0.2.0" }
+geam-cli = { path = "cli", version = "=0.2.0" }
+geam-json = { path = "builtins/json", version = "=0.2.0" }
+geam-macros = { path = "macros", version = "=0.2.0" }
+geam-stdlib = { path = "builtins/stdlib", version = "=0.2.0" }
+geam-time = { path = "builtins/time", version = "=0.2.0" }
 gleam-core = { package = "geam-gleam-core", version = "=1.18.1-geam.2" }
 gleam-compiler-core = { package = "geam-gleam-core", version = "=1.18.1-geam.2" }
 half = { version = "2.7.1", default-features = false }

--- a/cli/tests/fixtures/standalone_cli/providers/Cargo.lock
+++ b/cli/tests/fixtures/standalone_cli/providers/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/cli/tests/fixtures/standalone_cli/providers/geam-catalog/Cargo.toml
+++ b/cli/tests/fixtures/standalone_cli/providers/geam-catalog/Cargo.toml
@@ -13,6 +13,6 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"
 num-bigint = "0.4"
 standalone-catalog-domain = { path = "../catalog-domain", version = "0.1.0" }

--- a/cli/tests/fixtures/standalone_cli/providers/geam-counter/Cargo.toml
+++ b/cli/tests/fixtures/standalone_cli/providers/geam-counter/Cargo.toml
@@ -13,4 +13,4 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -48,6 +48,10 @@ checks the workspace and assembles package archives.
 
 1. Create a release branch and update `[workspace.package].version` plus every
    exact internal requirement in `[workspace.dependencies]` to the same version.
+   Update the exact `geam` requirements in the standalone fixture providers and
+   example providers, then reconcile the root and independently locked fixture
+   and example `Cargo.lock` files without upgrading unrelated dependencies.
+   Provider package versions and Gleam package versions remain independent.
 2. Run the full workspace checks and
    `cargo package --workspace --locked --no-verify` locally.
 3. Merge the release branch into `main` and wait for Checks.
@@ -71,9 +75,9 @@ Concurrent publish runs are serialized, and only `main` can publish.
 
 ## First Workspace Release
 
-The current workspace conversion keeps version `0.1.2` and does not publish
-these new package boundaries. The next release branch performs the first
-lockstep version update.
+The next workspace release is prepared at version `0.2.0`, including the
+provider authoring API. All seven packages and their exact internal
+requirements move together.
 
 The six newly named internal crates (`geam-core`, `geam-stdlib`, `geam-json`,
 `geam-time`, `geam-cli`, and `geam-macros`) do not yet exist on crates.io, so

--- a/examples/call_tracing/provider/Cargo.lock
+++ b/examples/call_tracing/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/call_tracing/provider/Cargo.toml
+++ b/examples/call_tracing/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"
 
 [workspace]
 resolver = "3"

--- a/examples/feature_flags/provider/Cargo.lock
+++ b/examples/feature_flags/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/feature_flags/provider/Cargo.toml
+++ b/examples/feature_flags/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"
 
 [workspace]
 resolver = "3"

--- a/examples/generic_box/provider/Cargo.lock
+++ b/examples/generic_box/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/generic_box/provider/Cargo.toml
+++ b/examples/generic_box/provider/Cargo.toml
@@ -17,7 +17,7 @@ gleam-package = "example_generic_box"
 gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
-geam = "=0.1.2"
+geam = "=0.2.0"
 
 [workspace]
 resolver = "3"

--- a/examples/request_ids/provider/Cargo.lock
+++ b/examples/request_ids/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/request_ids/provider/Cargo.toml
+++ b/examples/request_ids/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"
 num-bigint = "0.4.6"
 
 [workspace]

--- a/examples/run_metrics/provider/Cargo.lock
+++ b/examples/run_metrics/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/run_metrics/provider/Cargo.toml
+++ b/examples/run_metrics/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"
 num-bigint = "0.4.6"
 
 [workspace]

--- a/examples/tag_set/provider/Cargo.lock
+++ b/examples/tag_set/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/tag_set/provider/Cargo.toml
+++ b/examples/tag_set/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"
 num-bigint = "0.4.6"
 
 [workspace]

--- a/examples/text_pattern/provider/Cargo.lock
+++ b/examples/text_pattern/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/text_pattern/provider/Cargo.toml
+++ b/examples/text_pattern/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"
 regex = "1.12"
 
 [workspace]

--- a/examples/text_tools/provider/Cargo.lock
+++ b/examples/text_tools/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/text_tools/provider/Cargo.toml
+++ b/examples/text_tools/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"
 
 [workspace]
 resolver = "3"

--- a/examples/value_types/provider/Cargo.lock
+++ b/examples/value_types/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/value_types/provider/Cargo.toml
+++ b/examples/value_types/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.1.2"
+geam = "=0.2.0"
 num-bigint = "=0.4.6"
 
 [workspace]

--- a/macros/tests/fixtures/cross_crate/Cargo.lock
+++ b/macros/tests/fixtures/cross_crate/Cargo.lock
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/tests/fixtures/provider_sdk/Cargo.lock
+++ b/tests/fixtures/provider_sdk/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitvec",
  "camino",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "geam-core",
  "geam-macros",


### PR DESCRIPTION
## Summary

- Bump all seven workspace packages and their exact internal requirements from `0.1.2` to `0.2.0`.
- Update Geam dependencies in standalone fixtures and all nine provider examples, and reconcile all 13 tracked Cargo lockfiles without unrelated dependency upgrades.
- Document the complete version-bump scope while keeping provider package versions and Gleam package versions independent.

## Release Boundary

This change only updates version metadata, lockfiles, and publishing documentation. Runtime behavior, public APIs, CLI grammar, toolchain versions, and external dependency versions are unchanged by this PR.

The local workspace publish dry run verified all seven packages without uploading them. Actual publication remains a separate step after merge and successful CI.

Version-bump automation will be handled in a follow-up rather than included in this release preparation.
