### PR TITLE
Release Geam 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "ecow",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "ecow",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "ecow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.96"
 license = "Apache-2.0"
@@ -56,12 +56,12 @@ clap = { version = "4", features = ["derive"] }
 # does not compile against ecow 0.3.0.
 ecow = "=0.2.6"
 flate2 = "1"
-geam-core = { path = "core", version = "=0.2.0" }
-geam-cli = { path = "cli", version = "=0.2.0" }
-geam-json = { path = "builtins/json", version = "=0.2.0" }
-geam-macros = { path = "macros", version = "=0.2.0" }
-geam-stdlib = { path = "builtins/stdlib", version = "=0.2.0" }
-geam-time = { path = "builtins/time", version = "=0.2.0" }
+geam-core = { path = "core", version = "=0.2.1" }
+geam-cli = { path = "cli", version = "=0.2.1" }
+geam-json = { path = "builtins/json", version = "=0.2.1" }
+geam-macros = { path = "macros", version = "=0.2.1" }
+geam-stdlib = { path = "builtins/stdlib", version = "=0.2.1" }
+geam-time = { path = "builtins/time", version = "=0.2.1" }
 gleam-core = { package = "geam-gleam-core", version = "=1.18.1-geam.2" }
 gleam-compiler-core = { package = "geam-gleam-core", version = "=1.18.1-geam.2" }
 half = { version = "2.7.1", default-features = false }

--- a/cli/tests/fixtures/standalone_cli/providers/Cargo.lock
+++ b/cli/tests/fixtures/standalone_cli/providers/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/cli/tests/fixtures/standalone_cli/providers/geam-catalog/Cargo.toml
+++ b/cli/tests/fixtures/standalone_cli/providers/geam-catalog/Cargo.toml
@@ -13,6 +13,6 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"
 num-bigint = "0.4"
 standalone-catalog-domain = { path = "../catalog-domain", version = "0.1.0" }

--- a/cli/tests/fixtures/standalone_cli/providers/geam-counter/Cargo.toml
+++ b/cli/tests/fixtures/standalone_cli/providers/geam-counter/Cargo.toml
@@ -13,4 +13,4 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"

