### PR TITLE
Unify generated project loading

### DIFF
--- a/cli/src/embedding.rs
+++ b/cli/src/embedding.rs
@@ -1421,7 +1421,7 @@ fn feature_flags_configuration() -> HostProviderConfiguration {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let program = geam_bindings::project()?.compile()?;
+    let program = geam_bindings::project().compile()?;
     let builder = HostedModuleBuilder::new(program)?;
     let (bindings, functions) = geam_bindings::bind(builder)?;
     let module = bindings.seal()?;
@@ -1623,7 +1623,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     assert_eq!(geam_bindings::ROOT_MODULE, "built_in_embedding_application");
     let _consume = consume_functions;
     let _bind = geam_bindings::bind::<Vec<IoOutput>, FixedTime>;
-    let _program = geam_bindings::project::<Vec<IoOutput>, FixedTime>()?.compile()?;
+    let _program = geam_bindings::project::<Vec<IoOutput>, FixedTime>().compile()?;
     let mut state = geam_bindings::RunStateInputs {
         stdlib: GleamStdlibRunState::from_seed([7; 32]),
         time: FixedTime,

--- a/cli/src/embedding/providers.rs
+++ b/cli/src/embedding/providers.rs
@@ -569,7 +569,7 @@ mod words {
                 r#"mod geam_bindings;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let program = geam_bindings::project()?.compile()?;
+    let program = geam_bindings::project().compile()?;
     let builder = runtime::embedding::HostedModuleBuilder::new(program)?;
     let (bindings, functions) = geam_bindings::bind(builder)?;
     let module = bindings.seal()?;

--- a/cli/src/embedding/render.rs
+++ b/cli/src/embedding/render.rs
@@ -173,13 +173,18 @@ fn push_hosted_project(
 ) {
     let profile = profile_type(components);
     output.push_str(&format!(
-        "pub fn project{}() -> Result<HostedProject<{profile}>, HostRegistrationError>",
+        "pub fn project{}() -> HostedProject<{profile}>",
         generics(components),
     ));
     push_bounds_open(output, alias, components);
-    output.push_str("    Ok(HostedProject::new(\n");
+    output.push_str("    HostedProject::new(\n");
     push_project_root_argument(output, project_path, "        ");
-    output.push_str("        ROOT_MODULE,\n        host_providers()?,\n    ))\n}\n\n");
+    output.push_str("        ROOT_MODULE,\n");
+    let registration = match generics(components) {
+        "" => "host_providers".to_owned(),
+        generics => format!("host_providers::{generics}"),
+    };
+    output.push_str(&format!("        {registration},\n    )\n}}\n\n"));
 }
 
 fn project_root(project_path: &Utf8Path) -> String {
@@ -859,10 +864,8 @@ pub fn bind(builder: ModuleBuilder) -> Result<(ModuleBindings, Functions), Bindi
     fn renders_exact_host_capability_and_component_closures() {
         let stdlib = hosted_source(HostedComponents::from_builtin(BuiltInProvider::Stdlib));
         assert!(stdlib.contains("pub struct Profile<Io>"));
-        assert!(stdlib.contains(
-            "pub fn project<Io>() -> Result<HostedProject<Profile<Io>>, HostRegistrationError>"
-        ));
-        assert!(stdlib.contains("host_providers()?"));
+        assert!(stdlib.contains("pub fn project<Io>() -> HostedProject<Profile<Io>>"));
+        assert!(stdlib.contains("host_providers::<Io>"));
         assert!(stdlib.contains("pub struct RunStateInputs<Io>"));
         assert!(stdlib.contains("pub stdlib: runtime::gleam_stdlib::GleamStdlibRunState<Io>"));
         assert!(stdlib.contains("pub fn initialize(self) -> RunState<Io>"));
@@ -914,6 +917,8 @@ pub fn bind(builder: ModuleBuilder) -> Result<(ModuleBindings, Functions), Bindi
         let external = external_components();
         let external_only = hosted_source(external_components());
         assert!(external_only.contains("pub struct Profile;"));
+        assert!(external_only.contains("pub fn project() -> HostedProject<Profile>"));
+        assert!(external_only.contains("        host_providers,"));
         assert!(external_only.contains("pub struct RunStateInputs"));
         assert!(external_only.contains("pub example_text_pattern: HostProviderConfiguration"));
         assert!(external_only.contains(

--- a/core/src/embedding.rs
+++ b/core/src/embedding.rs
@@ -16,7 +16,8 @@
 //! retained storage. See [`List`] for lazy reads and ownership restrictions.
 //!
 //! [`Project`] and [`HostedProject`] retain one source selection until it is
-//! compiled into the corresponding existing typed program owner.
+//! compiled into the corresponding existing typed program owner. Hosted
+//! compilation also performs the generated static provider registration.
 
 mod binding;
 mod error;
@@ -35,7 +36,7 @@ pub use hosted::{HostedModule, HostedModuleBindings, HostedModuleBuilder};
 pub use input::InputShape;
 pub use list::{Iter, List};
 pub use num_bigint::BigInt;
-pub use project::{HostedProject, Project};
+pub use project::{HostedProject, HostedProjectError, Project};
 
 use self::input::ArgumentsInput;
 use self::value::{Arguments, ReturnValue};

--- a/core/src/embedding/project.rs
+++ b/core/src/embedding/project.rs
@@ -2,9 +2,12 @@ use crate::frontend::{
     HostedTypedProgram, ProjectError, TypedProgram, compile_typed_host_project,
     compile_typed_project,
 };
-use crate::host::{HostProfile, HostProviderSet};
+use crate::host::{HostProfile, HostProviderSet, HostRegistrationError};
 use camino::Utf8PathBuf;
 use ecow::EcoString;
+
+mod error;
+pub use error::HostedProjectError;
 
 /// One resolved Gleam project selection for plain Rust embedding.
 pub struct Project {
@@ -12,11 +15,12 @@ pub struct Project {
     module: EcoString,
 }
 
-/// One resolved Gleam project selection and provider set for hosted Rust embedding.
+/// One resolved Gleam project selection and static provider registration for
+/// hosted embedding.
 pub struct HostedProject<Profile: HostProfile> {
     root: Utf8PathBuf,
     module: EcoString,
-    providers: HostProviderSet<Profile>,
+    register_providers: fn() -> Result<HostProviderSet<Profile>, HostRegistrationError>,
 }
 
 impl Project {
@@ -35,31 +39,36 @@ impl Project {
 }
 
 impl<Profile: HostProfile> HostedProject<Profile> {
-    /// Selects a root module and its already registered static providers.
+    /// Selects a root module and defers its static provider registration until
+    /// compilation.
     pub fn new(
         root: impl Into<Utf8PathBuf>,
         module: impl Into<EcoString>,
-        providers: HostProviderSet<Profile>,
+        register_providers: fn() -> Result<HostProviderSet<Profile>, HostRegistrationError>,
     ) -> Self {
         Self {
             root: root.into(),
             module: module.into(),
-            providers,
+            register_providers,
         }
     }
 
-    /// Compiles the selected project and consumes its loading inputs.
-    pub fn compile(self) -> Result<HostedTypedProgram<Profile>, ProjectError> {
-        compile_typed_host_project(self.root, self.module, self.providers)
+    /// Registers static providers, then compiles the selected project and
+    /// consumes its inputs.
+    pub fn compile(self) -> Result<HostedTypedProgram<Profile>, HostedProjectError> {
+        let providers = (self.register_providers)()?;
+        compile_typed_host_project(self.root, self.module, providers)
+            .map_err(HostedProjectError::from)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{HostedProject, Project};
+    use super::{HostedProject, HostedProjectError, Project};
     use crate::embedding::{FunctionDeclaration, HostedModuleBuilder};
     use crate::{
-        HostModule, HostProviderModule, HostProviderSet, ProjectError, StatelessHostProfile,
+        HostModule, HostProviderModule, HostProviderSet, HostRegistrationError, ProjectError,
+        StatelessHostProfile,
     };
     use camino::{Utf8Path, Utf8PathBuf};
     use num_bigint::BigInt;
@@ -90,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn carries_host_providers_into_project_compilation() {
+    fn registers_host_providers_during_project_compilation() {
         let project = project();
         write_file(
             &project,
@@ -111,20 +120,13 @@ pub fn quantity() -> Int {
 pub fn quantity() -> Int
 "#,
         );
-        let provider =
-            HostProviderModule::<StatelessHostProfile>::new("application", "inventory_support")
-                .expect("provider module should be valid")
-                .with_function("quantity", || BigInt::from(42))
-                .expect("provider function should be valid");
-        let providers = HostProviderSet::with_providers(
-            Vec::<HostModule<StatelessHostProfile>>::new(),
-            [provider],
+        let program = HostedProject::new(
+            project_root(&project),
+            "inventory_rules",
+            inventory_providers,
         )
-        .expect("provider set should be valid");
-
-        let program = HostedProject::new(project_root(&project), "inventory_rules", providers)
-            .compile()
-            .expect("hosted project descriptor should preserve its providers");
+        .compile()
+        .expect("hosted project descriptor should register its providers during compilation");
         let builder = HostedModuleBuilder::new(program).expect("hosted project should plan");
         let (bindings, quantity) = builder
             .function(FunctionDeclaration::<(), BigInt>::new("quantity"))
@@ -149,6 +151,60 @@ pub fn quantity() -> Int
             error,
             ProjectError::ConfigIo { path, .. } if path == root.join("gleam.toml")
         ));
+    }
+
+    #[test]
+    fn preserves_host_registration_error_identity() {
+        let project = project();
+        let error =
+            HostedProject::new(project_root(&project), "inventory_rules", invalid_providers)
+                .compile()
+                .err()
+                .expect("invalid static provider registration should fail during compilation");
+
+        assert!(matches!(
+            error,
+            HostedProjectError::HostRegistration(
+                HostRegistrationError::InvalidModuleName { module }
+            ) if module == "invalid module"
+        ));
+    }
+
+    #[test]
+    fn preserves_hosted_project_error_identity() {
+        let directory = tempdir().expect("temporary directory should be created");
+        let root = project_root(&directory).join("missing");
+        let error = HostedProject::new(root.clone(), "inventory_rules", inventory_providers)
+            .compile()
+            .err()
+            .expect("missing hosted project should retain its config read failure");
+
+        assert!(matches!(
+            error,
+            HostedProjectError::Project(ProjectError::ConfigIo { path, .. })
+                if path == root.join("gleam.toml")
+        ));
+    }
+
+    fn inventory_providers() -> Result<HostProviderSet<StatelessHostProfile>, HostRegistrationError>
+    {
+        let provider =
+            HostProviderModule::<StatelessHostProfile>::new("application", "inventory_support")
+                .expect("provider module should be valid")
+                .with_function("quantity", || BigInt::from(42))
+                .expect("provider function should be valid");
+        let providers = HostProviderSet::with_providers(
+            Vec::<HostModule<StatelessHostProfile>>::new(),
+            [provider],
+        )
+        .expect("provider set should be valid");
+        Ok(providers)
+    }
+
+    fn invalid_providers() -> Result<HostProviderSet<StatelessHostProfile>, HostRegistrationError> {
+        Err(HostRegistrationError::InvalidModuleName {
+            module: "invalid module".into(),
+        })
     }
 
     fn project() -> TempDir {

--- a/core/src/embedding/project/error.rs
+++ b/core/src/embedding/project/error.rs
@@ -1,0 +1,14 @@
+use crate::{HostRegistrationError, ProjectError};
+use thiserror::Error;
+
+/// A failure while registering providers or loading a hosted Gleam project.
+#[derive(Debug, Error)]
+pub enum HostedProjectError {
+    /// Static host provider registration failed.
+    #[error(transparent)]
+    HostRegistration(#[from] HostRegistrationError),
+
+    /// The selected Gleam project failed to load or compile.
+    #[error(transparent)]
+    Project(#[from] ProjectError),
+}

--- a/docs/reference/embedding-boundary.md
+++ b/docs/reference/embedding-boundary.md
@@ -23,24 +23,24 @@ expected to be reviewed and committed.
 Unsupported public declarations fail synchronization with the function and
 nested type position. They are not silently omitted from `Functions`.
 
-## Plain And Hosted Loading
+## Project Loading
 
-A provider-free generated project compiles through the plain project loader:
+Generated bindings expose one loading shape whether the selected source closure
+is provider-free or hosted:
 
 ```rust
 let program = geam_bindings::project().compile()?;
 ```
 
-A source closure with built-in or external providers performs static
-registration before the same project compilation boundary:
+`project()` only constructs a project selection. When the source closure uses
+built-in or external providers, `compile()` performs the generated static
+provider registration before loading the selected Gleam source. Registration
+and project-loading failures remain distinguishable through the returned error.
 
-```rust
-let program = geam_bindings::project()?.compile()?;
-```
-
-Both forms read `gleam.toml`, `manifest.toml`, root source, and locked package
-source from the conventional `gleam/` directory. They do not invoke Gleam CLI,
-download packages, or rewrite project files at runtime.
+Provider-free and hosted loading both read `gleam.toml`, `manifest.toml`, root
+source, and locked package source from the conventional `gleam/` directory.
+They do not invoke Gleam CLI, download packages, or rewrite project files at
+runtime.
 
 The lower-level `compile_typed_project` and `compile_typed_host_project`
 functions remain available when an application deliberately owns source

--- a/examples/rust_embedding_application/src/geam_bindings.rs
+++ b/examples/rust_embedding_application/src/geam_bindings.rs
@@ -155,15 +155,15 @@ where
     HostProviderSet::with_providers(Vec::<HostModule<Profile<Io>>>::new(), providers)
 }
 
-pub fn project<Io>() -> Result<HostedProject<Profile<Io>>, HostRegistrationError>
+pub fn project<Io>() -> HostedProject<Profile<Io>>
 where
     Io: geam::gleam_stdlib::IoSink + 'static,
 {
-    Ok(HostedProject::new(
+    HostedProject::new(
         concat!(env!("CARGO_MANIFEST_DIR"), "/gleam"),
         ROOT_MODULE,
-        host_providers()?,
-    ))
+        host_providers::<Io>,
+    )
 }
 
 #[allow(clippy::type_complexity)]

--- a/examples/rust_embedding_application/src/inventory.rs
+++ b/examples/rust_embedding_application/src/inventory.rs
@@ -61,7 +61,6 @@ mod tests {
     #[test]
     fn reviews_receipts_with_reusable_bindings_and_caller_owned_outputs() {
         let program = geam_bindings::project()
-            .expect("example providers")
             .compile()
             .expect("example Gleam project");
         let builder = HostedModuleBuilder::new(program).expect("example library");

--- a/examples/rust_embedding_application/src/main.rs
+++ b/examples/rust_embedding_application/src/main.rs
@@ -10,7 +10,7 @@ use std::error::Error;
 use std::io::{self, Write};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let program = geam_bindings::project()?.compile()?;
+    let program = geam_bindings::project().compile()?;
     let builder = HostedModuleBuilder::new(program)?;
     let (bindings, functions) = geam_bindings::bind(builder)?;
     let module = bindings.seal()?;


### PR DESCRIPTION
## Summary

Unifies generated project loading so plain and hosted embeddings use the same infallible project selection API. Hosted provider registration now occurs at the project compilation boundary while preserving registration and project-loading failures separately.

Closes #146.

## Changes

- defer generated hosted provider registration until `HostedProject::compile`
- expose `HostedProjectError` for transparent registration and project-loading failures
- generate one `geam_bindings::project().compile()?` flow across provider-free and hosted source closures
- update owner tests, integration fixtures, the canonical embedding application, and reference documentation
