### PR TITLE
Show standalone preparation progress

### DIFF
--- a/cli/src/cargo.rs
+++ b/cli/src/cargo.rs
@@ -1,8 +1,9 @@
 use crate::error::CliError;
-use crate::process::run_checked;
+use crate::process::run_checked_with_progress;
+use crate::progress::Progress;
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::{Metadata, MetadataCommand};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum CargoMetadataMode {
@@ -17,6 +18,7 @@ pub(super) trait CargoMetadataLoader {
         current_directory: &Utf8Path,
         manifest: &Utf8Path,
         mode: CargoMetadataMode,
+        progress: &mut Progress<'_>,
     ) -> Result<Metadata, CliError>;
 }
 
@@ -28,6 +30,7 @@ impl CargoMetadataLoader for SystemCargoMetadata {
         current_directory: &Utf8Path,
         manifest: &Utf8Path,
         mode: CargoMetadataMode,
+        progress: &mut Progress<'_>,
     ) -> Result<Metadata, CliError> {
         let mut command = Command::new("cargo");
         command
@@ -46,7 +49,7 @@ impl CargoMetadataLoader for SystemCargoMetadata {
                 command.arg("--locked");
             }
         }
-        let output = run_checked(&mut command)?;
+        let output = run_checked_with_progress(&mut command, progress, Stdio::piped())?;
         parse_metadata_output(manifest, &output.stdout)
     }
 }
@@ -79,6 +82,7 @@ mod tests {
         parse_metadata_output,
     };
     use crate::error::CliError;
+    use crate::progress::Progress;
     use camino::Utf8PathBuf;
 
     #[test]
