### PR TITLE
Support Erlang and Geam in the text-pattern example

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -83,7 +83,7 @@ jobs:
           - example: generic_box
             test: runs_the_documented_generic_box_provider_with_persistent_values
           - example: text_pattern
-            test: runs_the_documented_text_pattern_provider_from_its_local_path
+            test: runs_the_documented_text_pattern_on_erlang_and_geam
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ compiler-boundary details, and sync policy.
 
 ## Testing
 
-With the Rust toolchain and Gleam `v1.18.1` installed, run the full test suite:
+With the Rust toolchain, Gleam `v1.18.1`, and Erlang/OTP `29` installed, run the
+full test suite:
 
 ```sh
 cargo test --locked

--- a/docs/host-providers.md
+++ b/docs/host-providers.md
@@ -464,7 +464,7 @@ name = "geam-example-text-pattern"
 [package.metadata.geam.provider]
 schema = 1
 gleam-package = "example_text_pattern"
-gleam-version = ">= 1.0.0 and < 2.0.0"
+gleam-version = ">= 0.1.0 and < 0.2.0"
 ```
 
 The [complete example](../examples/text_pattern/README.md) executes this crate

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -85,10 +85,10 @@ example_text_pattern
 ```
 
 The example project contains an ordinary local Gleam dependency and no Geam
-mapping metadata. Its provider crate is package-ready but remains unpublished
-while the higher-level macro authoring API is still planned. The bounded
-registry tests separately verify discovery, approval, archive validation, and
-the same production runner path without requiring a published fixture crate.
+mapping metadata. Its independently packageable provider uses Geam's public
+authoring macros. The bounded registry tests separately verify discovery,
+approval, archive validation, and the same production runner path without
+requiring a published fixture crate.
 
 Explicit selection is itself approval:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -178,6 +178,13 @@ orchestration test owns search, sparse-index, checksum, archive metadata,
 approval, registry-shaped dependency, lock, check, and run coverage without
 requiring a fixture crate to be published.
 
+The same text-pattern test first runs the common Gleam entrypoint and the
+Erlang-specific example using the package's native `re` implementation, before
+adding a Rust provider. It then runs the common entrypoint twice on Geam and
+checks Geam-specific replacement syntax, pattern equality, and exact inspection.
+This test requires Erlang/OTP as well as Gleam; CI supplies OTP `29`. The native
+Erlang source is included in the exported Hex package.
+
 CI formats, tests, lints, and packages every independent example provider. The
 nine macro examples select the current unreleased authoring surface through
 repository-local patches and complete standalone execution. The independent
@@ -225,7 +232,8 @@ tests.
 
 ## Commands
 
-With the Rust toolchain and Gleam `v1.18.1` installed, run the full test suite:
+With the Rust toolchain, Gleam `v1.18.1`, and Erlang/OTP `29` installed, run the
+full test suite:
 
 ```sh
 cargo test --workspace --locked

--- a/examples/text_pattern/README.md
+++ b/examples/text_pattern/README.md
@@ -1,9 +1,9 @@
 # Text Pattern Provider Example
 
 This example pairs an ordinary Gleam package with a separately packageable Rust
