### PR TITLE
Automate Geam release preparation and publishing

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,118 @@
+name: "Geam: Prepare release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: read
+
+concurrency:
+  group: geam-prepare-release
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  prepare:
+    name: Release PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      CARGO_NET_OFFLINE: "false"
+    steps:
+      - name: Require the main branch
+        env:
+          SELECTED_REF: ${{ github.ref }}
+        run: test "$SELECTED_REF" = refs/heads/main
+
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.96"
+
+      - name: Install release tools
+        run: |
+          cargo install cargo-release --version 1.1.4 --locked
+          cargo install cargo-edit --version 0.13.13 --locked --no-default-features --features upgrade
+
+      - name: Bump workspace versions
+        env:
+          RELEASE_BUMP: ${{ inputs.bump }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+          cargo release version "$RELEASE_BUMP" --workspace --execute --no-confirm
+          version=$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "geam") | .version')
+          echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Check release branch and PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="release/$RELEASE_VERSION"
+          refs=$(git ls-remote origin "refs/heads/$branch" "refs/tags/v$RELEASE_VERSION")
+          test -z "$refs" || { echo "Release branch or tag already exists" >&2; exit 1; }
+          test "$(gh pr list --state all --head "$branch" --json number --jq length)" = 0
+          git switch -c "$branch"
+
+      - name: Update standalone provider requirements
+        working-directory: cli/tests/fixtures/standalone_cli/providers
+        run: cargo upgrade --package "geam@=$RELEASE_VERSION" --pinned --recursive false
+
+      - name: Update example provider requirements
+        run: |
+          for manifest in examples/*/provider/Cargo.toml; do
+            (cd "$(dirname "$manifest")" && cargo upgrade --package "geam@=$RELEASE_VERSION" --pinned --recursive false)
+          done
+
+      - name: Refresh tracked Cargo locks
+        run: |
+          while IFS= read -r lock; do
+            (cd "$(dirname "$lock")" && cargo update --workspace)
+          done < <(git ls-files '*Cargo.lock')
+          git diff --check
+          git diff --stat
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add --update -- '*Cargo.toml' '*Cargo.lock'
+          git commit -F - <<EOF
+          Prepare Geam $RELEASE_VERSION
+
+          - Bump workspace versions and provider requirements together.
+          - Refresh independently owned Cargo locks.
+          EOF
+          git push --set-upstream origin "release/$RELEASE_VERSION"
+          gh pr create --draft --base main --head "release/$RELEASE_VERSION" \
+            --title "Release Geam $RELEASE_VERSION" --body-file - <<EOF
+          ## Release checklist
+
+          - [ ] Add and review \`docs/releases/$RELEASE_VERSION.md\`.
+          - [ ] Review the version and lockfile diff.
+          - [ ] Approve the PR workflow runs and wait for all checks.
+          - [ ] Mark ready and squash-merge; wait for main's checks at the merge SHA.
+
+          Publish separately using the [publishing guide](https://github.com/$GITHUB_REPOSITORY/blob/main/docs/publishing.md).
+          EOF

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,25 @@ name: "Geam: Publish crates"
 on:
   workflow_dispatch:
     inputs:
+      operation:
+        description: Operation
+        required: true
+        default: Publish workspace
+        type: choice
+        options:
+          - Publish workspace
+          - Retry packages
+          - Create GitHub Release
+      commit:
+        description: Full release commit SHA
+        required: true
+        type: string
+      packages:
+        description: For Retry packages only, space-separated
+        required: false
+        type: string
       dry_run:
-        description: Check and package the workspace without publishing
+        description: dry-run
         required: true
         default: true
         type: boolean
@@ -22,46 +39,137 @@ env:
 
 jobs:
   publish:
-    name: workspace crates to crates.io
+    name: ${{ inputs.operation }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: crates-io
     permissions:
-      contents: read
+      actions: read
+      contents: write
       id-token: write
+    env:
+      RELEASE_OPERATION: ${{ inputs.operation }}
+      RELEASE_COMMIT: ${{ inputs.commit }}
+      RELEASE_PACKAGES: ${{ inputs.packages }}
 
     steps:
-      - name: Require the main branch
+      - name: Validate inputs
         env:
           SELECTED_REF: ${{ github.ref }}
-        run: test "$SELECTED_REF" = refs/heads/main
+        run: |
+          if [[ "$SELECTED_REF" != refs/heads/main ]]; then
+            echo "::error::Run this workflow from main."
+            exit 1
+          fi
+          if [[ ! "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::commit must be a full 40-character lowercase hexadecimal SHA."
+            exit 1
+          fi
+          case "$RELEASE_OPERATION" in
+            "Retry packages")
+              if [[ ! "$RELEASE_PACKAGES" =~ [^[:space:]] ]]; then
+                echo "::error::Retry packages requires at least one crate in packages."
+                exit 1
+              fi
+              ;;
+            "Publish workspace"|"Create GitHub Release")
+              if [[ -n "$RELEASE_PACKAGES" ]]; then
+                echo "::error::packages must be empty for $RELEASE_OPERATION."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Select Publish workspace, Retry packages, or Create GitHub Release."
+              exit 1
+              ;;
+          esac
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ inputs.commit }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.96"
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@v2
         with:
           shared-key: geam-publish
 
-      - name: Verify workspace packages
-        if: ${{ inputs.dry_run == true }}
-        run: cargo publish --workspace --locked --dry-run
+      - name: Validate release commit and notes
+        id: release
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main
+          metadata=$(cargo metadata --locked --no-deps --format-version 1)
+          version=$(jq -r '.packages[] | select(.name == "geam") | .version' <<< "$metadata")
+          jq -e --arg version "$version" 'all(.packages[]; .version == $version)' <<< "$metadata" > /dev/null
+          notes="docs/releases/$version.md"
+          test -s "$notes" || { echo "Missing release notes: $notes" >&2; exit 1; }
+          test "$(head -n 1 "$notes")" = "# Geam $version"
+          tail -n +2 "$notes" | grep '[^[:space:]]' > /dev/null
+          if grep -nE 'TODO|TBD|FIXME|<!--' "$notes"; then
+            echo "Replace release note placeholders before publishing" >&2
+            exit 1
+          fi
+          if git show-ref --verify --quiet "refs/tags/v$version"; then
+            test "$(git rev-parse "v$version^{commit}")" = "$RELEASE_COMMIT"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Require successful main checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for workflow in workspace.yml coverage.yml acceptance.yml; do
+            runs=$(gh run list --workflow "$workflow" --branch main --event push --commit "$RELEASE_COMMIT" --limit 1 --json status,conclusion)
+            jq -e 'length == 1 and .[0].status == "completed" and .[0].conclusion == "success"' <<< "$runs" > /dev/null || {
+              echo "$workflow must succeed at $RELEASE_COMMIT before publication" >&2
+              exit 1
+            }
+          done
 
       - name: Authenticate to crates.io
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry_run == false && inputs.operation != 'Create GitHub Release' }}
         id: auth
-        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        uses: rust-lang/crates-io-auth-action@v1
 
-      - name: Publish workspace packages
-        if: ${{ inputs.dry_run == false }}
+      - name: Publish or dry-run selected crates
+        if: ${{ inputs.operation != 'Create GitHub Release' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish --workspace --locked
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          args=(--locked)
+          if [[ "$RELEASE_OPERATION" == "Retry packages" ]]; then
+            read -r -a packages <<< "${RELEASE_PACKAGES//$'\n'/ }"
+            for package in "${packages[@]}"; do args+=(--package "$package"); done
+          else
+            args+=(--workspace)
+          fi
+          if [[ "$DRY_RUN" == true ]]; then args+=(--dry-run); fi
+          cargo publish "${args[@]}"
+
+      - name: Verify every workspace crate is published
+        if: ${{ inputs.dry_run == false || inputs.operation == 'Create GitHub Release' }}
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          packages=$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[].name')
+          while IFS= read -r package; do
+            (cd "$RUNNER_TEMP" && cargo info "$package@$RELEASE_VERSION" --registry crates-io > /dev/null)
+          done <<< "$packages"
+
+      - name: Create GitHub Release
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          gh release create "v$RELEASE_VERSION" --target "$RELEASE_COMMIT" \
+            --title "Geam $RELEASE_VERSION" --notes-file "docs/releases/$RELEASE_VERSION.md"

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,95 +1,131 @@
 # Publishing
 
-Geam publishes seven lockstep crates from one workspace:
+Geam publishes seven lockstep crates: `geam-core`, `geam-macros`,
+`geam-stdlib`, `geam-json`, `geam-time`, `geam-cli`, and the root `geam` facade.
+The root owns the installable `geam` binary. Cargo derives dependency order
+from the workspace graph and polls the registry after uploads.
 
-```text
-geam-core + geam-macros
-  -> geam-stdlib
+`Cargo.toml` owns the release version; this guide does not repeat the current
+version. Provider package versions, Gleam versions, compiler dependencies, and
+the Rust toolchain are independent of a Geam version bump.
 
-geam-core + geam-macros + geam-stdlib
-  -> geam-json
-  -> geam-time
+## Prepare And Review
 
-geam-core + geam-stdlib + geam-json + geam-time
-  -> geam-cli
+1. Run **Geam: Prepare release** from `main` and choose `patch`, `minor`, or
+   `major`. The default is `patch`; cargo-release computes the next version.
+2. The workflow updates workspace and provider requirements, reconciles tracked
+   Cargo locks, and opens a draft PR on `release/<version>`. It refuses an
+   existing release branch, PR, or tag and never force-pushes.
+3. Add `docs/releases/<version>.md` to the PR following the
+   [release note guide](releases/README.md). Write and review user-facing changes
+   manually. Preparation does not invent release notes.
+4. Approve workflow runs requested for the generated PR and wait for all checks.
+   The workflow uses `GITHUB_TOKEN`, not an App or personal token. The repository
+   must allow Actions to create PRs. If PR creation fails after pushing, open the
+   PR from the retained branch instead of overwriting it with another prepare.
+5. Review the manifest/lock changes and notes, mark the PR ready, squash-merge,
+   then wait for the `Workspace`, `Coverage`, and `Acceptance` push runs at the
+   merged commit.
 
-geam-core + geam-macros + built-ins + geam-cli
-  -> geam
-```
+Preparation delegates workspace versions and exact internal requirements to
+[cargo-release](https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md).
+[cargo-edit](https://github.com/killercup/cargo-edit) updates only the independent
+providers' exact `geam` requirements, with recursive dependency upgrades disabled.
+Each tracked lock is reconciled by `cargo update --workspace` from its own
+directory, preserving its local Cargo configuration. Provider package versions
+and unrelated dependencies must remain unchanged in the reviewed PR.
 
-The root `geam` crate remains the public facade and owns the installable
-`geam` binary. The other crates are internal ownership boundaries rather than
-separately versioned products. Every release updates all seven package versions
-and their exact internal dependency requirements together.
+The [prepare workflow](../.github/workflows/prepare-release.yml) pins the release
+tool versions and owns this sequence; there is no separate release script.
+To preview only the workspace version change, run
+`cargo release version patch --workspace` without `--execute`.
+To inspect the complete preparation locally,
+run the workflow's bump, requirement-update, and lock-refresh steps in a
+disposable checkout, stopping before its commit/push/PR step.
 
-The manual `Geam: Publish crates` workflow uses one
-`cargo publish --workspace --locked` command. Cargo derives dependency order
-from the workspace graph, verifies each package against the packages assembled
-before it, and polls the registry index after each upload. The workflow does not
-create a Git tag or GitHub release, and it does not duplicate Cargo's ordering
-or polling with a release script.
+## Publish
+
+Run **Geam: Publish crates** from `main` and select an `operation`:
+
+| Operation | `packages` | Work performed |
+| --- | --- | --- |
+| `Publish workspace` | Empty | Publish all workspace crates, then create the GitHub Release. |
+| `Retry packages` | Remaining crate names, space-separated | Publish those crates, then create the GitHub Release. |
+| `Create GitHub Release` | Empty | Verify all crates are published, then create only the GitHub Release. |
+
+Every operation requires the full release `commit` SHA. There is no fallback to
+the latest main commit. For a new release, select `Publish workspace`, enter the
+reviewed merge SHA, leave `packages` empty, and enable **dry-run** first.
+
+The first `Validate inputs` step rejects a non-main workflow ref, a malformed
+SHA, an unknown operation, or an invalid operation/package combination before
+checkout. It reports the reason without authentication, uploads, or Release
+creation; correct the inputs and dispatch again.
+
+Before authentication or uploads, the workflow checks:
+
+- checkout at the exact release SHA, on main's history;
+- matching workspace versions;
+- a matching, nonempty release note file without placeholder markers;
+- successful push runs of all three verification workflows at that SHA;
+- an existing release tag, if any, pointing to that same SHA.
+
+Dry-run runs the same validation for every operation. Publishing operations
+invoke native `cargo publish --locked ... --dry-run`; `Create GitHub Release`
+only checks the exact registry versions. Neither creates tags, uploads, or
+GitHub Releases. A successful dry-run does not prove actual OIDC permissions or
+upload availability.
+
+For a new release, run `Publish workspace` again with **dry-run** disabled and
+the **same full commit SHA**. It authenticates through Trusted Publishing and
+runs native `cargo publish --workspace --locked`. Cargo owns dependency
+ordering, package verification, and index polling.
+
+After uploading, `cargo info <crate>@<version> --registry crates-io` checks every
+workspace package from outside the checkout, so local packages and patches
+cannot satisfy the check. Only then does `gh release create` publish the reviewed
+note file verbatim, creating `v<version>` at the selected SHA. It does not move
+existing tags or overwrite existing releases.
+
+## Retry
+
+Dispatch Publish from main with `commit` set to the original full SHA, as for
+the first attempt. Do not select a newer main commit for the same version.
+
+- If some uploads failed, select `Retry packages` and enter only the remaining
+  names in `packages`, separated by spaces, for example `geam-cli geam`.
+  Cargo receives one `--package` per name.
+  It does not automatically skip published versions. If other packages are still
+  missing, the final registry check fails without creating a GitHub Release.
+- An upload error can occur after crates.io received the package. Check the
+  upload log and exact published versions before choosing the retry packages.
+- If all crates were uploaded, select `Create GitHub Release` and leave
+  `packages` empty. This skips authentication and Cargo publish, checks all
+  exact registry versions, then creates the GitHub Release. Its dry-run performs
+  the checks without creating a tag or release.
+- If GitHub already created the release before reporting a failure, inspect the
+  existing release; this workflow does not overwrite it.
+- A failure before any upload can use **Re-run failed jobs**, retaining the
+  original SHA and inputs. A partial upload needs a new dispatch with the retry
+  selection above.
+
+Registry and GitHub network or permission failures stop the run. There is no
+custom registry client, missing-package inference, or automatic recovery loop.
+
+Publication attempts are serialized. There is no upload retry loop, personal
+token fallback, or publication from a non-main workflow ref.
 
 ## Authentication
 
-The workflow runs in the repository's `crates-io` environment. Each of the seven
-crates uses this crates.io Trusted Publisher identity:
+All seven crates have been bootstrapped and configured for Trusted Publishing:
 
 - repository owner: `panarch`
 - repository: `geam`
 - workflow: `publish.yml`
 - environment: `crates-io`
 
-The environment restricts deployment branches to `main`. An actual publish run
-requests a short-lived crates.io token through OIDC, so no long-lived registry
-token is stored in GitHub. A dry run does not authenticate because it only
-checks the workspace and assembles package archives.
-
-## Regular Release
-
-1. Create a release branch and update `[workspace.package].version` plus every
-   exact internal requirement in `[workspace.dependencies]` to the same version.
-   Update the exact `geam` requirements in the standalone fixture providers and
-   example providers, then reconcile the root and independently locked fixture
-   and example `Cargo.lock` files without upgrading unrelated dependencies.
-   Provider package versions and Gleam package versions remain independent.
-2. Run the full workspace checks and
-   `cargo package --workspace --locked --no-verify` locally.
-3. Merge the release branch into `main` and wait for Checks.
-4. Run `Geam: Publish crates` from `main` with `dry_run` enabled. This runs
-   `cargo publish --workspace --locked --dry-run`, which assembles and verifies
-   all seven packages without authentication or upload.
-5. Run the workflow again with `dry_run` disabled. It authenticates once and
-   Cargo publishes in dependency order:
-
-```text
-geam-core
-geam-macros
-geam-stdlib
-geam-json
-geam-time
-geam-cli
-geam
-```
-
-Concurrent publish runs are serialized, and only `main` can publish.
-
-## First Workspace Release
-
-The next workspace release is prepared at version `0.2.0`, including the
-provider authoring API. All seven packages and their exact internal
-requirements move together.
-
-The six newly named internal crates (`geam-core`, `geam-stdlib`, `geam-json`,
-`geam-time`, `geam-cli`, and `geam-macros`) do not yet exist on crates.io, so
-they cannot have Trusted Publisher records before their first upload. Bootstrap
-the first workspace release once from a locally authenticated checkout with the
-same workspace command:
-
-```sh
-cargo publish --workspace --locked
-```
-
-After all seven crates exist, register `publish.yml` and the `crates-io`
-environment as the Trusted Publisher for each package. Subsequent releases use
-only the regular workflow above. The local credential is a one-time bootstrap
-mechanism, not a second maintained release path.
+Keep the workflow filename and environment stable. The environment allows main
+only; crates.io requires Trusted Publishing for new versions. `id-token: write`
+permits short-lived crates.io authentication, `actions: read` checks CI, and
+`contents: write` permits the tag and GitHub Release. No long-lived registry
+token or local-publish fallback is part of the regular release path.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,25 @@
+# Release Notes
+
+Each release PR supplies one reviewed `docs/releases/<version>.md` file.
+Use the workspace version in both its filename and first heading:
+
+```markdown
+# Geam <version>
+
+## Changes
+
+- Describe the user-visible changes and fixes in this release.
+
+## Compatibility
+
+- Explain any migration steps or changed behavior, when applicable.
+```
+
+Replace the example prose with actual release content; omit sections that do
+not apply. Notes are written and reviewed by people, not generated from commit
+subjects. Distinguish shipped behavior from future work.
+
+Publishing rejects a missing file, mismatched heading, heading-only content,
+or `TODO`, `TBD`, `FIXME`, and HTML comment placeholders. Mechanical checks do
+not replace editorial review. The reviewed file becomes the GitHub Release body
+without a second manual copy or changelog update.


### PR DESCRIPTION
## Summary

- Add a main-only **Prepare release** workflow with `patch`, `minor`, and `major` choices. Delegate version and dependency updates to cargo-release and cargo-edit, refresh independently owned Cargo locks, and open a draft release PR.
- Give **Publish crates** three explicit operations: `Publish workspace`, `Retry packages`, and `Create GitHub Release`. Every operation requires the full release commit SHA; dry-run is enabled by default.
- Reject invalid input combinations before checkout, require reviewed release notes and successful main CI at the selected commit, and create the GitHub Release only after all exact workspace versions are available on crates.io.
- Document the preparation, review, publishing, and manual retry procedure. Keep the existing Trusted Publisher workflow filename and environment, with no separate release scripts or automatic recovery framework.

This PR changes workflows and documentation only. The workspace remains at **0.2.0**; it does not publish a version, create a release tag, or generate release notes. Release notes remain human-authored in `docs/releases/<version>.md`.

## Verify 0.2.1 After Merge

The main-only Actions flow needs the automation to be merged before end-to-end verification. Local checks covered version/lock updates, workspace publish dry-run, input and operation boundaries, and workflow lint; GitHub permissions and actual Trusted Publishing still need the following run.

- [ ] Run **Prepare release** on main with `patch` and confirm the generated 0.2.1 draft PR contains only the intended manifest and lockfile changes.
- [ ] Add and review `docs/releases/0.2.1.md`, approve the PR workflow runs, and wait for CI.
- [ ] Mark the release PR ready, squash-merge it, and wait for all main checks at that merge SHA.
- [ ] Run **Publish crates** with `Publish workspace`, the full merge SHA, and dry-run enabled.
- [ ] Repeat with the same SHA and dry-run disabled; confirm all seven crates and the GitHub Release with the reviewed notes.

If a real attempt fails, use `Retry packages` for the remaining crates or `Create GitHub Release` after all uploads have completed, always with the original release SHA. Recovery does not require a new source commit.
