### PR TITLE
Verify the published provider distribution

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -59,6 +59,125 @@ jobs:
             (cd "cli/tests/fixtures/standalone_cli/project/packages/$package" && gleam export hex-tarball)
           done
 
+  published-provider:
+    name: Published provider
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GEAM_VERSION: "0.2.1"
+      GLEAM_PACKAGE_VERSION: "0.1.0"
+      PROVIDER_VERSION: "0.1.0"
+      GEAM_ROOT: ${{ runner.temp }}/published-geam
+      GEAM_BIN: ${{ runner.temp }}/published-geam/bin/geam
+      PROJECT_ROOT: ${{ runner.temp }}/published-provider
+
+    steps:
+      - name: Install Gleam toolchain
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: "29"
+          gleam-version: "1.18.1"
+          rebar3-version: "3"
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: "1.96"
+          cache: false
+          rustflags: ""
+
+      - name: Install published Geam
+        run: |
+          cargo install geam --version "=$GEAM_VERSION" --locked --root "$GEAM_ROOT"
+          test "$("$GEAM_BIN" --version)" = "geam $GEAM_VERSION"
+
+      - name: Create clean Gleam project
+        run: gleam new --name published_provider --skip-git --skip-github "$PROJECT_ROOT"
+
+      - name: Add published Gleam package
+        working-directory: ${{ env.PROJECT_ROOT }}
+        run: |
+          gleam add "example_text_pattern@$GLEAM_PACKAGE_VERSION"
+          sed -i.bak "s/^example_text_pattern = .*/example_text_pattern = \"$GLEAM_PACKAGE_VERSION\"/" gleam.toml
+          rm gleam.toml.bak
+          grep -Fx "example_text_pattern = \"$GLEAM_PACKAGE_VERSION\"" gleam.toml
+          gleam deps download
+          grep -E "name = \"example_text_pattern\", version = \"$GLEAM_PACKAGE_VERSION\".*source = \"hex\"" manifest.toml
+
+      - name: Write provider-backed entry module
+        working-directory: ${{ env.PROJECT_ROOT }}
+        run: |
+          cat > src/published_provider.gleam <<'GLEAM'
+          import example_text_pattern as pattern
+
+          pub fn main() -> Nil {
+            let assert Ok(words) = pattern.compile("[A-Za-z]+")
+            assert pattern.is_match(words, "Geam + Gleam 2026")
+            assert pattern.find_all(words, "Geam + Gleam 2026") == ["Geam", "Gleam"]
+            assert pattern.replace_all(words, "Geam + Gleam 2026", "<word>")
+              == "<word> + <word> 2026"
+            let assert Error(pattern.CompileError(message)) = pattern.compile("(")
+            assert message != ""
+          }
+          GLEAM
+
+      - name: Approve discovered crates.io provider
+        working-directory: ${{ env.PROJECT_ROOT }}
+        run: |
+          test ! -e Cargo.toml
+          printf 'y\n' | script --quiet --return --command "$GEAM_BIN prepare" "$RUNNER_TEMP/provider-approval.log"
+          test "$(grep -Fc "Approve geam-example-text-pattern $PROVIDER_VERSION? [y/N]" "$RUNNER_TEMP/provider-approval.log")" -eq 1
+
+      - name: Verify published provider selection
+        working-directory: ${{ env.PROJECT_ROOT }}
+        run: |
+          cargo metadata --format-version 1 --locked --manifest-path Cargo.toml > "$RUNNER_TEMP/provider-metadata.json"
+          jq -e --arg manifest "$PROJECT_ROOT/Cargo.toml" --arg version "$PROVIDER_VERSION" '
+            [
+              .packages[]
+              | select(.manifest_path == $manifest)
+              | .dependencies[]
+              | select(
+                  .rename == "geam_provider_example_text_pattern"
+                  and .name == "geam-example-text-pattern"
+                  and .req == ("=" + $version)
+                  and .path == null
+                  and (.source | startswith("registry+"))
+                )
+            ]
+            | length == 1
+          ' "$RUNNER_TEMP/provider-metadata.json"
+          jq -e --arg geam "$GEAM_VERSION" --arg provider "$PROVIDER_VERSION" '
+            ([
+              .packages[]
+              | select(
+                  .name == "geam"
+                  and .version == $geam
+                  and (.source | startswith("registry+"))
+                )
+            ] | length == 1)
+            and
+            ([
+              .packages[]
+              | select(
+                  .name == "geam-example-text-pattern"
+                  and .version == $provider
+                  and (.source | startswith("registry+"))
+                )
+            ] | length == 1)
+          ' "$RUNNER_TEMP/provider-metadata.json"
+          grep -F "geam_provider_example_text_pattern::Component" build/geam/runner.rs
+          sha256sum Cargo.toml Cargo.lock build/geam/runner.rs > "$RUNNER_TEMP/provider-files.before"
+
+      - name: Run and repeat published project
+        working-directory: ${{ env.PROJECT_ROOT }}
+        run: |
+          test -z "$("$GEAM_BIN" run)"
+          "$GEAM_BIN" prepare
+          test -z "$("$GEAM_BIN" run)"
+          sha256sum Cargo.toml Cargo.lock build/geam/runner.rs > "$RUNNER_TEMP/provider-files.after"
+          diff --unified "$RUNNER_TEMP/provider-files.before" "$RUNNER_TEMP/provider-files.after"
+
   example-providers:
     name: Provider examples (${{ matrix.example }})
     runs-on: ubuntu-latest

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -67,9 +67,6 @@ jobs:
       GEAM_VERSION: "0.2.1"
       GLEAM_PACKAGE_VERSION: "0.1.0"
       PROVIDER_VERSION: "0.1.0"
