### PR TITLE
Reconcile the upstream Gleam compiler baseline

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -117,6 +117,19 @@ jobs:
         with:
           workspaces: ". -> target"
 
+      - name: Check documented compiler pin
+        shell: bash
+        run: |
+          version=$(cargo metadata --locked --format-version 1 | jq -er '
+            [.packages[] | select(.name == "geam-gleam-core") | .version] |
+            if length == 1 then .[0]
+            else error("expected exactly one geam-gleam-core package") end
+          ')
+          if ! grep -Fxq "Cargo:      geam-gleam-core $version" docs/upstream-gleam.md; then
+            echo "::error file=docs/upstream-gleam.md::Expected compiler pin geam-gleam-core $version; review the upstream baseline manually."
+            exit 1
+          fi
+
       - name: Test workspace packages
         run: cargo test --workspace --exclude geam --locked
 

--- a/docs/upstream-gleam.md
+++ b/docs/upstream-gleam.md
@@ -14,15 +14,21 @@ Repository: https://github.com/gleam-lang/gleam
 Release:    v1.18.1
 Commit:     4a83802ca33a8a96227a1b332768725f232f9779
 Published:  2026-08-01
-Cargo:      geam-gleam-core 1.18.1-geam.1
+Cargo:      geam-gleam-core 1.18.1-geam.2
 ```
 
 The baseline is release-based rather than `main`-based so typed AST and
 compiler-boundary behavior are compared against a published Gleam toolchain.
+The release, commit, and publication date above refer to the
+[upstream Gleam release](https://github.com/gleam-lang/gleam/releases/tag/v1.18.1)
+(UTC), not the compiler crate's publication date.
+
 The `geam-gleam-core` package and its compiler-component dependencies are
-published from the release-tracking `panarch/gleam` mirror. Geam pins that
-package exactly so the crates.io dependency graph and this recorded upstream
-source identity advance together.
+published from the release-tracking `panarch/gleam` mirror. Its
+[packaging release](https://github.com/panarch/gleam/releases/tag/geam-v1.18.1-geam.2)
+records the same upstream commit. Geam pins that package exactly; the `geam.2`
+suffix is a mirror packaging revision, not a different Gleam release or Geam's
+own lockstep version.
 
 The official standard library has an independent baseline:
 
@@ -426,6 +432,16 @@ smaller execution profile is enforced by typed-AST planning, not by forking
 Gleam's parser or type inferencer.
 
 ## Sync Policy
+
+This document is maintained manually when the upstream baseline or mirror
+packaging revision changes. Geam release-version automation must not update
+compiler or official package baselines.
+
+The [Workspace workflow](../.github/workflows/workspace.yml) checks the `Cargo:`
+line against the compiler version resolved by `cargo metadata --locked`. This
+only detects pin drift: release identity, publication date, and compatibility
+claims still require manual verification against the upstream and mirror
+releases. The check does not infer or rewrite that narrative.
 
 When updating Geam to a newer Gleam baseline, record:
 


### PR DESCRIPTION
## Summary

- Correct `docs/upstream-gleam.md` to record `geam-gleam-core 1.18.1-geam.2`, matching the existing manifest and lock.
- Separate the upstream release/date, mirror packaging revision, and Geam release version. Keep provenance and compatibility descriptions manually maintained.
- Add a narrow check to Workspace / Tests that compares the documented Cargo pin with `cargo metadata --locked`. It fails on drift without rewriting the document or adding a separate script.

## Baseline Audit

- The [official v1.18.1 release](https://github.com/gleam-lang/gleam/releases/tag/v1.18.1) still points to `4a83802ca33a8a96227a1b332768725f232f9779` and was published on 2026-08-01 UTC.
- The [geam.2 packaging release](https://github.com/panarch/gleam/releases/tag/geam-v1.18.1-geam.2) records that same upstream commit. Its mirror commit matches the installed crate's VCS provenance.
- README, toolchain references, and the stdlib/HTTP/JSON/Time fixture baselines were checked and remain unchanged. No dependency, version, lockfile, or runtime changes are included.

The actual workflow command passed locally. Failure checks covered stale/missing/wrong-package documentation, missing/multiple resolved compiler packages, and Cargo failure propagation. Formatting, Actionlint/ShellCheck, and diff checks also passed.

Closes #126.
