### PR TITLE
List selected standalone providers

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -39,6 +39,7 @@ pub(super) struct Provider {
 #[derive(Debug, PartialEq, Eq, Subcommand)]
 pub(super) enum ProviderCommand {
     Add(AddProvider),
+    List,
     Remove(RemoveProvider),
 }
 
@@ -123,7 +124,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_registry_path_git_and_remove_provider_commands() {
+    fn parses_registry_path_git_list_and_remove_provider_commands() {
         let registry = Cli::try_parse_from(["geam", "provider", "add", "geam-images@1.2.3"])
             .expect("registry provider should parse");
         assert_eq!(
@@ -189,6 +190,17 @@ mod tests {
                         rev: Some("abc123".to_owned()),
                         package: Some("geam-images".to_owned()),
                     }),
+                }),
+            },
+        );
+
+        let list =
+            Cli::try_parse_from(["geam", "provider", "list"]).expect("list command should parse");
+        assert_eq!(
+            list,
+            Cli {
+                command: Command::Provider(Provider {
+                    command: ProviderCommand::List,
                 }),
             },
         );

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -95,6 +95,9 @@ pub(super) enum CliError {
         error: io::Error,
     },
 
+    #[error("failed to write provider list")]
+    ProviderListIo(#[source] io::Error),
+
     #[error("provider configuration {spec} is invalid: {reason}")]
     InvalidProviderConfiguration { spec: String, reason: String },
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -46,6 +46,7 @@ fn run_command(cli: Cli, current_directory: camino::Utf8PathBuf) -> Result<(), C
             ProviderCommand::Add(command) => {
                 provider::add(&project_root, current_directory.as_std_path(), command)
             }
+            ProviderCommand::List => provider::list(&project_root),
             ProviderCommand::Remove(command) => provider::remove(&project_root, command),
         },
     }

--- a/cli/src/provider.rs
+++ b/cli/src/provider.rs
@@ -1,4 +1,5 @@
 mod approval;
+mod list;
 mod manifest;
 mod metadata;
 mod reconcile;
@@ -83,6 +84,10 @@ pub(super) fn add(
         command,
         &crate::runner::SystemCargo,
     )