@@ -104,7 +108,12 @@ mod tests {
             .expect("temporary path should be valid UTF-8");
         let manifest = root.join("missing/Cargo.toml");
         let error = SystemCargoMetadata
-            .load(&root, &manifest, CargoMetadataMode::Locked)
+            .load(
+                &root,
+                &manifest,
+                CargoMetadataMode::Locked,
+                &mut Progress::Hidden,
+            )
             .expect_err("missing manifest should fail");
         let expected_command =
             format!("cargo metadata --format-version 1 --manifest-path {manifest} --locked");

--- a/cli/src/embedding/package.rs
+++ b/cli/src/embedding/package.rs
@@ -4,6 +4,7 @@ mod project;
 use super::identifier::RustIdentifier;
 use crate::cargo::{CargoMetadataLoader, CargoMetadataMode, SystemCargoMetadata};
 use crate::error::CliError;
+use crate::progress::Progress;
 use crate::provider::ProviderCandidate;
 use camino::Utf8Path;
 use cargo_metadata::{DependencyKind, Metadata, Package, PackageId};
@@ -68,6 +69,7 @@ impl EmbeddingPackage {
             &project.manifest.with_file_name(""),
             &project.manifest,
             mode,
+            &mut Progress::Hidden,
         )?;
         let package = select_package(&metadata, &project.manifest)?;
         let mut direct_dependencies = direct_normal_dependencies(&metadata, package)?;
@@ -293,6 +295,7 @@ mod tests {
     use super::EmbeddingPackage;
     use crate::cargo::{CargoMetadataLoader, CargoMetadataMode};
     use crate::error::CliError;
+    use crate::progress::Progress;
     use camino::{Utf8Path, Utf8PathBuf};
     use cargo_metadata::{Metadata, MetadataCommand};
     use serde_json::{Value, json};
@@ -316,11 +319,14 @@ mod tests {
             current_directory: &Utf8Path,
             manifest: &Utf8Path,
             mode: CargoMetadataMode,
+            progress: &mut Progress<'_>,
         ) -> Result<Metadata, CliError> {
             if mode == CargoMetadataMode::Workspace {
-                self.workspace.load(current_directory, manifest, mode)
+                self.workspace
+                    .load(current_directory, manifest, mode, progress)
             } else {
-                self.resolved.load(current_directory, manifest, mode)
+                self.resolved
+                    .load(current_directory, manifest, mode, progress)
             }
         }
     }
@@ -331,6 +337,7 @@ mod tests {
             _current_directory: &Utf8Path,
             _manifest: &Utf8Path,
             _mode: CargoMetadataMode,
+            _progress: &mut Progress<'_>,
         ) -> Result<Metadata, CliError> {
             Ok(MetadataCommand::parse(&self.source)
                 .expect("fixed Cargo metadata fixture should be valid"))
@@ -343,6 +350,7 @@ mod tests {
             _current_directory: &Utf8Path,
             manifest: &Utf8Path,
             _mode: CargoMetadataMode,
+            _progress: &mut Progress<'_>,
         ) -> Result<Metadata, CliError> {
             Err(CliError::InvalidCargoMetadata {
                 manifest: manifest.to_path_buf(),

--- a/cli/src/embedding/package/project.rs
+++ b/cli/src/embedding/package/project.rs
@@ -49,7 +49,12 @@ impl EmbeddingProject {
         loader: &dyn CargoMetadataLoader,
     ) -> Result<Self, CliError> {
         let manifest = find_manifest(current_directory)?;
-        let metadata = loader.load(current_directory, &manifest, CargoMetadataMode::Workspace)?;
+        let metadata = loader.load(
+            current_directory,
+            &manifest,
+            CargoMetadataMode::Workspace,
+            &mut crate::progress::Progress::Hidden,
+        )?;
         let package = select_package(&metadata, &manifest)?;
         let package_name = package.name.to_string();
         if package

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -113,6 +113,9 @@ pub(super) enum CliError {
     #[error("failed to write embedding progress")]
     EmbeddingProgressIo(#[source] io::Error),
 
+    #[error("failed to write preparation progress")]
+    PreparationProgressIo(#[source] io::Error),
+
     #[error("refusing to replace existing embedding file {path}: {reason}")]
     EmbeddingFileConflict { path: Utf8PathBuf, reason: String },
 
@@ -154,6 +157,13 @@ pub(super) enum CliError {
 
     #[error("failed to start `{command}`")]
     ProcessIo {
+        command: String,
+        #[source]
+        error: io::Error,
+    },
+
+    #[error("failed to forward output from `{command}`")]
+    ProcessOutputIo {
         command: String,
         #[source]
         error: io::Error,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,6 +4,7 @@ mod command;
 mod embedding;
 mod error;
 mod process;
+mod progress;
 mod project;
 mod provider;
 mod runner;
@@ -15,6 +16,7 @@ use command::{
 };
 use error::CliError;
 use std::env;
+use std::io::Write;
 use std::process::ExitCode;
 
 pub fn run() -> ExitCode {
@@ -26,7 +28,8 @@ pub fn run() -> ExitCode {
     match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            eprintln!("geam: {error}");
+            // A closed stderr must not turn the original failure into a panic.
+            let _ = writeln!(std::io::stderr(), "geam: {error}");
             ExitCode::FAILURE
         }
     }

--- a/cli/src/process.rs
+++ b/cli/src/process.rs
@@ -1,6 +1,9 @@
+mod streaming;
+
 use crate::error::CliError;
+use crate::progress::Progress;
 use std::ffi::OsStr;
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 
 pub(super) fn run_checked(command: &mut Command) -> Result<Output, CliError> {
     let display = display_command(command);
@@ -8,14 +11,17 @@ pub(super) fn run_checked(command: &mut Command) -> Result<Output, CliError> {
         command: display.clone(),
         error,
     })?;
-    if output.status.success() {
-        Ok(output)
-    } else {
-        Err(CliError::ProcessFailure {
-            command: display,
-            status: output.status.code(),
-            stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
-        })
+    check_status(display, output)
+}
+
+pub(crate) fn run_checked_with_progress(
+    command: &mut Command,
+    progress: &mut Progress<'_>,
+    stdout: Stdio,
+) -> Result<Output, CliError> {
+    match progress {
+        Progress::Hidden => run_checked(command),
+        Progress::Visible(writer) => streaming::run(command, *writer, stdout),
     }
 }
 
@@ -43,10 +49,23 @@ fn display_command(command: &Command) -> String {
         .join(" ")
 }
 
+fn check_status(command: String, output: Output) -> Result<Output, CliError> {
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(CliError::ProcessFailure {
+            command,
+            status: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{run_checked, run_inherited};
+    use super::{run_checked, run_checked_with_progress, run_inherited};
     use crate::error::CliError;
+    use crate::progress::Progress;
     use std::process::{Command, Stdio};
 
     #[test]
@@ -55,6 +74,31 @@ mod tests {
             .expect("rustc version should succeed");
 
         assert!(String::from_utf8_lossy(&output.stdout).starts_with("rustc "));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn selects_capture_or_live_output_without_exposing_machine_stdout() {
+        let native = "printf '{\"packages\":[]}'; printf 'native\\routput' >&2";
+        let captured = run_checked_with_progress(
+            Command::new("sh").args(["-c", native]),
+            &mut Progress::Hidden,
+            Stdio::inherit(),
+        )
+        .expect("hidden progress should retain both streams");
+        assert_eq!(captured.stdout, b"{\"packages\":[]}");
+        assert_eq!(captured.stderr, b"native\routput");
+
+        let mut progress = Vec::new();
+        let streamed = run_checked_with_progress(
+            Command::new("sh").args(["-c", native]),
+            &mut Progress::Visible(&mut progress),
+            Stdio::piped(),
+        )
+        .expect("visible progress should forward stderr but keep JSON private");
+        assert_eq!(streamed.stdout, captured.stdout);
+        assert_eq!(streamed.stderr, captured.stderr);
+        assert_eq!(progress, b"native\routput");
     }
 
     #[test]
@@ -114,5 +158,31 @@ mod tests {
                 if command == "geam-command-that-does-not-exist"
                     && error.kind() == std::io::ErrorKind::NotFound
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn leaves_application_input_and_output_destinations_untouched() {
+        let directory = tempfile::tempdir().expect("stream directory");
+        let input = directory.path().join("stdin");
+        let stdout = directory.path().join("stdout");
+        let stderr = directory.path().join("stderr");
+        std::fs::write(&input, b"application input\n").expect("stdin bytes");
+        run_inherited(
+            Command::new("sh")
+                .args(["-c", "cat; printf 'application stderr' >&2"])
+                .stdin(std::fs::File::open(input).expect("stdin source"))
+                .stdout(std::fs::File::create(&stdout).expect("stdout destination"))
+                .stderr(std::fs::File::create(&stderr).expect("stderr destination")),
+        )
+        .expect("application streams should remain directly connected");
+        assert_eq!(
+            std::fs::read(stdout).expect("stdout bytes"),
+            b"application input\n"
+        );
+        assert_eq!(
+            std::fs::read(stderr).expect("stderr bytes"),
+            b"application stderr"
+        );
     }
 }

--- a/cli/src/process/streaming.rs
+++ b/cli/src/process/streaming.rs
@@ -1,0 +1,321 @@
+use crate::error::CliError;
+use std::io::{self, Read, Write};
+use std::process::{Command, Output, Stdio};
+use std::thread;
+
+pub(super) fn run(
+    command: &mut Command,
+    writer: &mut (dyn Write + Send),
+    stdout: Stdio,
+) -> Result<Output, CliError> {
+    run_with_pipe(command, writer, stdout, io::pipe())
+}
+
+fn run_with_pipe(
+    command: &mut Command,
+    writer: &mut (dyn Write + Send),
+    stdout: Stdio,
+    pipe: io::Result<(io::PipeReader, io::PipeWriter)>,
+) -> Result<Output, CliError> {
+    let display = super::display_command(command);
+    let output_error = |error| CliError::ProcessOutputIo {
+        command: display.clone(),
+        error,
+    };
+    let (mut reader, pipe_writer) = pipe.map_err(&output_error)?;
+    command
+        .stdin(Stdio::null())
+        .stdout(stdout)
+        .stderr(pipe_writer);
+    let mut stderr = Vec::new();
+    let mut forwarding = Ok(());
+    let output = thread::scope(|scope| {
+        let captured = &mut stderr;
+        let result = &mut forwarding;
+        let relay = thread::Builder::new().spawn_scoped(scope, move || {
+            *result = forward(&mut reader, writer, captured);
+        });
+        let output = relay.map_err(&output_error).and_then(|_| {
+            command.output().map_err(|error| CliError::ProcessIo {
+                command: display.clone(),
+                error,
+            })
+        });
+        // Command retains its pipe writer after the child exits; close it so
+        // the relay can reach EOF before the scope joins its thread.
+        command.stderr(Stdio::null());
+        output
+    })?;
+    let output = super::check_status(display.clone(), Output { stderr, ..output })?;
+    forwarding.map_err(output_error)?;
+    Ok(output)
+}
+
+fn forward(
+    reader: &mut dyn Read,
+    writer: &mut dyn Write,
+    captured: &mut Vec<u8>,
+) -> io::Result<()> {
+    let mut buffer = [0; 8192];
+    let mut forwarding = Ok(());
+    loop {
+        let count = match reader.read(&mut buffer) {
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            result => result?,
+        };
+        if count == 0 {
+            return forwarding;
+        }
+        let bytes = &buffer[..count];
+        captured.extend_from_slice(bytes);
+        if forwarding.is_ok() {
+            forwarding = writer.write_all(bytes).and_then(|()| writer.flush());
+        }
+        // Continue draining after output failure so the child can finish and
+        // its full stderr remains available for the structured process error.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{forward, run, run_with_pipe};
+    use crate::error::CliError;
+    use std::error::Error as _;
+    use std::io::{self, Read, Write};
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+
+    #[test]
+    fn preserves_pipe_setup_failure_before_starting_a_child() {
+        let mut native = Vec::new();
+        let error = run_with_pipe(
+            &mut Command::new("geam-command-that-does-not-exist"),
+            &mut native,
+            Stdio::piped(),
+            Err(io::Error::other("pipe unavailable")),
+        )
+        .expect_err("pipe failure must precede process startup");
+        assert_eq!(
+            error.to_string(),
+            "failed to forward output from `geam-command-that-does-not-exist`"
+        );
+        assert_eq!(
+            error.source().expect("original IO error").to_string(),
+            "pipe unavailable"
+        );
+        assert!(native.is_empty());
+    }
+
+    #[test]
+    fn forwards_native_bytes_and_flushes_before_the_next_read() {
+        let (sent, received) = mpsc::channel();
+        let chunks: [&[u8]; 3] = [b"partial\r", b"\x1b[31m\xff", b"\nlast"];
+        let mut output = AcknowledgedOutput {
+            bytes: Vec::new(),
+            sent,
+        };
+        let mut input = AcknowledgedInput {
+            chunks: chunks.into_iter(),
+            received,
+            waiting: false,
+        };
+        let mut captured = Vec::new();
+        forward(&mut input, &mut output, &mut captured).expect("native bytes should stream");
+        assert_eq!(output.bytes, b"partial\r\x1b[31m\xff\nlast");
+        assert_eq!(captured, output.bytes);
+    }
+
+    struct AcknowledgedOutput {
+        bytes: Vec<u8>,
+        sent: mpsc::Sender<()>,
+    }
+
+    impl Write for AcknowledgedOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.bytes.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.sent
+                .send(())
+                .expect("reader should still be connected");
+            Ok(())
+        }
+    }
+
+    struct AcknowledgedInput<'a> {
+        chunks: std::array::IntoIter<&'a [u8], 3>,
+        received: mpsc::Receiver<()>,
+        waiting: bool,
+    }
+
+    impl Read for AcknowledgedInput<'_> {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            if self.waiting {
+                self.received
+                    .try_recv()
+                    .expect("previous chunk must already be flushed");
+            }
+            match self.chunks.next() {
+                Some(chunk) => {
+                    buffer[..chunk.len()].copy_from_slice(chunk);
+                    self.waiting = true;
+                    Ok(chunk.len())
+                }
+                None => Ok(0),
+            }
+        }
+    }
+
+    struct FailedOutput {
+        fail_write: bool,
+    }
+
+    impl Write for FailedOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            if self.fail_write {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed writer"))
+            } else {
+                Ok(bytes.len())
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed writer"))
+        }
+    }
+
+    #[test]
+    fn drains_and_captures_after_write_or_flush_failure() {
+        let bytes = vec![b'x'; 32768];
+        for fail_write in [true, false] {
+            let mut input = bytes.as_slice();
+            let mut captured = Vec::new();
+            let error = forward(&mut input, &mut FailedOutput { fail_write }, &mut captured)
+                .expect_err("closed writer must be reported after draining");
+            assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+            assert!(input.is_empty());
+            assert_eq!(captured, bytes);
+        }
+    }
+
+    #[test]
+    fn preserves_read_errors_and_retries_interrupted_reads() {
+        struct InterruptedThenFailed(bool);
+        impl Read for InterruptedThenFailed {
+            fn read(&mut self, _buffer: &mut [u8]) -> io::Result<usize> {
+                let kind = if std::mem::take(&mut self.0) {
+                    io::ErrorKind::Interrupted
+                } else {
+                    io::ErrorKind::BrokenPipe
+                };
+                Err(io::Error::new(kind, "read failed"))
+            }
+        }
+        let error = forward(
+            &mut InterruptedThenFailed(true),
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .expect_err("non-interrupted read failure should propagate");
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn captures_stdout_privately_while_streaming_large_stderr_without_reading_stdin() {
+        let mut native = Vec::new();
+        let output = run(
+            Command::new("sh").args(["-c", "if read answer; then exit 9; fi; head -c 131072 /dev/zero; head -c 131072 /dev/zero >&2; printf '{\"ready\":true}'"]),
+            &mut native,
+            Stdio::piped(),
+        ).expect("checked process should drain both pipes and see stdin EOF");
+        let mut expected = vec![0; 131072];
+        expected.extend_from_slice(b"{\"ready\":true}");
+        assert_eq!(output.stdout, expected);
+        assert_eq!(output.stderr, vec![0; 131072]);
+        assert_eq!(native, output.stderr);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reaps_successful_children_before_reporting_relay_failure() {
+        let marker = tempfile::tempdir().expect("marker directory");
+        let path = marker.path().join("finished");
+        let error = run(
+            Command::new("sh")
+                .args([
+                    "-c",
+                    "head -c 131072 /dev/zero >&2; printf finished > \"$1\"",
+                    "sh",
+                ])
+                .arg(&path),
+            &mut FailedOutput { fail_write: true },
+            Stdio::inherit(),
+        )
+        .expect_err("output failure must not prevent the child from being drained and reaped");
+        assert_eq!(std::fs::read(path).expect("child must finish"), b"finished");
+        assert!(
+            error
+                .to_string()
+                .starts_with("failed to forward output from `sh -c ")
+        );
+        assert!(matches!(error, CliError::ProcessOutputIo { error, .. }
+            if error.kind() == io::ErrorKind::BrokenPipe));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn keeps_stdout_on_its_destination_and_native_failure_context_after_relay_failure() {
+        let directory = tempfile::tempdir().expect("output directory");
+        let path = directory.path().join("stdout");
+        let mut native = Vec::new();
+        let output = run(
+            Command::new("sh").args(["-c", "printf 'native stdout'; printf 'native stderr' >&2"]),
+            &mut native,
+            Stdio::from(std::fs::File::create(&path).expect("stdout destination")),
+        )
+        .expect("stdout should go directly to its configured destination");
+        assert!(output.stdout.is_empty());
+        assert_eq!(std::fs::read(path).expect("stdout bytes"), b"native stdout");
+        assert_eq!(native, b"native stderr");
+        assert_eq!(output.stderr, native);
+
+        let error = run(
+            Command::new("sh").args(["-c", "printf 'native failure' >&2; exit 7"]),
+            &mut FailedOutput { fail_write: true },
+            Stdio::piped(),
+        )
+        .expect_err("native failure must retain its command, status and captured stderr");
+        assert!(
+            matches!(error, CliError::ProcessFailure { command, status: Some(7), stderr }
+            if command == "sh -c printf 'native failure' >&2; exit 7" && stderr == "native failure")
+        );
+    }
+
+    #[test]
+    fn preserves_start_and_status_failures_with_captured_stderr() {
+        let mut native = Vec::new();
+        let error = run(
+            &mut Command::new("geam-command-that-does-not-exist"),
+            &mut native,
+            Stdio::piped(),
+        )
+        .expect_err("missing command should fail without hanging the relay");
+        assert!(matches!(error, CliError::ProcessIo { error, .. }
+            if error.kind() == io::ErrorKind::NotFound));
+
+        let error = run(
+            Command::new("rustc").arg("--definitely-not-a-rustc-option"),
+            &mut native,
+            Stdio::piped(),
+        )
+        .expect_err("native failure should retain stderr");
+        assert!(
+            matches!(error, CliError::ProcessFailure { command, status: Some(1), stderr }
+            if command == "rustc --definitely-not-a-rustc-option"
+                && stderr == String::from_utf8_lossy(&native).trim())
+        );
+    }
+}

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -1,0 +1,93 @@
+use crate::error::CliError;
+use std::fmt::Arguments;
+use std::io::Write;
+
+pub(crate) enum Progress<'a> {
+    Hidden,
+    Visible(&'a mut (dyn Write + Send)),
+}
+
+impl Progress<'_> {
+    pub(crate) fn report(&mut self, message: Arguments<'_>) -> Result<(), CliError> {
+        match self {
+            Self::Hidden => Ok(()),
+            Self::Visible(writer) => writeln!(writer, "geam: {message}")
+                .and_then(|()| writer.flush())
+                .map_err(CliError::PreparationProgressIo),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Progress;
+    use crate::error::CliError;
+    use std::io::{self, Write};
+
+    #[derive(Default)]
+    struct RecordedOutput {
+        bytes: Vec<u8>,
+        flushes: Vec<usize>,
+    }
+
+    impl Write for RecordedOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.bytes.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.flushes.push(self.bytes.len());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn appends_and_flushes_each_geam_phase_without_terminal_controls() {
+        let mut output = RecordedOutput::default();
+        let mut progress = Progress::Visible(&mut output);
+        progress
+            .report(format_args!("Preparing app"))
+            .expect("first phase");
+        progress
+            .report(format_args!("Prepared app"))
+            .expect("completed phase");
+
+        assert_eq!(output.bytes, b"geam: Preparing app\ngeam: Prepared app\n");
+        assert_eq!(output.flushes, [20, 39]);
+        Progress::Hidden
+            .report(format_args!("hidden"))
+            .expect("hidden output");
+    }
+
+    struct FailedOutput {
+        fail_write: bool,
+    }
+
+    impl Write for FailedOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            if self.fail_write {
+                Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed output"))
+            } else {
+                Ok(bytes.len())
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed output"))
+        }
+    }
+
+    #[test]
+    fn preserves_phase_write_and_flush_failures() {
+        for fail_write in [true, false] {
+            let mut output = FailedOutput { fail_write };
+            let error = Progress::Visible(&mut output)
+                .report(format_args!("Preparing app"))
+                .expect_err("closed output must fail");
+            assert_eq!(error.to_string(), "failed to write preparation progress");
+            assert!(matches!(error, CliError::PreparationProgressIo(error)
+                if error.kind() == io::ErrorKind::BrokenPipe));
+        }
+    }
+}

--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -1,7 +1,8 @@
 mod locked;
 
 use crate::error::CliError;
-use crate::process::run_checked;
+use crate::process::run_checked_with_progress;
+use crate::progress::Progress;
 use camino::{Utf8Path, Utf8PathBuf};
 use geam_core::{ProjectError, TypedProgram, compile_typed_project};
 use gleam_core::config::PackageConfig;
@@ -11,7 +12,7 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::ffi::OsString;
 use std::fs;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 pub(super) use locked::restore_locked_dependencies;
 
@@ -68,7 +69,18 @@ pub(super) fn entry_module(
 }
 
 pub(super) fn read_resolved_project(project_root: &Utf8Path) -> Result<ResolvedProject, CliError> {
-    read_resolved_project_with(project_root, &ProcessDependencyDownloader::gleam())
+    read_resolved_project_with_progress(project_root, &mut Progress::Hidden)
+}
+
+pub(super) fn read_resolved_project_with_progress(
+    project_root: &Utf8Path,
+    progress: &mut Progress<'_>,
+) -> Result<ResolvedProject, CliError> {
+    read_resolved_project_with(
+        project_root,
+        &ProcessDependencyDownloader::gleam(),
+        progress,
+    )
 }
 
 pub(super) fn read_existing_resolved_project(
@@ -78,19 +90,20 @@ pub(super) fn read_existing_resolved_project(
 }
 
 pub(super) fn prepare_dependencies(project_root: &Utf8Path) -> Result<(), CliError> {
-    ProcessDependencyDownloader::gleam().download(project_root)
+    ProcessDependencyDownloader::gleam().download(project_root, &mut Progress::Hidden)
 }
 
 fn read_resolved_project_with(
     project_root: &Utf8Path,
     downloader: &dyn DependencyDownloader,
+    progress: &mut Progress<'_>,
 ) -> Result<ResolvedProject, CliError> {
     match read_resolved_project_files(project_root) {
         Err(CliError::FileRead { path, error })
             if path == project_root.join(MANIFEST_FILE)
                 && error.kind() == std::io::ErrorKind::NotFound =>
         {
-            downloader.download(project_root)?;
+            download_dependencies(project_root, downloader, progress)?;
             read_resolved_project_files(project_root)
         }
         result => result,
@@ -123,11 +136,13 @@ fn read_resolved_project_files(project_root: &Utf8Path) -> Result<ResolvedProjec
 pub(super) fn compile_resolved_project(
     project_root: &Utf8Path,
     root_module: String,
+    progress: &mut Progress<'_>,
 ) -> Result<TypedProgram, CliError> {
     compile_resolved_project_with(
         project_root,
         root_module,
         &ProcessDependencyDownloader::gleam(),
+        progress,
     )
 }
 
@@ -135,11 +150,13 @@ fn compile_resolved_project_with(
     project_root: &Utf8Path,
     root_module: String,
     downloader: &dyn DependencyDownloader,
+    progress: &mut Progress<'_>,
 ) -> Result<TypedProgram, CliError> {
+    progress.report(format_args!("Checking Gleam source for {root_module}"))?;
     match compile_typed_project(project_root, root_module.clone()) {
         Ok(program) => Ok(program),
         Err(error) if should_download_dependencies(&error) => {
-            downloader.download(project_root)?;
+            download_dependencies(project_root, downloader, progress)?;
             compile_typed_project(project_root, root_module).map_err(CliError::from)
         }
         Err(error) => Err(error.into()),
@@ -154,7 +171,22 @@ fn should_download_dependencies(error: &ProjectError) -> bool {
 }
 
 trait DependencyDownloader {
-    fn download(&self, project_root: &Utf8Path) -> Result<(), CliError>;
+    fn download(
+        &self,
+        project_root: &Utf8Path,
+        progress: &mut Progress<'_>,
+    ) -> Result<(), CliError>;
+}
+
+fn download_dependencies(
+    project_root: &Utf8Path,
+    downloader: &dyn DependencyDownloader,
+    progress: &mut Progress<'_>,
+) -> Result<(), CliError> {
+    progress.report(format_args!(
+        "Preparing Gleam dependencies in {project_root}"
+    ))?;
+    downloader.download(project_root, progress)
 }
 
 struct ProcessDependencyDownloader {
@@ -183,11 +215,17 @@ impl ProcessDependencyDownloader {
 }
 
 impl DependencyDownloader for ProcessDependencyDownloader {
-    fn download(&self, project_root: &Utf8Path) -> Result<(), CliError> {
-        run_checked(
+    fn download(
+        &self,
+        project_root: &Utf8Path,
+        progress: &mut Progress<'_>,
+    ) -> Result<(), CliError> {
+        run_checked_with_progress(
             Command::new(&self.program)
                 .args(&self.arguments)
                 .current_dir(project_root),
+            progress,
+            Stdio::inherit(),
         )?;
         Ok(())
     }
@@ -220,6 +258,7 @@ mod tests {
         read_resolved_project, read_resolved_project_with, should_download_dependencies,
     };
     use crate::error::CliError;
+    use crate::progress::Progress;
     use camino::{Utf8Path, Utf8PathBuf};
     use geam_core::ProjectError;
     use std::cell::Cell;
@@ -232,7 +271,11 @@ mod tests {
     }
 
     impl DependencyDownloader for RecordingDownloader {
-        fn download(&self, project_root: &Utf8Path) -> Result<(), CliError> {
+        fn download(
+            &self,
+            project_root: &Utf8Path,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             self.calls.set(self.calls.get() + 1);
             fs::write(project_root.join("manifest.toml"), self.manifest)
                 .expect("recording downloader should write its fixture manifest");
@@ -243,7 +286,11 @@ mod tests {
     struct FailingDownloader;
 
     impl DependencyDownloader for FailingDownloader {
-        fn download(&self, _project_root: &Utf8Path) -> Result<(), CliError> {
+        fn download(
+            &self,
+            _project_root: &Utf8Path,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             Err(CliError::ProcessFailure {
                 command: "gleam deps download".to_owned(),
                 status: Some(1),
@@ -399,8 +446,9 @@ packages = [
             calls: Cell::new(0),
             manifest: "packages = []\n[requirements]\n",
         };
-        let resolved = read_resolved_project_with(&utf8_path(&project), &downloader)
-            .expect("missing resolved manifest should be downloaded once");
+        let resolved =
+            read_resolved_project_with(&utf8_path(&project), &downloader, &mut Progress::Hidden)
+                .expect("missing resolved manifest should be downloaded once");
         assert_eq!(resolved.root_package(), "application");
         assert_eq!(downloader.calls.get(), 1);
 
@@ -409,9 +457,10 @@ packages = [
             calls: Cell::new(0),
             manifest: "invalid",
         };
-        let error = read_resolved_project_with(&utf8_path(&project), &downloader)
-            .err()
-            .expect("invalid downloaded resolution should be preserved");
+        let error =
+            read_resolved_project_with(&utf8_path(&project), &downloader, &mut Progress::Hidden)
+                .err()
+                .expect("invalid downloaded resolution should be preserved");
         assert!(matches!(
             error,
             CliError::InvalidToml { kind, path, reason }
@@ -428,15 +477,24 @@ packages = [
             manifest: "packages = []\n[requirements]\n",
         };
 
-        let program = compile_resolved_project_with(&root, "application".to_owned(), &downloader)
-            .expect("missing manifest should be resolved once");
+        let program = compile_resolved_project_with(
+            &root,
+            "application".to_owned(),
+            &downloader,
+            &mut Progress::Hidden,
+        )
+        .expect("missing manifest should be resolved once");
         assert_eq!(program.root_package(), "application");
         assert_eq!(downloader.calls.get(), 1);
 
         let project = project_without_manifest("application", "1.0.0");
-        let error = read_resolved_project_with(&utf8_path(&project), &FailingDownloader)
-            .err()
-            .expect("resolved manifest download failure should be preserved");
+        let error = read_resolved_project_with(
+            &utf8_path(&project),
+            &FailingDownloader,
+            &mut Progress::Hidden,
+        )
+        .err()
+        .expect("resolved manifest download failure should be preserved");
         assert!(matches!(
             error,
             CliError::ProcessFailure { command, status: Some(1), stderr }
@@ -452,6 +510,7 @@ packages = [
             &utf8_path(&project),
             "application".to_owned(),
             &downloader,
+            &mut Progress::Hidden,
         )
         .expect_err("invalid downloaded manifest should be preserved");
         assert!(matches!(
@@ -463,8 +522,13 @@ packages = [
         assert_eq!(downloader.calls.get(), 1);
 
         fs::write(root.join("manifest.toml"), "invalid").expect("manifest should be replaced");
-        let error = compile_resolved_project_with(&root, "application".to_owned(), &downloader)
-            .expect_err("invalid manifest should not trigger dependency download");
+        let error = compile_resolved_project_with(
+            &root,
+            "application".to_owned(),
+            &downloader,
+            &mut Progress::Hidden,
+        )
+        .expect_err("invalid manifest should not trigger dependency download");
         assert!(matches!(
             error,
             CliError::Project(ProjectError::InvalidManifest { path, reason })
@@ -477,6 +541,7 @@ packages = [
             &utf8_path(&project),
             "application".to_owned(),
             &FailingDownloader,
+            &mut Progress::Hidden,
         )
         .expect_err("dependency download failure should be preserved");
         assert!(matches!(
@@ -484,6 +549,97 @@ packages = [
             CliError::ProcessFailure { command, status: Some(1), stderr }
                 if command == "gleam deps download" && stderr == "fixture failure"
         ));
+    }
+
+    #[test]
+    fn reports_acquisition_only_when_invoked_and_source_checks_on_each_attempt() {
+        let project = project_without_manifest("application", "1.0.0");
+        let root = utf8_path(&project);
+        let downloader = RecordingDownloader {
+            calls: Cell::new(0),
+            manifest: "packages = []\n[requirements]\n",
+        };
+        let mut output = Vec::new();
+        read_resolved_project_with(&root, &downloader, &mut Progress::Visible(&mut output))
+            .expect("missing manifest should be acquired");
+        assert_eq!(
+            output,
+            format!("geam: Preparing Gleam dependencies in {root}\n").as_bytes()
+        );
+        output.clear();
+        read_resolved_project_with(&root, &downloader, &mut Progress::Visible(&mut output))
+            .expect("existing manifest should be reused");
+        assert!(output.is_empty());
+        assert_eq!(downloader.calls.get(), 1);
+
+        fs::remove_file(root.join("manifest.toml")).expect("remove acquired manifest");
+        compile_resolved_project_with(
+            &root,
+            "application".to_owned(),
+            &downloader,
+            &mut Progress::Visible(&mut output),
+        )
+        .expect("source loading should acquire missing inputs before retrying");
+        assert_eq!(output, format!(
+            "geam: Checking Gleam source for application\ngeam: Preparing Gleam dependencies in {root}\n",
+        ).as_bytes());
+        assert_eq!(downloader.calls.get(), 2);
+
+        output.clear();
+        fs::write(
+            root.join("src/application.gleam"),
+            "pub fn main() { missing }",
+        )
+        .expect("write invalid source");
+        let error = compile_resolved_project_with(
+            &root,
+            "application".to_owned(),
+            &downloader,
+            &mut Progress::Visible(&mut output),
+        )
+        .expect_err("source errors should not trigger acquisition");
+        assert_eq!(error.to_string(), "failed to analyse Gleam module");
+        assert_eq!(output, b"geam: Checking Gleam source for application\n");
+        assert_eq!(downloader.calls.get(), 2);
+    }
+
+    #[test]
+    fn stops_before_acquisition_or_source_check_when_progress_cannot_be_written() {
+        let project = project_without_manifest("application", "1.0.0");
+        let root = utf8_path(&project);
+        let downloader = RecordingDownloader {
+            calls: Cell::new(0),
+            manifest: "packages = []\n[requirements]\n",
+        };
+        let mut output = fs::File::open(root.join("gleam.toml")).expect("open read-only output");
+        let error =
+            read_resolved_project_with(&root, &downloader, &mut Progress::Visible(&mut output))
+                .err()
+                .expect("failed progress should prevent acquisition");
+        assert_eq!(error.to_string(), "failed to write preparation progress");
+        let error = compile_resolved_project_with(
+            &root,
+            "application".to_owned(),
+            &downloader,
+            &mut Progress::Visible(&mut output),
+        )
+        .expect_err("failed source-check progress should prevent compilation and acquisition");
+        assert_eq!(error.to_string(), "failed to write preparation progress");
+        assert_eq!(downloader.calls.get(), 0);
+        assert!(!root.join("manifest.toml").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn forwards_native_dependency_output_without_interpreting_it() {
+        let project = project_without_manifest("application", "1.0.0");
+        let downloader =
+            ProcessDependencyDownloader::new("sh", ["-c", "printf 'native\\rpartial' >&2"]);
+        let mut output = Vec::new();
+        downloader
+            .download(&utf8_path(&project), &mut Progress::Visible(&mut output))
+            .expect("native dependency output should be visible");
+        assert_eq!(output, b"native\rpartial");
     }
 
     #[test]
@@ -509,7 +665,7 @@ packages = [
         let project = project_without_manifest("application", "1.0.0");
         let downloader = ProcessDependencyDownloader::new("rustc", ["--version"]);
         downloader
-            .download(&utf8_path(&project))
+            .download(&utf8_path(&project), &mut Progress::Hidden)
             .expect("configured process should run");
 
         let downloader = ProcessDependencyDownloader::new(
@@ -517,7 +673,7 @@ packages = [
             std::iter::empty::<&str>(),
         );
         let error = downloader
-            .download(&utf8_path(&project))
+            .download(&utf8_path(&project), &mut Progress::Hidden)
             .expect_err("missing downloader process should be preserved");
         assert!(matches!(
             error,
@@ -532,8 +688,9 @@ packages = [
         let project = project("application", "1.0.0", "packages = []\n[requirements]\n");
         let root = utf8_path(&project);
 
-        let program = compile_resolved_project(&root, "application".to_owned())
-            .expect("resolved project should compile directly");
+        let program =
+            compile_resolved_project(&root, "application".to_owned(), &mut Progress::Hidden)
+                .expect("resolved project should compile directly");
 
         assert_eq!(program.root_module(), "application");
     }

--- a/cli/src/project/locked.rs
+++ b/cli/src/project/locked.rs
@@ -285,6 +285,7 @@ mod tests {
     };
     use crate::error::CliError;
     use crate::process::run_checked;
+    use crate::progress::Progress;
     use crate::project::{DependencyDownloader, ProcessDependencyDownloader, prepare_dependencies};
     use camino::{Utf8Path, Utf8PathBuf};
     use geam_core::{ExecutionPlan, Value, compile_typed_project, plan_program, run_main};
@@ -300,7 +301,7 @@ mod tests {
     struct UnavailableDownloader(Cell<usize>);
 
     impl DependencyDownloader for UnavailableDownloader {
-        fn download(&self, _root: &Utf8Path) -> Result<(), CliError> {
+        fn download(&self, _root: &Utf8Path, _progress: &mut Progress<'_>) -> Result<(), CliError> {
             self.0.set(self.0.get() + 1);
             Err(CliError::ProcessFailure {
                 command: "gleam deps download".to_owned(),

--- a/cli/src/project/locked/download.rs
+++ b/cli/src/project/locked/download.rs
@@ -24,7 +24,7 @@ pub(super) fn acquire(
         write_documents(&root, config, manifest)
             .and_then(|()| read_toml::<Manifest>("Gleam download manifest", &path))
             .and_then(|expected| {
-                downloader.download(&root)?;
+                downloader.download(&root, &mut crate::progress::Progress::Hidden)?;
                 let mut actual = read_toml::<Manifest>("Gleam download manifest", &path)?;
                 actual.packages.sort();
                 let mut expected_packages = expected.packages;
@@ -124,6 +124,7 @@ fn documents(packages: &[ManifestPackage]) -> (DocumentMut, DocumentMut) {
 mod tests {
     use super::{acquire, documents, write_documents};
     use crate::error::CliError;
+    use crate::progress::Progress;
     use crate::project::{DependencyDownloader, ProcessDependencyDownloader};
     use camino::{Utf8Path, Utf8PathBuf};
     use gleam_core::config::PackageConfig;
@@ -179,7 +180,7 @@ git_root = { git = "https://example.invalid/root", ref = "root_commit" }
     }
 
     impl DependencyDownloader for ManifestDownload<'_> {
-        fn download(&self, root: &Utf8Path) -> Result<(), CliError> {
+        fn download(&self, root: &Utf8Path, _progress: &mut Progress<'_>) -> Result<(), CliError> {
             fs::create_dir_all(root.join("build/packages/unexpected"))
                 .expect("downloaded cache fixture");
             match self.manifest {

--- a/cli/src/provider.rs
+++ b/cli/src/provider.rs
@@ -9,6 +9,7 @@ mod resolution;
 
 use crate::command::{AddProvider, RemoveProvider};
 use crate::error::CliError;
+use crate::progress::Progress;
 use crate::project::{ResolvedProject, read_resolved_project};
 pub(crate) use approval::{ProviderApproval, TerminalApproval};
 use camino::Utf8Path;
@@ -45,6 +46,7 @@ impl ProviderSelectionReconciler for SystemProviderReconciler<'_> {
         project: &ResolvedProject,
         program: &geam_core::TypedProgram,
         managed: &mut ManagedProject,
+        progress: &mut Progress<'_>,
     ) -> Result<(), CliError> {
         reconcile_registry(
             &self.registry,
@@ -53,6 +55,7 @@ impl ProviderSelectionReconciler for SystemProviderReconciler<'_> {
             project,
             program,
             managed,
+            progress,
         )
     }
 }
@@ -64,6 +67,7 @@ pub(crate) fn reconcile_registry(
     project: &ResolvedProject,
     program: &geam_core::TypedProgram,
     managed: &mut ManagedProject,
+    progress: &mut Progress<'_>,
 ) -> Result<(), CliError> {
     let discovery = RegistryProviderDiscovery::new(registry);
     let resolver = reconcile::SystemApprovedProviderResolver;
@@ -72,6 +76,7 @@ pub(crate) fn reconcile_registry(
         project,
         program,
         managed,
+        progress,
     )
 }
 
@@ -129,7 +134,7 @@ fn add_with(
     ))?;
     crate::runner::reconcile_source(project_root, &managed.provider_aliases())?;
     let manifest_changed = managed.write()?;
-    crate::runner::reconcile_lock(project_root, manifest_changed, cargo)?;
+    crate::runner::reconcile_lock(project_root, manifest_changed, cargo, &mut Progress::Hidden)?;
     Ok(())
 }
 
@@ -148,7 +153,7 @@ fn remove_with(
     managed.retain_packages(&project.package_names());
     crate::runner::reconcile_source(project_root, &managed.provider_aliases())?;
     let manifest_changed = managed.write()?;
-    crate::runner::reconcile_lock(project_root, manifest_changed, cargo)?;
+    crate::runner::reconcile_lock(project_root, manifest_changed, cargo, &mut Progress::Hidden)?;
     Ok(())
 }
 
@@ -161,6 +166,7 @@ mod tests {
     use super::{add_with, remove_with};
     use crate::command::{AddProvider, RemoveProvider};
     use crate::error::CliError;
+    use crate::progress::Progress;
     use crate::runner::CargoLock;
     use camino::Utf8PathBuf;
     use std::fs;
@@ -169,7 +175,11 @@ mod tests {
     struct TestCargo;
 
     impl CargoLock for TestCargo {
-        fn generate_lockfile(&self, project_root: &camino::Utf8Path) -> Result<(), CliError> {
+        fn generate_lockfile(
+            &self,
+            project_root: &camino::Utf8Path,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             fs::write(project_root.join("Cargo.lock"), "fixture lock\n")
                 .expect("fixture lock should be written");
             Ok(())
@@ -179,7 +189,11 @@ mod tests {
     struct FailingCargoLock;
 
     impl CargoLock for FailingCargoLock {
-        fn generate_lockfile(&self, _project_root: &camino::Utf8Path) -> Result<(), CliError> {
+        fn generate_lockfile(
+            &self,
+            _project_root: &camino::Utf8Path,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             Err(CliError::ProcessFailure {
                 command: "cargo generate-lockfile".to_owned(),
                 status: Some(1),

--- a/cli/src/provider/reconcile.rs
+++ b/cli/src/provider/reconcile.rs
@@ -3,6 +3,7 @@ use super::discovery::ProviderDiscovery;
 use super::manifest::{ManagedProject, ProviderSelection, ProviderSource};
 use super::metadata::ProviderMetadata;
 use crate::error::CliError;
+use crate::progress::Progress;
 use crate::project::ResolvedProject;
 use camino::Utf8Path;
 use hexpm::version::Version as GleamVersion;
@@ -15,6 +16,7 @@ pub(crate) trait ProviderSelectionReconciler {
         project: &ResolvedProject,
         program: &geam_core::TypedProgram,
         managed: &mut ManagedProject,
+        progress: &mut Progress<'_>,
     ) -> Result<(), CliError>;
 }
 
@@ -23,6 +25,7 @@ pub(super) trait ApprovedProviderResolver {
         &self,
         project_root: &Utf8Path,
         selection: &ProviderSelection,
+        progress: &mut Progress<'_>,
     ) -> Result<ProviderMetadata, CliError>;
 }
 
@@ -33,8 +36,9 @@ impl ApprovedProviderResolver for SystemApprovedProviderResolver {
         &self,
         project_root: &Utf8Path,
         selection: &ProviderSelection,
+        progress: &mut Progress<'_>,
     ) -> Result<ProviderMetadata, CliError> {
-        super::resolution::resolve_selection(project_root, selection)
+        super::resolution::resolve_selection(project_root, selection, progress)
     }
 }
 
@@ -63,6 +67,7 @@ impl<'a> ProviderReconciler<'a> {
         project: &ResolvedProject,
         required_packages: BTreeSet<String>,
         managed: &mut ManagedProject,
+        progress: &mut Progress<'_>,
     ) -> Result<(), CliError> {
         let mut compatible = BTreeSet::new();
         let mut pending = BTreeMap::new();
@@ -76,7 +81,11 @@ impl<'a> ProviderReconciler<'a> {
                     package: package.to_owned(),
                 });
             }
-            let metadata = self.resolver.resolve(project_root, &selection)?;
+            progress.report(format_args!(
+                "Resolving provider {} for {package} {version}",
+                selection.crate_name()
+            ))?;
+            let metadata = self.resolver.resolve(project_root, &selection, progress)?;
             validate_selected_metadata(&selection, &metadata)?;
             if metadata.supports(version) {
                 compatible.insert(package.to_owned());
@@ -112,6 +121,10 @@ impl<'a> ProviderReconciler<'a> {
 
         let mut discovered = Vec::new();
         for pending in pending.into_values() {
+            progress.report(format_args!(
+                "Discovering native providers for {} {}",
+                pending.package, pending.version
+            ))?;
             let candidates = self
                 .discovery
                 .discover(&pending.package, &pending.version)?;
@@ -156,12 +169,13 @@ impl ProviderSelectionReconciler for ProviderReconciler<'_> {
         project: &ResolvedProject,
         program: &geam_core::TypedProgram,
         managed: &mut ManagedProject,
+        progress: &mut Progress<'_>,
     ) -> Result<(), CliError> {
         let required_packages = geam_core::required_host_functions(program)
             .into_iter()
             .map(|requirement| requirement.package().to_string())
             .collect();
-        self.reconcile_packages(project_root, project, required_packages, managed)
+        self.reconcile_packages(project_root, project, required_packages, managed, progress)
     }
 }
 
@@ -205,6 +219,7 @@ mod tests {
         SystemApprovedProviderResolver,
     };
     use crate::error::CliError;
+    use crate::progress::Progress;
     use crate::project::read_resolved_project;
     use crate::provider::approval::ProviderApproval;
     use crate::provider::manifest::{ManagedProject, ProviderSelection, ProviderSource};
@@ -245,6 +260,7 @@ mod tests {
         )]);
         let mut approval = FixedApproval::new([Decision::Select("geam-search-alt")]);
         let mut reconciler = ProviderReconciler::new(&resolver, &discovery, &mut approval);
+        let mut output = Vec::new();
 
         reconciler
             .reconcile_packages(
@@ -252,8 +268,19 @@ mod tests {
                 &resolved,
                 BTreeSet::from(["images".to_owned(), "search".to_owned()]),
                 &mut managed,
+                &mut Progress::Visible(&mut output),
             )
             .expect("missing provider should be approved");
+
+        assert_eq!(
+            output,
+            concat!(
+                "geam: Resolving provider geam-fallback for fallback 1.0.0\n",
+                "geam: Resolving provider geam-images for images 1.5.0\n",
+                "geam: Discovering native providers for search 2.0.0\n",
+            )
+            .as_bytes()
+        );
 
         assert_eq!(
             resolver.calls.borrow().as_slice(),
@@ -281,6 +308,39 @@ mod tests {
             },
         );
         assert!(managed.has_provider("fallback"));
+    }
+
+    #[test]
+    fn failed_progress_stops_resolution_or_discovery_before_approval_and_mutation() {
+        let project = resolved_project(&[("images", "1.0.0")]);
+        let root = utf8_path(&project);
+        let resolved = read_resolved_project(&root).expect("project should resolve");
+        for selected in [false, true] {
+            let mut managed = ManagedProject::load(&root, "application")
+                .expect("managed project should initialize");
+            if selected {
+                managed.replace(selection("images", "geam-images", "1.0.0"));
+            }
+            let original = managed.provider("images").cloned();
+            let resolver = FixedResolver::new([]);
+            let discovery = FixedDiscovery::new([]);
+            let mut approval = FixedApproval::new([]);
+            let mut output = fs::File::open(root.join("gleam.toml")).expect("read-only output");
+            let error = ProviderReconciler::new(&resolver, &discovery, &mut approval)
+                .reconcile_packages(
+                    &root,
+                    &resolved,
+                    BTreeSet::from(["images".to_owned()]),
+                    &mut managed,
+                    &mut Progress::Visible(&mut output),
+                )
+                .expect_err("progress failure should stop before provider work");
+            assert_eq!(error.to_string(), "failed to write preparation progress");
+            assert!(resolver.calls.borrow().is_empty());
+            assert!(discovery.calls.borrow().is_empty());
+            assert!(approval.calls.borrow().is_empty());
+            assert_eq!(managed.provider("images"), original.as_ref());
+        }
     }
 
     #[test]
@@ -320,6 +380,7 @@ mod tests {
                 &resolved,
                 BTreeSet::from(["images".to_owned(), "search".to_owned()]),
                 &mut managed,
+                &mut Progress::Hidden,
             ),
             Err(CliError::ProviderApprovalCancelled { ref package }) if package == "search"
         ));
@@ -341,6 +402,7 @@ mod tests {
                 &resolved,
                 BTreeSet::from(["images".to_owned(), "search".to_owned()]),
                 &mut managed,
+                &mut Progress::Hidden,
             )
             .expect("all approved replacements should commit together");
         assert_eq!(
@@ -372,6 +434,7 @@ mod tests {
                 &builtin_resolved,
                 BTreeSet::new(),
                 &mut managed,
+                &mut Progress::Hidden,
             ),
             Err(CliError::BuiltInProviderPackage { ref package }) if package == "gleam_json"
         ));
@@ -405,6 +468,7 @@ mod tests {
                     &resolved,
                     BTreeSet::new(),
                     &mut managed,
+                    &mut Progress::Hidden,
                 ),
                 Err(CliError::InvalidProviderMetadata { package, reason })
                     if package == "geam-images" && reason == expected_reason
@@ -423,6 +487,7 @@ mod tests {
                 &resolved,
                 BTreeSet::from(["images".to_owned()]),
                 &mut managed,
+                &mut Progress::Hidden,
             ),
             Err(CliError::ProviderCandidatesUnavailable {
                 package,
@@ -456,6 +521,7 @@ mod tests {
                 &resolved,
                 BTreeSet::new(),
                 &mut managed,
+                &mut Progress::Hidden,
             ),
             Err(CliError::InvalidProviderMetadata { package, reason })
                 if package == "geam-images" && reason == "fixture resolution failure"
@@ -473,6 +539,7 @@ mod tests {
                 &resolved,
                 BTreeSet::from(["images".to_owned()]),
                 &mut managed,
+                &mut Progress::Hidden,
             ),
             Err(CliError::ProviderRegistryAccess { package, reason })
                 if package == "images" && reason == "fixture discovery failure"
@@ -513,7 +580,7 @@ mod tests {
             },
         );
         let metadata = SystemApprovedProviderResolver
-            .resolve(&root, &selection)
+            .resolve(&root, &selection, &mut Progress::Hidden)
             .expect("path provider should resolve through Cargo metadata");
         assert_eq!(metadata.gleam_package(), "images");
     }
@@ -550,6 +617,7 @@ mod tests {
             &self,
             _project_root: &Utf8Path,
             selection: &ProviderSelection,
+            _progress: &mut Progress<'_>,
         ) -> Result<ProviderMetadata, CliError> {
             self.calls
                 .borrow_mut()
@@ -569,6 +637,7 @@ mod tests {
             &self,
             _project_root: &Utf8Path,
             selection: &ProviderSelection,
+            _progress: &mut Progress<'_>,
         ) -> Result<ProviderMetadata, CliError> {
             Err(CliError::InvalidProviderMetadata {
                 package: selection.crate_name().to_owned(),

--- a/cli/src/provider/resolution.rs
+++ b/cli/src/provider/resolution.rs
@@ -4,6 +4,7 @@ use crate::cargo::{CargoMetadataLoader, CargoMetadataMode, SystemCargoMetadata};
 use crate::command::AddProvider;
 use crate::error::CliError;
 use crate::process::run_checked;
+use crate::progress::Progress;
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::{Metadata, Package};
 use semver::Version;
@@ -32,8 +33,9 @@ pub(super) fn resolve(
 pub(super) fn resolve_selection(
     project_root: &Utf8Path,
     selection: &super::manifest::ProviderSelection,
+    progress: &mut Progress<'_>,
 ) -> Result<ProviderMetadata, CliError> {
-    resolve_selection_with(project_root, selection, &SystemCargoMetadata)
+    resolve_selection_with(project_root, selection, &SystemCargoMetadata, progress)
 }
 
 fn resolve_with(
@@ -56,6 +58,7 @@ fn resolve_with_candidate(
         project_root,
         candidate.manifest(),
         CargoMetadataMode::Resolve,
+        &mut Progress::Hidden,
     )?;
     let package = resolved_dependency(&metadata, CANDIDATE_ALIAS)?;
     let provider = ProviderMetadata::from_package(package)?;
@@ -70,9 +73,10 @@ fn resolve_selection_with(
     project_root: &Utf8Path,
     selection: &super::manifest::ProviderSelection,
     loader: &dyn CargoMetadataLoader,
+    progress: &mut Progress<'_>,
 ) -> Result<ProviderMetadata, CliError> {
     let manifest = project_root.join("Cargo.toml");
-    let metadata = loader.load(project_root, &manifest, CargoMetadataMode::Locked)?;
+    let metadata = loader.load(project_root, &manifest, CargoMetadataMode::Locked, progress)?;
     let package = resolved_dependency(&metadata, &selection.alias())?;
     ProviderMetadata::from_package(package)
 }
@@ -198,7 +202,12 @@ fn inspect_workspace(
     if !manifest.is_file() {
         return Err(CliError::MissingProviderManifest { path: manifest });
     }
-    let metadata = loader.load(path, &manifest, CargoMetadataMode::Workspace)?;
+    let metadata = loader.load(
+        path,
+        &manifest,
+        CargoMetadataMode::Workspace,
+        &mut Progress::Hidden,
+    )?;
     let workspace = metadata.workspace_packages();
     let package = if let Some(requested) = requested_package {
         workspace
@@ -533,6 +542,7 @@ mod tests {
     use crate::cargo::{CargoMetadataLoader, CargoMetadataMode, SystemCargoMetadata};
     use crate::command::AddProvider;
     use crate::error::CliError;
+    use crate::progress::Progress;
     use crate::provider::manifest::{ProviderSelection, ProviderSource};
     use camino::{Utf8Path, Utf8PathBuf};
     use cargo_metadata::Metadata;
@@ -551,6 +561,7 @@ mod tests {
             _current_directory: &camino::Utf8Path,
             manifest: &camino::Utf8Path,
             _mode: CargoMetadataMode,
+            _progress: &mut Progress<'_>,
         ) -> Result<Metadata, CliError> {
             Err(CliError::InvalidCargoMetadata {
                 manifest: manifest.to_path_buf(),
@@ -567,6 +578,7 @@ mod tests {
             _current_directory: &camino::Utf8Path,
             _manifest: &camino::Utf8Path,
             _mode: CargoMetadataMode,
+            _progress: &mut Progress<'_>,
         ) -> Result<Metadata, CliError> {
             Ok(self.0.clone())
         }
@@ -582,6 +594,7 @@ mod tests {
             _current_directory: &camino::Utf8Path,
             manifest: &camino::Utf8Path,
             mode: CargoMetadataMode,
+            _progress: &mut Progress<'_>,
         ) -> Result<Metadata, CliError> {
             self.call.replace(Some((manifest.to_path_buf(), mode)));
             Err(CliError::InvalidCargoMetadata {
@@ -1089,8 +1102,13 @@ mod tests {
             ProviderSource::Registry { version },
         );
 
-        let metadata = resolve_selection_with(&project, &selection, &SystemCargoMetadata)
-            .expect("approved provider should resolve from the managed graph");
+        let metadata = resolve_selection_with(
+            &project,
+            &selection,
+            &SystemCargoMetadata,
+            &mut Progress::Hidden,
+        )
+        .expect("approved provider should resolve from the managed graph");
 
         assert_eq!(metadata.crate_name(), "geam-images");
         assert_eq!(metadata.gleam_package(), "images");
@@ -1099,8 +1117,13 @@ mod tests {
             lock_before,
         );
         fs::remove_file(&root_lock).expect("root lock should be removable");
-        let error = resolve_selection_with(&project, &selection, &SystemCargoMetadata)
-            .expect_err("approved provider resolution must not recreate a missing root lock");
+        let error = resolve_selection_with(
+            &project,
+            &selection,
+            &SystemCargoMetadata,
+            &mut Progress::Hidden,
+        )
+        .expect_err("approved provider resolution must not recreate a missing root lock");
         assert!(matches!(
             error,
             CliError::ProcessFailure {
@@ -1127,7 +1150,12 @@ mod tests {
         let candidate =
             CandidateWorkspace::new(&request).expect("candidate workspace should be written");
         let metadata = SystemCargoMetadata
-            .load(&project, candidate.manifest(), CargoMetadataMode::Resolve)
+            .load(
+                &project,
+                candidate.manifest(),
+                CargoMetadataMode::Resolve,
+                &mut Progress::Hidden,
+            )
             .expect("candidate metadata should load");
         let selection = ProviderSelection::new(
             "images".to_owned(),
@@ -1137,8 +1165,13 @@ mod tests {
             },
         );
 
-        let error = resolve_selection_with(&project, &selection, &FixedLoader(metadata))
-            .expect_err("missing approved dependency alias should be preserved");
+        let error = resolve_selection_with(
+            &project,
+            &selection,
+            &FixedLoader(metadata),
+            &mut Progress::Hidden,
+        )
+        .expect_err("missing approved dependency alias should be preserved");
 
         assert!(matches!(
             error,
@@ -1156,6 +1189,7 @@ mod tests {
                 &path,
                 &path.join("Cargo.toml"),
                 CargoMetadataMode::Workspace,
+                &mut Progress::Hidden,
             )
             .expect("provider metadata should load");
         let package = metadata
@@ -1359,6 +1393,7 @@ mod tests {
                 &path,
                 &path.join("Cargo.toml"),
                 CargoMetadataMode::Workspace,
+                &mut Progress::Hidden,
             )
             .expect("provider metadata should load");
         metadata
@@ -1636,7 +1671,12 @@ mod tests {
         let candidate =
             CandidateWorkspace::new(&path_request).expect("candidate manifest should be written");
         let metadata = SystemCargoMetadata
-            .load(&project, candidate.manifest(), CargoMetadataMode::Resolve)
+            .load(
+                &project,
+                candidate.manifest(),
+                CargoMetadataMode::Resolve,
+                &mut Progress::Hidden,
+            )
             .expect("candidate metadata should load");
         let resolution_request = ProviderRequest::Registry {
             crate_name: "geam-images".to_owned(),
@@ -1690,7 +1730,12 @@ mod tests {
         let candidate =
             CandidateWorkspace::new(&request).expect("candidate manifest should be written");
         let metadata = SystemCargoMetadata
-            .load(&project, candidate.manifest(), CargoMetadataMode::Resolve)
+            .load(
+                &project,
+                candidate.manifest(),
+                CargoMetadataMode::Resolve,
+                &mut Progress::Hidden,
+            )
             .expect("candidate metadata should load");
         assert_eq!(
             resolved_dependency(&metadata, CANDIDATE_ALIAS)

--- a/cli/src/runner/cargo.rs
+++ b/cli/src/runner/cargo.rs
@@ -1,17 +1,27 @@
 use crate::error::CliError;
-use crate::process::{run_checked, run_inherited};
+use crate::process::{run_checked_with_progress, run_inherited};
+use crate::progress::Progress;
 use camino::{Utf8Path, Utf8PathBuf};
 use std::fs;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 const TARGET_DIRECTORY: &str = "build/geam/target";
 
 pub(crate) trait CargoLock {
-    fn generate_lockfile(&self, project_root: &Utf8Path) -> Result<(), CliError>;
+    fn generate_lockfile(
+        &self,
+        project_root: &Utf8Path,
+        progress: &mut Progress<'_>,
+    ) -> Result<(), CliError>;
 }
 
 pub(crate) trait RunnerChecker {
-    fn check(&self, project_root: &Utf8Path, module: &str) -> Result<(), CliError>;
+    fn check(
+        &self,
+        project_root: &Utf8Path,
+        module: &str,
+        progress: &mut Progress<'_>,
+    ) -> Result<(), CliError>;
 }
 
 pub(crate) trait RunnerExecutor {
@@ -26,25 +36,36 @@ pub(crate) trait RunnerExecutor {
 pub(crate) struct SystemCargo;
 
 impl CargoLock for SystemCargo {
-    fn generate_lockfile(&self, project_root: &Utf8Path) -> Result<(), CliError> {
-        finish_process(run_checked(
+    fn generate_lockfile(
+        &self,
+        project_root: &Utf8Path,
+        progress: &mut Progress<'_>,
+    ) -> Result<(), CliError> {
+        finish_process(run_checked_with_progress(
             Command::new("cargo")
                 .arg("generate-lockfile")
                 .arg("--manifest-path")
                 .arg(project_root.join("Cargo.toml"))
                 .current_dir(project_root)
                 .env("CARGO_TARGET_DIR", project_root.join(TARGET_DIRECTORY)),
+            progress,
+            Stdio::inherit(),
         ))
     }
 }
 
 impl RunnerChecker for SystemCargo {
-    fn check(&self, project_root: &Utf8Path, module: &str) -> Result<(), CliError> {
-        finish_process(run_checked(&mut runner_command(
-            project_root,
-            "check",
-            module,
-        )))
+    fn check(
+        &self,
+        project_root: &Utf8Path,
+        module: &str,
+        progress: &mut Progress<'_>,
+    ) -> Result<(), CliError> {
+        finish_process(run_checked_with_progress(
+            &mut runner_command(project_root, "check", module),
+            progress,
+            Stdio::inherit(),
+        ))
     }
 }
 
@@ -67,7 +88,6 @@ fn runner_command(project_root: &Utf8Path, mode: &str, module: &str) -> Command 
     let mut command = Command::new("cargo");
     command
         .arg("run")
-        .arg("--quiet")
         .arg("--locked")
         .arg("--bin")
         .arg("geam-runner")
@@ -96,13 +116,17 @@ pub(crate) fn reconcile_lock(
     project_root: &Utf8Path,
     manifest_changed: bool,
     cargo: &dyn CargoLock,
+    progress: &mut Progress<'_>,
 ) -> Result<(), CliError> {
     let lock = project_root.join("Cargo.lock");
     if manifest_changed {
         remove_stale_lock(&lock)?;
     }
     if manifest_changed || !lock.is_file() {
-        cargo.generate_lockfile(project_root)?;
+        progress.report(format_args!(
+            "Resolving Cargo dependencies in {project_root}"
+        ))?;
+        cargo.generate_lockfile(project_root, progress)?;
     }
     Ok(())
 }
@@ -124,6 +148,7 @@ mod tests {
         CargoLock, RunnerChecker, SystemCargo, execution_command, reconcile_lock, runner_command,
     };
     use crate::error::CliError;
+    use crate::progress::Progress;
     use camino::{Utf8Path, Utf8PathBuf};
     use std::cell::RefCell;
     use std::fs;
@@ -135,7 +160,11 @@ mod tests {
     }
 
     impl CargoLock for RecordingCargo {
-        fn generate_lockfile(&self, project_root: &Utf8Path) -> Result<(), CliError> {
+        fn generate_lockfile(
+            &self,
+            project_root: &Utf8Path,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             self.operations.borrow_mut().push("lock".to_owned());
             fs::write(project_root.join("Cargo.lock"), "fixture lock\n")
                 .expect("fixture lock should be written");
@@ -146,7 +175,11 @@ mod tests {
     struct FailingCargo;
 
     impl CargoLock for FailingCargo {
-        fn generate_lockfile(&self, _project_root: &Utf8Path) -> Result<(), CliError> {
+        fn generate_lockfile(
+            &self,
+            _project_root: &Utf8Path,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             Err(CliError::ProcessFailure {
                 command: "cargo generate-lockfile".to_owned(),
                 status: Some(1),
@@ -169,7 +202,6 @@ mod tests {
                 .collect::<Vec<_>>(),
             [
                 "run",
-                "--quiet",
                 "--locked",
                 "--bin",
                 "geam-runner",
@@ -191,7 +223,6 @@ mod tests {
                 .collect::<Vec<_>>(),
             [
                 "run".to_owned(),
-                "--quiet".to_owned(),
                 "--locked".to_owned(),
                 "--bin".to_owned(),
                 "geam-runner".to_owned(),
@@ -213,17 +244,51 @@ mod tests {
         let root = Utf8PathBuf::from_path_buf(project.path().to_path_buf())
             .expect("temporary path should be valid UTF-8");
         let cargo = RecordingCargo::default();
+        let mut output = Vec::new();
 
-        reconcile_lock(&root, true, &cargo).expect("initial lock should reconcile");
+        reconcile_lock(&root, true, &cargo, &mut Progress::Visible(&mut output))
+            .expect("initial lock should reconcile");
         assert_eq!(cargo.operations.borrow().as_slice(), ["lock"]);
+        assert_eq!(
+            output,
+            format!("geam: Resolving Cargo dependencies in {root}\n").as_bytes()
+        );
 
         cargo.operations.borrow_mut().clear();
-        reconcile_lock(&root, false, &cargo).expect("unchanged lock should reconcile");
+        output.clear();
+        reconcile_lock(&root, false, &cargo, &mut Progress::Visible(&mut output))
+            .expect("unchanged lock should reconcile");
         assert!(cargo.operations.borrow().is_empty());
+        assert!(output.is_empty());
 
         fs::remove_file(root.join("Cargo.lock")).expect("fixture lock should be removed");
-        reconcile_lock(&root, false, &cargo).expect("missing lock should be regenerated");
+        reconcile_lock(&root, false, &cargo, &mut Progress::Visible(&mut output))
+            .expect("missing lock should be regenerated");
         assert_eq!(cargo.operations.borrow().as_slice(), ["lock"]);
+        assert_eq!(
+            output,
+            format!("geam: Resolving Cargo dependencies in {root}\n").as_bytes()
+        );
+    }
+
+    #[test]
+    fn failed_progress_stops_before_generating_a_lock() {
+        let project = tempdir().expect("temporary project should be created");
+        let root = Utf8PathBuf::from_path_buf(project.path().to_path_buf())
+            .expect("temporary path should be valid UTF-8");
+        let cargo = RecordingCargo::default();
+        let path = root.join("output");
+        fs::write(&path, "read-only\n").expect("output fixture");
+        let mut output = fs::File::open(&path).expect("read-only output");
+        let error = reconcile_lock(&root, false, &cargo, &mut Progress::Visible(&mut output))
+            .expect_err("progress failure should prevent Cargo execution");
+        assert_eq!(error.to_string(), "failed to write preparation progress");
+        assert!(cargo.operations.borrow().is_empty());
+        assert!(!root.join("Cargo.lock").exists());
+        assert_eq!(
+            fs::read(path).expect("unchanged output fixture"),
+            b"read-only\n"
+        );
     }
 
     #[test]
@@ -233,7 +298,7 @@ mod tests {
             .expect("temporary path should be valid UTF-8");
         fs::write(root.join("Cargo.lock"), "stale lock\n")
             .expect("stale fixture lock should be written");
-        let error = reconcile_lock(&root, true, &FailingCargo)
+        let error = reconcile_lock(&root, true, &FailingCargo, &mut Progress::Hidden)
             .expect_err("lock failure should be preserved");
         assert!(matches!(
             error,
@@ -250,7 +315,7 @@ mod tests {
         let expected_kind = fs::remove_file(&lock)
             .expect_err("directory should reject file removal")
             .kind();
-        let error = reconcile_lock(&root, true, &FailingCargo)
+        let error = reconcile_lock(&root, true, &FailingCargo, &mut Progress::Hidden)
             .expect_err("an unremovable stale lock should fail before Cargo");
         assert!(matches!(
             error,
@@ -266,7 +331,7 @@ mod tests {
             .expect("temporary path should be valid UTF-8");
 
         let generation = SystemCargo
-            .generate_lockfile(&root)
+            .generate_lockfile(&root, &mut Progress::Hidden)
             .expect_err("missing manifest should reject lock generation");
         assert!(matches!(
             generation,
@@ -280,14 +345,14 @@ mod tests {
         ));
 
         let check = SystemCargo
-            .check(&root, "application")
+            .check(&root, "application", &mut Progress::Hidden)
             .expect_err("missing manifest should reject runner checking");
         assert!(matches!(
             check,
             CliError::ProcessFailure { command, status: Some(101), stderr }
                 if command
                     == format!(
-                        "cargo run --quiet --locked --bin geam-runner -- check {root} application"
+                        "cargo run --locked --bin geam-runner -- check {root} application"
                     )
                     && stderr.contains("could not find `Cargo.toml`")
         ));

--- a/cli/src/standalone.rs
+++ b/cli/src/standalone.rs
@@ -1,5 +1,6 @@
 use crate::error::CliError;
-use crate::project::{compile_resolved_project, read_resolved_project};
+use crate::progress::Progress;
+use crate::project::{compile_resolved_project, read_resolved_project_with_progress};
 use crate::provider::{ManagedProject, ProviderSelectionReconciler, SystemProviderReconciler};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::collections::BTreeMap;
@@ -10,17 +11,17 @@ mod integration;
 
 pub(super) fn prepare(project_root: &Utf8Path, module: String) -> Result<(), CliError> {
     let stdin = std::io::stdin();
-    let stdout = std::io::stdout();
     let mut input = stdin.lock();
-    let mut output = stdout.lock();
+    let mut output = std::io::stderr();
+    let mut progress_output = std::io::stderr();
     let mut providers = SystemProviderReconciler::new(stdin.is_terminal(), &mut input, &mut output);
-    prepare_with(
+    Preparation {
         project_root,
-        module,
-        &crate::runner::SystemCargo,
-        &crate::runner::SystemCargo,
-        &mut providers,
-    )
+        lock: &crate::runner::SystemCargo,
+        providers: &mut providers,
+        progress: Progress::Visible(&mut progress_output),
+    }
+    .prepare(module, &crate::runner::SystemCargo)
 }
 
 pub(super) fn run(
@@ -30,66 +31,93 @@ pub(super) fn run(
     configuration_specs: Vec<String>,
 ) -> Result<(), CliError> {
     let stdin = std::io::stdin();
-    let stdout = std::io::stdout();
     let mut input = stdin.lock();
-    let mut output = stdout.lock();
+    let mut output = std::io::stderr();
+    let mut progress_output = std::io::stderr();
     let mut providers = SystemProviderReconciler::new(stdin.is_terminal(), &mut input, &mut output);
-    run_with(
+    Preparation {
         project_root,
+        lock: &crate::runner::SystemCargo,
+        providers: &mut providers,
+        progress: Progress::Visible(&mut progress_output),
+    }
+    .run(
         current_directory,
         module,
         configuration_specs,
         &crate::runner::SystemCargo,
-        &crate::runner::SystemCargo,
-        &mut providers,
     )
 }
 
-fn prepare_with(
-    project_root: &Utf8Path,
-    module: String,
-    lock: &dyn crate::runner::CargoLock,
-    checker: &dyn crate::runner::RunnerChecker,
-    providers: &mut dyn ProviderSelectionReconciler,
-) -> Result<(), CliError> {
-    reconcile(project_root, &module, lock, providers)?;
-    checker.check(project_root, &module)
+struct Preparation<'a> {
+    project_root: &'a Utf8Path,
+    lock: &'a dyn crate::runner::CargoLock,
+    providers: &'a mut dyn ProviderSelectionReconciler,
+    progress: Progress<'a>,
 }
 
-fn run_with(
-    project_root: &Utf8Path,
-    current_directory: &Utf8Path,
-    module: String,
-    configuration_specs: Vec<String>,
-    lock: &dyn crate::runner::CargoLock,
-    executor: &dyn crate::runner::RunnerExecutor,
-    providers: &mut dyn ProviderSelectionReconciler,
-) -> Result<(), CliError> {
-    let managed = reconcile(project_root, &module, lock, providers)?;
-    let configurations =
-        resolve_provider_configurations(current_directory, &managed, configuration_specs)?;
-    executor.execute(project_root, &module, &configurations)
-}
-
-fn reconcile(
-    project_root: &Utf8Path,
-    module: &str,
-    lock: &dyn crate::runner::CargoLock,
-    providers: &mut dyn ProviderSelectionReconciler,
-) -> Result<ManagedProject, CliError> {
-    let project = read_resolved_project(project_root)?;
-    let typed = compile_resolved_project(project_root, module.to_owned())?;
-    let mut managed = ManagedProject::load(project_root, project.root_package())?;
-    managed.retain_packages(&project.package_names());
-    if managed.has_providers() {
-        let manifest_changed = managed.write()?;
-        crate::runner::reconcile_lock(project_root, manifest_changed, lock)?;
+impl Preparation<'_> {
+    fn prepare(
+        &mut self,
+        module: String,
+        checker: &dyn crate::runner::RunnerChecker,
+    ) -> Result<(), CliError> {
+        self.reconcile(&module)?;
+        self.progress
+            .report(format_args!("Checking standalone runner for {module}"))?;
+        checker.check(self.project_root, &module, &mut self.progress)?;
+        self.progress.report(format_args!("Prepared {module}"))
     }
-    providers.reconcile(project_root, &project, &typed, &mut managed)?;
-    crate::runner::reconcile_source(project_root, &managed.provider_aliases())?;
-    let manifest_changed = managed.write()?;
-    crate::runner::reconcile_lock(project_root, manifest_changed, lock)?;
-    Ok(managed)
+
+    fn run(
+        &mut self,
+        current_directory: &Utf8Path,
+        module: String,
+        configuration_specs: Vec<String>,
+        executor: &dyn crate::runner::RunnerExecutor,
+    ) -> Result<(), CliError> {
+        let managed = self.reconcile(&module)?;
+        let configurations =
+            resolve_provider_configurations(current_directory, &managed, configuration_specs)?;
+        self.progress
+            .report(format_args!("Starting standalone runner for {module}"))?;
+        executor.execute(self.project_root, &module, &configurations)
+    }
+
+    fn reconcile(&mut self, module: &str) -> Result<ManagedProject, CliError> {
+        let project_root = self.project_root;
+        self.progress
+            .report(format_args!("Preparing {module} in {project_root}"))?;
+        let project = read_resolved_project_with_progress(project_root, &mut self.progress)?;
+        let typed = compile_resolved_project(project_root, module.to_owned(), &mut self.progress)?;
+        let mut managed = ManagedProject::load(project_root, project.root_package())?;
+        managed.retain_packages(&project.package_names());
+        if managed.has_providers() {
+            let manifest_changed = managed.write()?;
+            crate::runner::reconcile_lock(
+                project_root,
+                manifest_changed,
+                self.lock,
+                &mut self.progress,
+            )?;
+        }
+        self.providers.reconcile(
+            project_root,
+            &project,
+            &typed,
+            &mut managed,
+            &mut self.progress,
+        )?;
+        crate::runner::reconcile_source(project_root, &managed.provider_aliases())?;
+        let manifest_changed = managed.write()?;
+        crate::runner::reconcile_lock(
+            project_root,
+            manifest_changed,
+            self.lock,
+            &mut self.progress,
+        )?;
+        Ok(managed)
+    }
 }
 
 fn resolve_provider_configurations(
@@ -130,12 +158,14 @@ fn resolve_provider_configurations(
 mod tests {
     use super::resolve_provider_configurations;
     use crate::error::CliError;
+    use crate::progress::Progress;
     use crate::project::ResolvedProject;
     use crate::provider::{ManagedProject, ProviderSelectionReconciler};
     use crate::runner::{CargoLock, RunnerChecker, RunnerExecutor};
     use camino::{Utf8Path, Utf8PathBuf};
     use std::cell::{Cell, RefCell};
     use std::fs;
+    use std::io::{self, Write};
     use tempfile::{TempDir, tempdir};
 
     const MANAGED_HEADER: &str =
@@ -147,7 +177,11 @@ mod tests {
     }
 
     impl CargoLock for RecordingCargo {
-        fn generate_lockfile(&self, project_root: &Utf8Path) -> Result<(), CliError> {
+        fn generate_lockfile(
+            &self,
+            project_root: &Utf8Path,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             self.operations.borrow_mut().push("lock".to_owned());
             fs::write(project_root.join("Cargo.lock"), "fixture lock\n")
                 .expect("fixture lock should be written");
@@ -156,7 +190,12 @@ mod tests {
     }
 
     impl RunnerChecker for RecordingCargo {
-        fn check(&self, _project_root: &Utf8Path, module: &str) -> Result<(), CliError> {
+        fn check(
+            &self,
+            _project_root: &Utf8Path,
+            module: &str,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             self.operations.borrow_mut().push(format!("check:{module}"));
             Ok(())
         }
@@ -184,7 +223,11 @@ mod tests {
     struct FailingCheck;
 
     impl CargoLock for FailingCheck {
-        fn generate_lockfile(&self, project_root: &Utf8Path) -> Result<(), CliError> {
+        fn generate_lockfile(
+            &self,
+            project_root: &Utf8Path,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             fs::write(project_root.join("Cargo.lock"), "fixture lock\n")
                 .expect("fixture lock should be written");
             Ok(())
@@ -192,7 +235,12 @@ mod tests {
     }
 
     impl RunnerChecker for FailingCheck {
-        fn check(&self, _project_root: &Utf8Path, _module: &str) -> Result<(), CliError> {
+        fn check(
+            &self,
+            _project_root: &Utf8Path,
+            _module: &str,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             Err(CliError::ProcessFailure {
                 command: "cargo run".to_owned(),
                 status: Some(1),
@@ -204,7 +252,11 @@ mod tests {
     struct FailingLock;
 
     impl CargoLock for FailingLock {
-        fn generate_lockfile(&self, _project_root: &Utf8Path) -> Result<(), CliError> {
+        fn generate_lockfile(
+            &self,
+            _project_root: &Utf8Path,
+            _progress: &mut Progress<'_>,
+        ) -> Result<(), CliError> {
             Err(CliError::ProcessFailure {
                 command: "cargo generate-lockfile".to_owned(),
                 status: Some(1),
@@ -238,6 +290,7 @@ mod tests {
             _project: &ResolvedProject,
             _program: &geam_core::TypedProgram,
             _managed: &mut ManagedProject,
+            _progress: &mut Progress<'_>,
         ) -> Result<(), CliError> {
             Ok(())
         }
@@ -254,6 +307,7 @@ mod tests {
             _project: &ResolvedProject,
             _program: &geam_core::TypedProgram,
             managed: &mut ManagedProject,
+            _progress: &mut Progress<'_>,
         ) -> Result<(), CliError> {
             assert_eq!(
                 fs::read_to_string(project_root.join("Cargo.lock"))
@@ -278,7 +332,13 @@ mod tests {
         lock: &dyn CargoLock,
         checker: &dyn RunnerChecker,
     ) -> Result<(), CliError> {
-        super::prepare_with(project_root, module, lock, checker, &mut UnchangedProviders)
+        super::Preparation {
+            project_root,
+            lock,
+            providers: &mut UnchangedProviders,
+            progress: Progress::Hidden,
+        }
+        .prepare(module, checker)
     }
 
     fn run_with(
@@ -289,15 +349,13 @@ mod tests {
         lock: &dyn CargoLock,
         executor: &dyn RunnerExecutor,
     ) -> Result<(), CliError> {
-        super::run_with(
+        super::Preparation {
             project_root,
-            current_directory,
-            module,
-            configuration_specs,
             lock,
-            executor,
-            &mut UnchangedProviders,
-        )
+            providers: &mut UnchangedProviders,
+            progress: Progress::Hidden,
+        }
+        .run(current_directory, module, configuration_specs, executor)
     }
 
     #[test]
@@ -305,22 +363,64 @@ mod tests {
         let project = project("application", "pub fn main() { 1 }\n");
         let root = utf8_path(&project);
         let cargo = RecordingCargo::default();
+        let mut output = Vec::new();
 
-        prepare_with(&root, "application".to_owned(), &cargo, &cargo)
-            .expect("pure project should prepare");
+        super::Preparation {
+            project_root: &root,
+            lock: &cargo,
+            providers: &mut UnchangedProviders,
+            progress: Progress::Visible(&mut output),
+        }
+        .prepare("application".to_owned(), &cargo)
+        .expect("pure project should prepare");
         assert_eq!(
             cargo.operations.borrow().as_slice(),
             ["lock", "check:application"],
+        );
+        assert_eq!(
+            output,
+            format!(
+                concat!(
+                    "geam: Preparing application in {}\n",
+                    "geam: Checking Gleam source for application\n",
+                    "geam: Resolving Cargo dependencies in {}\n",
+                    "geam: Checking standalone runner for application\n",
+                    "geam: Prepared application\n",
+                ),
+                root, root
+            )
+            .as_bytes()
         );
         let manifest = fs::read_to_string(root.join("Cargo.toml"))
             .expect("managed manifest should be readable");
         let source = fs::read_to_string(root.join("build/geam/runner.rs"))
             .expect("runner source should be readable");
+        let lock = fs::read(root.join("Cargo.lock")).expect("lock should be readable");
 
         cargo.operations.borrow_mut().clear();
-        prepare_with(&root, "application".to_owned(), &cargo, &cargo)
-            .expect("repeated prepare should succeed");
+        output.clear();
+        super::Preparation {
+            project_root: &root,
+            lock: &cargo,
+            providers: &mut UnchangedProviders,
+            progress: Progress::Visible(&mut output),
+        }
+        .prepare("application".to_owned(), &cargo)
+        .expect("repeated prepare should succeed");
         assert_eq!(cargo.operations.borrow().as_slice(), ["check:application"]);
+        assert_eq!(
+            output,
+            format!(
+                concat!(
+                    "geam: Preparing application in {}\n",
+                    "geam: Checking Gleam source for application\n",
+                    "geam: Checking standalone runner for application\n",
+                    "geam: Prepared application\n",
+                ),
+                root
+            )
+            .as_bytes()
+        );
         assert_eq!(
             fs::read_to_string(root.join("Cargo.toml"))
                 .expect("managed manifest should remain readable"),
@@ -331,6 +431,156 @@ mod tests {
                 .expect("runner source should remain readable"),
             source,
         );
+        assert_eq!(
+            fs::read(root.join("Cargo.lock")).expect("lock should remain readable"),
+            lock
+        );
+    }
+
+    #[test]
+    fn reports_run_handoff_without_a_check_or_completion_footer() {
+        let project = project("application", "pub fn main() { 1 }\n");
+        let root = utf8_path(&project);
+        let cargo = RecordingCargo::default();
+        let mut output = Vec::new();
+        super::Preparation {
+            project_root: &root,
+            lock: &cargo,
+            providers: &mut UnchangedProviders,
+            progress: Progress::Visible(&mut output),
+        }
+        .run(&root, "application".to_owned(), Vec::new(), &cargo)
+        .expect("run should prepare and execute once");
+        assert_eq!(
+            cargo.operations.borrow().as_slice(),
+            ["lock", "run:application:"]
+        );
+        assert_eq!(
+            output,
+            format!(
+                concat!(
+                    "geam: Preparing application in {}\n",
+                    "geam: Checking Gleam source for application\n",
+                    "geam: Resolving Cargo dependencies in {}\n",
+                    "geam: Starting standalone runner for application\n",
+                ),
+                root, root
+            )
+            .as_bytes()
+        );
+    }
+
+    #[test]
+    fn failed_runner_checks_have_no_prepared_message() {
+        let project = project("application", "pub fn main() { 1 }\n");
+        let root = utf8_path(&project);
+        let cargo = RecordingCargo::default();
+        let mut output = Vec::new();
+        let error = super::Preparation {
+            project_root: &root,
+            lock: &cargo,
+            providers: &mut UnchangedProviders,
+            progress: Progress::Visible(&mut output),
+        }
+        .prepare("application".to_owned(), &FailingCheck)
+        .expect_err("runner check should fail");
+        assert_eq!(
+            error.to_string(),
+            "`cargo run` failed with status Some(1): fixture check failed"
+        );
+        assert_eq!(
+            output,
+            format!(
+                concat!(
+                    "geam: Preparing application in {}\n",
+                    "geam: Checking Gleam source for application\n",
+                    "geam: Resolving Cargo dependencies in {}\n",
+                    "geam: Checking standalone runner for application\n",
+                ),
+                root, root
+            )
+            .as_bytes()
+        );
+    }
+
+    #[test]
+    fn failed_progress_stops_preparation_before_mutation() {
+        let project = project("application", "pub fn main() { 1 }\n");
+        let root = utf8_path(&project);
+        let cargo = RecordingCargo::default();
+        let mut output = fs::File::open(root.join("gleam.toml")).expect("open read-only output");
+        let error = super::Preparation {
+            project_root: &root,
+            lock: &cargo,
+            providers: &mut UnchangedProviders,
+            progress: Progress::Visible(&mut output),
+        }
+        .prepare("application".to_owned(), &cargo)
+        .expect_err("closed progress output should stop preparation");
+        assert_eq!(error.to_string(), "failed to write preparation progress");
+        assert!(cargo.operations.borrow().is_empty());
+        assert!(!root.join("Cargo.toml").exists());
+        assert!(!root.join("build/geam").exists());
+    }
+
+    #[test]
+    fn failed_handoff_progress_stops_before_checking_or_running() {
+        struct OutputBeforeHandoff {
+            remaining_lines: usize,
+            bytes: Vec<u8>,
+        }
+
+        impl Write for OutputBeforeHandoff {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                if self.remaining_lines == 0 {
+                    return Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed output"));
+                }
+                self.bytes.extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                self.remaining_lines -= 1;
+                Ok(())
+            }
+        }
+
+        for run in [false, true] {
+            let project = project("application", "pub fn main() { 1 }\n");
+            let root = utf8_path(&project);
+            let cargo = RecordingCargo::default();
+            let mut output = OutputBeforeHandoff {
+                remaining_lines: 3,
+                bytes: Vec::new(),
+            };
+            let mut providers = UnchangedProviders;
+            let mut preparation = super::Preparation {
+                project_root: &root,
+                lock: &cargo,
+                providers: &mut providers,
+                progress: Progress::Visible(&mut output),
+            };
+            let result = if run {
+                preparation.run(&root, "application".to_owned(), Vec::new(), &cargo)
+            } else {
+                preparation.prepare("application".to_owned(), &cargo)
+            };
+            let error = result.expect_err("handoff should stop before invoking the runner");
+            assert_eq!(error.to_string(), "failed to write preparation progress");
+            assert_eq!(cargo.operations.borrow().as_slice(), ["lock"]);
+            assert_eq!(
+                output.bytes,
+                format!(
+                    concat!(
+                        "geam: Preparing application in {}\n",
+                        "geam: Checking Gleam source for application\n",
+                        "geam: Resolving Cargo dependencies in {}\n",
+                    ),
+                    root, root
+                )
+                .as_bytes()
+            );
+        }
     }
 
     #[test]
@@ -355,13 +605,13 @@ pub fn main() { required() }
             observed: &observed,
         };
 
-        super::prepare_with(
-            &root,
-            "application".to_owned(),
-            &cargo,
-            &cargo,
-            &mut providers,
-        )
+        super::Preparation {
+            project_root: &root,
+            lock: &cargo,
+            providers: &mut providers,
+            progress: Progress::Hidden,
+        }
+        .prepare("application".to_owned(), &cargo)
         .expect("missing root lock should be restored before provider resolution");
 
         assert!(observed.get());
@@ -397,13 +647,13 @@ pub fn main() { required() }
             observed: &observed,
         };
 
-        let error = super::prepare_with(
-            &root,
-            "application".to_owned(),
-            &cargo,
-            &cargo,
-            &mut providers,
-        )
+        let error = super::Preparation {
+            project_root: &root,
+            lock: &cargo,
+            providers: &mut providers,
+            progress: Progress::Hidden,
+        }
+        .prepare("application".to_owned(), &cargo)
         .expect_err("pruned manifest write failure should stop before provider resolution");
 
         assert!(matches!(
@@ -429,13 +679,13 @@ pub fn main() { required() }
             observed: &observed,
         };
 
-        let error = super::prepare_with(
-            &root,
-            "application".to_owned(),
-            &FailingLock,
-            &RecordingCargo::default(),
-            &mut providers,
-        )
+        let error = super::Preparation {
+            project_root: &root,
+            lock: &FailingLock,
+            providers: &mut providers,
+            progress: Progress::Hidden,
+        }
+        .prepare("application".to_owned(), &RecordingCargo::default())
         .expect_err("missing root lock failure should stop before provider resolution");
 
         assert!(matches!(
@@ -611,6 +861,7 @@ pub fn main() { 1 }
                 _project: &ResolvedProject,
                 _program: &geam_core::TypedProgram,
                 _managed: &mut ManagedProject,
+                _progress: &mut Progress<'_>,
             ) -> Result<(), CliError> {
                 Err(CliError::ProviderApprovalRequired {
                     package: "application".to_owned(),
@@ -620,13 +871,13 @@ pub fn main() { 1 }
         }
 
         assert!(matches!(
-            super::prepare_with(
-                &root,
-                "application".to_owned(),
-                &RecordingCargo::default(),
-                &RecordingCargo::default(),
-                &mut FailingProviders,
-            )
+            super::Preparation {
+                project_root: &root,
+                lock: &RecordingCargo::default(),
+                providers: &mut FailingProviders,
+                progress: Progress::Hidden,
+            }
+            .prepare("application".to_owned(), &RecordingCargo::default())
             .expect_err("provider reconciliation should fail"),
             CliError::ProviderApprovalRequired { package, command }
                 if package == "application"

--- a/cli/src/standalone/integration.rs
+++ b/cli/src/standalone/integration.rs
@@ -1,5 +1,6 @@
 use crate::error::CliError;
 use crate::process::run_checked;
+use crate::progress::Progress;
 use crate::project::ResolvedProject;
 use crate::provider::registry::{ProviderRegistry, RegistryAccessError};
 use crate::provider::{ManagedProject, ProviderSelectionReconciler, TerminalApproval};
@@ -12,9 +13,10 @@ use sha2::{Digest, Sha256};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::Cursor;
+use std::io::{self, Cursor, Write};
 use std::path::Path;
 use std::process::Command;
+use std::sync::{Arc, Mutex};
 use tempfile::{TempDir, tempdir};
 
 #[test]
@@ -24,21 +26,25 @@ fn discovers_approves_locks_builds_and_runs_registry_providers() {
     let catalog = provider_archive("geam-catalog");
     let counter = provider_archive("geam-counter");
     let registry = FakeRegistry::new([catalog, counter]);
-    let mut reconciler = RegistryReconciler::new(&registry, b"y\ny\n".to_vec());
+    let mut output = Transcript::default();
+    let mut reconciler = RegistryReconciler::new(&registry, b"y\ny\n".to_vec(), output.clone());
 
-    super::prepare_with(
-        &project_root,
-        "standalone_fixture".to_owned(),
-        &SystemCargo,
-        &SystemCargo,
-        &mut reconciler,
-    )
+    super::Preparation {
+        project_root: &project_root,
+        lock: &SystemCargo,
+        providers: &mut reconciler,
+        progress: Progress::Visible(&mut output),
+    }
+    .prepare("standalone_fixture".to_owned(), &SystemCargo)
     .expect("discovered providers should prepare through the generated runner");
 
-    let prompt =
-        String::from_utf8(reconciler.prompt().to_vec()).expect("approval prompt should be UTF-8");
+    let initial = output.take();
+    let prompt_start = initial.find("Gleam package catalog").expect("first prompt");
+    let lock_start = initial
+        .find("geam: Resolving Cargo dependencies")
+        .expect("Cargo resolution");
     assert_eq!(
-        prompt,
+        &initial[prompt_start..lock_start],
         concat!(
             "Gleam package catalog 1.0.0 requires native provider code.\n",
             "Metadata compatibility is not an endorsement.\n",
@@ -50,6 +56,23 @@ fn discovers_approves_locks_builds_and_runs_registry_providers() {
             "Approve geam-counter 1.0.0? [y/N] ",
         ),
     );
+    assert_eq!(
+        &initial[..prompt_start],
+        format!(
+            concat!(
+                "geam: Preparing standalone_fixture in {}\n",
+                "geam: Checking Gleam source for standalone_fixture\n",
+                "geam: Discovering native providers for catalog 1.0.0\n",
+                "geam: Discovering native providers for counter 1.0.0\n",
+            ),
+            project_root
+        ),
+    );
+    let check_start = initial
+        .find("geam: Checking standalone runner")
+        .expect("runner check");
+    assert!(lock_start < check_start);
+    assert!(initial.ends_with("geam: Prepared standalone_fixture\n"));
 
     let manifest = fs::read_to_string(project_root.join("Cargo.toml"))
         .expect("managed manifest should be readable");
@@ -110,14 +133,30 @@ fn discovers_approves_locks_builds_and_runs_registry_providers() {
         ],
     );
 
-    super::prepare_with(
-        &project_root,
-        "standalone_fixture".to_owned(),
-        &SystemCargo,
-        &SystemCargo,
-        &mut reconciler,
-    )
+    super::Preparation {
+        project_root: &project_root,
+        lock: &SystemCargo,
+        providers: &mut reconciler,
+        progress: Progress::Visible(&mut output),
+    }
+    .prepare("standalone_fixture".to_owned(), &SystemCargo)
     .expect("approved providers should prepare without rediscovery");
+    let repeated = output.take();
+    assert_eq!(
+        repeated
+            .lines()
+            .filter(|line| line.starts_with("geam: "))
+            .collect::<Vec<_>>(),
+        [
+            format!("geam: Preparing standalone_fixture in {project_root}"),
+            "geam: Checking Gleam source for standalone_fixture".to_owned(),
+            "geam: Resolving provider geam-catalog for catalog 1.0.0".to_owned(),
+            "geam: Resolving provider geam-counter for counter 1.0.0".to_owned(),
+            "geam: Checking standalone runner for standalone_fixture".to_owned(),
+            "geam: Prepared standalone_fixture".to_owned(),
+        ],
+    );
+    assert!(!repeated.contains("Approve "));
     assert_eq!(
         fs::read_to_string(project_root.join("Cargo.toml"))
             .expect("managed manifest should remain readable"),
@@ -134,8 +173,13 @@ fn discovers_approves_locks_builds_and_runs_registry_providers() {
     );
     assert_eq!(registry.calls().len(), 8);
 
-    super::run_with(
-        &project_root,
+    super::Preparation {
+        project_root: &project_root,
+        lock: &SystemCargo,
+        providers: &mut reconciler,
+        progress: Progress::Visible(&mut output),
+    }
+    .run(
         &project_root,
         "standalone_fixture".to_owned(),
         vec![
@@ -143,10 +187,23 @@ fn discovers_approves_locks_builds_and_runs_registry_providers() {
             "counter=config/counter.toml".to_owned(),
         ],
         &SystemCargo,
-        &SystemCargo,
-        &mut reconciler,
     )
     .expect("approved providers should execute through the generated runner");
+    let running = output.take();
+    assert_eq!(
+        running
+            .lines()
+            .filter(|line| line.starts_with("geam: "))
+            .collect::<Vec<_>>(),
+        [
+            format!("geam: Preparing standalone_fixture in {project_root}"),
+            "geam: Checking Gleam source for standalone_fixture".to_owned(),
+            "geam: Resolving provider geam-catalog for catalog 1.0.0".to_owned(),
+            "geam: Resolving provider geam-counter for counter 1.0.0".to_owned(),
+            "geam: Starting standalone runner for standalone_fixture".to_owned(),
+        ],
+    );
+    assert!(!running.contains("Approve "));
     assert_eq!(registry.calls().len(), 8);
     assert_eq!(
         cargo_locks(&project_root),
@@ -157,20 +214,16 @@ fn discovers_approves_locks_builds_and_runs_registry_providers() {
 struct RegistryReconciler<'registry> {
     registry: &'registry dyn ProviderRegistry,
     input: Cursor<Vec<u8>>,
-    prompt: Vec<u8>,
+    output: Transcript,
 }
 
 impl<'registry> RegistryReconciler<'registry> {
-    fn new(registry: &'registry dyn ProviderRegistry, input: Vec<u8>) -> Self {
+    fn new(registry: &'registry dyn ProviderRegistry, input: Vec<u8>, output: Transcript) -> Self {
         Self {
             registry,
             input: Cursor::new(input),
-            prompt: Vec::new(),
+            output,
         }
-    }
-
-    fn prompt(&self) -> &[u8] {
-        &self.prompt
     }
 }
 
@@ -181,8 +234,9 @@ impl ProviderSelectionReconciler for RegistryReconciler<'_> {
         project: &ResolvedProject,
         program: &geam_core::TypedProgram,
         managed: &mut ManagedProject,
+        progress: &mut Progress<'_>,
     ) -> Result<(), CliError> {
-        let mut approval = TerminalApproval::new(true, &mut self.input, &mut self.prompt);
+        let mut approval = TerminalApproval::new(true, &mut self.input, &mut self.output);
         crate::provider::reconcile_registry(
             self.registry,
             &mut approval,
@@ -190,7 +244,32 @@ impl ProviderSelectionReconciler for RegistryReconciler<'_> {
             project,
             program,
             managed,
+            progress,
         )
+    }
+}
+
+#[derive(Clone, Default)]
+struct Transcript(Arc<Mutex<Vec<u8>>>);
+
+impl Transcript {
+    fn take(&self) -> String {
+        let bytes = std::mem::take(&mut *self.0.lock().expect("transcript should be available"));
+        String::from_utf8(bytes).expect("fixture transcript should be UTF-8")
+    }
+}
+
+impl Write for Transcript {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("transcript should be available")
+            .extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -30,6 +30,33 @@ initializes state and executes directly without a separate check run. A main
 return value is not printed; Gleam IO writes to its selected stream and Echo
 writes to stderr in source order.
 
+## Preparation Output
+
+`prepare` and `run` write plain `geam: ...` progress lines to stderr before each
+preparation phase. These identify the selected module, Gleam dependency
+acquisition, provider resolution or discovery, Cargo dependency resolution,
+and runner check or execution. Provider approval prompts also use stderr;
+responses still come from stdin.
+
+Cargo and Gleam output is shown as those tools produce it, without Geam adding
+prefixes or changing their color, progress, or verbosity settings. Output needed
+for structured failures is forwarded while the command runs and retained for
+diagnostics. Native output stays on its original stream; Cargo metadata JSON
+stays private. Native rendering can differ between a terminal and a pipe; Geam
+does not emulate a terminal.
+
+Repeated commands still report work they actually perform, such as checking
+source and invoking the runner. A dependency acquisition, registry discovery,
+or lock-resolution line appears only when that operation is invoked. Cargo
+decides whether a rebuild is necessary and reports its own build activity.
+
+`prepare` ends with `geam: Prepared MODULE` only after its check succeeds. `run`
+prints `geam: Starting standalone runner for MODULE` before handing control to
+Cargo, then leaves application stdin, stdout, and stderr directly connected.
+There is no completion footer after the application. Geam's preparation lines
+and approval prompts do not go to stdout. On failure, the final diagnostic can
+repeat native stderr that was already forwarded.
+
 ## Managed Files
 
 Geam creates these files in the Gleam project root:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -234,6 +234,14 @@ the real root Cargo lock, generated runner check, and runner execution.
 Fixture-only Cargo patches keep acquisition local while preserving the
 production manifest, resolution, build, and execution path.
 
+CLI owner tests fix the exact preparation messages, conditional acquisition
+and lock work, and native byte forwarding without newline buffering. Process
+tests cover private metadata stdout, checked-process stdin isolation, large
+output, failure diagnostics, and draining after output failure. The fake-registry
+test also checks progress/approval ordering and repeated preparation. Binary and
+distribution tests keep application stdout and IO/Echo ordering separate from
+preparation stderr; native Cargo/Gleam wording is not a version-pinned assertion.
+
 The [provider authoring examples](../examples) are consumer-facing macro
 acceptance cases. `text_tools` maps one stateless provider to three Gleam
 modules, `value_types` fixes every scalar mapping plus one-, multi-, and

--- a/examples/call_tracing/README.md
+++ b/examples/call_tracing/README.md
@@ -36,7 +36,7 @@ geam run
 geam run
 ```
 
-A successful run produces no output. Read
+A successful run produces no application output. Read
 [`project/packages/example_call_tracing/src/example_call_tracing.gleam`](project/packages/example_call_tracing/src/example_call_tracing.gleam),
 [`provider/src/lib.rs`](provider/src/lib.rs), and
 [`project/src/call_tracing_example.gleam`](project/src/call_tracing_example.gleam)

--- a/examples/generic_box/README.md
+++ b/examples/generic_box/README.md
@@ -60,7 +60,7 @@ geam run
 geam run
 ```
 
-A successful run produces no output. Read
+A successful run produces no application output. Read
 [`project/packages/example_generic_box/src/example_generic_box.gleam`](project/packages/example_generic_box/src/example_generic_box.gleam),
 [`provider/src/lib.rs`](provider/src/lib.rs), and
 [`project/src/generic_box_example.gleam`](project/src/generic_box_example.gleam)

--- a/examples/request_ids/README.md
+++ b/examples/request_ids/README.md
@@ -31,7 +31,7 @@ geam run
 ```
 
 Each run checks the initial count, two generated IDs, and the read-only count
-after each mutation. A successful run produces no output.
+after each mutation. A successful run produces no application output.
 
 Read [`project/packages/example_request_ids/src/example_request_ids.gleam`](project/packages/example_request_ids/src/example_request_ids.gleam),
 [`provider/src/lib.rs`](provider/src/lib.rs), and

--- a/examples/run_metrics/README.md
+++ b/examples/run_metrics/README.md
@@ -37,7 +37,7 @@ geam run
 No provider configuration file is needed, so the component omits both state and
 initialization. All metrics data lives in the source-visible `Metrics` values.
 The entrypoint checks empty, one-sample, multi-sample, missing-key, old-value
-preservation, and equality behavior. A successful run produces no output.
+preservation, and equality behavior. A successful run produces no application output.
 
 The tracked `.cargo/config.toml` files only redirect the unreleased Geam
 authoring API to this repository checkout. They are development wiring for this

--- a/examples/tag_set/README.md
+++ b/examples/tag_set/README.md
@@ -38,7 +38,7 @@ geam prepare
 geam run
 ```
 
-A successful run produces no output. The entrypoint executes every public
+A successful run produces no application output. The entrypoint executes every public
 function and checks persistent old values, duplicate insertion, membership,
 size, and equality between independently constructed values.
 

--- a/examples/text_tools/README.md
+++ b/examples/text_tools/README.md
@@ -49,7 +49,7 @@ geam prepare
 geam run
 ```
 
-A successful run produces no output. The entrypoint imports all three modules
+A successful run produces no application output. The entrypoint imports all three modules
 and executes every public function.
 
 Read the three files under

--- a/examples/value_types/README.md
+++ b/examples/value_types/README.md
@@ -163,7 +163,7 @@ geam prepare
 geam run
 ```
 
-A successful run produces no output. The entrypoint executes every public
+A successful run produces no application output. The entrypoint executes every public
 function and checks all scalar mappings, one-, two-, three-element and nested
 tuples, empty, indexed, pass-through, reversed and tuple-item Lists, unit,
 tuple, named, nested and List-bearing custom constructors, plus source Result

--- a/tests/binary.rs
+++ b/tests/binary.rs
@@ -55,6 +55,25 @@ fn reports_current_directory_failures_through_the_binary_boundary() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn fails_without_panicking_when_preparation_stderr_is_closed() {
+    let project = gleam_project();
+    for operation in ["prepare", "run"] {
+        let (reader, writer) = std::io::pipe().expect("stderr pipe should open");
+        drop(reader);
+        let output = geam_command(&project, [operation])
+            .stderr(writer)
+            .output()
+            .expect("Geam CLI should start with a closed stderr reader");
+        assert_eq!(output.status.code(), Some(1));
+        assert!(output.stdout.is_empty());
+        assert!(output.stderr.is_empty());
+        assert!(!project.path().join("Cargo.toml").exists());
+        assert!(!project.path().join("build/geam").exists());
+    }
+}
+
 #[test]
 fn prepares_and_runs_pure_projects_without_printing_main_results() {
     let project = gleam_project();
@@ -67,6 +86,22 @@ fn prepares_and_runs_pure_projects_without_printing_main_results() {
     );
     assert!(project.path().join("Cargo.lock").is_file());
     assert!(project.path().join("build/geam/runner.rs").is_file());
+    assert!(prepare.stdout.is_empty());
+    let root = fs::canonicalize(project.path()).expect("project path should canonicalize");
+    let prepared = String::from_utf8_lossy(&prepare.stderr);
+    assert_eq!(
+        prepared
+            .lines()
+            .filter(|line| line.starts_with("geam: "))
+            .collect::<Vec<_>>(),
+        [
+            format!("geam: Preparing application in {}", root.display()),
+            "geam: Checking Gleam source for application".to_owned(),
+            format!("geam: Resolving Cargo dependencies in {}", root.display()),
+            "geam: Checking standalone runner for application".to_owned(),
+            "geam: Prepared application".to_owned(),
+        ],
+    );
 
     let run = geam(&project, ["run", "--module", "application"]);
     assert!(
@@ -75,10 +110,17 @@ fn prepares_and_runs_pure_projects_without_printing_main_results() {
         String::from_utf8_lossy(&run.stderr),
     );
     assert!(run.stdout.is_empty());
-    assert!(
-        run.stderr.is_empty(),
-        "run wrote unexpected stderr: {}",
-        String::from_utf8_lossy(&run.stderr),
+    let running = String::from_utf8_lossy(&run.stderr);
+    assert_eq!(
+        running
+            .lines()
+            .filter(|line| line.starts_with("geam: "))
+            .collect::<Vec<_>>(),
+        [
+            format!("geam: Preparing application in {}", root.display()),
+            "geam: Checking Gleam source for application".to_owned(),
+            "geam: Starting standalone runner for application".to_owned(),
+        ],
     );
 }
 
@@ -94,6 +136,9 @@ fn streams_gleam_io_and_echo_in_source_order_before_runtime_failure() {
     );
     assert_eq!(String::from_utf8_lossy(&run.stdout), "stdout");
     let stderr = String::from_utf8_lossy(&run.stderr);
+    let handoff = stderr
+        .find("geam: Starting standalone runner for application\n")
+        .expect("preparation should hand off to the runner before application output");
     let first = stderr
         .find("stderr-one\n")
         .expect("first stderr IO should be present");
@@ -103,7 +148,8 @@ fn streams_gleam_io_and_echo_in_source_order_before_runtime_failure() {
     let last = stderr
         .find("stderr-two\n")
         .expect("last stderr IO should be present");
-    assert!(first < echo && echo < last);
+    assert!(handoff < first && first < echo && echo < last);
+    assert!(stderr.ends_with("stderr-two\n"));
 
     #[cfg(unix)]
     {
@@ -137,7 +183,17 @@ pub fn main() {
     assert!(!failed.status.success());
     assert!(failed.stdout.is_empty());
     let stderr = String::from_utf8_lossy(&failed.stderr);
-    assert!(stderr.starts_with("before panic\n"));
+    let handoff = stderr
+        .find("geam: Starting standalone runner for application\n")
+        .expect("preparation should finish before the failing application starts");
+    let before = stderr
+        .find("before panic\n")
+        .expect("IO before panic should be preserved");
+    let failure = stderr
+        .find("geam runner:")
+        .expect("runner should report the source failure");
+    assert!(handoff < before && before < failure);
+    assert!(!stderr.contains("geam: Prepared "));
     assert!(stderr.contains("stop"));
 }
 

--- a/tests/provider_examples.rs
+++ b/tests/provider_examples.rs
@@ -33,7 +33,10 @@ fn runs_the_documented_run_metrics_provider_without_configuration() {
         String::from_utf8_lossy(&run.stderr),
     );
     assert!(run.stdout.is_empty());
-    assert!(run.stderr.is_empty());
+    assert!(
+        String::from_utf8_lossy(&run.stderr)
+            .contains("geam: Starting standalone runner for run_metrics_example\n")
+    );
 
     let independent_run = geam_at(&project, ["run"]);
     assert!(
@@ -42,7 +45,10 @@ fn runs_the_documented_run_metrics_provider_without_configuration() {
         String::from_utf8_lossy(&independent_run.stderr),
     );
     assert!(independent_run.stdout.is_empty());
-    assert!(independent_run.stderr.is_empty());
+    assert!(
+        String::from_utf8_lossy(&independent_run.stderr)
+            .contains("geam: Starting standalone runner for run_metrics_example\n")
+    );
 }
 
 #[test]
@@ -72,7 +78,10 @@ fn runs_the_documented_text_tools_provider_across_three_modules() {
             String::from_utf8_lossy(&run.stderr),
         );
         assert!(run.stdout.is_empty());
-        assert!(run.stderr.is_empty());
+        assert!(
+            String::from_utf8_lossy(&run.stderr)
+                .contains("geam: Starting standalone runner for text_tools_example\n")
+        );
     }
 }
 
@@ -103,7 +112,10 @@ fn runs_the_documented_value_types_provider_without_configuration() {
             String::from_utf8_lossy(&run.stderr),
         );
         assert!(run.stdout.is_empty());
-        assert!(run.stderr.is_empty());
+        assert!(
+            String::from_utf8_lossy(&run.stderr)
+                .contains("geam: Starting standalone runner for value_types_example\n")
+        );
     }
 }
 
@@ -134,7 +146,10 @@ fn runs_the_documented_tag_set_provider_without_configuration() {
             String::from_utf8_lossy(&run.stderr),
         );
         assert!(run.stdout.is_empty());
-        assert!(run.stderr.is_empty());
+        assert!(
+            String::from_utf8_lossy(&run.stderr)
+                .contains("geam: Starting standalone runner for tag_set_example\n")
+        );
     }
 }
 
@@ -165,7 +180,10 @@ fn runs_the_documented_request_ids_provider_with_fresh_default_state() {
             String::from_utf8_lossy(&run.stderr),
         );
         assert!(run.stdout.is_empty());
-        assert!(run.stderr.is_empty());
+        assert!(
+            String::from_utf8_lossy(&run.stderr)
+                .contains("geam: Starting standalone runner for request_ids_example\n")
+        );
     }
 }
 
@@ -196,7 +214,10 @@ fn runs_the_documented_call_tracing_provider_with_fresh_callback_state() {
             String::from_utf8_lossy(&run.stderr),
         );
         assert!(run.stdout.is_empty());
-        assert!(run.stderr.is_empty());
+        assert!(
+            String::from_utf8_lossy(&run.stderr)
+                .contains("geam: Starting standalone runner for call_tracing_example\n")
+        );
     }
 }
 
@@ -227,7 +248,10 @@ fn runs_the_documented_generic_box_provider_with_persistent_values() {
             String::from_utf8_lossy(&run.stderr),
         );
         assert!(run.stdout.is_empty());
-        assert!(run.stderr.is_empty());
+        assert!(
+            String::from_utf8_lossy(&run.stderr)
+                .contains("geam: Starting standalone runner for generic_box_example\n")
+        );
     }
 }
 
@@ -265,7 +289,10 @@ fn runs_the_documented_feature_flags_provider_with_explicit_configuration() {
             String::from_utf8_lossy(&run.stderr),
         );
         assert!(run.stdout.is_empty());
-        assert!(run.stderr.is_empty());
+        assert!(
+            String::from_utf8_lossy(&run.stderr)
+                .contains("geam: Starting standalone runner for feature_flags_example\n")
+        );
     }
 
     let missing = geam_at(&project, ["run"]);
@@ -362,7 +389,10 @@ fn runs_the_documented_text_pattern_on_erlang_and_geam() {
             String::from_utf8_lossy(&run.stderr),
         );
         assert!(run.stdout.is_empty());
-        assert!(run.stderr.is_empty());
+        assert!(
+            String::from_utf8_lossy(&run.stderr)
+                .contains("geam: Starting standalone runner for text_pattern_example\n")
+        );
     }
 
     let run = geam_at(&project, ["run", "--module", "text_pattern_geam"]);
@@ -374,8 +404,19 @@ fn runs_the_documented_text_pattern_on_erlang_and_geam() {
     assert!(run.stdout.is_empty());
     let canonical_project =
         fs::canonicalize(&project).expect("text pattern project should canonicalize");
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    let handoff = stderr
+        .find("geam: Starting standalone runner for text_pattern_geam\n")
+        .expect("Geam should hand off before Echo output");
+    let echo = stderr
+        .find(&format!(
+            "{}/src/text_pattern_geam.gleam:8",
+            canonical_project.display()
+        ))
+        .expect("Geam-specific Echo should be preserved");
+    assert!(handoff < echo);
     assert_eq!(
-        String::from_utf8_lossy(&run.stderr),
+        &stderr[echo..],
         format!(
             "{}/src/text_pattern_geam.gleam:8 compiled pattern\nPattern(\"[A-Za-z]+\")\n",
             canonical_project.display(),

--- a/tests/standalone_distribution.rs
+++ b/tests/standalone_distribution.rs
@@ -119,6 +119,9 @@ fn runs_the_canonical_standalone_project_with_independent_path_providers() {
             "\"count:3/count:4\"\n"
         );
         let stderr = String::from_utf8_lossy(&run.stderr);
+        let handoff = stderr
+            .find("geam: Starting standalone runner for standalone_fixture\n")
+            .expect("preparation should finish before application output");
         let before = stderr
             .find("provider-before\n")
             .expect("first IO event should be present");
@@ -128,7 +131,8 @@ fn runs_the_canonical_standalone_project_with_independent_path_providers() {
         let after = stderr
             .find("provider-after\n")
             .expect("final IO event should be present");
-        assert!(before < echo && echo < after);
+        assert!(handoff < before && before < echo && echo < after);
+        assert!(stderr.ends_with("provider-after\n"));
     }
     assert_eq!(
         fs::read_to_string(project.join("build/geam/runner.rs"))
@@ -154,7 +158,9 @@ fn runs_the_canonical_standalone_project_with_independent_path_providers() {
         String::from_utf8_lossy(&alternate.stderr),
     );
     assert_eq!(String::from_utf8_lossy(&alternate.stdout), "alternate\n");
-    assert!(alternate.stderr.is_empty());
+    let stderr = String::from_utf8_lossy(&alternate.stderr);
+    assert!(stderr.contains("geam: Starting standalone runner for alternate\n"));
+    assert!(!stderr.contains("geam: Prepared "));
 
     let missing_configuration = geam_at(&project, ["run"]);
     assert!(!missing_configuration.status.success());


### PR DESCRIPTION
## Summary

`geam prepare` and the implicit preparation in `geam run` could appear stalled: native tool output was captured, the generated runner used Cargo's `--quiet`, and provider discovery had no progress messages.

- Report actual preparation phases as flushed, append-only `geam:` lines on stderr. Announce dependency acquisition, provider resolution/discovery, and lock generation only when those operations run.
- Forward native Cargo/Gleam output while retaining structured failures and keeping Cargo metadata JSON private. Leave native rendering settings unchanged.
- Keep provider approval on stderr, checked subprocess stdin isolated, and application IO directly inherited. Finish successful `prepare` with a completion line; add no extra check or footer to `run`.
- Cover output forwarding, repeated preparation, failure handling, and closed stderr in the existing owner/acceptance tests. Update the standalone guide and example output expectations.

Closes #133.

## Additional Local Verification

Used a fresh temporary project and an interactive terminal with published `example_text_pattern 0.1.0` from Hex and `geam-example-text-pattern 0.1.0` from crates.io, patching Geam to this checkout.

First `prepare` (including discovery and approval), repeated `prepare`, and `run` all succeeded. The repeated commands omitted acquisition/discovery/approval, and the application printed `["Geam", "Gleam", "Rust"]` after the runner handoff. Existing global dependency caches were retained; this was not an all-caches-empty benchmark.
