### PR TITLE
Add Zensical documentation site

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -113,6 +113,20 @@ jobs:
       - name: Build workspace documentation
         run: cargo doc --workspace --no-deps --locked
 
+  zensical:
+    name: Zensical
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+
+      - name: Build documentation site
+        run: uvx --from zensical==0.0.50 zensical build --clean --strict
+
   workspace-tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.caffold/
 /.notes/
+/site/
 /target/
 *.snap.new

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,21 @@
+:root {
+  --geam-heading-font: "Lexend", var(--md-text-font);
+}
+
+.md-header__button.md-logo,
+.md-nav__button.md-logo {
+  display: none;
+}
+
+.md-header__title,
+.md-nav__title,
+.md-nav__item--section > .md-nav__link,
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4,
+.md-typeset h5,
+.md-typeset h6 {
+  font-family: var(--geam-heading-font);
+  letter-spacing: 0;
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,67 @@
+[project]
+site_name = "Geam"
+site_url = "https://geam.run/"
+site_description = "Run Gleam projects through Rust, embed Gleam in Rust applications, and extend Gleam packages with Rust host providers."
+docs_dir = "docs"
+site_dir = "site"
+repo_url = "https://github.com/panarch/geam"
+repo_name = "panarch/geam"
+edit_uri = "edit/main/docs/"
+extra_css = [
+  "https://fonts.googleapis.com/css2?family=Lexend:wght@400;700&display=swap",
+  "stylesheets/extra.css",
+]
+nav = [
+  { "Home" = "index.md" },
+  { "Guides" = [
+    { "Run a Gleam project" = "standalone.md" },
+    { "Embed Gleam in Rust" = "embedding.md" },
+    { "Author a host provider" = "host-providers.md" },
+  ] },
+  { "Reference" = [
+    "reference/README.md",
+    { "Compatibility" = "reference/compatibility.md" },
+    { "Architecture" = "reference/architecture.md" },
+    { "Embedding boundary" = "reference/embedding-boundary.md" },
+    { "Provider boundary" = "reference/provider-boundary.md" },
+    { "Runtime semantics" = "reference/runtime-semantics.md" },
+  ] },
+  { "Releases" = [
+    "releases/README.md",
+    { "0.2.1" = "releases/0.2.1.md" },
+  ] },
+  { "Development" = [
+    "development/README.md",
+    { "Testing" = "development/testing.md" },
+    { "Test development" = "development/test-development.md" },
+    { "Review policy" = "development/review-policy.md" },
+    { "Upstream Gleam" = "development/upstream-gleam.md" },
+    { "Release notes" = "development/release-notes.md" },
+    { "Publishing" = "development/publishing.md" },
+  ] },
+]
+
+[project.theme]
+language = "en"
+font.text = "Outfit"
+features = [
+  "content.action.view",
+  "content.code.copy",
+  "navigation.footer",
+  "navigation.indexes",
+  "navigation.sections",
+  "navigation.top",
+  "toc.follow",
+]
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: light)"
+scheme = "default"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: dark)"
+scheme = "slate"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"


### PR DESCRIPTION
## Summary

- configure the repository documentation as a Zensical site with explicit guide, reference, release, and development navigation
- keep the presentation restrained with Outfit and Lexend typography, a text-only header, and system-aware light and dark palettes
- validate pinned strict Zensical builds in Workspace CI without publishing generated site output

## Manual verification

- reviewed desktop and 390px mobile previews in light and dark modes
- verified operating-system color preference selection and persisted manual theme switching
