### PR TITLE
Automate reference example releases

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -49,10 +49,17 @@ jobs:
         with:
           toolchain: "1.96"
 
+      - name: Install Gleam toolchain
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: "29"
+          gleam-version: "1.18.1"
+          rebar3-version: "3"
+
       - name: Install release tools
         run: |
           cargo install cargo-release --version 1.1.4 --locked
-          cargo install cargo-edit --version 0.13.13 --locked --no-default-features --features upgrade
+          cargo install cargo-edit --version 0.13.13 --locked --no-default-features --features upgrade,set-version
 
       - name: Bump workspace versions
         env:
@@ -83,6 +90,34 @@ jobs:
             (cd "$(dirname "$manifest")" && cargo upgrade --package "geam@=$RELEASE_VERSION" --pinned --recursive false)
           done
 
+      - name: Align published reference packages
+        run: |
+          provider=examples/text_pattern/provider
+          package=examples/text_pattern/project/packages/example_text_pattern
+          project=examples/text_pattern/project
+
+          (cd "$provider" && cargo set-version "$RELEASE_VERSION")
+          test "$(grep -Ec '^gleam-version = "[^"]+"$' "$provider/Cargo.toml")" = 1
+          sed -i.bak -E "s/^gleam-version = \"[^\"]+\"$/gleam-version = \"$RELEASE_VERSION\"/" "$provider/Cargo.toml"
+          rm "$provider/Cargo.toml.bak"
+
+          test "$(grep -Ec '^version = "[^"]+"$' "$package/gleam.toml")" = 1
+          sed -i.bak -E "s/^version = \"[^\"]+\"$/version = \"$RELEASE_VERSION\"/" "$package/gleam.toml"
+          rm "$package/gleam.toml.bak"
+          (cd "$project" && gleam deps update example_text_pattern)
+
+          metadata=$(cargo metadata --manifest-path "$provider/Cargo.toml" --locked --no-deps --format-version 1)
+          jq -e --arg version "$RELEASE_VERSION" '
+            (.packages | length == 1)
+            and (.packages[0].version == $version)
+            and (.packages[0].metadata.geam.provider["gleam-version"] == $version)
+            and ([
+              .packages[0].dependencies[]
+              | select(.name == "geam" and .req == ("=" + $version))
+            ] | length == 1)
+          ' <<< "$metadata" > /dev/null
+          grep -F "name = \"example_text_pattern\", version = \"$RELEASE_VERSION\"" "$project/manifest.toml"
+
       - name: Refresh tracked Cargo locks
         run: |
           while IFS= read -r lock; do
@@ -97,12 +132,12 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add --update -- '*Cargo.toml' '*Cargo.lock'
+          git add --update -- '*Cargo.toml' '*Cargo.lock' '*gleam.toml' '*manifest.toml'
           git commit -F - <<EOF
           Prepare Geam $RELEASE_VERSION
 
-          - Bump workspace versions and provider requirements together.
-          - Refresh independently owned Cargo locks.
+          - Bump workspace and published reference packages together.
+          - Update provider requirements and dependency locks.
           EOF
           git push --set-upstream origin "release/$RELEASE_VERSION"
           gh pr create --draft --base main --head "release/$RELEASE_VERSION" \

--- a/.github/workflows/publish-reference-example.yml
+++ b/.github/workflows/publish-reference-example.yml
@@ -1,0 +1,237 @@
+name: "Geam: Publish reference example"
+
+run-name: "Geam: ${{ inputs.operation }} at ${{ inputs.commit }}"
+
+on:
+  workflow_call:
+    inputs:
+      operation:
+        required: true
+        type: string
+      commit:
+        required: true
+        type: string
+      dry_run:
+        required: true
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Operation
+        required: true
+        default: Publish reference example
+        type: choice
+        options:
+          - Publish reference example
+          - Publish Hex package
+          - Publish Rust provider
+          - Verify published example
+      commit:
+        description: Full release commit SHA
+        required: true
+        type: string
+      dry_run:
+        description: dry-run
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: geam-reference-example-publish
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  publish:
+    name: ${{ inputs.operation }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: crates-io
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    env:
+      RELEASE_OPERATION: ${{ inputs.operation }}
+      RELEASE_COMMIT: ${{ inputs.commit }}
+      REFERENCE_PROVIDER: geam-example-text-pattern
+      REFERENCE_GLEAM_PACKAGE: example_text_pattern
+
+    steps:
+      - name: Validate inputs
+        env:
+          SELECTED_REF: ${{ github.ref }}
+        run: |
+          if [[ "$SELECTED_REF" != refs/heads/main ]]; then
+            echo "::error::Run this workflow from main."
+            exit 1
+          fi
+          if [[ ! "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::commit must be a full 40-character lowercase hexadecimal SHA."
+            exit 1
+          fi
+          case "$RELEASE_OPERATION" in
+            "Publish reference example"|"Publish Hex package"|"Publish Rust provider"|"Verify published example") ;;
+            *)
+              echo "::error::Select a supported reference example operation."
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ inputs.commit }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.96"
+
+      - name: Install Gleam toolchain
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: "29"
+          gleam-version: "1.18.1"
+          rebar3-version: "3"
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: geam-reference-example-publish
+
+      - name: Validate release commit and reference versions
+        id: release
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main
+          workspace_metadata=$(cargo metadata --locked --no-deps --format-version 1)
+          version=$(jq -r '.packages[] | select(.name == "geam") | .version' <<< "$workspace_metadata")
+          jq -e --arg version "$version" 'all(.packages[]; .version == $version)' <<< "$workspace_metadata" > /dev/null
+
+          provider_metadata=$(cargo metadata --manifest-path examples/text_pattern/provider/Cargo.toml --locked --no-deps --format-version 1)
+          jq -e --arg version "$version" --arg provider "$REFERENCE_PROVIDER" --arg package "$REFERENCE_GLEAM_PACKAGE" '
+            (.packages | length == 1)
+            and (.packages[0].name == $provider)
+            and (.packages[0].version == $version)
+            and (.packages[0].metadata.geam.provider["gleam-package"] == $package)
+            and (.packages[0].metadata.geam.provider["gleam-version"] == $version)
+            and ([
+              .packages[0].dependencies[]
+              | select(.name == "geam" and .req == ("=" + $version))
+            ] | length == 1)
+          ' <<< "$provider_metadata" > /dev/null
+
+          gleam_manifest=examples/text_pattern/project/packages/example_text_pattern/gleam.toml
+          test "$(grep -Ec '^version = "[^"]+"$' "$gleam_manifest")" = 1
+          test "$(sed -n 's/^version = "\([^"]*\)"$/\1/p' "$gleam_manifest")" = "$version"
+          grep -F "name = \"$REFERENCE_GLEAM_PACKAGE\", version = \"$version\"" examples/text_pattern/project/manifest.toml
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Require successful main checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for workflow in workspace.yml coverage.yml acceptance.yml; do
+            runs=$(gh run list --workflow "$workflow" --branch main --event push --commit "$RELEASE_COMMIT" --limit 1 --json status,conclusion)
+            jq -e 'length == 1 and .[0].status == "completed" and .[0].conclusion == "success"' <<< "$runs" > /dev/null || {
+              echo "$workflow must succeed at $RELEASE_COMMIT before publication" >&2
+              exit 1
+            }
+          done
+
+      - name: Authenticate to crates.io
+        if: ${{ inputs.dry_run == false && (inputs.operation == 'Publish reference example' || inputs.operation == 'Publish Rust provider') }}
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish or dry-run Rust provider
+        if: ${{ inputs.operation == 'Publish reference example' || inputs.operation == 'Publish Rust provider' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          manifest=examples/text_pattern/provider/Cargo.toml
+          if [[ "$DRY_RUN" == true ]]; then
+            cargo publish --manifest-path "$manifest" --locked --dry-run \
+              --config "patch.crates-io.geam.path='$GITHUB_WORKSPACE'"
+          else
+            cargo update --manifest-path "$manifest" --package geam --precise "$RELEASE_VERSION"
+            test "$(git diff --name-only)" = examples/text_pattern/provider/Cargo.lock
+            cargo publish --manifest-path "$manifest" --locked --allow-dirty
+          fi
+
+      - name: Verify Rust provider is published
+        if: ${{ (inputs.dry_run == false && (inputs.operation == 'Publish reference example' || inputs.operation == 'Publish Rust provider')) || inputs.operation == 'Verify published example' }}
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          for attempt in {1..12}; do
+            if (cd "$RUNNER_TEMP" && cargo info "$REFERENCE_PROVIDER@$RELEASE_VERSION" --registry crates-io > /dev/null); then
+              break
+            fi
+            if [[ "$attempt" == 12 ]]; then
+              echo "$REFERENCE_PROVIDER $RELEASE_VERSION is not available from crates.io" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+
+      - name: Publish or dry-run Hex package
+        if: ${{ inputs.operation == 'Publish reference example' || inputs.operation == 'Publish Hex package' }}
+        working-directory: examples/text_pattern/project/packages/example_text_pattern
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}
+        run: |
+          if [[ "$DRY_RUN" == true ]]; then
+            gleam export hex-tarball
+          else
+            test -n "$HEXPM_API_KEY"
+            gleam publish --yes
+          fi
+
+      - name: Verify published example
+        if: ${{ (inputs.dry_run == false && inputs.operation == 'Publish reference example') || inputs.operation == 'Verify published example' }}
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          cargo install geam --version "=$RELEASE_VERSION" --locked --root "$RUNNER_TEMP/published-geam"
+          test "$("$RUNNER_TEMP/published-geam/bin/geam" --version)" = "geam $RELEASE_VERSION"
+
+          project="$RUNNER_TEMP/published-provider"
+          gleam new --name published_provider --skip-git --skip-github "$project"
+          (
+            cd "$project"
+            gleam add "$REFERENCE_GLEAM_PACKAGE@$RELEASE_VERSION"
+            sed -i.bak "s/^$REFERENCE_GLEAM_PACKAGE = .*/$REFERENCE_GLEAM_PACKAGE = \"$RELEASE_VERSION\"/" gleam.toml
+            rm gleam.toml.bak
+            gleam deps download
+            grep -E "name = \"$REFERENCE_GLEAM_PACKAGE\", version = \"$RELEASE_VERSION\".*source = \"hex\"" manifest.toml
+            cat > src/published_provider.gleam <<'GLEAM'
+          import example_text_pattern as pattern
+
+          pub fn main() -> Nil {
+            let assert Ok(words) = pattern.compile("[A-Za-z]+")
+            assert pattern.find_all(words, "Geam + Gleam 2026") == ["Geam", "Gleam"]
+          }
+          GLEAM
+            printf 'y\n' | script --quiet --return --command "$RUNNER_TEMP/published-geam/bin/geam prepare" "$RUNNER_TEMP/provider-approval.log"
+            test "$(grep -Fc "Approve $REFERENCE_PROVIDER $RELEASE_VERSION? [y/N]" "$RUNNER_TEMP/provider-approval.log")" -eq 1
+            cargo metadata --format-version 1 --locked --manifest-path Cargo.toml > "$RUNNER_TEMP/provider-metadata.json"
+            jq -e --arg version "$RELEASE_VERSION" --arg provider "$REFERENCE_PROVIDER" '
+              ([.packages[] | select(.name == "geam" and .version == $version and (.source | startswith("registry+")))] | length == 1)
+              and
+              ([.packages[] | select(.name == $provider and .version == $version and (.source | startswith("registry+")))] | length == 1)
+            ' "$RUNNER_TEMP/provider-metadata.json" > /dev/null
+            test -z "$("$RUNNER_TEMP/published-geam/bin/geam" run)"
+          )

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: "Geam: Publish crates"
+name: "Geam: Publish release"
 
 on:
   workflow_dispatch:
@@ -6,18 +6,18 @@ on:
       operation:
         description: Operation
         required: true
-        default: Publish workspace
+        default: Publish release
         type: choice
         options:
-          - Publish workspace
-          - Retry packages
+          - Publish release
+          - Retry workspace crates
           - Create GitHub Release
       commit:
         description: Full release commit SHA
         required: true
         type: string
-      packages:
-        description: For Retry packages only, space-separated
+      crates:
+        description: For Retry workspace crates only, space-separated crate names
         required: false
         type: string
       dry_run:
@@ -30,7 +30,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: geam-crates-io-publish
+  group: geam-release-publish
   cancel-in-progress: false
 
 env:
@@ -38,19 +38,21 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  publish:
+  workspace:
     name: ${{ inputs.operation }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: crates-io
     permissions:
       actions: read
-      contents: write
+      contents: read
       id-token: write
+    outputs:
+      version: ${{ steps.release.outputs.version }}
     env:
       RELEASE_OPERATION: ${{ inputs.operation }}
       RELEASE_COMMIT: ${{ inputs.commit }}
-      RELEASE_PACKAGES: ${{ inputs.packages }}
+      RELEASE_CRATES: ${{ inputs.crates }}
 
     steps:
       - name: Validate inputs
@@ -66,20 +68,20 @@ jobs:
             exit 1
           fi
           case "$RELEASE_OPERATION" in
-            "Retry packages")
-              if [[ ! "$RELEASE_PACKAGES" =~ [^[:space:]] ]]; then
-                echo "::error::Retry packages requires at least one crate in packages."
+            "Retry workspace crates")
+              if [[ ! "$RELEASE_CRATES" =~ [^[:space:]] ]]; then
+                echo "::error::Retry workspace crates requires at least one crate in crates."
                 exit 1
               fi
               ;;
-            "Publish workspace"|"Create GitHub Release")
-              if [[ -n "$RELEASE_PACKAGES" ]]; then
-                echo "::error::packages must be empty for $RELEASE_OPERATION."
+            "Publish release"|"Create GitHub Release")
+              if [[ -n "$RELEASE_CRATES" ]]; then
+                echo "::error::crates must be empty for $RELEASE_OPERATION."
                 exit 1
               fi
               ;;
             *)
-              echo "::error::Select Publish workspace, Retry packages, or Create GitHub Release."
+              echo "::error::Select Publish release, Retry workspace crates, or Create GitHub Release."
               exit 1
               ;;
           esac
@@ -139,16 +141,16 @@ jobs:
         id: auth
         uses: rust-lang/crates-io-auth-action@v1
 
-      - name: Publish or dry-run selected crates
+      - name: Publish or dry-run workspace crates
         if: ${{ inputs.operation != 'Create GitHub Release' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           args=(--locked)
-          if [[ "$RELEASE_OPERATION" == "Retry packages" ]]; then
-            read -r -a packages <<< "${RELEASE_PACKAGES//$'\n'/ }"
-            for package in "${packages[@]}"; do args+=(--package "$package"); done
+          if [[ "$RELEASE_OPERATION" == "Retry workspace crates" ]]; then
+            read -r -a crates <<< "${RELEASE_CRATES//$'\n'/ }"
+            for crate in "${crates[@]}"; do args+=(--package "$crate"); done
           else
             args+=(--workspace)
           fi
@@ -160,16 +162,46 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
-          packages=$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[].name')
-          while IFS= read -r package; do
-            (cd "$RUNNER_TEMP" && cargo info "$package@$RELEASE_VERSION" --registry crates-io > /dev/null)
-          done <<< "$packages"
+          crates=$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[].name')
+          while IFS= read -r crate; do
+            (cd "$RUNNER_TEMP" && cargo info "$crate@$RELEASE_VERSION" --registry crates-io > /dev/null)
+          done <<< "$crates"
+
+  reference-example:
+    name: Reference example
+    needs: workspace
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-reference-example.yml
+    with:
+      operation: ${{ inputs.operation == 'Create GitHub Release' && 'Verify published example' || 'Publish reference example' }}
+      commit: ${{ inputs.commit }}
+      dry_run: ${{ inputs.dry_run }}
+
+  github-release:
+    name: Create GitHub Release
+    needs:
+      - workspace
+      - reference-example
+    if: ${{ inputs.dry_run == false }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
 
       - name: Create GitHub Release
-        if: ${{ inputs.dry_run == false }}
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_COMMIT: ${{ inputs.commit }}
+          RELEASE_VERSION: ${{ needs.workspace.outputs.version }}
         run: |
           gh release create "v$RELEASE_VERSION" --target "$RELEASE_COMMIT" \
             --title "Geam $RELEASE_VERSION" --notes-file "docs/releases/$RELEASE_VERSION.md"

--- a/docs/host-providers.md
+++ b/docs/host-providers.md
@@ -466,25 +466,19 @@ Geam metadata. The component demonstrates:
 - scalar arguments and returns plus `List(String)` output; and
 - generated stateless component initialization and typed registration.
 
-Its Cargo manifest uses the canonical discovery name and schema-1 metadata:
-
-```toml
-[package]
-name = "geam-example-text-pattern"
-
-[package.metadata.geam.provider]
-schema = 1
-gleam-package = "example_text_pattern"
-gleam-version = ">= 0.1.0 and < 0.2.0"
-```
+Its [Cargo manifest](../examples/text_pattern/provider/Cargo.toml) uses the
+canonical `geam-example-text-pattern` discovery name and schema-1 metadata. This
+release-coupled provider pins the actual `example_text_pattern` Hex package
+version exactly.
 
 The [complete example](../examples/text_pattern/README.md) executes this crate
 through explicit path selection and packages it with ordinary Cargo tooling.
 The matching Gleam package and provider are also published on Hex and crates.io;
 the package's [public usage guide](../examples/text_pattern/project/packages/example_text_pattern/README.md)
 shows discovery and approval without an explicit provider selection. CI keeps
-that released path separate from checkout tests and verifies it with a fixed
-combination of published Geam, Gleam package, and provider versions. The
+that released path separate from checkout tests and verifies a known published
+combination. The reference-example publication workflow verifies each new
+same-version combination before the GitHub Release is created. The
 [provider README](../examples/text_pattern/provider/README.md) explains the
 complete macro-authored Rust mapping and why `Pattern` owns manual source
 semantics.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,21 +1,25 @@
 # Publishing
 
-Geam publishes seven lockstep crates: `geam-core`, `geam-macros`,
-`geam-stdlib`, `geam-json`, `geam-time`, `geam-cli`, and the root `geam` facade.
-The root owns the installable `geam` binary. Cargo derives dependency order
-from the workspace graph and polls the registry after uploads.
+Each Geam release publishes nine artifacts at one version: seven workspace
+crates, the `geam-example-text-pattern` reference provider on crates.io, and the
+`example_text_pattern` package on Hex. The workspace crates are `geam-core`,
+`geam-macros`, `geam-stdlib`, `geam-json`, `geam-time`, `geam-cli`, and the root
+`geam` facade. The root owns the installable `geam` binary.
 
 `Cargo.toml` owns the release version; this guide does not repeat the current
-version. Provider package versions, Gleam versions, compiler dependencies, and
-the Rust toolchain are independent of a Geam version bump.
+version. The reference packages are public distribution fixtures rather than
+independent products, so preparation copies that version into both package
+manifests and the provider's exact Geam and Gleam requirements.
 
 ## Prepare And Review
 
 1. Run **Geam: Prepare release** from `main` and choose `patch`, `minor`, or
    `major`. The default is `patch`; cargo-release computes the next version.
-2. The workflow updates workspace and provider requirements, reconciles tracked
-   Cargo locks, and opens a draft PR on `release/<version>`. It refuses an
-   existing release branch, PR, or tag and never force-pushes.
+2. The workflow updates workspace, fixture, and example-provider requirements;
+   aligns both published reference packages to the release version; reconciles
+   tracked Cargo and Gleam manifests; and opens a draft PR on
+   `release/<version>`. It refuses an existing release branch, PR, or tag and
+   never force-pushes.
 3. Add `docs/releases/<version>.md` to the PR following the
    [release note guide](releases/README.md). Write and review user-facing changes
    manually. Preparation does not invent release notes.
@@ -29,11 +33,13 @@ the Rust toolchain are independent of a Geam version bump.
 
 Preparation delegates workspace versions and exact internal requirements to
 [cargo-release](https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md).
-[cargo-edit](https://github.com/killercup/cargo-edit) updates only the independent
-providers' exact `geam` requirements, with recursive dependency upgrades disabled.
-Each tracked lock is reconciled by `cargo update --workspace` from its own
-directory, preserving its local Cargo configuration. Provider package versions
-and unrelated dependencies must remain unchanged in the reviewed PR.
+[cargo-edit](https://github.com/killercup/cargo-edit) updates exact Geam
+requirements in standalone fixtures and example providers, and sets the
+reference provider package version. The workflow sets the matching Hex package
+and provider metadata to the same version, then asks Gleam to update the local
+package entry in `manifest.toml`. Each tracked Cargo lock is reconciled by
+`cargo update --workspace` from its own directory, preserving its local Cargo
+configuration and checkout patches before the new crates exist on crates.io.
 
 The [prepare workflow](../.github/workflows/prepare-release.yml) pins the release
 tool versions and owns this sequence; there is no separate release script.
@@ -45,24 +51,24 @@ disposable checkout, stopping before its commit/push/PR step.
 
 ## Publish
 
-Run **Geam: Publish crates** from `main` and select an `operation`:
+Run **Geam: Publish release** from `main` and select an `operation`:
 
-| Operation | `packages` | Work performed |
+| Operation | `crates` | Work performed |
 | --- | --- | --- |
-| `Publish workspace` | Empty | Publish all workspace crates, then create the GitHub Release. |
-| `Retry packages` | Remaining crate names, space-separated | Publish those crates, then create the GitHub Release. |
-| `Create GitHub Release` | Empty | Verify all crates are published, then create only the GitHub Release. |
+| `Publish release` | Empty | Publish all seven workspace crates, call the reference-example workflow, then create the GitHub Release. |
+| `Retry workspace crates` | Remaining workspace crate names, space-separated | Publish those crates, call the reference-example workflow, then create the GitHub Release. |
+| `Create GitHub Release` | Empty | Verify the workspace and reference example, then create only the GitHub Release. |
 
 Every operation requires the full release `commit` SHA. There is no fallback to
-the latest main commit. For a new release, select `Publish workspace`, enter the
-reviewed merge SHA, leave `packages` empty, and enable **dry-run** first.
+the latest main commit. For a new release, select `Publish release`, enter the
+reviewed merge SHA, leave `crates` empty, and enable **dry-run** first.
 
 The first `Validate inputs` step rejects a non-main workflow ref, a malformed
-SHA, an unknown operation, or an invalid operation/package combination before
+SHA, an unknown operation, or an invalid operation/crate combination before
 checkout. It reports the reason without authentication, uploads, or Release
 creation; correct the inputs and dispatch again.
 
-Before authentication or uploads, the workflow checks:
+Before workspace authentication or uploads, the workflow checks:
 
 - checkout at the exact release SHA, on main's history;
 - matching workspace versions;
@@ -70,39 +76,72 @@ Before authentication or uploads, the workflow checks:
 - successful push runs of all three verification workflows at that SHA;
 - an existing release tag, if any, pointing to that same SHA.
 
-Dry-run runs the same validation for every operation. Publishing operations
-invoke native `cargo publish --locked ... --dry-run`; `Create GitHub Release`
-only checks the exact registry versions. Neither creates tags, uploads, or
-GitHub Releases. A successful dry-run does not prove actual OIDC permissions or
-upload availability.
+After the workspace succeeds, the workflow calls
+[Geam: Publish reference example](../.github/workflows/publish-reference-example.yml)
+synchronously. That workflow independently validates the provider and Hex
+package versions, publishes or dry-runs the two reference artifacts, and checks
+the public execution path. The GitHub Release job starts only after both owners
+have completed successfully.
 
-For a new release, run `Publish workspace` again with **dry-run** disabled and
-the **same full commit SHA**. It authenticates through Trusted Publishing and
-runs native `cargo publish --workspace --locked`. Cargo owns dependency
-ordering, package verification, and index polling.
+Dry-run invokes native `cargo publish --locked ... --dry-run` for the workspace,
+`gleam export hex-tarball` for the Hex package, and a provider dry-run patched to
+the reviewed checkout because the new registry version does not exist yet. No
+dry-run creates tags, uploads, or GitHub Releases. A successful dry-run does not
+prove actual OIDC or Hex credentials, nor upload availability.
+
+For a new release, run `Publish release` again with **dry-run** disabled and the
+**same full commit SHA**. The workspace job publishes its seven crates through
+Trusted Publishing. The reference workflow publishes the provider against the
+released workspace, waits until crates.io serves it, then runs
+`gleam publish --yes` with the Hex API key stored in the release environment.
 
 After uploading, `cargo info <crate>@<version> --registry crates-io` checks every
-workspace package from outside the checkout, so local packages and patches
-cannot satisfy the check. Only then does `gh release create` publish the reviewed
-note file verbatim, creating `v<version>` at the selected SHA. It does not move
-existing tags or overwrite existing releases.
+Rust package from outside the checkout, so local packages and patches cannot
+satisfy the check. A clean Gleam project then installs the exact same-version Hex
+package, discovers and approves the same-version provider, and runs with the
+released Geam. Only then does `gh release create` publish the reviewed note file
+verbatim, creating `v<version>` at the selected SHA. It does not move existing
+tags or overwrite existing releases.
+
+## Reference Example
+
+The reference workflow is also directly dispatchable from `main`. Its operation
+is independent of the workspace retry input:
+
+| Operation | Work performed |
+| --- | --- |
+| `Publish reference example` | Publish and verify the Rust provider, publish the Hex package, then verify the complete public path. |
+| `Publish Hex package` | Publish or dry-run only `example_text_pattern`. |
+| `Publish Rust provider` | Publish or dry-run only `geam-example-text-pattern`; an actual publish waits for crates.io availability. |
+| `Verify published example` | Perform no publication; install and execute the exact released Geam, Hex package, and provider combination. |
+
+All operations require the original full release `commit` SHA. The workflow
+accepts only a commit on main's history with successful `Workspace`, `Coverage`,
+and `Acceptance` push runs, and requires the workspace, provider, provider
+metadata, and Hex package to use the same version. **dry-run** applies to the
+three publishing operations; verification is always read-only.
 
 ## Retry
 
-Dispatch Publish from main with `commit` set to the original full SHA, as for
-the first attempt. Do not select a newer main commit for the same version.
+Use the original full release SHA for every recovery operation. Do not select a
+newer main commit for the same version.
 
-- If some uploads failed, select `Retry packages` and enter only the remaining
-  names in `packages`, separated by spaces, for example `geam-cli geam`.
-  Cargo receives one `--package` per name.
-  It does not automatically skip published versions. If other packages are still
-  missing, the final registry check fails without creating a GitHub Release.
+- If workspace uploads failed, run **Geam: Publish release**, select
+  `Retry workspace crates`, and enter only the remaining names in `crates`, for
+  example `geam-cli geam`. Each name becomes a Cargo `--package` selection. Once
+  all workspace crates are available, the normal reference workflow follows.
+- If reference publication stopped after the workspace completed, inspect which
+  component versions are public, then run **Geam: Publish reference example**
+  once for each missing component. Publish the Rust provider before the Hex
+  package. Use `Verify published example` after component recovery when the
+  registry state needs an explicit check. The workflow does not automatically
+  skip published versions; verification fails if any component is still absent.
 - An upload error can occur after crates.io received the package. Check the
-  upload log and exact published versions before choosing the retry packages.
-- If all crates were uploaded, select `Create GitHub Release` and leave
-  `packages` empty. This skips authentication and Cargo publish, checks all
-  exact registry versions, then creates the GitHub Release. Its dry-run performs
-  the checks without creating a tag or release.
+  upload log and exact published versions before choosing a component retry.
+- Once all packages are available, run **Geam: Publish release**, select
+  `Create GitHub Release`, and leave `crates` empty. This skips authentication
+  and publication, checks all exact registry versions, then creates the GitHub
+  Release. Its dry-run performs the checks without creating a tag or release.
 - If GitHub already created the release before reporting a failure, inspect the
   existing release; this workflow does not overwrite it.
 - A failure before any upload can use **Re-run failed jobs**, retaining the
@@ -117,15 +156,27 @@ token fallback, or publication from a non-main workflow ref.
 
 ## Authentication
 
-All seven crates have been bootstrapped and configured for Trusted Publishing:
+The seven workspace crates use this Trusted Publisher configuration:
 
 - repository owner: `panarch`
 - repository: `geam`
 - workflow: `publish.yml`
 - environment: `crates-io`
 
-Keep the workflow filename and environment stable. The environment allows main
-only; crates.io requires Trusted Publishing for new versions. `id-token: write`
-permits short-lived crates.io authentication, `actions: read` checks CI, and
-`contents: write` permits the tag and GitHub Release. No long-lived registry
-token or local-publish fallback is part of the regular release path.
+The reference provider needs two configurations with the same repository and
+environment: `publish.yml` authorizes the reusable workflow when the main
+release calls it, while `publish-reference-example.yml` authorizes direct
+component recovery. crates.io identifies the workflow that entered the run, so
+these two explicit entry points cannot share one workflow-file configuration.
+
+Keep those workflow filenames and the environment stable. The environment
+allows main only; crates.io requires Trusted Publishing for new versions.
+`id-token: write` permits short-lived crates.io authentication, `actions: read`
+checks CI, and the final release job alone receives `contents: write`. No
+long-lived registry token or local-publish fallback is part of the regular
+release path.
+
+The same `crates-io` environment stores `HEXPM_API_KEY` for the Hex publication.
+The reference workflow resolves that environment secret in both automatic and
+direct runs. It does not use the key for crates.io and does not provide a local
+or personal-token fallback for either registry.

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -118,15 +118,16 @@ authoring macros. The bounded fake-registry tests separately verify discovery,
 approval, archive validation, and the same production runner path
 deterministically against the current checkout.
 
-The Gleam package and Rust provider are also published as
-`example_text_pattern 0.1.0` on Hex and `geam-example-text-pattern 0.1.0` on
-crates.io. A separate CI acceptance job installs the published `geam 0.2.1`,
-creates a clean Gleam project, adds the Hex package, discovers and approves the
-real crates.io provider without `geam provider add`, and then locks, builds, and
-executes the generated runner. Repeating `prepare` and `run` must preserve the
-managed manifest, lock, and runner source. This fixed released combination
-monitors the public distribution path; it does not replace checkout regression
-tests and changes only when the corresponding artifacts have been published.
+The Gleam package is published as `example_text_pattern` on Hex, and its Rust
+provider is published as `geam-example-text-pattern` on crates.io. A separate CI
+acceptance job installs a known published combination, creates a clean Gleam
+project, discovers and approves the provider without `geam provider add`, and
+then locks, builds, and executes the generated runner. Repeating `prepare` and
+`run` must preserve the managed manifest, lock, and runner source. The separately
+recoverable reference-example publication workflow verifies each new
+same-version Geam, provider, and Hex package combination before release
+finalization. These released-artifact checks do not replace checkout regression
+tests.
 
 Explicit selection is itself approval:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -267,14 +267,15 @@ owns deterministic checkout coverage of search, sparse-index, checksum,
 archive metadata, approval, registry-shaped dependency, lock, check, and run.
 
 A separate `Published provider` acceptance job exercises the released
-distribution rather than the checkout. It installs `geam 0.2.1`, creates a
-clean project, pins `example_text_pattern 0.1.0` from Hex, and uses a real PTY
-approval to select `geam-example-text-pattern 0.1.0` from crates.io without an
-explicit provider add. Cargo metadata must show exact registry dependencies,
-the generated runner must include the provider component, and repeated
-prepare/run must preserve the managed manifest, lock, and runner source. The
-small Gleam entry module is kept inline in the workflow because this job owns a
-single released command sequence rather than reusable source behavior.
+distribution rather than the checkout. It installs a known published Geam,
+creates a clean project, pins the matching Hex package, and uses a real PTY
+approval to select the matching crates.io provider without an explicit provider
+add. Metadata must show exact registry dependencies, the generated runner must
+include the provider component, and repeated prepare/run must preserve the
+managed manifest, lock, and runner source. The reference-example publication
+workflow runs the same path against every new same-version combination before
+release finalization. The small Gleam entry module is kept inline because these
+jobs own released command sequences rather than reusable source behavior.
 
 The same text-pattern test first runs the common Gleam entrypoint and the
 Erlang-specific example using the package's native `re` implementation, before
@@ -308,8 +309,9 @@ The normal suite executes the full generated runner with the fixture's locked
 Gleam and Rust dependencies. CI exports the standalone fixture's three local
 Gleam dependencies and all nine example Gleam packages. It also packages the
 two standalone fixture providers and every example provider. No test-only
-fixture package is published; the text-pattern packages are public
-documentation examples with their own release cycle.
+fixture package is published. The text-pattern provider and matching Hex package
+are release-coupled public documentation artifacts and share every Geam release
+version.
 
 The root package keeps four explicit acceptance targets:
 

--- a/examples/text_pattern/README.md
+++ b/examples/text_pattern/README.md
@@ -4,6 +4,7 @@ This example pairs a Gleam package published on Hex with a Rust provider
 published on crates.io for [Geam](https://github.com/panarch/geam). The Gleam
 package includes an Erlang `re` implementation. The Rust crate implements the
 same API with `regex` through Geam's public provider authoring macros.
+The release workflow keeps all three at the same version.
 
 See the [Gleam package README](project/packages/example_text_pattern/README.md)
 for installation and API usage, and the [provider README](provider/README.md)

--- a/examples/text_pattern/project/packages/example_text_pattern/README.md
+++ b/examples/text_pattern/project/packages/example_text_pattern/README.md
@@ -48,7 +48,7 @@ output.
 The same source also runs with the
 [geam-example-text-pattern provider](https://github.com/panarch/geam/tree/main/examples/text_pattern/provider),
 which uses Rust's `regex` crate. This workflow requires Geam and Rust/Cargo,
-plus the matching Rust provider published on crates.io:
+plus the same-version Rust provider published on crates.io:
 
 ```sh
 geam prepare

--- a/examples/text_pattern/provider/Cargo.toml
+++ b/examples/text_pattern/provider/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools", "text-processing"]
 [package.metadata.geam.provider]
 schema = 1
 gleam-package = "example_text_pattern"
-gleam-version = ">= 0.1.0 and < 0.2.0"
+gleam-version = "0.1.0"
 
 [dependencies]
 ecow = "=0.2.6"

--- a/examples/text_pattern/provider/README.md
+++ b/examples/text_pattern/provider/README.md
@@ -59,9 +59,10 @@ matches the [Gleam declarations](https://github.com/panarch/geam/blob/main/examp
 - ordinary Rust `Result<Pattern, CompileError>` maps to Gleam `Result`; and
 - `Vec<EcoString>` constructs the returned Gleam `List(String)` once.
 
-The crate's Cargo metadata identifies the target Gleam package and compatible
-versions for Geam's provider discovery. The Gleam package itself carries no
-Geam-specific metadata.
+The crate's Cargo metadata identifies the target Gleam package and version for
+Geam's provider discovery. This release-coupled reference provider pins the
+same version published for Geam and the Hex package. The Gleam package itself
+carries no Geam-specific metadata.
 
 See the [provider authoring guide](https://github.com/panarch/geam/blob/main/docs/host-providers.md)
 for the API contracts, or the [other provider examples](https://github.com/panarch/geam/blob/main/examples/README.md)


### PR DESCRIPTION
## Summary

- align the published Rust provider and Hex package with each Geam release during preparation
- separate reference-example publication from workspace crate publication while keeping the normal release flow synchronous
- support direct component recovery and verify the complete public path before creating the GitHub Release
- update provider and publishing documentation for the same-version release contract

## Verification

- `actionlint -color .github/workflows/*.yml`
- syntax-check every workflow `run` block with `bash -n`
- simulate preparation of `0.2.2` in a disposable checkout, including workspace and provider `cargo publish --dry-run` plus Hex tarball export

## Configuration

Keep the existing `geam-example-text-pattern` Trusted Publisher entry for `publish.yml`, and add a second entry for `publish-reference-example.yml` using the same `crates-io` environment. The latter authorizes direct component recovery.