-      GEAM_ROOT: ${{ runner.temp }}/published-geam
-      GEAM_BIN: ${{ runner.temp }}/published-geam/bin/geam
-      PROJECT_ROOT: ${{ runner.temp }}/published-provider
 
     steps:
       - name: Install Gleam toolchain
@@ -88,14 +85,14 @@ jobs:
 
       - name: Install published Geam
         run: |
-          cargo install geam --version "=$GEAM_VERSION" --locked --root "$GEAM_ROOT"
-          test "$("$GEAM_BIN" --version)" = "geam $GEAM_VERSION"
+          cargo install geam --version "=$GEAM_VERSION" --locked --root "$RUNNER_TEMP/published-geam"
+          test "$("$RUNNER_TEMP/published-geam/bin/geam" --version)" = "geam $GEAM_VERSION"
 
       - name: Create clean Gleam project
-        run: gleam new --name published_provider --skip-git --skip-github "$PROJECT_ROOT"
+        run: gleam new --name published_provider --skip-git --skip-github "$RUNNER_TEMP/published-provider"
 
       - name: Add published Gleam package
-        working-directory: ${{ env.PROJECT_ROOT }}
+        working-directory: ${{ runner.temp }}/published-provider
         run: |
           gleam add "example_text_pattern@$GLEAM_PACKAGE_VERSION"
           sed -i.bak "s/^example_text_pattern = .*/example_text_pattern = \"$GLEAM_PACKAGE_VERSION\"/" gleam.toml
@@ -105,7 +102,7 @@ jobs:
           grep -E "name = \"example_text_pattern\", version = \"$GLEAM_PACKAGE_VERSION\".*source = \"hex\"" manifest.toml
 
       - name: Write provider-backed entry module
-        working-directory: ${{ env.PROJECT_ROOT }}
+        working-directory: ${{ runner.temp }}/published-provider
         run: |
           cat > src/published_provider.gleam <<'GLEAM'
           import example_text_pattern as pattern
@@ -122,17 +119,17 @@ jobs:
           GLEAM
 
       - name: Approve discovered crates.io provider
-        working-directory: ${{ env.PROJECT_ROOT }}
+        working-directory: ${{ runner.temp }}/published-provider
         run: |
           test ! -e Cargo.toml
-          printf 'y\n' | script --quiet --return --command "$GEAM_BIN prepare" "$RUNNER_TEMP/provider-approval.log"
+          printf 'y\n' | script --quiet --return --command "$RUNNER_TEMP/published-geam/bin/geam prepare" "$RUNNER_TEMP/provider-approval.log"
           test "$(grep -Fc "Approve geam-example-text-pattern $PROVIDER_VERSION? [y/N]" "$RUNNER_TEMP/provider-approval.log")" -eq 1
 
       - name: Verify published provider selection
