### PR TITLE
Prepare offline CI fixtures with locked workspace dependencies

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           cache-targets: false
 
+      - name: Fetch workspace dependencies for offline fixtures
+        run: cargo fetch --locked
+
       - name: Test root acceptance boundaries
         run: |
           cargo test --package geam --test binary --locked
@@ -328,6 +331,9 @@ jobs:
           workspaces: |
             . -> target
             examples/${{ matrix.example }}/provider -> ../../../target
+
+      - name: Fetch workspace dependencies for offline fixtures
+        run: cargo fetch --locked
 
       - name: Run documented provider example
         run: cargo test --package geam --test provider_examples --locked -- --exact "${{ matrix.test }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -126,6 +126,9 @@ jobs:
         with:
           workspaces: ". -> target"
 
+      - name: Fetch workspace dependencies for offline fixtures
+        run: cargo fetch --locked
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -330,8 +330,19 @@ With the Rust toolchain, Gleam `v1.18.1`, and Erlang/OTP `29` installed, run the
 full test suite:
 
 ```sh
+cargo fetch --locked
 cargo test --workspace --locked
 ```
+
+Run `cargo fetch --locked` before the CLI tests, root acceptance targets, or
+CLI coverage closure when starting with an empty Cargo cache or after changing
+the workspace lockfile. These tests run nested Cargo commands in offline
+fixtures. The workspace fetch supplies the complete locked dependency graph,
+including target-specific crates that a native build need not download.
+Provider fixtures separately fetch their own locked dependencies; their minimal
+provider profile does not include every built-in used by a generated runner.
+The relevant Acceptance and Coverage jobs explicitly fetch workspace
+dependencies before testing, whether or not a cache was restored.
 
 The workspace's explicit default members are the same seven packages, so
 `cargo test --locked` remains equivalent for local use. CI spells out


### PR DESCRIPTION
## Summary
- Fetch the complete locked workspace dependency graph before root acceptance, provider examples, and CLI/binary coverage.
- Document the same preparation for local offline fixtures.

## Background
The post-merge main checks failed when nested offline Cargo commands needed crates that had not been downloaded. Provider-only fetches omit built-in dependencies needed by generated runners, and native builds do not download every target-specific dependency needed by Cargo metadata. Warm PR caches had hidden this missing preparation.

The explicit workspace fetch makes dependency preparation independent of cache restoration. Existing fixture fetches still prepare their independent provider locks. Test behavior, native-provider approval, workflow boundaries, and the 100% coverage gates are unchanged.