+}
+
+pub(super) fn list(project_root: &Utf8Path) -> Result<(), CliError> {
+    list::write(project_root, &mut std::io::stdout().lock())
 }
 
 fn add_with(

--- a/cli/src/provider/list.rs
+++ b/cli/src/provider/list.rs
@@ -1,0 +1,182 @@
+use super::manifest::{ProviderSelection, ProviderSource, read_provider_selections};
+use crate::error::CliError;
+use camino::Utf8Path;
+use std::io::Write;
+
+const GLEAM_HEADER: &str = "GLEAM PACKAGE";
+const CRATE_HEADER: &str = "CARGO CRATE";
+
+pub(super) fn write(project_root: &Utf8Path, writer: &mut dyn Write) -> Result<(), CliError> {
+    let providers = read_provider_selections(project_root)?;
+    let output = render(&providers);
+    writer
+        .write_all(output.as_bytes())
+        .and_then(|()| writer.flush())
+        .map_err(CliError::ProviderListIo)
+}
+
+fn render(providers: &[ProviderSelection]) -> String {
+    if providers.is_empty() {
+        return "No external providers are selected.\n".to_owned();
+    }
+
+    let gleam_width = providers
+        .iter()
+        .map(|provider| provider.gleam_package().len())
+        .max()
+        .unwrap_or(0)
+        .max(GLEAM_HEADER.len());
+    let crate_width = providers
+        .iter()
+        .map(|provider| provider.crate_name().len())
+        .max()
+        .unwrap_or(0)
+        .max(CRATE_HEADER.len());
+    let mut output =
+        format!("{GLEAM_HEADER:<gleam_width$}  {CRATE_HEADER:<crate_width$}  SOURCE\n");
+    for provider in providers {
+        output.push_str(&format!(
+            "{:<gleam_width$}  {:<crate_width$}  {}\n",
+            provider.gleam_package(),
+            provider.crate_name(),
+            render_source(provider.source()),
+        ));
+    }
+    output
+}
+
+fn render_source(source: &ProviderSource) -> String {
+    match source {
+        ProviderSource::Registry { version } => format!("crates.io {version}"),
+        ProviderSource::Path { path } => format!("path {}", quoted(path.as_str())),
+        ProviderSource::Git { url, rev } => match rev {
+            Some(rev) => format!("git {} rev {}", quoted(url), quoted(rev)),
+            None => format!("git {}", quoted(url)),
+        },
+    }
+}
+
+fn quoted(value: &str) -> String {
+    format!("{value:?}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write;
+    use crate::error::CliError;
+    use crate::provider::manifest::MANAGED_HEADER;
+    use camino::Utf8PathBuf;
+    use std::fs;
+    use std::io::{self, Write};
+    use tempfile::tempdir;
+
+    #[test]
+    fn lists_managed_sources_in_package_order_with_fixed_columns() {
+        let project = tempdir().expect("temporary project should be created");
+        let root = utf8_root(&project);
+        let manifest = format!(
+            r#"{MANAGED_HEADER}
+[package.metadata.geam.runner]
+schema = 1
+
+[dependencies]
+toml = "0.9"
+geam_provider_search = {{ package = "geam-search", git = "https://example.com/search.git", rev = "abc123" }}
+geam_provider_catalog = {{ package = "geam-catalog", path = '/workspace/catalog "draft"' }}
+geam_provider_example_text_pattern = {{ package = "geam-example-text-pattern", version = "=0.1.0" }}
+geam_provider_websocket = {{ package = "geam-websocket", git = "https://example.com/websocket.git" }}
+"#,
+        );
+        fs::write(root.join("Cargo.toml"), &manifest).expect("managed manifest should be written");
+
+        let mut output = Vec::new();
+        write(&root, &mut output).expect("provider list should be written");
+
+        assert_eq!(
+            String::from_utf8(output).expect("provider list should be UTF-8"),
+            concat!(
+                "GLEAM PACKAGE         CARGO CRATE                SOURCE\n",
+                "catalog               geam-catalog               path \"/workspace/catalog \\\"draft\\\"\"\n",
+                "example_text_pattern  geam-example-text-pattern  crates.io 0.1.0\n",
+                "search                geam-search                git \"https://example.com/search.git\" rev \"abc123\"\n",
+                "websocket             geam-websocket             git \"https://example.com/websocket.git\"\n",
+            ),
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("Cargo.toml"))
+                .expect("managed manifest should remain readable"),
+            manifest,
+        );
+    }
+
+    #[test]
+    fn reports_an_empty_selection_without_creating_a_manifest() {
+        let project = tempdir().expect("temporary project should be created");
+        let root = utf8_root(&project);
+        let mut output = Vec::new();
+
+        write(&root, &mut output).expect("empty provider list should be written");
+
+        assert_eq!(output, b"No external providers are selected.\n");
+        assert!(!root.join("Cargo.toml").exists());
+    }
+
+    #[test]
+    fn preserves_managed_manifest_ownership_errors() {
+        let project = tempdir().expect("temporary project should be created");
+        let root = utf8_root(&project);
+        fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"application\"\n",
+        )
+        .expect("user-owned manifest should be written");
+
+        let error = write(&root, &mut Vec::new()).expect_err("user-owned manifest should fail");
+
+        assert!(matches!(
+            error,
+            CliError::UserOwnedCargoManifest { path } if path == root.join("Cargo.toml")
+        ));
+    }
+
+    #[test]
+    fn preserves_write_and_flush_failures() {
+        for (write_failure, expected_kind) in [
+            (Some(io::ErrorKind::BrokenPipe), io::ErrorKind::BrokenPipe),
+            (None, io::ErrorKind::WriteZero),
+        ] {
+            let project = tempdir().expect("temporary project should be created");
+            let root = utf8_root(&project);
+            let error = write(&root, &mut FailingWriter { write_failure })
+                .expect_err("provider list output should fail");
+
+            assert_eq!(error.to_string(), "failed to write provider list");
+            assert!(matches!(
+                error,
+                CliError::ProviderListIo(error) if error.kind() == expected_kind
+            ));
+        }
+    }
+
+    struct FailingWriter {
+        write_failure: Option<io::ErrorKind>,
+    }
+
+    impl Write for FailingWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            match self.write_failure {
+                Some(kind) => Err(io::Error::from(kind)),
+                None => Ok(buffer.len()),
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::from(io::ErrorKind::WriteZero))
+        }
+    }
+
+    fn utf8_root(project: &tempfile::TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(project.path().to_path_buf())
+            .expect("temporary path should be valid UTF-8")
+    }
+}