-        working-directory: ${{ env.PROJECT_ROOT }}
+        working-directory: ${{ runner.temp }}/published-provider
         run: |
           cargo metadata --format-version 1 --locked --manifest-path Cargo.toml > "$RUNNER_TEMP/provider-metadata.json"
-          jq -e --arg manifest "$PROJECT_ROOT/Cargo.toml" --arg version "$PROVIDER_VERSION" '
+          jq -e --arg manifest "$RUNNER_TEMP/published-provider/Cargo.toml" --arg version "$PROVIDER_VERSION" '
             [
               .packages[]
               | select(.manifest_path == $manifest)
@@ -170,11 +167,11 @@ jobs:
           sha256sum Cargo.toml Cargo.lock build/geam/runner.rs > "$RUNNER_TEMP/provider-files.before"
 
       - name: Run and repeat published project
-        working-directory: ${{ env.PROJECT_ROOT }}
+        working-directory: ${{ runner.temp }}/published-provider
         run: |
-          test -z "$("$GEAM_BIN" run)"
-          "$GEAM_BIN" prepare
-          test -z "$("$GEAM_BIN" run)"
+          test -z "$("$RUNNER_TEMP/published-geam/bin/geam" run)"
+          "$RUNNER_TEMP/published-geam/bin/geam" prepare
+          test -z "$("$RUNNER_TEMP/published-geam/bin/geam" run)"
           sha256sum Cargo.toml Cargo.lock build/geam/runner.rs > "$RUNNER_TEMP/provider-files.after"
           diff --unified "$RUNNER_TEMP/provider-files.before" "$RUNNER_TEMP/provider-files.after"
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ external semantics. Call tracing then demonstrates typed source callback
 invocation and same-component re-entry. Generic box then shows a source value
 retained without materialization and mapped through a typed callback. The final
 text-pattern example combines a regex-backed external, custom error, source
-`Result`, and `List(String)` output in one packageable macro-authored provider.
+`Result`, and `List(String)` output in one published macro-authored provider.
 
 Geam owns only a manifest carrying its exact managed marker, `Cargo.lock`, and
 `build/geam/` runner artifacts. It refuses to adopt an existing user Cargo

--- a/docs/host-providers.md
+++ b/docs/host-providers.md
@@ -469,7 +469,12 @@ gleam-version = ">= 0.1.0 and < 0.2.0"
 
 The [complete example](../examples/text_pattern/README.md) executes this crate
 through explicit path selection and packages it with ordinary Cargo tooling.
-Its [provider README](../examples/text_pattern/provider/README.md) explains the
+The matching Gleam package and provider are also published on Hex and crates.io;
+the package's [public usage guide](../examples/text_pattern/project/packages/example_text_pattern/README.md)
+shows discovery and approval without an explicit provider selection. CI keeps
+that released path separate from checkout tests and verifies it with a fixed
+combination of published Geam, Gleam package, and provider versions. The
+[provider README](../examples/text_pattern/provider/README.md) explains the
 complete macro-authored Rust mapping and why `Pattern` owns manual source
 semantics.
 

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -86,9 +86,19 @@ example_text_pattern
 
 The example project contains an ordinary local Gleam dependency and no Geam
 mapping metadata. Its independently packageable provider uses Geam's public
-authoring macros. The bounded registry tests separately verify discovery,
-approval, archive validation, and the same production runner path without
-requiring a published fixture crate.
+authoring macros. The bounded fake-registry tests separately verify discovery,
+approval, archive validation, and the same production runner path
+deterministically against the current checkout.
+
+The Gleam package and Rust provider are also published as
+`example_text_pattern 0.1.0` on Hex and `geam-example-text-pattern 0.1.0` on
+crates.io. A separate CI acceptance job installs the published `geam 0.2.1`,
+creates a clean Gleam project, adds the Hex package, discovers and approves the
+real crates.io provider without `geam provider add`, and then locks, builds, and
+executes the generated runner. Repeating `prepare` and `run` must preserve the
+managed manifest, lock, and runner source. This fixed released combination
+monitors the public distribution path; it does not replace checkout regression
+tests and changes only when the corresponding artifacts have been published.
 
 Explicit selection is itself approval:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -173,10 +173,19 @@ crates are released.
 The [`examples/text_pattern`](../examples/text_pattern) example adds a
 distribution-ready advanced macro provider. Its path test executes manual
 external semantics, a custom error, source Result, and List output through the
-managed root lock and generated runner. The existing fake-registry
-orchestration test owns search, sparse-index, checksum, archive metadata,
-approval, registry-shaped dependency, lock, check, and run coverage without
-requiring a fixture crate to be published.
+managed root lock and generated runner. The fake-registry orchestration test
+owns deterministic checkout coverage of search, sparse-index, checksum,
+archive metadata, approval, registry-shaped dependency, lock, check, and run.
+
+A separate `Published provider` acceptance job exercises the released
+distribution rather than the checkout. It installs `geam 0.2.1`, creates a
+clean project, pins `example_text_pattern 0.1.0` from Hex, and uses a real PTY
+approval to select `geam-example-text-pattern 0.1.0` from crates.io without an
+explicit provider add. Cargo metadata must show exact registry dependencies,
+the generated runner must include the provider component, and repeated
+prepare/run must preserve the managed manifest, lock, and runner source. The
+small Gleam entry module is kept inline in the workflow because this job owns a
+single released command sequence rather than reusable source behavior.
 
 The same text-pattern test first runs the common Gleam entrypoint and the
 Erlang-specific example using the package's native `re` implementation, before
@@ -195,7 +204,10 @@ The [Acceptance workflow](../.github/workflows/acceptance.yml) runs one matrix
 job per documented example. Each job selects its exact `provider_examples`
 test, runs the independent provider's tests, verifies its Cargo package, and
 exports its Gleam package. A failed example does not cancel the other matrix
-jobs. Formatting and Clippy remain in the Workspace workflow.
+jobs. The parallel `Published provider` job has no repository checkout and
+therefore cannot substitute path dependencies or checkout binaries for the
+released artifacts it monitors. Formatting and Clippy remain in the Workspace
+workflow.
 
 Each example has a distinct cache key. Within a job, the root test binary and
 independent provider use the checkout's `target/` directory so Cargo can reuse
@@ -206,8 +218,9 @@ those isolated runner artifacts are not shared or cached between jobs.
 The normal suite executes the full generated runner with the fixture's locked
 Gleam and Rust dependencies. CI exports the standalone fixture's three local
 Gleam dependencies and all nine example Gleam packages. It also packages the
-two standalone fixture providers and every example provider. No fixture package
-is published.
+two standalone fixture providers and every example provider. No test-only
+fixture package is published; the text-pattern packages are public
+documentation examples with their own release cycle.
 
 The root package keeps four explicit acceptance targets:
 

--- a/examples/text_pattern/README.md
+++ b/examples/text_pattern/README.md
@@ -1,9 +1,9 @@
 # Text Pattern Provider Example
 
-This example pairs an ordinary Gleam package with a separately packageable Rust
-provider for [Geam](https://github.com/panarch/geam). The Gleam package includes
-an Erlang `re` implementation. The Rust crate implements the same API with
-`regex` through Geam's public provider authoring macros.
+This example pairs a Gleam package published on Hex with a Rust provider
+published on crates.io for [Geam](https://github.com/panarch/geam). The Gleam
+package includes an Erlang `re` implementation. The Rust crate implements the
+same API with `regex` through Geam's public provider authoring macros.
 
 See the [Gleam package README](project/packages/example_text_pattern/README.md)
 for installation and API usage, and the [provider README](provider/README.md)


### PR DESCRIPTION
## Summary

- verify the released `geam 0.2.1`, Hex `example_text_pattern 0.1.0`, and crates.io `geam-example-text-pattern 0.1.0` as one public distribution path
- discover and approve the real provider without a checkout, path dependency, Git dependency, Cargo patch, or explicit provider selection
- distinguish fake-registry, local-path, and released-distribution evidence in the standalone, provider, and testing documentation

## Verification

- installed `geam =0.2.1` from crates.io and ran the released Hex/provider combination through approval, locking, generated-runner execution, and repeated preparation
- confirmed the managed manifest, Cargo lock, and generated runner remained byte-for-byte stable on repeat

Closes #117
