### PR TITLE
Fix release preparation for reference locks

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -77,7 +77,7 @@ jobs:
           branch="release/$RELEASE_VERSION"
           refs=$(git ls-remote origin "refs/heads/$branch" "refs/tags/v$RELEASE_VERSION")
           test -z "$refs" || { echo "Release branch or tag already exists" >&2; exit 1; }
-          test "$(gh pr list --state all --head "$branch" --json number --jq length)" = 0
+          test "$(gh pr list --state open --head "$branch" --json number --jq length)" = 0
           git switch -c "$branch"
 
       - name: Update standalone provider requirements
@@ -94,7 +94,8 @@ jobs:
         run: |
           provider=examples/text_pattern/provider
           package=examples/text_pattern/project/packages/example_text_pattern
-          project=examples/text_pattern/project
+          reference_project=examples/text_pattern/project
+          embedding_project=examples/rust_embedding_application/gleam
 
           (cd "$provider" && cargo set-version "$RELEASE_VERSION")
           test "$(grep -Ec '^gleam-version = "[^"]+"$' "$provider/Cargo.toml")" = 1
@@ -104,7 +105,9 @@ jobs:
           test "$(grep -Ec '^version = "[^"]+"$' "$package/gleam.toml")" = 1
           sed -i.bak -E "s/^version = \"[^\"]+\"$/version = \"$RELEASE_VERSION\"/" "$package/gleam.toml"
           rm "$package/gleam.toml.bak"
-          (cd "$project" && gleam deps update example_text_pattern)
+          for project in "$reference_project" "$embedding_project"; do
+            (cd "$project" && gleam deps update example_text_pattern)
+          done
 
           metadata=$(cargo metadata --manifest-path "$provider/Cargo.toml" --locked --no-deps --format-version 1)
           jq -e --arg version "$RELEASE_VERSION" '
@@ -116,7 +119,9 @@ jobs:
               | select(.name == "geam" and .req == ("=" + $version))
             ] | length == 1)
           ' <<< "$metadata" > /dev/null
-          grep -F "name = \"example_text_pattern\", version = \"$RELEASE_VERSION\"" "$project/manifest.toml"
+          for project in "$reference_project" "$embedding_project"; do
+            grep -F "name = \"example_text_pattern\", version = \"$RELEASE_VERSION\"" "$project/manifest.toml"
+          done
 
       - name: Refresh tracked Cargo locks
         run: |

--- a/cli/src/embedding.rs
+++ b/cli/src/embedding.rs
@@ -1372,6 +1372,14 @@ pub fn double(value: Int) -> Int {
             let text_pattern = self
                 .repository
                 .join("examples/text_pattern/project/packages/example_text_pattern");
+            let text_pattern_config = fs::read_to_string(text_pattern.join("gleam.toml"))
+                .expect("text pattern Gleam config should be readable");
+            let text_pattern_config = text_pattern_config
+                .parse::<toml_edit::DocumentMut>()
+                .expect("text pattern Gleam config should be valid TOML");
+            let text_pattern_version = text_pattern_config["version"]
+                .as_str()
+                .expect("text pattern Gleam version should be a string");
             let feature_flags = self
                 .repository
                 .join("examples/feature_flags/project/packages/example_feature_flags");
@@ -1501,7 +1509,7 @@ example_text_pattern = {{ path = {text_pattern:?} }}
                 format!(
                     r#"packages = [
   {{ name = "example_feature_flags", version = "1.0.0", build_tools = ["gleam"], requirements = [], source = "local", path = {feature_flags:?} }},
-  {{ name = "example_text_pattern", version = "0.1.0", build_tools = ["gleam"], requirements = [], source = "local", path = {text_pattern:?} }},
+  {{ name = "example_text_pattern", version = {text_pattern_version:?}, build_tools = ["gleam"], requirements = [], source = "local", path = {text_pattern:?} }},
 ]
 
 [requirements]

--- a/docs/development/publishing.md
+++ b/docs/development/publishing.md
@@ -18,8 +18,8 @@ manifests and the provider's exact Geam and Gleam requirements.
 2. The workflow updates workspace, fixture, and example-provider requirements;
    aligns both published reference packages to the release version; reconciles
    tracked Cargo and Gleam manifests; and opens a draft PR on
-   `release/<version>`. It refuses an existing release branch, PR, or tag and
-   never force-pushes.
+   `release/<version>`. It refuses an existing release branch or tag, or an open
+   PR from that branch, and never force-pushes.
 3. Add `docs/releases/<version>.md` to the PR following the
    [release note guide](release-notes.md), and add the new version to the release
    index. Write and review user-facing changes manually. Preparation does not
@@ -28,6 +28,9 @@ manifests and the provider's exact Geam and Gleam requirements.
    The workflow uses `GITHUB_TOKEN`, not an App or personal token. The repository
    must allow Actions to create PRs. If PR creation fails after pushing, open the
    PR from the retained branch instead of overwriting it with another prepare.
+   To discard an unsuccessful preparation, close its PR and delete its remote
+   release branch. A later dispatch may then prepare the same version again;
+   the closed PR remains as the history of the abandoned attempt.
 5. Review the manifest/lock changes and notes, mark the PR ready, squash-merge,
    then wait for the `Workspace`, `Coverage`, and `Acceptance` push runs at the
    merged commit.
@@ -38,9 +41,10 @@ Preparation delegates workspace versions and exact internal requirements to
 requirements in standalone fixtures and example providers, and sets the
 reference provider package version. The workflow sets the matching Hex package
 and provider metadata to the same version, then asks Gleam to update the local
-package entry in `manifest.toml`. Each tracked Cargo lock is reconciled by
-`cargo update --workspace` from its own directory, preserving its local Cargo
-configuration and checkout patches before the new crates exist on crates.io.
+package entry in both the reference project and the canonical Rust embedding
+application. Each tracked Cargo lock is reconciled by `cargo update --workspace`
+from its own directory, preserving its local Cargo configuration and checkout
+patches before the new crates exist on crates.io.
 
 The [prepare workflow](https://github.com/panarch/geam/blob/main/.github/workflows/prepare-release.yml) pins the release
 tool versions and owns this sequence; there is no separate release script.


### PR DESCRIPTION
## Summary

- Refresh the reference project and Rust embedding application manifests when the published reference package version changes.
- Derive the hosted embedding test fixture version from the real reference package configuration.
- Allow an abandoned release preparation to be retried after its PR is closed and remote branch is deleted.
- Document the complete preparation and retry ownership.

## Local verification

- Simulated an `example_text_pattern` bump to `9.9.9` in a disposable checkout and verified that both Gleam manifests were refreshed.
- Ran the hosted embedding fixture tests with the synthetic `9.9.9` package and provider versions.
