### PR TITLE
Fix workspace Rustdoc recursion overflow

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -91,6 +91,28 @@ jobs:
             (cd "examples/$example/provider" && cargo clippy --all-targets --locked -- -D warnings)
           done
 
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          rustflags: ""
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: Build workspace documentation
+        run: cargo doc --workspace --no-deps --locked
+
   workspace-tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 #[cfg(not(target_pointer_width = "64"))]
 compile_error!("geam requires a 64-bit target");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 #[cfg(feature = "gleam-json")]
 pub mod gleam_json;
 #[cfg(feature = "gleam-stdlib")]


### PR DESCRIPTION
## Summary

Rustdoc's automatic trait analysis traverses Geam's recursive planner expression graph beyond the default crate recursion limit. Ordinary builds and package verification therefore passed while API HTML generation failed.

- Raise the compile-time recursion limit to 256 for `geam-core` and the root `geam` facade, where Rustdoc evaluates the public type graph independently.
- Add a dedicated `Workspace / Documentation` check that builds every workspace crate's public documentation with `cargo doc --workspace --no-deps --locked`.
- Keep the existing Rustdoc warning policy unchanged while making documentation generation an explicit merge gate.

Closes #139.