--- a/cli/src/provider/manifest.rs
+++ b/cli/src/provider/manifest.rs
@@ -49,6 +49,12 @@ pub(super) enum ProviderSource {
     Git { url: String, rev: Option<String> },
 }
 
+pub(super) fn read_provider_selections(
+    root: &Utf8Path,
+) -> Result<Vec<ProviderSelection>, CliError> {
+    Ok(read_providers(root)?.into_values().collect())
+}
+
 pub(crate) struct ManagedProject {
     root: Utf8PathBuf,
     root_package: String,
@@ -57,65 +63,10 @@ pub(crate) struct ManagedProject {
 
 impl ManagedProject {
     pub(crate) fn load(root: &Utf8Path, root_package: impl Into<String>) -> Result<Self, CliError> {
-        let path = root.join("Cargo.toml");
-        let root_package = root_package.into();
-        if !path.exists() {
-            return Ok(Self {
-                root: root.to_path_buf(),
-                root_package,
-                providers: BTreeMap::new(),
-            });
-        }
-        let source = fs::read_to_string(&path).map_err(|error| CliError::FileRead {
-            path: path.clone(),
-            error,
-        })?;
-        if !source.starts_with(MANAGED_HEADER) {
-            return Err(CliError::UserOwnedCargoManifest { path });
-        }
-        let document = source
-            .parse::<toml::Table>()
-            .map_err(|error| CliError::InvalidToml {
-                kind: "managed Cargo manifest",
-                path: path.clone(),
-                reason: error.to_string(),
-            })?;
-        let schema = document
-            .get("package")
-            .and_then(toml::Value::as_table)
-            .and_then(|package| package.get("metadata"))
-            .and_then(toml::Value::as_table)
-            .and_then(|metadata| metadata.get("geam"))
-            .and_then(toml::Value::as_table)
-            .and_then(|geam| geam.get("runner"))
-            .and_then(toml::Value::as_table)
-            .and_then(|runner| runner.get("schema"))
-            .and_then(toml::Value::as_integer)
-            .ok_or_else(|| CliError::InvalidToml {
-                kind: "managed Cargo manifest",
-                path: path.clone(),
-                reason: "missing package.metadata.geam.runner.schema".to_owned(),
-            })?;
-        if schema != RUNNER_SCHEMA {
-            return Err(CliError::UnsupportedRunnerSchema { path, schema });
-        }
-        let dependencies = document
-            .get("dependencies")
-            .and_then(toml::Value::as_table)
-            .ok_or_else(|| CliError::InvalidToml {
-                kind: "managed Cargo manifest",
-                path: path.clone(),
-                reason: "missing dependencies table".to_owned(),
-            })?;
-        let providers = dependencies
-            .iter()
-            .filter(|(alias, _)| alias.starts_with(PROVIDER_ALIAS_PREFIX))
-            .map(|(alias, value)| parse_provider_dependency(alias, value))
-            .collect::<Result<BTreeMap<_, _>, _>>()?;
         Ok(Self {
             root: root.to_path_buf(),
-            root_package,
-            providers,
+            root_package: root_package.into(),
+            providers: read_providers(root)?,
         })
     }
 
@@ -226,6 +177,59 @@ impl ManagedProject {
         source.push_str("\n[workspace]\nresolver = \"3\"\n");
         source
     }
+}
+
+fn read_providers(root: &Utf8Path) -> Result<BTreeMap<String, ProviderSelection>, CliError> {
+    let path = root.join("Cargo.toml");
+    if !path.exists() {
+        return Ok(BTreeMap::new());
+    }
+    let source = fs::read_to_string(&path).map_err(|error| CliError::FileRead {
+        path: path.clone(),
+        error,
+    })?;
+    if !source.starts_with(MANAGED_HEADER) {
+        return Err(CliError::UserOwnedCargoManifest { path });
+    }
+    let document = source
+        .parse::<toml::Table>()
+        .map_err(|error| CliError::InvalidToml {
+            kind: "managed Cargo manifest",
+            path: path.clone(),
+            reason: error.to_string(),
+        })?;
+    let schema = document
+        .get("package")
+        .and_then(toml::Value::as_table)
+        .and_then(|package| package.get("metadata"))
+        .and_then(toml::Value::as_table)
+        .and_then(|metadata| metadata.get("geam"))
+        .and_then(toml::Value::as_table)
+        .and_then(|geam| geam.get("runner"))
+        .and_then(toml::Value::as_table)
+        .and_then(|runner| runner.get("schema"))
+        .and_then(toml::Value::as_integer)
+        .ok_or_else(|| CliError::InvalidToml {
+            kind: "managed Cargo manifest",
+            path: path.clone(),
+            reason: "missing package.metadata.geam.runner.schema".to_owned(),
+        })?;
+    if schema != RUNNER_SCHEMA {
+        return Err(CliError::UnsupportedRunnerSchema { path, schema });
+    }
+    let dependencies = document
+        .get("dependencies")
+        .and_then(toml::Value::as_table)
+        .ok_or_else(|| CliError::InvalidToml {
+            kind: "managed Cargo manifest",
+            path,
+            reason: "missing dependencies table".to_owned(),
+        })?;
+    dependencies
+        .iter()
+        .filter(|(alias, _)| alias.starts_with(PROVIDER_ALIAS_PREFIX))
+        .map(|(alias, value)| parse_provider_dependency(alias, value))
+        .collect()
 }
 
 fn replace_file(temporary: &Utf8Path, destination: &Utf8Path) -> Result<(), CliError> {

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -97,6 +97,7 @@ geam provider add geam-company-image@0.3.1
 geam provider add --path ../geam-company-image
 geam provider add --path ../provider-workspace --package geam-company-image
 geam provider add --git https://example.com/provider.git --rev COMMIT
+geam provider list
 geam provider remove company_image
 ```
 
@@ -104,6 +105,9 @@ Registry versions are recorded exactly. Git revisions and path packages follow
 Cargo source and lock semantics. One Gleam package has at most one provider, and
 provider metadata must declare that exact package and a compatible Hex version
 range. Provider crates export their component as `Component` at the crate root.
+`geam provider list` reads the stored external selections without compiling the
+project, contacting a registry, or changing the managed runner files. Built-in
+providers are not selections and are not included.
 
 ## Configuration
 

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -128,7 +128,7 @@ pub fn main() {
 }
 
 #[test]
-fn dispatches_provider_add_and_remove_through_the_binary_boundary() {
+fn dispatches_provider_add_list_and_remove_through_the_binary_boundary() {
     let project = gleam_project_with_dependency("images", "1.2.3");
     let provider = provider_package();
 
@@ -150,11 +150,43 @@ fn dispatches_provider_add_and_remove_through_the_binary_boundary() {
         String::from_utf8_lossy(&add.stderr),
     );
 
+    let list = geam(&project, ["provider", "list"]);
+    assert!(
+        list.status.success(),
+        "provider list failed: {}",
+        String::from_utf8_lossy(&list.stderr),
+    );
+    let canonical_provider =
+        fs::canonicalize(provider.path()).expect("provider path should canonicalize");
+    let provider_path = format!(
+        "{:?}",
+        canonical_provider
+            .to_str()
+            .expect("provider path should be valid UTF-8"),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&list.stdout),
+        format!(
+            "GLEAM PACKAGE  CARGO CRATE  SOURCE\nimages         geam-images  path {provider_path}\n"
+        ),
+    );
+
     let remove = geam(&project, ["provider", "remove", "images"]);
     assert!(
         remove.status.success(),
         "provider remove failed: {}",
         String::from_utf8_lossy(&remove.stderr),
+    );
+
+    let empty = geam(&project, ["provider", "list"]);
+    assert!(
+        empty.status.success(),
+        "empty provider list failed: {}",
+        String::from_utf8_lossy(&empty.stderr),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&empty.stdout),
+        "No external providers are selected.\n",
     );
 }
 


### PR DESCRIPTION
## Summary

- add `geam provider list` for persisted external provider selections
- render deterministic Gleam package, Cargo crate, and registry/path/Git source columns
- keep listing read-only and document that it does not compile, reconcile, or contact registries

## Additional verification

- `cargo install --path . --locked --root target/install-smoke`
