### PR TITLE
Parallelize provider example checks

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -60,8 +60,32 @@ jobs:
           done
 
   example-providers:
-    name: Provider examples
+    name: Provider examples (${{ matrix.example }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - example: text_tools
+            test: runs_the_documented_text_tools_provider_across_three_modules
+          - example: value_types
+            test: runs_the_documented_value_types_provider_without_configuration
+          - example: tag_set
+            test: runs_the_documented_tag_set_provider_without_configuration
+          - example: request_ids
+            test: runs_the_documented_request_ids_provider_with_fresh_default_state
+          - example: feature_flags
+            test: runs_the_documented_feature_flags_provider_with_explicit_configuration
+          - example: run_metrics
+            test: runs_the_documented_run_metrics_provider_without_configuration
+          - example: call_tracing
+            test: runs_the_documented_call_tracing_provider_with_fresh_callback_state
+          - example: generic_box
+            test: runs_the_documented_generic_box_provider_with_persistent_values
+          - example: text_pattern
+            test: runs_the_documented_text_pattern_provider_from_its_local_path
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
 
     steps:
       - name: Checkout
@@ -83,45 +107,25 @@ jobs:
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
         with:
+          key: ${{ matrix.example }}
           workspaces: |
             . -> target
-            examples/text_tools/provider -> target
-            examples/value_types/provider -> target
-            examples/tag_set/provider -> target
-            examples/request_ids/provider -> target
-            examples/feature_flags/provider -> target
-            examples/run_metrics/provider -> target
-            examples/call_tracing/provider -> target
-            examples/generic_box/provider -> target
-            examples/text_pattern/provider -> target
+            examples/${{ matrix.example }}/provider -> ../../../target
 
-      - name: Run documented provider examples
-        run: cargo test --package geam --test provider_examples --locked
+      - name: Run documented provider example
+        run: cargo test --package geam --test provider_examples --locked -- --exact "${{ matrix.test }}"
 
-      - name: Test and package example providers
-        run: |
-          for example in text_tools value_types tag_set request_ids feature_flags run_metrics call_tracing generic_box text_pattern; do
-            (cd "examples/$example/provider" && cargo test --locked)
-            (cd "examples/$example/provider" && cargo package --locked)
-          done
+      - name: Test example provider
+        working-directory: examples/${{ matrix.example }}/provider
+        run: cargo test --locked
 
-      - name: Verify example Gleam packages
-        run: |
-          for package in \
-            text_tools/example_text_tools \
-            value_types/example_value_types \
-            tag_set/example_tag_set \
-            request_ids/example_request_ids \
-            feature_flags/example_feature_flags \
-            run_metrics/example_run_metrics \
-            call_tracing/example_call_tracing \
-            generic_box/example_generic_box \
-            text_pattern/example_text_pattern
-          do
-            example="${package%%/*}"
-            gleam_package="${package#*/}"
-            (cd "examples/$example/project/packages/$gleam_package" && gleam export hex-tarball)
-          done
+      - name: Verify example provider package
+        working-directory: examples/${{ matrix.example }}/provider
+        run: cargo package --locked
+
+      - name: Verify example Gleam package
+        working-directory: examples/${{ matrix.example }}/project/packages/example_${{ matrix.example }}
+        run: gleam export hex-tarball
 
   external-provider-sdk:
     name: External provider SDK

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -184,6 +184,18 @@ repository-local patches and complete standalone execution. The independent
 Provider SDK fixture remains the canonical low-level typed-host ABI acceptance
 owner.
 
+The [Acceptance workflow](../.github/workflows/acceptance.yml) runs one matrix
+job per documented example. Each job selects its exact `provider_examples`
+test, runs the independent provider's tests, verifies its Cargo package, and
+exports its Gleam package. A failed example does not cancel the other matrix
+jobs. Formatting and Clippy remain in the Workspace workflow.
+
+Each example has a distinct cache key. Within a job, the root test binary and
+independent provider use the checkout's `target/` directory so Cargo can reuse
+matching build artifacts without changing either workspace's lockfile. The
+generated runner still uses its temporary project's `build/geam/target/`;
+those isolated runner artifacts are not shared or cached between jobs.
+
 The normal suite executes the full generated runner with the fixture's locked
 Gleam and Rust dependencies. CI exports the standalone fixture's three local
 Gleam dependencies and all nine example Gleam packages. It also packages the
@@ -239,6 +251,15 @@ cargo test --package geam --test cross_crate_http --locked
 cargo test --package geam --test provider_examples --locked
 cargo test --package geam --test standalone_distribution --locked
 ```
+
+To run one provider example with the same exact selection used by its CI job:
+
+```sh
+cargo test --package geam --test provider_examples --locked -- \
+  --exact runs_the_documented_text_tools_provider_across_three_modules
+```
+
+The unfiltered `provider_examples` command still runs all nine examples locally.
 
 Planner unit tests use the crate-internal `planner::dsl` expected-plan helpers
 instead of snapshots, so supported lowering changes update the expected plan


### PR DESCRIPTION
## Summary

- Split provider-example acceptance into nine independent matrix jobs, one per documented example, with `fail-fast: false`.
- Keep each example's exact binary/generated-runner test, provider tests, Cargo package verification, and Gleam package export.
- Use distinct example cache keys and reuse the checkout target within each job. Generated runners keep their isolated targets; lockfiles and other CI jobs are unchanged.
- Document the matrix boundary and exact local test selection.

All 36 matrix commands passed locally, along with formatting, Actionlint/ShellCheck, and diff checks.

## CI Timing

The previous [provider-example job](https://github.com/panarch/geam/actions/runs/33050829075/job/98445638370) took 29m39s on a cache miss. Actual parallel-run timing and cache behavior remain to be compared in this PR; local timings are not a CI speedup measurement.

Closes #128.
