### PR TITLE
Fix pre-1.0 Hex reference publishing

### DIFF
--- a/.github/workflows/publish-reference-example.yml
+++ b/.github/workflows/publish-reference-example.yml
@@ -193,11 +193,18 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}
         run: |
+          set -o pipefail
           if [[ "$DRY_RUN" == true ]]; then
             gleam export hex-tarball
           else
             test -n "$HEXPM_API_KEY"
-            gleam publish --yes
+            log="$RUNNER_TEMP/hex-publish.log"
+            # Gleam requires this exact acknowledgement for pre-1.0 packages.
+            printf '%s\n' 'I am not using semantic versioning' | gleam publish --yes | tee "$log"
+            if grep -Fqx 'Not publishing.' "$log"; then
+              echo "Gleam declined to publish the Hex package" >&2
+              exit 1
+            fi
           fi
 
       - name: Verify published example

--- a/docs/development/publishing.md
+++ b/docs/development/publishing.md
@@ -99,6 +99,8 @@ For a new release, run `Publish release` again with **dry-run** disabled and the
 Trusted Publishing. The reference workflow publishes the provider against the
 released workspace, waits until crates.io serves it, then runs
 `gleam publish --yes` with the Hex API key stored in the release environment.
+For pre-1.0 versions, it supplies Gleam's required textual acknowledgement on
+standard input and rejects Gleam's successful `Not publishing.` no-op result.
 
 After uploading, `cargo info <crate>@<version> --registry crates-io` checks every
 Rust package from outside the checkout, so local packages and patches cannot


### PR DESCRIPTION
## Summary

- Supply Gleam's required acknowledgement when publishing the pre-1.0 reference Hex package.
- Preserve `gleam publish` failures through `tee` and reject its successful `Not publishing.` no-op.
- Document the reference release behavior.

## Verification

- Confirmed the acknowledgement reaches Hex authentication with an intentionally invalid key.
- Confirmed the no-op path is rejected by the workflow guard.