--- a/docs/releases/0.2.1.md
+++ b/docs/releases/0.2.1.md
@@ -1,0 +1,31 @@
+# Geam 0.2.1
+
+Geam 0.2.1 is a maintenance release focused on release automation,
+contributor feedback, and documentation accuracy. It does not change runtime
+behavior or the provider authoring API introduced in 0.2.0.
+
+## Changes
+
+- Add a release preparation workflow that updates all seven workspace crates,
+  exact internal and example-provider requirements, and tracked Cargo locks
+  together, then opens a draft PR for review.
+  ([#127](https://github.com/panarch/geam/pull/127), @panarch)
+- Publish from an explicit release commit after checking its CI results and
+  reviewed release notes. Support retrying selected packages or creating only
+  the GitHub Release after successful uploads. The reviewed notes become the
+  GitHub Release body.
+  ([#127](https://github.com/panarch/geam/pull/127), @panarch)
+- Run the nine provider examples in independent CI jobs, retaining each
+  example's standalone execution, provider tests, Cargo package verification,
+  and Gleam package export checks.
+  ([#129](https://github.com/panarch/geam/pull/129), @panarch)
+- Correct the upstream compiler documentation to match the already-pinned
+  `geam-gleam-core 1.18.1-geam.2` and add a CI check for documentation drift.
+  This is a documentation correction, not a compiler upgrade.
+  ([#130](https://github.com/panarch/geam/pull/130), @panarch)
+
+## Compatibility
+
+- No source migration is required from 0.2.0. Rust APIs, provider macros,
+  CLI commands, and Gleam execution semantics are unchanged.
+- The Rust 1.96 requirement and Gleam 1.18.1 compatibility baseline are unchanged.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -6,9 +6,11 @@ Use the workspace version in both its filename and first heading:
 ```markdown
 # Geam <version>
 
+Summarize the purpose and scope of the release in a short paragraph.
+
 ## Changes
 
-- Describe the user-visible changes and fixes in this release.
+- Explain a change and its effect. ([#number](PR_URL), @author)
 
 ## Compatibility
 
@@ -18,6 +20,30 @@ Use the workspace version in both its filename and first heading:
 Replace the example prose with actual release content; omit sections that do
 not apply. Notes are written and reviewed by people, not generated from commit
 subjects. Distinguish shipped behavior from future work.
+
+## Content And Attribution
+
+- Review the full comparison with the previous release so substantive PRs are
+  not missed. Do not present mechanical version or lock updates as new features.
+- Explain what changed and why it matters, rather than copying commit titles.
+  Identify maintenance-only releases without implying runtime improvements.
+- Link the relevant PRs at the end of each change item. Group related PRs when
+  they deliver one change; a PR does not have to become a separate item.
+- Credit verified human contributors with their GitHub handles, including
+  relevant co-authors. Use the same convention for maintainers and external
+  contributors; do not credit automated bump bots.
+
+## First-Time Contributors
+
+When a release includes first-time contributors, add a `## New Contributors`
+section after the release content. Welcome each person by their GitHub handle
+and link their first merged PR. Verify that it is their first contribution to
+the repository, not merely their first in this release.
+
+Omit this section when there are no new contributors. Ordinary attribution stays
+with each change item; do not duplicate it in a separate contributors list.
+
+## Publication Checks
 
 Publishing rejects a missing file, mismatched heading, heading-only content,
 or `TODO`, `TBD`, `FIXME`, and HTML comment placeholders. Mechanical checks do

--- a/examples/call_tracing/provider/Cargo.lock
+++ b/examples/call_tracing/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/call_tracing/provider/Cargo.toml
+++ b/examples/call_tracing/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"
 
 [workspace]
 resolver = "3"

--- a/examples/feature_flags/provider/Cargo.lock
+++ b/examples/feature_flags/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/feature_flags/provider/Cargo.toml
+++ b/examples/feature_flags/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"
 
 [workspace]
 resolver = "3"

--- a/examples/generic_box/provider/Cargo.lock
+++ b/examples/generic_box/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/generic_box/provider/Cargo.toml
+++ b/examples/generic_box/provider/Cargo.toml
@@ -17,7 +17,7 @@ gleam-package = "example_generic_box"
 gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
-geam = "=0.2.0"
+geam = "=0.2.1"
 
 [workspace]
 resolver = "3"

--- a/examples/request_ids/provider/Cargo.lock
+++ b/examples/request_ids/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/request_ids/provider/Cargo.toml
+++ b/examples/request_ids/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"
 num-bigint = "0.4.6"
 
 [workspace]

--- a/examples/run_metrics/provider/Cargo.lock
+++ b/examples/run_metrics/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/run_metrics/provider/Cargo.toml
+++ b/examples/run_metrics/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"
 num-bigint = "0.4.6"
 
 [workspace]

--- a/examples/tag_set/provider/Cargo.lock
+++ b/examples/tag_set/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/tag_set/provider/Cargo.toml
+++ b/examples/tag_set/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"
 num-bigint = "0.4.6"
 
 [workspace]

--- a/examples/text_pattern/provider/Cargo.lock
+++ b/examples/text_pattern/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/text_pattern/provider/Cargo.toml
+++ b/examples/text_pattern/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"
 regex = "1.12"
 
 [workspace]

--- a/examples/text_tools/provider/Cargo.lock
+++ b/examples/text_tools/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/text_tools/provider/Cargo.toml
+++ b/examples/text_tools/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"
 
 [workspace]
 resolver = "3"

--- a/examples/value_types/provider/Cargo.lock
+++ b/examples/value_types/provider/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",

--- a/examples/value_types/provider/Cargo.toml
+++ b/examples/value_types/provider/Cargo.toml
@@ -18,7 +18,7 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 
 [dependencies]
 ecow = "=0.2.6"
-geam = "=0.2.0"
+geam = "=0.2.1"
 num-bigint = "=0.4.6"
 
 [workspace]

--- a/macros/tests/fixtures/cross_crate/Cargo.lock
+++ b/macros/tests/fixtures/cross_crate/Cargo.lock
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/tests/fixtures/provider_sdk/Cargo.lock
+++ b/tests/fixtures/provider_sdk/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "geam"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-cli",
  "geam-core",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "geam-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "geam-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitvec",
  "camino",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "geam-json"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ecow",
  "geam-core",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "geam-macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "geam-stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bitvec",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "geam-time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "geam-core",
  "geam-macros",


### PR DESCRIPTION
Prepared by the [Prepare release workflow](https://github.com/panarch/geam/actions/runs/33058595986). The version and lockfile commit was already pushed; this PR was opened manually after Actions was denied permission to create it. The prepared commit is unchanged.

## Release checklist

- [ ] Add and review `docs/releases/0.2.1.md`.
- [ ] Review the version and lockfile diff.
- [ ] Approve any PR workflow runs that require it and wait for all checks.
- [ ] Mark ready and squash-merge; wait for main's checks at the merge SHA.

Publish separately using the [publishing guide](https://github.com/panarch/geam/blob/main/docs/publishing.md).