-provider for [Geam](https://github.com/panarch/geam). The Gleam package declares
-only its public types and Erlang externals. The Rust crate implements those
-externals with `regex` through Geam's public provider authoring macros.
+provider for [Geam](https://github.com/panarch/geam). The Gleam package includes
+an Erlang `re` implementation. The Rust crate implements the same API with
+`regex` through Geam's public provider authoring macros.
 
 See the [Gleam package README](project/packages/example_text_pattern/README.md)
 for installation and API usage, and the [provider README](provider/README.md)
@@ -17,27 +17,34 @@ provider/                          geam-example-text-pattern crate
 
 ## Run From a Checkout
 
-With Rust and Cargo installed, clone Geam and install the CLI from the same
-checkout:
+### Erlang
+
+With Gleam and Erlang/OTP installed, the example runs without Geam or Rust:
 
 ```sh
 git clone https://github.com/panarch/geam.git
-cd geam
-cargo install --path . --locked
+cd geam/examples/text_pattern/project
+gleam run --target erlang
 ```
 
-From the repository root, select the local provider and run the Gleam project:
+### Geam
+
+With Gleam, Rust, and Cargo installed, start from the repository root to install
+Geam, select the local provider, and run the same project:
 
 ```sh
+cargo install --path . --locked
 cd examples/text_pattern/project
 geam provider add --path ../provider
 geam prepare
 geam run
 ```
 
-No provider configuration is required. A successful run checks regex compilation,
-matching, replacement, invalid-pattern errors, and pattern equality, and echoes
-`Pattern("[A-Za-z]+")` to stderr. Running `geam run` again repeats the same checks.
+No provider configuration is required. Both runtimes execute
+[`text_pattern_example.gleam`](project/src/text_pattern_example.gleam), checking
+compilation, matching, literal replacement, Unicode, empty results, and invalid
+patterns. A successful run prints no application output. Running the command
+again repeats the same checks.
 
 This checkout uses the Gleam package as a local path dependency. Provider
 selection comes from the Rust crate's Cargo metadata; the Gleam package needs no
@@ -49,12 +56,34 @@ provider can be tested without publishing it. The local
 and runner builds. See the [standalone guide](../../docs/standalone.md) for
 provider selection and managed project files.
 
+## Runtime-Specific Examples
+
+From `examples/text_pattern/project`, run the additional entrypoint for each
+runtime:
+
+```sh
+gleam run --target erlang --module text_pattern_erlang
+geam run --module text_pattern_geam
+```
+
+- [`text_pattern_erlang.gleam`](project/src/text_pattern_erlang.gleam) uses OTP's
+  `&` and `\\1` capture replacements and a lookahead pattern.
+- [`text_pattern_geam.gleam`](project/src/text_pattern_geam.gleam) uses Rust's
+  `$0` and `$1` replacements, rejects lookahead, and preserves Geam's
+  source-text pattern equality. It echoes `Pattern("[A-Za-z]+")` to stderr.
+
+The package keeps the engines' native syntax instead of translating between
+them. See its [runtime semantics](project/packages/example_text_pattern/README.md#runtime-semantics)
+for the boundary shared by the public API.
+
 ## Read the Implementation
 
 Read the matching declarations together:
 
 - [`project/packages/example_text_pattern/src/example_text_pattern.gleam`](project/packages/example_text_pattern/src/example_text_pattern.gleam)
   declares the constructorless `Pattern`, `CompileError`, and public functions;
+- [`project/packages/example_text_pattern/src/example_text_pattern_ffi.erl`](project/packages/example_text_pattern/src/example_text_pattern_ffi.erl)
+  supplies the native Erlang implementation shipped in the Hex package;
 - [`provider/src/lib.rs`](provider/src/lib.rs) implements the same shapes with
   `#[geam::external]`, `#[geam::custom]`, and `#[geam::function]`; and
 - [`provider/README.md`](provider/README.md) explains why this advanced example

--- a/examples/text_pattern/README.md
+++ b/examples/text_pattern/README.md
@@ -1,9 +1,12 @@
 # Text Pattern Provider Example
 
 This example pairs an ordinary Gleam package with a separately packageable Rust
-provider. The Gleam package declares only its public types and Erlang
-externals. The Rust crate implements those externals with `regex` through
-Geam's typed provider component API.
+provider for [Geam](https://github.com/panarch/geam). The Gleam package declares
+only its public types and Erlang externals. The Rust crate implements those
+externals with `regex` through Geam's public provider authoring macros.
+
+See the [provider README](provider/README.md) for the crate overview, Gleam API,
+and a short usage example.
 
 ```text
 project/
@@ -11,9 +14,18 @@ project/
 provider/                          geam-example-text-pattern crate
 ```
 
-The provider is deliberately not a Geam built-in. Its Rust source uses the
-same public authoring macros available to an independently published provider.
-Select the local crate explicitly while developing and reviewing it:
+## Run From a Checkout
+
+With Rust and Cargo installed, clone Geam and install the CLI from the same
+checkout:
+
+```sh
+git clone https://github.com/panarch/geam.git
+cd geam
+cargo install --path . --locked
+```
+
+From the repository root, select the local provider and run the Gleam project:
 
 ```sh
 cd examples/text_pattern/project
@@ -22,10 +34,21 @@ geam prepare
 geam run
 ```
 
-The local package needs no Geam metadata and is not published to Hex. Its
-provider mapping comes from the Rust crate's Cargo metadata. The provider crate
-is formatted, tested, linted, packaged, and executed in CI, but is intentionally
-not published yet.
+No provider configuration is required. A successful run checks regex compilation,
+matching, replacement, invalid-pattern errors, and pattern equality, and echoes
+`Pattern("[A-Za-z]+")` to stderr. Running `geam run` again repeats the same checks.
+
+The Gleam package is a checked-in path dependency, not a Hex package. Provider
+selection comes from the Rust crate's Cargo metadata; the Gleam package needs no
+Geam-specific metadata. The provider is not a Geam built-in.
+
+This checkout workflow uses an explicit path selection so changes to the
+provider can be tested without publishing it. The local
+[Cargo patch](.cargo/config.toml) selects the same Geam checkout for provider
+and runner builds. See the [standalone guide](../../docs/standalone.md) for
+provider selection and managed project files.
+
+## Read the Implementation
 
 Read the matching declarations together:
 
@@ -35,3 +58,7 @@ Read the matching declarations together:
   `#[geam::external]`, `#[geam::custom]`, and `#[geam::function]`; and
 - [`provider/README.md`](provider/README.md) explains why this advanced example
   uses manual external semantics while ordinary registration remains generated.
+
+The [provider authoring guide](../../docs/host-providers.md) covers the API
+contracts. The [examples index](../README.md) offers smaller examples of the
+individual authoring patterns used here.

--- a/examples/text_pattern/README.md
+++ b/examples/text_pattern/README.md
@@ -5,8 +5,9 @@ provider for [Geam](https://github.com/panarch/geam). The Gleam package declares
 only its public types and Erlang externals. The Rust crate implements those
 externals with `regex` through Geam's public provider authoring macros.
 
-See the [provider README](provider/README.md) for the crate overview, Gleam API,
-and a short usage example.
+See the [Gleam package README](project/packages/example_text_pattern/README.md)
+for installation and API usage, and the [provider README](provider/README.md)
+for the matching Rust implementation and authoring macros.
 
 ```text
 project/
@@ -38,7 +39,7 @@ No provider configuration is required. A successful run checks regex compilation
 matching, replacement, invalid-pattern errors, and pattern equality, and echoes
 `Pattern("[A-Za-z]+")` to stderr. Running `geam run` again repeats the same checks.
 
-The Gleam package is a checked-in path dependency, not a Hex package. Provider
+This checkout uses the Gleam package as a local path dependency. Provider
 selection comes from the Rust crate's Cargo metadata; the Gleam package needs no
 Geam-specific metadata. The provider is not a Geam built-in.
 

--- a/examples/text_pattern/project/gleam.toml
+++ b/examples/text_pattern/project/gleam.toml
@@ -1,6 +1,6 @@
 name = "text_pattern_example"
 version = "0.1.0"
-description = "Standalone Geam text pattern provider example"
+description = "Text pattern example for Erlang and Geam"
 licences = ["Apache-2.0"]
 
 [dependencies]

--- a/examples/text_pattern/project/gleam.toml
+++ b/examples/text_pattern/project/gleam.toml
@@ -1,5 +1,5 @@
 name = "text_pattern_example"
-version = "1.0.0"
+version = "0.1.0"
 description = "Standalone Geam text pattern provider example"
 licences = ["Apache-2.0"]
 

--- a/examples/text_pattern/project/manifest.toml
+++ b/examples/text_pattern/project/manifest.toml
@@ -1,5 +1,5 @@
 packages = [
-  { name = "example_text_pattern", version = "1.0.0", build_tools = ["gleam"], requirements = [], source = "local", path = "packages/example_text_pattern" },
+  { name = "example_text_pattern", version = "0.1.0", build_tools = ["gleam"], requirements = [], source = "local", path = "packages/example_text_pattern" },
 ]
 
 [requirements]

--- a/examples/text_pattern/project/packages/example_text_pattern/README.md
+++ b/examples/text_pattern/project/packages/example_text_pattern/README.md
@@ -1,0 +1,73 @@
+# example_text_pattern
+
+Regular expressions for Gleam programs running on
+[Geam](https://github.com/panarch/geam), a Rust runtime for Gleam. The matching
+[geam-example-text-pattern provider](https://github.com/panarch/geam/tree/main/examples/text_pattern/provider)
+implements this API with Rust's `regex` crate.
+
+Run programs using this package with Geam. The package declares external
+functions for the Rust provider; it does not include Erlang or JavaScript
+implementations.
+
+## Use the Published Packages
+
+This workflow requires the Gleam package on Hex and the matching Rust provider
+on crates.io, with Gleam, Geam, and Rust/Cargo installed. For local development
+without publishing either package, use the
+[checkout instructions](https://github.com/panarch/geam/blob/main/examples/text_pattern/README.md).
+
+From your Gleam project directory, add the package:
+
+```sh
+gleam add example_text_pattern
+```
+
+Use the following in your project's entry module:
+
+```gleam
+import example_text_pattern as pattern
+
+pub fn main() {
+  let assert Ok(words) = pattern.compile("[A-Za-z]+")
+  assert pattern.is_match(words, "Geam + Gleam 2026")
+  assert pattern.find_all(words, "Geam + Gleam 2026") == ["Geam", "Gleam"]
+  assert pattern.replace_all(words, "Geam + Gleam 2026", "<$0>")
+    == "<Geam> + <Gleam> 2026"
+
+  let assert Error(pattern.CompileError(message)) = pattern.compile("(")
+  assert message != ""
+}
+```
+
+Prepare and run it with Geam:
+
+```sh
+geam prepare
+geam run
+```
+
+On the first `prepare`, review and approve the matching
+`geam-example-text-pattern` candidate in an interactive terminal. This approves
+native Rust code. Geam records the selected dependency and Cargo lock, then
+builds and checks the runner. No explicit `geam provider add` or provider
+configuration is needed for this workflow.
+
+The example succeeds when every assertion passes; it prints no application
+output. See the
+[standalone guide](https://github.com/panarch/geam/blob/main/docs/standalone.md)
+for provider approval, managed files, and entry module selection.
+
+## API
+
+- `compile(source)` returns `Ok(Pattern)` or `Error(CompileError(message))`.
+- `is_match(pattern, text)` checks whether any part of the text matches.
+- `find_all(pattern, text)` returns non-overlapping matches in source order.
+- `replace_all(pattern, text, replacement)` replaces every match; `$0` inserts
+  the complete match.
+
+`Pattern` is opaque to Gleam. Patterns compiled from identical source text
+compare equal, even when compiled separately. Inspection shows the pattern
+text, for example `Pattern("[A-Za-z]+")`, rather than Rust's regex internals.
+
+For the paired Rust implementation and its authoring macros, read the
+[provider README](https://github.com/panarch/geam/blob/main/examples/text_pattern/provider/README.md).

--- a/examples/text_pattern/project/packages/example_text_pattern/README.md
+++ b/examples/text_pattern/project/packages/example_text_pattern/README.md
@@ -1,22 +1,19 @@
 # example_text_pattern
 
-Regular expressions for Gleam programs running on
-[Geam](https://github.com/panarch/geam), a Rust runtime for Gleam. The matching
-[geam-example-text-pattern provider](https://github.com/panarch/geam/tree/main/examples/text_pattern/provider)
-implements this API with Rust's `regex` crate.
+Regular expressions for Gleam, with an Erlang implementation using OTP's `re`
+module and a matching Rust provider for
+[Geam](https://github.com/panarch/geam), a Rust runtime for Gleam.
 
-Run programs using this package with Geam. The package declares external
-functions for the Rust provider; it does not include Erlang or JavaScript
-implementations.
+Both runtimes use the same `Pattern`, `CompileError`, and four functions below.
+Each keeps its native regex semantics; read Runtime Semantics below before
+switching engines. There is no JavaScript implementation.
 
-## Use the Published Packages
+## Run on Erlang
 
-This workflow requires the Gleam package on Hex and the matching Rust provider
-on crates.io, with Gleam, Geam, and Rust/Cargo installed. For local development
-without publishing either package, use the
+With Gleam and Erlang/OTP installed, add the published Hex package to your
+project. Rust and Geam are not required. For local development without
+publishing either package, use the
 [checkout instructions](https://github.com/panarch/geam/blob/main/examples/text_pattern/README.md).
-
-From your Gleam project directory, add the package:
 
 ```sh
 gleam add example_text_pattern
@@ -31,15 +28,27 @@ pub fn main() {
   let assert Ok(words) = pattern.compile("[A-Za-z]+")
   assert pattern.is_match(words, "Geam + Gleam 2026")
   assert pattern.find_all(words, "Geam + Gleam 2026") == ["Geam", "Gleam"]
-  assert pattern.replace_all(words, "Geam + Gleam 2026", "<$0>")
-    == "<Geam> + <Gleam> 2026"
+  assert pattern.replace_all(words, "Geam + Gleam 2026", "<word>")
+    == "<word> + <word> 2026"
 
   let assert Error(pattern.CompileError(message)) = pattern.compile("(")
   assert message != ""
 }
 ```
 
-Prepare and run it with Geam:
+```sh
+gleam run --target erlang
+```
+
+The example succeeds when every assertion passes; it prints no application
+output.
+
+## Run on Geam
+
+The same source also runs with the
+[geam-example-text-pattern provider](https://github.com/panarch/geam/tree/main/examples/text_pattern/provider),
+which uses Rust's `regex` crate. This workflow requires Geam and Rust/Cargo,
+plus the matching Rust provider published on crates.io:
 
 ```sh
 geam prepare
@@ -52,8 +61,7 @@ native Rust code. Geam records the selected dependency and Cargo lock, then
 builds and checks the runner. No explicit `geam provider add` or provider
 configuration is needed for this workflow.
 
-The example succeeds when every assertion passes; it prints no application
-output. See the
+Geam uses the Rust provider, not the packaged Erlang implementation. See the
 [standalone guide](https://github.com/panarch/geam/blob/main/docs/standalone.md)
 for provider approval, managed files, and entry module selection.
 
@@ -62,12 +70,27 @@ for provider approval, managed files, and entry module selection.
 - `compile(source)` returns `Ok(Pattern)` or `Error(CompileError(message))`.
 - `is_match(pattern, text)` checks whether any part of the text matches.
 - `find_all(pattern, text)` returns non-overlapping matches in source order.
-- `replace_all(pattern, text, replacement)` replaces every match; `$0` inserts
-  the complete match.
+- `replace_all(pattern, text, replacement)` replaces every match using the
+  engine's replacement syntax.
 
-`Pattern` is opaque to Gleam. Patterns compiled from identical source text
-compare equal, even when compiled separately. Inspection shows the pattern
-text, for example `Pattern("[A-Za-z]+")`, rather than Rust's regex internals.
+## Runtime Semantics
+
+| Runtime | Engine | Whole-match replacement | First capture replacement |
+| --- | --- | --- | --- |
+| Erlang | [`re`](https://www.erlang.org/doc/apps/stdlib/re.html), with `unicode` and `ucp` | `"&"` | `"\\1"` in a Gleam string |
+| Geam | Rust [`regex`](https://docs.rs/regex/latest/regex/) | `"$0"` | `"$1"` |
+
+Patterns and replacement strings are passed to the selected engine without
+translation. Regex features, zero-length match behavior, resource limits, and
+compile-error messages follow that engine. For example, Erlang accepts
+`Geam(?=-)` lookahead; Rust `regex` rejects it. Use literal replacements such as
+`"<word>"` when sharing the example across runtimes.
+
+`Pattern` is opaque. Equality and inspection are not portable between runtimes.
+On Geam, patterns compiled from identical source text compare equal, and
+inspection shows `Pattern("[A-Za-z]+")` rather than Rust's regex internals. On
+Erlang, the value is OTP's opaque compiled pattern; use the API to inspect its
+matching behavior rather than relying on its representation or equality.
 
 For the paired Rust implementation and its authoring macros, read the
 [provider README](https://github.com/panarch/geam/blob/main/examples/text_pattern/provider/README.md).

--- a/examples/text_pattern/project/packages/example_text_pattern/gleam.toml
+++ b/examples/text_pattern/project/packages/example_text_pattern/gleam.toml
@@ -2,3 +2,13 @@ name = "example_text_pattern"
 version = "0.1.0"
 description = "Typed text patterns backed by a native Geam provider"
 licences = ["Apache-2.0"]
+
+links = [
+  { title = "Geam", href = "https://github.com/panarch/geam" },
+  { title = "Rust provider", href = "https://github.com/panarch/geam/tree/main/examples/text_pattern/provider" },
+  { title = "Complete example", href = "https://github.com/panarch/geam/tree/main/examples/text_pattern" },
+]
+
+[repository]
+type = "custom"
+url = "https://github.com/panarch/geam/tree/main/examples/text_pattern/project/packages/example_text_pattern"

--- a/examples/text_pattern/project/packages/example_text_pattern/gleam.toml
+++ b/examples/text_pattern/project/packages/example_text_pattern/gleam.toml
@@ -1,4 +1,4 @@
 name = "example_text_pattern"
-version = "1.0.0"
+version = "0.1.0"
 description = "Typed text patterns backed by a native Geam provider"
 licences = ["Apache-2.0"]

--- a/examples/text_pattern/project/packages/example_text_pattern/gleam.toml
+++ b/examples/text_pattern/project/packages/example_text_pattern/gleam.toml
@@ -1,6 +1,6 @@
 name = "example_text_pattern"
 version = "0.1.0"
-description = "Typed text patterns backed by a native Geam provider"
+description = "Regular expressions for Gleam on Erlang and Geam"
 licences = ["Apache-2.0"]
 
 links = [

--- a/examples/text_pattern/project/packages/example_text_pattern/src/example_text_pattern.gleam
+++ b/examples/text_pattern/project/packages/example_text_pattern/src/example_text_pattern.gleam
@@ -1,39 +1,48 @@
-//// Regular expressions for Gleam programs running on
+//// Regular expressions for Gleam on Erlang and
 //// [Geam](https://github.com/panarch/geam).
 ////
-//// The `geam-example-text-pattern` Rust provider implements these externals.
-//// This package does not include Erlang or JavaScript implementations.
+//// Erlang uses the included OTP `re` implementation with `unicode` and `ucp`.
+//// Geam uses the `geam-example-text-pattern` Rust provider and its `regex`
+//// engine. Pattern syntax, replacement syntax, zero-length matches, resource
+//// limits, and error messages follow each engine. There is no JavaScript
+//// implementation.
 
 /// A compiled regular expression, opaque to Gleam.
 ///
-/// Patterns compiled from identical source text compare equal. Inspection
-/// displays the pattern text, for example `Pattern("[A-Za-z]+")`.
-@external(erlang, "geam_example_text_pattern", "Pattern")
+/// Equality and inspection are runtime-specific, not portable guarantees.
+/// On Geam, identical source text compares equal and inspection displays the
+/// pattern text, for example `Pattern("[A-Za-z]+")`. On Erlang, this is OTP's
+/// opaque compiled pattern.
+@external(erlang, "example_text_pattern_ffi", "Pattern")
 pub type Pattern
 
-/// An invalid regular expression, with a message from the Rust regex parser.
+/// An invalid regular expression, with a message from the active regex engine.
 pub type CompileError {
   CompileError(message: String)
 }
 
 /// Compile a regular expression, or return `Error(CompileError(message))` if
-/// the pattern is invalid.
-@external(erlang, "geam_example_text_pattern", "compile")
+/// the pattern is invalid. Syntax is interpreted by the active engine without
+/// translation; a pattern accepted by one engine may be rejected by the other.
+@external(erlang, "example_text_pattern_ffi", "compile")
 pub fn compile(source: String) -> Result(Pattern, CompileError)
 
 /// Check whether any part of `text` matches the pattern.
 /// The pattern is not automatically anchored to the start or end of the text.
-@external(erlang, "geam_example_text_pattern", "is_match")
+@external(erlang, "example_text_pattern_ffi", "is_match")
 pub fn is_match(pattern: Pattern, text: String) -> Bool
 
-/// Return every non-overlapping match in source order, or an empty list if
-/// there are no matches.
-@external(erlang, "geam_example_text_pattern", "find_all")
+/// Return whole, non-overlapping matches from left to right, or an empty list
+/// if there are no matches. Capturing groups are not returned separately.
+/// Zero-length matches follow the active engine's iteration rules.
+@external(erlang, "example_text_pattern_ffi", "find_all")
 pub fn find_all(pattern: Pattern, text: String) -> List(String)
 
 /// Replace every non-overlapping match with `replacement`.
-/// `$0` in the replacement inserts the complete match.
-@external(erlang, "geam_example_text_pattern", "replace_all")
+/// Replacement syntax follows the active engine. Geam uses `$0` for the whole
+/// match and `$1` for the first capture. Erlang uses `&` and `\\1` respectively
+/// (the latter written with an escaped backslash in a Gleam string).
+@external(erlang, "example_text_pattern_ffi", "replace_all")
 pub fn replace_all(
   pattern: Pattern,
   text: String,

--- a/examples/text_pattern/project/packages/example_text_pattern/src/example_text_pattern.gleam
+++ b/examples/text_pattern/project/packages/example_text_pattern/src/example_text_pattern.gleam
@@ -1,19 +1,38 @@
+//// Regular expressions for Gleam programs running on
+//// [Geam](https://github.com/panarch/geam).
+////
+//// The `geam-example-text-pattern` Rust provider implements these externals.
+//// This package does not include Erlang or JavaScript implementations.
+
+/// A compiled regular expression, opaque to Gleam.
+///
+/// Patterns compiled from identical source text compare equal. Inspection
+/// displays the pattern text, for example `Pattern("[A-Za-z]+")`.
 @external(erlang, "geam_example_text_pattern", "Pattern")
 pub type Pattern
 
+/// An invalid regular expression, with a message from the Rust regex parser.
 pub type CompileError {
   CompileError(message: String)
 }
 
+/// Compile a regular expression, or return `Error(CompileError(message))` if
+/// the pattern is invalid.
 @external(erlang, "geam_example_text_pattern", "compile")
 pub fn compile(source: String) -> Result(Pattern, CompileError)
 
+/// Check whether any part of `text` matches the pattern.
+/// The pattern is not automatically anchored to the start or end of the text.
 @external(erlang, "geam_example_text_pattern", "is_match")
 pub fn is_match(pattern: Pattern, text: String) -> Bool
 
+/// Return every non-overlapping match in source order, or an empty list if
+/// there are no matches.
 @external(erlang, "geam_example_text_pattern", "find_all")
 pub fn find_all(pattern: Pattern, text: String) -> List(String)
 
+/// Replace every non-overlapping match with `replacement`.
+/// `$0` in the replacement inserts the complete match.
 @external(erlang, "geam_example_text_pattern", "replace_all")
 pub fn replace_all(
   pattern: Pattern,

--- a/examples/text_pattern/project/packages/example_text_pattern/src/example_text_pattern_ffi.erl
+++ b/examples/text_pattern/project/packages/example_text_pattern/src/example_text_pattern_ffi.erl
@@ -1,0 +1,37 @@
+-module(example_text_pattern_ffi).
+
+-export([compile/1, is_match/2, find_all/2, replace_all/3]).
+-export_type(['Pattern'/0]).
+
+-opaque 'Pattern'() :: re:mp().
+
+-spec compile(binary()) ->
+    {ok, 'Pattern'()} | {error, example_text_pattern:compile_error()}.
+compile(Source) ->
+    case re:compile(Source, [unicode, ucp]) of
+        {ok, Pattern} ->
+            {ok, Pattern};
+        {error, {Reason, Offset}} ->
+            Message = unicode:characters_to_binary(
+                io_lib:format("~ts at byte ~B", [Reason, Offset])
+            ),
+            {error, {compile_error, Message}}
+    end.
+
+-spec is_match('Pattern'(), binary()) -> boolean().
+is_match(Pattern, Text) ->
+    case re:run(Text, Pattern, [{capture, none}]) of
+        match -> true;
+        nomatch -> false
+    end.
+
+-spec find_all('Pattern'(), binary()) -> [binary()].
+find_all(Pattern, Text) ->
+    case re:run(Text, Pattern, [global, {capture, first, binary}]) of
+        {match, Matches} -> [Match || [Match] <- Matches];
+        nomatch -> []
+    end.
+
+-spec replace_all('Pattern'(), binary(), binary()) -> binary().
+replace_all(Pattern, Text, Replacement) ->
+    re:replace(Text, Pattern, Replacement, [global, {return, binary}]).

--- a/examples/text_pattern/project/src/text_pattern_erlang.gleam
+++ b/examples/text_pattern/project/src/text_pattern_erlang.gleam
@@ -1,0 +1,18 @@
+import example_text_pattern as pattern
+
+pub fn main() {
+  let assert Ok(words) = pattern.compile("[A-Za-z]+")
+  assert pattern.replace_all(words, "Geam + Gleam + Rust 2026", "<&>")
+    == "<Geam> + <Gleam> + <Rust> 2026"
+
+  let assert Ok(captures) = pattern.compile("([A-Za-z]+)-([0-9]+)")
+  assert pattern.replace_all(captures, "Geam-12 Gleam-34", "\\2:\\1")
+    == "12:Geam 34:Gleam"
+
+  let assert Ok(lookahead) = pattern.compile("Geam(?=-)")
+  assert pattern.find_all(lookahead, "Geam-12 Geam") == ["Geam"]
+
+  // The native diagnostic at the OTP 29 verification baseline.
+  assert pattern.compile("abc(")
+    == Error(pattern.CompileError("missing closing parenthesis at byte 4"))
+}

--- a/examples/text_pattern/project/src/text_pattern_example.gleam
+++ b/examples/text_pattern/project/src/text_pattern_example.gleam
@@ -1,29 +1,42 @@
-import example_text_pattern
+import example_text_pattern as pattern
 
 pub fn main() {
-  let assert Ok(words) = example_text_pattern.compile("[A-Za-z]+")
-  let assert Ok(same_words) = example_text_pattern.compile("[A-Za-z]+")
-  let assert Ok(numbers) = example_text_pattern.compile("[0-9]+")
+  let assert Ok(words) = pattern.compile("[A-Za-z]+")
+  let assert Ok(numbers) = pattern.compile("[0-9]+")
 
-  echo words as "compiled pattern"
-  assert words == same_words
-  assert words != numbers
-  assert example_text_pattern.is_match(words, "Geam + Gleam + Rust 2026")
-  assert !example_text_pattern.is_match(words, "2026")
-  assert example_text_pattern.find_all(words, "Geam + Gleam + Rust 2026")
+  assert pattern.is_match(words, "Geam + Gleam + Rust 2026")
+  assert !pattern.is_match(words, "2026")
+  assert !pattern.is_match(words, "")
+  assert pattern.find_all(words, "Geam + Gleam + Rust 2026")
     == [
       "Geam",
       "Gleam",
       "Rust",
     ]
-  assert example_text_pattern.replace_all(
-      words,
-      "Geam + Gleam + Rust 2026",
-      "<$0>",
-    )
-    == "<Geam> + <Gleam> + <Rust> 2026"
+  assert pattern.find_all(words, "2026") == []
+  assert pattern.find_all(words, "") == []
+  assert pattern.find_all(numbers, "Geam + Gleam + Rust 2026") == ["2026"]
+  assert pattern.replace_all(words, "Geam + Gleam + Rust 2026", "<word>")
+    == "<word> + <word> + <word> 2026"
+  assert pattern.replace_all(words, "2026", "<word>") == "2026"
+  assert pattern.replace_all(words, "", "<word>") == ""
+  assert pattern.replace_all(words, "Geam + Gleam", "") == " + "
 
-  let assert Error(example_text_pattern.CompileError(message)) =
-    example_text_pattern.compile("(")
+  let assert Ok(captures) = pattern.compile("([A-Za-z]+)-([0-9]+)")
+  assert pattern.find_all(captures, "Geam-12 Gleam-34")
+    == ["Geam-12", "Gleam-34"]
+
+  let assert Ok(unicode_words) = pattern.compile("\\w+")
+  assert pattern.find_all(unicode_words, "caf\u{e9} \u{d55c}\u{ae00} Rust")
+    == ["caf\u{e9}", "\u{d55c}\u{ae00}", "Rust"]
+  assert pattern.replace_all(unicode_words, "caf\u{e9}", "th\u{e9}")
+    == "th\u{e9}"
+
+  let assert Ok(empty) = pattern.compile("")
+  assert pattern.is_match(empty, "")
+  assert pattern.find_all(empty, "ab") == ["", "", ""]
+  assert pattern.replace_all(empty, "ab", "-") == "-a-b-"
+
+  let assert Error(pattern.CompileError(message)) = pattern.compile("(")
   assert message != ""
 }

--- a/examples/text_pattern/project/src/text_pattern_geam.gleam
+++ b/examples/text_pattern/project/src/text_pattern_geam.gleam
@@ -1,0 +1,20 @@
+import example_text_pattern as pattern
+
+pub fn main() {
+  let assert Ok(words) = pattern.compile("[A-Za-z]+")
+  let assert Ok(same_words) = pattern.compile("[A-Za-z]+")
+  let assert Ok(numbers) = pattern.compile("[0-9]+")
+
+  echo words as "compiled pattern"
+  assert words == same_words
+  assert words != numbers
+  assert pattern.replace_all(words, "Geam + Gleam + Rust 2026", "<$0>")
+    == "<Geam> + <Gleam> + <Rust> 2026"
+
+  let assert Ok(captures) = pattern.compile("([A-Za-z]+)-([0-9]+)")
+  assert pattern.replace_all(captures, "Geam-12 Gleam-34", "$2:$1")
+    == "12:Geam 34:Gleam"
+
+  let assert Error(pattern.CompileError(message)) = pattern.compile("Geam(?=-)")
+  assert message != ""
+}

--- a/examples/text_pattern/provider/Cargo.toml
+++ b/examples/text_pattern/provider/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools", "text-processing"]
 [package.metadata.geam.provider]
 schema = 1
 gleam-package = "example_text_pattern"
-gleam-version = ">= 1.0.0 and < 2.0.0"
+gleam-version = ">= 0.1.0 and < 0.2.0"
 
 [dependencies]
 ecow = "=0.2.6"

--- a/examples/text_pattern/provider/README.md
+++ b/examples/text_pattern/provider/README.md
@@ -26,9 +26,14 @@ pub fn main() {
 }
 ```
 
-`Pattern` is opaque to Gleam. Patterns compiled from the same source text
+On Geam, `Pattern` is opaque to Gleam. Patterns compiled from the same source text
 compare equal, and inspection shows the pattern text rather than Rust's regex
 internals.
+
+The Gleam package also includes an Erlang `re` implementation for `gleam run`.
+This crate implements the Geam side. Pattern and replacement syntax, equality,
+and inspection follow the selected runtime, as described in the
+[runtime semantics](https://github.com/panarch/geam/blob/main/examples/text_pattern/project/packages/example_text_pattern/README.md#runtime-semantics).
 
 ## Run the Example
 

--- a/examples/text_pattern/provider/README.md
+++ b/examples/text_pattern/provider/README.md
@@ -32,12 +32,13 @@ internals.
 
 ## Run the Example
 
-The matching Gleam package is a local dependency in the Geam repository, not
-a package published to Hex. Installing this Cargo crate alone does not add
-the Gleam declarations to a project.
+The matching `example_text_pattern` Gleam package supplies the source
+declarations. Installing this Cargo crate alone does not add them to a project.
+The [Gleam package guide](https://github.com/panarch/geam/blob/main/examples/text_pattern/project/packages/example_text_pattern/README.md)
+covers Hex installation, native provider approval, and execution with Geam.
 
 Follow the [complete example and setup instructions](https://github.com/panarch/geam/blob/main/examples/text_pattern/README.md)
-to prepare and run the project with Geam. No provider configuration is required.
+to run from a local checkout instead. No provider configuration is required.
 The [standalone guide](https://github.com/panarch/geam/blob/main/docs/standalone.md)
 explains provider selection and the generated Cargo runner.
 

--- a/examples/text_pattern/provider/README.md
+++ b/examples/text_pattern/provider/README.md
@@ -1,12 +1,50 @@
 # geam-example-text-pattern
 
-`geam-example-text-pattern` implements the ordinary
-`example_text_pattern` Gleam package with Rust's `regex` crate. The provider
-uses Geam's public authoring macros; its source contains only component
-identity, source type declarations, source-visible semantics, and function
-bodies.
+An example provider for [Geam](https://github.com/panarch/geam), a Rust runtime
+for a supported subset of Gleam. It implements the `example_text_pattern`
+Gleam package with Rust's `regex` crate and demonstrates how to expose Rust
+functionality to Gleam through Geam's public provider authoring macros.
 
-The complete mapping lives in [`src/lib.rs`](src/lib.rs):
+## Gleam API
+
+- `compile(source)` returns a compiled `Pattern` or `CompileError(message)` in
+  a Gleam `Result`.
+- `is_match(pattern, text)` checks whether the text contains a match.
+- `find_all(pattern, text)` returns the non-overlapping matches in source order.
+- `replace_all(pattern, text, replacement)` replaces every match; `$0` refers to
+  the complete match.
+
+```gleam
+import example_text_pattern as pattern
+
+pub fn main() {
+  let assert Ok(words) = pattern.compile("[A-Za-z]+")
+  assert pattern.is_match(words, "Geam + Gleam 2026")
+  assert pattern.find_all(words, "Geam + Gleam 2026") == ["Geam", "Gleam"]
+  assert pattern.replace_all(words, "Geam + Gleam 2026", "<$0>")
+    == "<Geam> + <Gleam> 2026"
+}
+```
+
+`Pattern` is opaque to Gleam. Patterns compiled from the same source text
+compare equal, and inspection shows the pattern text rather than Rust's regex
+internals.
+
+## Run the Example
+
+The matching Gleam package is a local dependency in the Geam repository, not
+a package published to Hex. Installing this Cargo crate alone does not add
+the Gleam declarations to a project.
+
+Follow the [complete example and setup instructions](https://github.com/panarch/geam/blob/main/examples/text_pattern/README.md)
+to prepare and run the project with Geam. No provider configuration is required.
+The [standalone guide](https://github.com/panarch/geam/blob/main/docs/standalone.md)
+explains provider selection and the generated Cargo runner.
+
+## Provider Authoring
+
+The [Rust implementation](https://github.com/panarch/geam/blob/main/examples/text_pattern/provider/src/lib.rs)
+matches the [Gleam declarations](https://github.com/panarch/geam/blob/main/examples/text_pattern/project/packages/example_text_pattern/src/example_text_pattern.gleam):
 
 - `#[geam::provider]` declares the target Gleam package and module;
 - `#[geam::external(..., manual)]` stores a compiled regular expression while
@@ -15,10 +53,10 @@ The complete mapping lives in [`src/lib.rs`](src/lib.rs):
 - ordinary Rust `Result<Pattern, CompileError>` maps to Gleam `Result`; and
 - `Vec<EcoString>` constructs the returned Gleam `List(String)` once.
 
-The crate remains independently packageable. Its Cargo metadata is the
-crates.io discovery contract; the Gleam package itself carries no Geam
-metadata. The repository-local Cargo patch selects the current checkout until
-the next lockstep Geam release publishes the authoring surface.
+The crate's Cargo metadata identifies the target Gleam package and compatible
+versions for Geam's provider discovery. The Gleam package itself carries no
+Geam-specific metadata.
 
-See the [complete example](../README.md) for the matching Gleam declaration and
-standalone commands.
+See the [provider authoring guide](https://github.com/panarch/geam/blob/main/docs/host-providers.md)
+for the API contracts, or the [other provider examples](https://github.com/panarch/geam/blob/main/examples/README.md)
+for smaller starting points and additional authoring patterns.

--- a/examples/text_pattern/provider/README.md
+++ b/examples/text_pattern/provider/README.md
@@ -1,9 +1,9 @@
 # geam-example-text-pattern
 
 An example provider for [Geam](https://github.com/panarch/geam), a Rust runtime
-for a supported subset of Gleam. It implements the `example_text_pattern`
-Gleam package with Rust's `regex` crate and demonstrates how to expose Rust
-functionality to Gleam through Geam's public provider authoring macros.
+for Gleam. It implements the `example_text_pattern` Gleam package with Rust's
+`regex` crate and demonstrates how to expose Rust functionality to Gleam
+through Geam's public provider authoring macros.
 
 ## Gleam API
 

--- a/tests/provider_examples.rs
+++ b/tests/provider_examples.rs
@@ -289,9 +289,33 @@ fn runs_the_documented_feature_flags_provider_with_explicit_configuration() {
 }
 
 #[test]
-fn runs_the_documented_text_pattern_provider_from_its_local_path() {
+fn runs_the_documented_text_pattern_on_erlang_and_geam() {
     let fixture = provider_example("text_pattern");
     let project = fixture.path().join("project");
+
+    for module in ["text_pattern_example", "text_pattern_erlang"] {
+        let run = Command::new("gleam")
+            .args([
+                "run",
+                "--target",
+                "erlang",
+                "--no-print-progress",
+                "--module",
+                module,
+            ])
+            .current_dir(&project)
+            .output()
+            .expect("Gleam CLI should start with Erlang installed");
+        assert!(
+            run.status.success(),
+            "Erlang text pattern example {module} failed: {}",
+            String::from_utf8_lossy(&run.stderr),
+        );
+        assert!(run.stdout.is_empty());
+        assert!(run.stderr.is_empty());
+    }
+    assert!(!project.join("Cargo.toml").exists());
+    assert!(!project.join("Cargo.lock").exists());
 
     let add = geam_at(&project, ["provider", "add", "--path", "../provider"]);
     assert!(
@@ -330,10 +354,21 @@ fn runs_the_documented_text_pattern_provider_from_its_local_path() {
     );
     assert!(runner.contains("geam_provider_example_text_pattern::Component"));
 
-    let run = geam_at(&project, ["run"]);
+    for _ in 0..2 {
+        let run = geam_at(&project, ["run"]);
+        assert!(
+            run.status.success(),
+            "text pattern run failed: {}",
+            String::from_utf8_lossy(&run.stderr),
+        );
+        assert!(run.stdout.is_empty());
+        assert!(run.stderr.is_empty());
+    }
+
+    let run = geam_at(&project, ["run", "--module", "text_pattern_geam"]);
     assert!(
         run.status.success(),
-        "text pattern run failed: {}",
+        "Geam-specific text pattern run failed: {}",
         String::from_utf8_lossy(&run.stderr),
     );
     assert!(run.stdout.is_empty());
@@ -342,7 +377,7 @@ fn runs_the_documented_text_pattern_provider_from_its_local_path() {
     assert_eq!(
         String::from_utf8_lossy(&run.stderr),
         format!(
-            "{}/src/text_pattern_example.gleam:8 compiled pattern\nPattern(\"[A-Za-z]+\")\n",
+            "{}/src/text_pattern_geam.gleam:8 compiled pattern\nPattern(\"[A-Za-z]+\")\n",
             canonical_project.display(),
         ),
     );


### PR DESCRIPTION
## Summary

Make the text-pattern example usable on both Erlang and Geam, and prepare the
Gleam and Rust package documentation for independent publication on Hex and
crates.io.

- Ship `example_text_pattern_ffi.erl`, an OTP `re` implementation of the existing Gleam API, in the Hex package.
- Keep the existing Rust `regex` provider unchanged; both implementations expose `Pattern`, `CompileError`, `compile`, `is_match`, `find_all`, and `replace_all`.
- Separate the executable examples into a shared entrypoint, Erlang-specific behavior, and Geam-specific behavior.
- Extend the existing provider acceptance test to run Erlang before selecting any Rust provider, then prepare and run the generated Geam runner, including repeated execution and exact inspection output. Update the existing CI matrix entry and document the OTP prerequisite.
- Give the Hex package and Rust provider their own installation/API documentation and absolute cross-links, while keeping local checkout and Cargo patch instructions in the example README.
- Align the Gleam project and package with the Rust provider's initial `0.1.0` version, including the resolved manifest and provider compatibility metadata.

## Runtime Boundary

The API is shared, but the regex engines are not made interchangeable by a
translation layer. Pattern and replacement strings go directly to each engine.
The examples and documentation distinguish capture replacement syntax,
lookahead support, native errors, and opaque-pattern equality and inspection.
Zero-length matching and resource limits also remain engine-specific.

The neutral Erlang FFI module name is independent of the discoverable Rust crate
name, `geam-example-text-pattern`. Geam continues to link by Gleam source
package/module/function or type identity and exact schema, not by the Erlang
annotation's native module name.

No changes to Geam runtime semantics, provider authoring APIs, CLI grammar,
discovery behavior, or Rust dependencies.

## Follow-Up

Related to #117. This PR prepares the packages and verifies local execution;
publication and live registry verification remain separate work.

- [ ] Publish `geam-example-text-pattern 0.1.0` to crates.io against released `geam 0.2.1`.
- [ ] Publish `example_text_pattern 0.1.0` to Hex, including its Erlang implementation.
- [ ] Verify the published Hex package in a fresh Erlang project.
- [ ] Complete #117's normal, non-ignored integration test for real crates.io discovery, interactive approval, exact selection, locking, runner build, and execution without explicit `geam provider add`; retain the existing fake-registry owner tests.
