### PR TITLE
Improve host provider documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,12 @@ Geam links that call to the Rust implementation.
 For automatic crates.io discovery, a provider for `example_text_tools` is named
 `geam-example-text-tools` or `geam-example-text-tools-<suffix>`. The name makes
 the crate discoverable; its metadata declares the Gleam package and versions it
-implements. The [provider names for automatic discovery](docs/host-providers.md#provider-names-for-automatic-discovery)
-section defines this rule. The same guide follows one function from its Gleam
-declaration to Rust and then through `geam run`.
+implements.
+
+The [Add Rust to a Gleam package](docs/host-providers.md) guide follows one
+function from its Gleam declaration to Rust and then through `geam run`. Its
+[provider names for automatic discovery](docs/host-providers.md#provider-names-for-automatic-discovery)
+section defines the crates.io naming rule.
 
 ## Where Geam fits
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,13 @@ provider, and repeated calls one step at a time.
 
 ### Start with a Gleam package that needs Rust
 
-For a Gleam package that needs native Rust code, keep its public API in Gleam and
-implement the target-specific functions in a separate Rust crate. The
-[host provider guide](docs/host-providers.md) starts with one function and shows
-how Geam connects the two packages.
+Most Gleam packages need no additional Rust code. When a package declares
+target-specific functions that should run in Geam, its Hex package still owns
+the Gleam API and a companion Rust crate supplies the Geam implementation. Geam
+calls that crate a host provider.
+
+The [host provider guide](docs/host-providers.md) follows one function from its
+Gleam declaration to Rust and then through `geam run`.
 
 ## Where Geam fits
 
@@ -111,8 +114,8 @@ Rust runtime. Generated Rust provides host integration: a managed standalone
 runner or typed embedding bindings.
 
 A Gleam package keeps its Hex identity, source, and existing target
-implementations. A companion Rust crate implements its target-specific
-functions for Geam, and each package follows its own release schedule.
+implementations when it gains a Geam provider. The companion Rust crate adds a
+Geam implementation; it does not replace or translate the Gleam package.
 
 ## Growing, but experimental
 
@@ -132,7 +135,7 @@ planning, Rust providers, and execution fit together.
 - [Standalone projects](docs/standalone.md)
 - [Rust embedding](docs/embedding.md)
 - [Executable examples](examples)
-- [Host provider authoring](docs/host-providers.md)
+- [Add Rust to a Gleam package](docs/host-providers.md)
 - [Technical reference](docs/reference/README.md)
 - [Geam development](docs/development/README.md)
 - [Release notes](docs/releases/README.md)

--- a/README.md
+++ b/README.md
@@ -143,8 +143,12 @@ pub fn main() {
 
 Geam links that call to the Rust implementation.
 
-The [host provider guide](docs/host-providers.md) follows one function from its
-Gleam declaration to Rust and then through `geam run`.
+For automatic crates.io discovery, a provider for `example_text_tools` is named
+`geam-example-text-tools` or `geam-example-text-tools-<suffix>`. The name makes
+the crate discoverable; its metadata declares the Gleam package and versions it
+implements. The [provider names for automatic discovery](docs/host-providers.md#provider-names-for-automatic-discovery)
+section defines this rule. The same guide follows one function from its Gleam
+declaration to Rust and then through `geam run`.
 
 ## Where Geam fits
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 Geam is a [Rust](https://www.rust-lang.org/) runtime and embedding layer for
 [Gleam](https://gleam.run/).
 
-Run a Gleam project, call Gleam functions from Rust, or add Rust capabilities
-to a Gleam package. You keep writing Gleam and using Gleam packages; Geam looks
-after the Rust side.
+Run a Gleam project, call Gleam functions from Rust, or connect a Gleam package
+to native Rust code. You keep writing Gleam and using Gleam packages; Geam
+looks after the Rust side.
 
 The basic arrangement is similar to embedding Lua in a native application: Rust
 owns the process, while Gleam supplies statically typed application logic. Gleam
@@ -31,7 +31,7 @@ Install Geam with Cargo:
 cargo install geam --locked
 ```
 
-### Start with a Gleam project
+### Run a Gleam project
 
 Run an existing Gleam application on Geam's Rust runtime:
 
@@ -44,7 +44,7 @@ Geam prepares and maintains the project-local Rust runner while you continue
 working in Gleam. The
 [standalone guide](docs/standalone.md) continues from here.
 
-### Start with a Rust application
+### Call Gleam from Rust
 
 To call Gleam functions from Rust, create a Rust application and initialize its
 nested Gleam project and generated bindings:
@@ -91,12 +91,57 @@ examples](examples/embedding)
 then add structured data, Gleam packages, IO routed through Rust, an external
 provider, and repeated calls one step at a time.
 
-### Start with a Gleam package that needs Rust
+### Add Rust to a Gleam package
 
-Most Gleam packages need no additional Rust code. When a package declares
-target-specific functions that should run in Geam, its Hex package still owns
-the Gleam API and a companion Rust crate supplies the Geam implementation. Geam
-calls that crate a host provider.
+Ordinary Gleam packages run without this extra step. When a function is
+implemented outside Gleam, the Gleam package still owns the public API and a
+companion Rust crate can provide its Geam implementation. Geam calls that crate
+a host provider.
+
+The Gleam package declares the function:
+
+```gleam
+// src/example_text_tools/casing.gleam
+@external(erlang, "geam_example_text_tools_casing", "upper")
+pub fn upper(value: String) -> String
+```
+
+`@external` marks the function as implemented outside Gleam. Geam follows the
+Erlang-compatible source path, but links this declaration to Rust instead of
+calling the named Erlang function.
+
+The provider implements the same package, module, function, and signature in
+Rust:
+
+```rust
+#[geam::provider(
+    package = "example_text_tools",
+    modules = [casing],
+)]
+pub struct Component;
+
+#[geam::module(path = "example_text_tools/casing")]
+mod casing {
+    use geam::provider::EcoString;
+
+    #[geam::function]
+    fn upper(value: EcoString) -> EcoString {
+        value.to_uppercase()
+    }
+}
+```
+
+The application keeps using the Gleam module:
+
+```gleam
+import example_text_tools/casing
+
+pub fn main() {
+  assert casing.upper("Geam") == "GEAM"
+}
+```
+
+Geam links that call to the Rust implementation.
 
 The [host provider guide](docs/host-providers.md) follows one function from its
 Gleam declaration to Rust and then through `geam run`.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -205,10 +205,36 @@ dependencies do not add Rust components.
 Most packages need nothing else. If an imported package has native functions
 implemented for Geam, its Hex package remains the Gleam dependency and a
 companion provider crate supplies the Rust implementation compiled into the
-host application. Sync verifies registry candidates and asks before adding
-that exact Cargo dependency. Existing compatible registry, path, or Git
-declarations are reused. A noninteractive sync cannot approve new native code,
-so perform and commit provider selection before relying on CI.
+host application.
+
+Automatic crates.io discovery uses the Gleam package name. For
+`company_image`, sync considers `geam-company-image` and
+`geam-company-image-<suffix>`, where the optional suffix is lowercase
+kebab-case. It lists the exact name first, but neither form is treated as
+official, trusted, or automatically selected. A differently named crate is not
+found from metadata alone. The
+[provider names for automatic discovery](host-providers.md#provider-names-for-automatic-discovery)
+section defines the complete rule.
+
+Sync verifies each candidate's metadata and package-version range before showing
+it. With several verified candidates, an interactive sync asks which provider
+to use and then asks for approval:
+
+```text
+Gleam package company_image 1.4.0 requires native provider code.
+Metadata compatibility is not an endorsement.
+  1. geam-company-image 0.3.1 (Gleam >= 1.0.0 and < 2.0.0)
+  2. geam-company-image-aws 0.2.0 (Gleam >= 1.4.0 and < 2.0.0)
+Select a provider [1-2], or 0 to cancel: 2
+Approve geam-company-image-aws 0.2.0? [y/N] y
+```
+
+With one verified candidate, sync skips the numbered selection and asks for
+approval directly. After approval, it records that exact Cargo dependency and
+regenerates the Rust bindings. Existing compatible registry, path, or Git
+declarations are reused and may use another crate name. A noninteractive sync
+cannot approve new native code, so perform and commit provider selection before
+relying on CI.
 
 When imported code needs IO, time, or provider state, the generated Rust API
 asks the application for those inputs.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -187,7 +187,7 @@ script regenerates it implicitly.
 Embedding commands use one fixed project, module, and output layout. This makes
 checkouts, generated code, CI, and examples agree on the same connection.
 
-## Bring in Gleam packages and Rust providers
+## Use Gleam packages and Rust providers
 
 Add Gleam dependencies from the nested project:
 
@@ -202,11 +202,11 @@ Sync enables only the built-in Geam support used by imported Gleam code.
 Official stdlib, JSON, and Time integrations are added explicitly; unused Gleam
 dependencies do not add Rust components.
 
-Most packages need nothing else. If an imported package declares a
-target-specific function that needs Rust, its Hex package remains the Gleam
-dependency and a companion provider crate supplies the implementation compiled
-into the host application. Sync verifies registry candidates and asks before
-adding that exact Cargo dependency. Existing compatible registry, path, or Git
+Most packages need nothing else. If an imported package has native functions
+implemented for Geam, its Hex package remains the Gleam dependency and a
+companion provider crate supplies the Rust implementation compiled into the
+host application. Sync verifies registry candidates and asks before adding
+that exact Cargo dependency. Existing compatible registry, path, or Git
 declarations are reused. A noninteractive sync cannot approve new native code,
 so perform and commit provider selection before relying on CI.
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -202,11 +202,13 @@ Sync enables only the built-in Geam support used by imported Gleam code.
 Official stdlib, JSON, and Time integrations are added explicitly; unused Gleam
 dependencies do not add Rust components.
 
-When an imported package requires another native provider, sync verifies
-registry candidates and asks before adding an exact Cargo dependency. Existing
-compatible registry, path, or Git declarations are reused. A noninteractive
-sync cannot approve new native code, so perform and commit provider selection
-before relying on CI.
+Most packages need nothing else. If an imported package declares a
+target-specific function that needs Rust, its Hex package remains the Gleam
+dependency and a companion provider crate supplies the implementation compiled
+into the host application. Sync verifies registry candidates and asks before
+adding that exact Cargo dependency. Existing compatible registry, path, or Git
+declarations are reused. A noninteractive sync cannot approve new native code,
+so perform and commit provider selection before relying on CI.
 
 When imported code needs IO, time, or provider state, the generated Rust API
 asks the application for those inputs.

--- a/docs/host-providers.md
+++ b/docs/host-providers.md
@@ -3,9 +3,9 @@
 Most Gleam packages need no provider. Geam can run ordinary Gleam source and
 its built-in package integrations directly.
 
-A package needs a companion Rust implementation only when its Gleam API relies
-on native code that should run inside the Rust host. Geam calls that companion
-crate a **host provider**.
+A **host provider** is a companion Rust crate that implements native functions
+from a Gleam package for Geam. Use one when part of the package API must run
+inside the Rust host.
 
 ## One API, two packages
 
@@ -35,7 +35,7 @@ application.
 
 ## Follow one function from Gleam to Rust
 
-Start with a Gleam declaration whose implementation is supplied by a target:
+The Gleam package declares a function without a Gleam body:
 
 ```gleam
 // src/example_text_tools/casing.gleam
@@ -163,10 +163,10 @@ Keep unit tests for Rust-only logic and use this end-to-end run to verify the
 Gleam declaration, provider metadata, generated component, and application call
 together.
 
-## Add only the capabilities the package needs
+## Grow the provider with the package
 
 The smallest provider is a collection of ordinary Rust functions. Add other
-capabilities only when the Gleam API calls for them:
+features only when the Gleam API calls for them:
 
 - Use Rust scalars, tuples, `Result`, `Option`, and Geam's lazy `List` boundary
   for ordinary source values.
@@ -195,8 +195,8 @@ Embedding applications construct the corresponding Rust configuration and
 state values through generated bindings. External values and mutable state stay
 inside the running application in both workflows.
 
-See [standalone provider selection](standalone.md#bring-rust-capabilities-to-a-gleam-package)
-and [embedding package synchronization](embedding.md#bring-in-gleam-packages-and-rust-providers)
+See [standalone provider selection](standalone.md#use-a-gleam-package-with-a-rust-provider)
+and [embedding package synchronization](embedding.md#use-gleam-packages-and-rust-providers)
 for the consuming side of each workflow.
 
 ## Publish the pair

--- a/docs/host-providers.md
+++ b/docs/host-providers.md
@@ -1,31 +1,41 @@
-# Author a host provider
+# Add Rust to a Gleam package
 
-Some Gleam packages declare functions or values that have a separate
-implementation for each target. A Geam host provider supplies the Rust
-implementation.
+Most Gleam packages need no provider. Geam can run ordinary Gleam source and
+its built-in package integrations directly.
 
-The Gleam package keeps its public API, and users keep importing the same
-modules and calling the same functions. The provider is a separate Rust crate
-that supplies the Rust implementation for Geam.
+A package needs a companion Rust implementation only when its Gleam API relies
+on native code that should run inside the Rust host. Geam calls that companion
+crate a **host provider**.
 
-Use a provider when a Gleam package needs a native Rust library, access to the
-host process, or a value or state that must remain in Rust.
+## One API, two packages
 
-The Gleam package and Rust provider remain separate packages:
+The Gleam package and provider have separate jobs:
+
+| Artifact | Contains | Used for |
+| --- | --- | --- |
+| Gleam package, usually on Hex | Public Gleam modules, types, and external declarations | What applications add, import, and call |
+| Rust provider on crates.io, Git, or a local path | Native implementations for those declarations | What Cargo compiles into the Geam host |
+
+The provider does not replace or translate the Gleam package. Users keep
+writing the same Gleam calls:
 
 ```text
-Gleam package on Hex
-  declares the public Gleam API and externals
-
-Rust provider on crates.io, Git, or a local path
-  implements those externals for Geam
+Gleam application
+  adds and imports example_text_tools as a Gleam dependency
+  calls example_text_tools/casing.upper("Geam")
+                              |
+                              v
+Geam links the declaration to geam-example-text-tools from Cargo
 ```
 
-The same provider works in standalone and Rust embedding projects.
+A package can keep separate Erlang or JavaScript implementations for the same
+API. The provider adds the implementation used when Geam runs the package. The
+same provider can be used by a standalone Gleam project or a Rust embedding
+application.
 
-## Start with a small provider
+## Follow one function from Gleam to Rust
 
-Imagine a Gleam package with one casing function implemented outside Gleam:
+Start with a Gleam declaration whose implementation is supplied by a target:
 
 ```gleam
 // src/example_text_tools/casing.gleam
@@ -33,14 +43,14 @@ Imagine a Gleam package with one casing function implemented outside Gleam:
 pub fn upper(value: String) -> String
 ```
 
-The `erlang` target in this declaration is intentional. Standard Geam workflows
-analyse the Erlang-compatible source path and treat bodyless Erlang externals as
-Rust provider requirements. Geam does not call the named Erlang module or
-function; the provider links the Gleam declaration to Rust by its package,
-module, function, and type signature. A bodyless JavaScript-only external is not
-discovered as a provider requirement in this workflow.
+The `erlang` target is intentional. Standard Geam workflows analyse the
+Erlang-compatible source path and treat a bodyless Erlang external as a Rust
+provider requirement. Geam does not call the named Erlang module or function;
+it links the declaration to Rust by package, module, function, and exact type
+signature. A bodyless JavaScript-only external is not available in this
+workflow.
 
-Create an ordinary Rust library crate for the provider:
+Create an ordinary Rust library crate beside the Gleam package:
 
 ```sh
 cargo new --lib geam-example-text-tools
@@ -48,10 +58,7 @@ cd geam-example-text-tools
 cargo add geam --no-default-features --features provider
 ```
 
-Geam re-exports its author-facing value types from `geam::provider`, so one Geam
-dependency supplies the types used in provider declarations.
-
-Declare which Gleam package and modules the crate implements:
+Then declare the package and implement the matching module and function:
 
 ```rust
 use geam::provider::EcoString;
@@ -73,15 +80,18 @@ mod casing {
 }
 ```
 
-The provider macro generates the Geam wiring for the Rust crate. Rust
-compilation checks its declarations and supported Rust types. `geam prepare`
-then compares the generated description with the typed Gleam package before any
-provider state is initialized or application code runs.
+The macros generate provider registration and typed wiring. Rust checks the
+declarations and supported Rust types at compile time. During preparation,
+Geam compares that generated description with the typed Gleam declaration
+before provider state is initialized or application code runs.
 
-## Tell Geam what the provider supports
+Geam re-exports its author-facing value types from `geam::provider`, so this
+single dependency supplies types such as `EcoString`, `BigInt`, and `List`.
 
-Provider metadata names the exact Gleam package and the range of that package's
-versions supported by the Rust implementation:
+## Declare which Gleam versions it supports
+
+Cargo metadata connects the crate to its Gleam package and states the package
+versions implemented by this Rust code:
 
 ```toml
 [package]
@@ -94,31 +104,43 @@ gleam-package = "example_text_tools"
 gleam-version = ">= 1.0.0 and < 2.0.0"
 ```
 
-The `gleam-version` field describes the target Hex package, not the Gleam
-compiler. Geam verifies metadata before recording a path, Git, or registry
-selection, but compatibility metadata is never treated as user approval.
+`gleam-version` refers to the target Hex package, not the Gleam compiler. The
+provider and Gleam package versions do not need to match.
 
-For crates.io discovery, derive the Rust package name from the Gleam package by
-adding `geam-` and replacing underscores with hyphens:
+For automatic crates.io discovery, derive the crate name by adding `geam-` to
+the Gleam package name and replacing underscores with hyphens:
 
 ```text
 example_text_tools -> geam-example-text-tools
 ```
 
-Explicitly selected providers can use another crate name, but metadata remains
-the authority for the target Gleam package.
+An explicitly selected provider may use another crate name. Its packaged
+metadata still has to identify the exact Gleam package and a compatible
+version range. Compatibility metadata helps Geam verify a selection; it is
+never treated as approval to add native code.
 
-## Try it from a Gleam project
+## Run the complete pair
 
-Keep a complete Gleam application beside the provider while authoring it:
+Keep a small Gleam application beside the provider while authoring it:
 
 ```text
 example/
-  project/   Gleam application and package source
+  project/   Gleam application and local Gleam package
   provider/  Rust provider crate
 ```
 
-Select the local crate and run the same path users rely on:
+The application imports the Gleam package and calls its API normally:
+
+```gleam
+import example_text_tools/casing
+
+pub fn main() {
+  assert casing.upper("Geam") == "GEAM"
+}
+```
+
+From the Gleam project, select the local companion crate and run the same path
+that a standalone user relies on:
 
 ```sh
 cd project
@@ -127,81 +149,73 @@ geam prepare
 geam run
 ```
 
-This checks that the provider metadata and Rust implementation match the Gleam
-declarations, then runs the application through the generated runner. Keep unit
-tests for Rust-only logic and use this end-to-end run to verify the complete
-Gleam-to-Rust connection.
+`provider add` verifies the crate metadata and records the local selection.
+`prepare` checks the Rust implementation against the Gleam declarations and
+builds the generated runner. `run` executes the Gleam application with that
+implementation.
 
-The repository's
-[text tools example](../examples/provider/text_tools)
-is the smallest complete provider. Read its Gleam declarations, provider
-`src/lib.rs`, and application entry point together.
+The repository's [text tools example](../examples/provider/text_tools) is this
+complete flow with three Gleam modules. Its entrypoint asserts results such as
+`upper("Geam") == "GEAM"`; a successful run is silent because every check
+passes.
 
-## Add only what the package needs
+Keep unit tests for Rust-only logic and use this end-to-end run to verify the
+Gleam declaration, provider metadata, generated component, and application call
+together.
 
-Start with scalar functions and add only the capabilities the Gleam package
-actually needs:
+## Add only the capabilities the package needs
 
-- Use native Rust tuples, `Result`, `Option`, and Geam's List boundary for
-  ordinary source values.
-- Add generated custom-value mappings when Rust constructs or receives a
-  source custom type.
-- Add an external payload when the source value must remain opaque to Gleam.
+The smallest provider is a collection of ordinary Rust functions. Add other
+capabilities only when the Gleam API calls for them:
+
+- Use Rust scalars, tuples, `Result`, `Option`, and Geam's lazy `List` boundary
+  for ordinary source values.
+- Map a Gleam custom type when Rust constructs or receives its constructors.
+- Use an external value when an opaque payload must remain owned by Rust.
 - Add component state for process-local mutable or read-only capabilities.
-- Add explicit configuration when state construction needs caller input.
-- Add typed callbacks only when provider code must call a supplied Gleam
-  function.
-- Use retained generic or advanced storage only when an external value must own
-  source values across calls.
+- Add explicit configuration when constructing that state needs caller input.
+- Accept a typed callback when provider code must call a Gleam function.
+- Retain a generic source value only when an external value must own it across
+  calls.
 
-The [provider examples](../examples/provider)
-form an ordered learning path:
+The [provider examples](../examples/provider) form an executable path through
+those choices, beginning with scalar functions and ending with a separately
+published Hex package and provider crate.
 
-```text
-text_tools
--> value_types
--> tag_set
--> request_ids
--> feature_flags
--> run_metrics
--> call_tracing
--> generic_box
--> text_pattern
-```
+## Use the provider from an application
 
-Each example adds one provider capability before the later examples combine
-them.
+Provider crates are native code. In a standalone project, Geam verifies a
+registry candidate and asks for approval before Cargo receives it. In a Rust
+embedding project, `geam embedding sync` performs the same selection and
+records the provider as an ordinary Cargo dependency. Geam verifies metadata
+and typed linkage, but neither step is a security endorsement.
 
-## Keep native code explicit
+Standalone applications pass provider configuration as TOML at run time.
+Embedding applications construct the corresponding Rust configuration and
+state values through generated bindings. External values and mutable state stay
+inside the running application in both workflows.
 
-Provider crates are native code. Geam verifies their package metadata and
-typed linkage, but neither step is a security endorsement. A standalone user
-must approve a discovered provider before Cargo receives it. An embedding
-application records the provider as an ordinary Cargo dependency and includes
-it in the generated bindings.
+See [standalone provider selection](standalone.md#bring-rust-capabilities-to-a-gleam-package)
+and [embedding package synchronization](embedding.md#bring-in-gleam-packages-and-rust-providers)
+for the consuming side of each workflow.
 
-Standalone applications read provider configuration from TOML at run time;
-embedding applications construct the corresponding Rust values. Provider state
-and external values stay in the running application.
+## Publish the pair
 
-## Release each package on its own schedule
+Publish the Gleam package with Gleam's Hex tooling and the provider with Cargo.
+The Hex release contains the API that applications import. The crates.io
+release contains the native code that Rust hosts compile. Test the packaged
+provider with `cargo publish --locked --dry-run`, verify the public
+Gleam-to-provider path, and widen `gleam-version` only when that package range
+has been checked.
 
-Publish the Gleam package with Gleam's Hex tooling and the Rust provider with
-Cargo. Their versions do not have to match, but the provider metadata must
-declare the actual compatible Gleam package range. Test the packaged provider
-with `cargo publish --locked --dry-run` and verify the public Gleam-to-provider
-path before widening that range.
-
-The published
-[text-pattern package and provider](../examples/provider/text_pattern)
-show independent Hex and crates.io packages that can also run on Erlang through
-the package's separate Erlang implementation.
+The final [text pattern example](../examples/provider/text_pattern) shows a Hex
+package, a crates.io provider, and a separate Erlang implementation of the same
+Gleam API.
 
 ## Exact reference
 
 Continue with the [host provider boundary](reference/provider-boundary.md) for
-the complete Rust type mappings, custom and external values, state,
-configuration, callback invocation, retained storage, generated component
-contract, and runner profile. The [runtime semantics](reference/runtime-semantics.md)
-document defines ownership, equality, hashing, inspection, and failure behavior
-after linkage.
+the complete type mappings, custom and external values, state, configuration,
+callbacks, retained storage, generated component contract, and runner profile.
+The [runtime semantics](reference/runtime-semantics.md) document defines
+ownership, equality, hashing, inspection, and failure behavior after linkage.

--- a/docs/host-providers.md
+++ b/docs/host-providers.md
@@ -33,6 +33,34 @@ API. The provider adds the implementation used when Geam runs the package. The
 same provider can be used by a standalone Gleam project or a Rust embedding
 application.
 
+## Provider names for automatic discovery
+
+Automatic provider discovery starts with the Gleam package name. Name a
+published provider by adding `geam-` and replacing underscores with hyphens:
+
+| Name form | Example for `company_image` |
+| --- | --- |
+| Exact name | `geam-company-image` |
+| Suffixed name | `geam-company-image-aws` |
+
+The suffix must use lowercase kebab-case. `geam prepare`, `geam run`, and
+`geam embedding sync` search both forms on crates.io. These are search patterns,
+not ownership claims. The exact name is listed first when both forms produce
+verified candidates, but neither form is treated as official, trusted, or
+automatically selected. A crate named `company-image-rust` is not found
+automatically, even if its metadata targets `company_image`.
+
+The naming pattern only determines which crates Geam examines. Packaged
+metadata declares which Gleam package and versions a crate implements. Geam
+checks that declaration before presenting a candidate, but neither the name nor
+compatible metadata is an endorsement. With one verified candidate, Geam asks
+for approval directly; with several, it asks the user to select one and then
+approve it.
+
+An explicitly selected registry, path, or Git provider may use another crate
+name. It still needs valid provider metadata for the exact Gleam package and a
+compatible version range.
+
 ## Follow one function from Gleam to Rust
 
 The Gleam package declares a function without a Gleam body:
@@ -107,17 +135,9 @@ gleam-version = ">= 1.0.0 and < 2.0.0"
 `gleam-version` refers to the target Hex package, not the Gleam compiler. The
 provider and Gleam package versions do not need to match.
 
-For automatic crates.io discovery, derive the crate name by adding `geam-` to
-the Gleam package name and replacing underscores with hyphens:
-
-```text
-example_text_tools -> geam-example-text-tools
-```
-
-An explicitly selected provider may use another crate name. Its packaged
-metadata still has to identify the exact Gleam package and a compatible
-version range. Compatibility metadata helps Geam verify a selection; it is
-never treated as approval to add native code.
+The discovery name alone is not enough. Geam uses this metadata to check the
+exact package identity and supported range. Compatibility metadata helps Geam
+verify a selection; it is never treated as approval to add native code.
 
 ## Run the complete pair
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
 Geam is a [Rust](https://www.rust-lang.org/) runtime and embedding layer for
 [Gleam](https://gleam.run/).
 
-Run a Gleam project, call Gleam functions from a Rust application, or add Rust
-capabilities to a Gleam package.
+Run a Gleam project, call Gleam functions from a Rust application, or connect a
+Gleam package to native Rust code.
 
 Gleam source stays Gleam. Geam runs the type-checked program and generates the
 Rust runner or bindings that connect it to the host.
@@ -76,13 +76,13 @@ What Geam manages depends on where you start:
   project-local Rust runner and approved providers.
 - In a **Rust embedding project**, Rust remains the application. Geam manages
   the nested Gleam project and generated bindings.
-- A **host provider** is the companion Rust implementation for target-specific
-  functions in a Gleam package. Either kind of project can use one.
+- A **host provider** is the companion Rust crate that implements a Gleam
+  package's native functions for Geam. Either kind of project can use one.
 
-Most Gleam packages need no provider. When one does, users still add the Hex
-package and import its Gleam modules as usual. The separate provider crate is
-compiled into the Rust host only to implement the functions that need native
-code.
+Most Gleam packages need no provider. When a package includes native functions,
+users still add the Hex package and import its Gleam modules as usual. The
+separate provider crate is compiled into the Rust host only to implement those
+functions for Geam.
 
 ## When Geam fits
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Rust runner or bindings that connect it to the host.
 | --- | --- | --- |
 | Run a Gleam application without writing a Rust runner | Standalone | [Run a Gleam project](standalone.md) |
 | Call selected Gleam functions from a Rust application | Rust embedding | [Embed Gleam in Rust](embedding.md) |
-| Give a Gleam package capabilities implemented in Rust | Host provider | [Author a host provider](host-providers.md) |
+| Add a Rust implementation to a Gleam package | Host provider | [Add Rust to a Gleam package](host-providers.md) |
 
 Each workflow is a complete starting point for the same runtime. Start with the
 project you already have.
@@ -76,13 +76,13 @@ What Geam manages depends on where you start:
   project-local Rust runner and approved providers.
 - In a **Rust embedding project**, Rust remains the application. Geam manages
   the nested Gleam project and generated bindings.
-- A **host provider** supplies Rust capabilities that either kind of project can
-  use from Gleam.
+- A **host provider** is the companion Rust implementation for target-specific
+  functions in a Gleam package. Either kind of project can use one.
 
-A provider remains separate from the Gleam package. The package can keep its
-existing source and target implementations while a Rust crate implements the
-functions that need native code. Users keep importing and calling the Gleam
-modules they already know.
+Most Gleam packages need no provider. When one does, users still add the Hex
+package and import its Gleam modules as usual. The separate provider crate is
+compiled into the Rust host only to implement the functions that need native
+code.
 
 ## When Geam fits
 

--- a/docs/reference/provider-boundary.md
+++ b/docs/reference/provider-boundary.md
@@ -485,8 +485,8 @@ Geam metadata. The component demonstrates:
 
 Its
 [Cargo manifest](../../examples/provider/text_pattern/provider/Cargo.toml)
-uses the
-canonical `geam-example-text-pattern` discovery name and schema-1 metadata. This
+uses the exact `geam-example-text-pattern` discovery-name form and schema-1
+metadata. This
 release-coupled provider pins the actual `example_text_pattern` Hex package
 version exactly.
 
@@ -627,11 +627,13 @@ separate strategies within that graph.
 
 To make a published provider discoverable, derive its Cargo package name from
 the target Gleam package: add the `geam-` prefix and replace underscores with
-hyphens. A provider whose metadata targets `company_image` therefore publishes
-as `geam-company-image`; alternatives may append a kebab-case suffix. The name
-only places the crate in the discovery namespace. Packaged metadata remains the
-authority for the exact `company_image` identity, and explicitly selected
-registry, path, or Git crates may use other names.
+hyphens. A provider whose metadata targets `company_image` can therefore use
+the exact name `geam-company-image` or a suffixed name such as
+`geam-company-image-aws`. The exact form is sorted first but has no authority
+over the suffixed form. Either name only places the crate in the discovery
+namespace. Packaged metadata supplies the target identity and version range Geam
+validates, but does not establish publisher authority or endorsement. Explicitly
+selected registry, path, or Git crates may use other names.
 
 Discovery, native-code approval, managed Cargo files, and runtime configuration
 belong to the CLI rather than this SDK. Provider callbacks, stores, and state

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -120,15 +120,33 @@ When imported code reaches a provider-backed function that is not built in,
 Geam searches crates.io for a companion crate with matching metadata and asks
 before adding that native code:
 
+| Role | Name |
+| --- | --- |
+| Gleam package | `company_image` |
+| Exact provider name | `geam-company-image` |
+| Suffixed provider name | `geam-company-image-<suffix>` |
+
+Geam searches both provider name forms. The exact name is listed first, but
+neither form is treated as official, trusted, or automatically selected. The
+optional suffix must use lowercase kebab-case. For example,
+`company-image-rust` is not found automatically, even if it carries provider
+metadata for `company_image`. See the
+[provider names for automatic discovery](host-providers.md#provider-names-for-automatic-discovery)
+section when publishing a provider.
+
 ```text
 Gleam package company_image 1.4.0 requires native provider code.
 Metadata compatibility is not an endorsement.
   1. geam-company-image 0.3.1 (Gleam >= 1.0.0 and < 2.0.0)
-Approve geam-company-image 0.3.1? [y/N]
+  2. geam-company-image-aws 0.2.0 (Gleam >= 1.4.0 and < 2.0.0)
+Select a provider [1-2], or 0 to cancel: 2
+Approve geam-company-image-aws 0.2.0? [y/N] y
 ```
 
-Approval records an exact Cargo dependency. Geam never treats matching metadata
-as consent, and noninteractive commands do not approve a new provider.
+With one verified candidate, Geam skips the numbered selection and asks for
+approval directly. Approval records an exact Cargo dependency. Geam never
+treats matching metadata as consent, and noninteractive commands do not approve
+a new provider.
 
 Before presenting a registry candidate, Geam checks its sparse-index version,
 archive checksum, packaged provider metadata, exact target Gleam package, and
@@ -151,10 +169,11 @@ geam provider list
 geam provider remove company_image
 ```
 
-An explicit selection is still verified against its packaged provider metadata
-and the resolved Gleam package. One Gleam package has at most one selected
-external provider. Built-in components are not stored selections and do not
-appear in `provider list`.
+An explicit registry, path, or Git selection does not have to follow the
+automatic discovery naming convention. It is still verified against its
+packaged provider metadata and the resolved Gleam package. One Gleam package
+has at most one selected external provider. Built-in components are not stored
+selections and do not appear in `provider list`.
 
 To author the companion crate, continue with
 [Add Rust to a Gleam package](host-providers.md).

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -105,13 +105,20 @@ and supported effects.
 
 ## Bring Rust capabilities to a Gleam package
 
-A Gleam package may already pair its source API with an Erlang or JavaScript
-external implementation. A Geam provider lets the same package gain a Rust
-implementation without moving that API out of Gleam.
+Most Gleam packages run without an additional Rust crate. When an imported
+package declares a target-specific function that Geam cannot execute from
+Gleam source, the package needs a companion Rust implementation. Geam calls
+that crate a provider.
 
-When imported code requires an external implementation that is not built in,
-Geam searches crates.io for provider crates with matching metadata and asks
-before adding native code:
+The two dependencies have different jobs: the Hex package contains the Gleam
+API and source that the application imports, while the provider crate contains
+the native implementation compiled into the Rust runner. A package may keep
+its existing Erlang or JavaScript implementation; adding a provider does not
+replace it or change how Gleam code imports the package.
+
+When imported code reaches a provider-backed function that is not built in,
+Geam searches crates.io for a companion crate with matching metadata and asks
+before adding that native code:
 
 ```text
 Gleam package company_image 1.4.0 requires native provider code.
@@ -149,7 +156,8 @@ and the resolved Gleam package. One Gleam package has at most one selected
 external provider. Built-in components are not stored selections and do not
 appear in `provider list`.
 
-To implement a provider, start with [host provider authoring](host-providers.md).
+To author the companion crate, continue with
+[Add Rust to a Gleam package](host-providers.md).
 
 ## Pass provider configuration at run time
 

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -103,12 +103,12 @@ Gleam source and the stdlib support required by its imported code.
 See [compatibility](reference/compatibility.md) for the exact package baselines
 and supported effects.
 
-## Bring Rust capabilities to a Gleam package
+## Use a Gleam package with a Rust provider
 
-Most Gleam packages run without an additional Rust crate. When an imported
-package declares a target-specific function that Geam cannot execute from
-Gleam source, the package needs a companion Rust implementation. Geam calls
-that crate a provider.
+Most Gleam packages run without an additional Rust crate. Some packages expose
+functions whose implementation is supplied separately for each execution
+target. When Geam runs one of those functions, a companion Rust crate supplies
+the implementation. Geam calls that crate a provider.
 
 The two dependencies have different jobs: the Hex package contains the Gleam
 API and source that the application imports, while the provider crate contains

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ Geam examples are grouped by the role Rust plays in the application:
 - [Rust embedding](embedding) starts from a Rust application that calls Gleam
   through generated bindings.
 - [Provider authoring](provider) pairs a Gleam package with the companion Rust
-  crate that implements its target-specific functions for Geam.
+  crate that implements its native functions for Geam.
 
 Each category has an ordered learning path. Every example is independently
 runnable and keeps its own source, configuration, and verification beside the

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,8 +4,8 @@ Geam examples are grouped by the role Rust plays in the application:
 
 - [Rust embedding](embedding) starts from a Rust application that calls Gleam
   through generated bindings.
-- [Provider authoring](provider) starts from a Gleam package whose native
-  functions are implemented by a Rust provider crate.
+- [Provider authoring](provider) pairs a Gleam package with the companion Rust
+  crate that implements its target-specific functions for Geam.
 
 Each category has an ordered learning path. Every example is independently
 runnable and keeps its own source, configuration, and verification beside the

--- a/examples/provider/README.md
+++ b/examples/provider/README.md
@@ -72,6 +72,12 @@ the companion Rust crate for the checkout. The provider's Cargo metadata names
 the Gleam package and compatible versions so Geam can verify the pair before
 it runs.
 
+These checkouts select local paths explicitly, but every provider crate also
+uses the exact discovery-name form. For example, `example_text_tools` maps to
+`geam-example-text-tools`. The suffixed form appends a lowercase kebab-case
+suffix; the [provider names for automatic discovery](../../docs/host-providers.md#provider-names-for-automatic-discovery)
+section defines the complete crates.io rule.
+
 `feature_flags` is the only staged example that needs runtime configuration:
 
 ```sh

--- a/examples/provider/README.md
+++ b/examples/provider/README.md
@@ -41,7 +41,7 @@ as `upper("Geam") == "GEAM"` and
 `join("geam", "-", "provider") == "geam-provider"`. A successful run is
 silent because its assertions pass.
 
-## Choose an example by capability
+## Find the feature you need
 
 After the first provider works, use this table when you need one particular
 host boundary:

--- a/examples/provider/README.md
+++ b/examples/provider/README.md
@@ -1,35 +1,33 @@
-# Provider Authoring Examples
+# Host Provider Examples
 
-These examples build a Rust provider one capability at a time. Start with
-scalar functions, then choose the example that matches the state,
-configuration, external value, callback, or generic value your package needs.
+A host provider is the companion Rust crate that implements target-specific
+functions declared by a Gleam package. These examples let you read the public
+Gleam API, its Rust implementation, and the application that connects them as
+one complete flow.
 
-| Example | State | Configuration | External semantics | Purpose |
-| --- | --- | --- | --- | --- |
-| [`text_tools`](text_tools/README.md) | None | None | None | One provider implementing three Gleam modules |
-| [`value_types`](value_types/README.md) | None | None | None | Scalar, tuple, lazy List, custom, Result, and Option mapping |
-| [`tag_set`](tag_set/README.md) | None | None | Generated | Stateless persistent external value |
-| [`request_ids`](request_ids/README.md) | `Default` | None | None | Mutable and read-only state access |
-| [`feature_flags`](feature_flags/README.md) | Configured | Required | None | Shared configuration and state |
-| [`run_metrics`](run_metrics/README.md) | None | None | Manual | Specialized equality, hashing, and inspection |
-| [`call_tracing`](call_tracing/README.md) | `Default` | None | None | Typed callback invocation and same-component re-entry |
-| [`generic_box`](generic_box/README.md) | None | None | Retained generic | Persistent generic source values and callback mapping |
-| [`text_pattern`](text_pattern/README.md) | None | None | Manual | Regex-backed external, custom error, Result, and List output |
+Read the examples in order when learning provider authoring. Each stage is an
+independently runnable Gleam project and Rust provider crate.
 
-The recommended reading order is:
+| Stage | Example | Adds |
+| --- | --- | --- |
+| First provider | [`text_tools`](text_tools/README.md) | Implement scalar functions across three Gleam modules |
+| Value boundary | [`value_types`](value_types/README.md) | Map scalars, tuples, Lists, custom types, Result, and Option |
+| Opaque Rust value | [`tag_set`](tag_set/README.md) | Keep a persistent `TagSet` payload owned by Rust |
+| Process state | [`request_ids`](request_ids/README.md) | Read and mutate fresh state for each execution |
+| Configuration | [`feature_flags`](feature_flags/README.md) | Initialize shared state from explicit TOML input |
+| Custom value behavior | [`run_metrics`](run_metrics/README.md) | Define equality, hashing, and inspection for an external value |
+| Gleam callback | [`call_tracing`](call_tracing/README.md) | Invoke a typed Gleam function and re-enter the same provider |
+| Retained Gleam value | [`generic_box`](generic_box/README.md) | Store a generic source value across provider calls |
+| Published pair | [`text_pattern`](text_pattern/README.md) | Pair a Hex package with a crates.io provider while keeping its Erlang implementation |
 
-```text
-text_tools -> value_types -> tag_set -> request_ids -> feature_flags -> run_metrics -> call_tracing -> generic_box -> text_pattern
-```
+Start with [`text_tools`](text_tools/README.md), then follow the next-example
+link in each README through [`text_pattern`](text_pattern/README.md). The
+[provider guide](../../docs/host-providers.md) explains why the Gleam package
+and Rust crate are separate before walking through the same first connection.
 
-Every example keeps the Gleam package and Rust provider separate:
+## Run the first provider
 
-```text
-project/   ordinary Gleam application and local Gleam dependency
-provider/  separately buildable and testable Rust provider crate
-```
-
-Run a macro-authored example with the same standalone workflow:
+With Gleam, Rust, and Geam installed, run from the repository root:
 
 ```sh
 cd examples/provider/text_tools/project
@@ -38,13 +36,48 @@ geam prepare
 geam run
 ```
 
-`feature_flags` additionally passes its checked-in configuration:
+The example imports three modules from the Gleam package and checks calls such
+as `upper("Geam") == "GEAM"` and
+`join("geam", "-", "provider") == "geam-provider"`. A successful run is
+silent because its assertions pass.
+
+## Choose an example by capability
+
+After the first provider works, use this table when you need one particular
+host boundary:
+
+| Example | Provider state | Runtime configuration | Rust-owned value |
+| --- | --- | --- | --- |
+| [`text_tools`](text_tools/README.md) | None | None | None |
+| [`value_types`](value_types/README.md) | None | None | None |
+| [`tag_set`](tag_set/README.md) | None | None | Generated equality, hashing, and inspection |
+| [`request_ids`](request_ids/README.md) | `Default` | None | None |
+| [`feature_flags`](feature_flags/README.md) | Configured | Required | None |
+| [`run_metrics`](run_metrics/README.md) | None | None | Custom equality, hashing, and inspection |
+| [`call_tracing`](call_tracing/README.md) | `Default` | None | None |
+| [`generic_box`](generic_box/README.md) | None | None | Retained generic Gleam value |
+| [`text_pattern`](text_pattern/README.md) | None | None | Regex payload with custom behavior |
+
+## Example layout
+
+Every example keeps the two packages side by side:
+
+```text
+project/   Gleam application and local Gleam package
+provider/  separately buildable and testable Rust provider crate
+```
+
+The application adds and imports the Gleam package. `geam provider add` selects
+the companion Rust crate for the checkout. The provider's Cargo metadata names
+the Gleam package and compatible versions so Geam can verify the pair before
+it runs.
+
+`feature_flags` is the only staged example that needs runtime configuration:
 
 ```sh
 geam run --provider-config example_feature_flags=config/feature_flags.toml
 ```
 
-The generated project `Cargo.toml`, `Cargo.lock`, and `build/` tree are ignored.
-Each provider's own `Cargo.lock` is tracked so its Rust package can be formatted,
-tested, linted, and packaged with `--locked` independently. See [host provider
-authoring](../../docs/host-providers.md) for the complete workflow and contract.
+Generated project `Cargo.toml`, `Cargo.lock`, and `build/` files are ignored in
+these checkouts. Each provider's own `Cargo.lock` is tracked so the Rust crate
+can be formatted, tested, linted, and packaged with `--locked` independently.

--- a/examples/provider/call_tracing/README.md
+++ b/examples/provider/call_tracing/README.md
@@ -1,8 +1,20 @@
-# Call Tracing Provider Example
+# Host Provider: Call Tracing
 
-This example shows one provider function invoking a typed Gleam callback. The
-callback re-enters the same provider, while one `Call` keeps the provider state
-and callback capability in the same active invocation:
+This example passes a Gleam function into Rust and calls it from the provider.
+The callback records another entry through the same provider, showing that one
+active call can re-enter Gleam without losing its provider state.
+
+## Read The Example
+
+1. [`project/packages/example_call_tracing/src/example_call_tracing.gleam`](project/packages/example_call_tracing/src/example_call_tracing.gleam)
+   declares the callback-taking API.
+2. [`provider/src/lib.rs`](provider/src/lib.rs) records entries around one typed
+   callback invocation.
+3. [`project/src/call_tracing_example.gleam`](project/src/call_tracing_example.gleam)
+   supplies the callback and checks its result and call order.
+
+The provider receives a typed callback and invokes it through the active
+`Call`:
 
 ```rust
 #[geam::function]
@@ -25,8 +37,10 @@ pub fn around(fn() -> item) -> item
 pub fn entries() -> List(String)
 ```
 
-Run the example twice to verify callback return identity, `before` / `inside` /
-`after` ordering, and fresh state for every standalone execution:
+## Run
+
+Run the example twice to verify callback return identity and fresh state for
+every standalone execution:
 
 ```sh
 cd examples/provider/call_tracing/project
@@ -36,8 +50,9 @@ geam run
 geam run
 ```
 
-A successful run produces no application output. Read
-[`project/packages/example_call_tracing/src/example_call_tracing.gleam`](project/packages/example_call_tracing/src/example_call_tracing.gleam),
-[`provider/src/lib.rs`](provider/src/lib.rs), and
-[`project/src/call_tracing_example.gleam`](project/src/call_tracing_example.gleam)
-together.
+Each run checks that `around(work) == 42` and that the shared trace is exactly
+`["before", "inside", "after"]`. Both runs are silent when all assertions
+pass.
+
+Continue with [generic box](../generic_box/README.md) to retain a typed Gleam
+value inside an external value across provider calls.

--- a/examples/provider/feature_flags/README.md
+++ b/examples/provider/feature_flags/README.md
@@ -1,8 +1,19 @@
-# Feature Flags Provider Example
+# Host Provider: Feature Flags
 
-This example configures a provider with an environment name and a list of
-enabled feature flags. Provider functions then read those settings through
-`&RunState`.
+This example initializes provider state from application-owned configuration.
+The Rust provider reads an environment name and enabled feature flags once,
+then Gleam functions observe that shared state through a small API.
+
+## Read The Example
+
+1. [`project/packages/example_feature_flags/src/example_feature_flags.gleam`](project/packages/example_feature_flags/src/example_feature_flags.gleam)
+   declares the two functions available to Gleam.
+2. [`provider/src/lib.rs`](provider/src/lib.rs) validates configuration and
+   initializes the provider state.
+3. [`project/config/feature_flags.toml`](project/config/feature_flags.toml)
+   supplies the application-owned values for this run.
+4. [`project/src/feature_flags_example.gleam`](project/src/feature_flags_example.gleam)
+   checks the configured environment and flags.
 
 The complete Gleam API is:
 
@@ -18,7 +29,9 @@ environment = "staging"
 enabled = ["new_checkout", "audit_log"]
 ```
 
-Run it with:
+## Run
+
+Pass the checked-in configuration when running the project:
 
 ```sh
 cd examples/provider/feature_flags/project
@@ -27,14 +40,17 @@ geam prepare
 geam run --provider-config example_feature_flags=config/feature_flags.toml
 ```
 
+The entrypoint checks that the environment is `"staging"`, that
+`"new_checkout"` and `"audit_log"` are enabled, and that an absent flag is
+disabled. A successful run is silent because all assertions pass.
+
+## Configuration Errors
+
 Omitting the configuration fails with
 `configuration key \`environment\` must be a String`. Supplying a non-array or
 a non-string array item for `enabled` fails with
 `configuration key \`enabled\` must be an Array of Strings`. Geam reports these
 configuration errors before application code runs.
 
-Read [`project/packages/example_feature_flags/src/example_feature_flags.gleam`](project/packages/example_feature_flags/src/example_feature_flags.gleam),
-[`provider/src/lib.rs`](provider/src/lib.rs),
-[`project/config/feature_flags.toml`](project/config/feature_flags.toml), and
-[`project/src/feature_flags_example.gleam`](project/src/feature_flags_example.gleam)
-together.
+Continue with [run metrics](../run_metrics/README.md) to customize source
+equality, hashing, and inspection for a Rust-owned value.

--- a/examples/provider/generic_box/README.md
+++ b/examples/provider/generic_box/README.md
@@ -1,8 +1,20 @@
-# Generic Box Provider Example
+# Host Provider: Generic Box
 
-This example shows the lifecycle of a generic Gleam value retained by an
-external provider-owned value. The Rust payload stores the source value without
-materializing it into a universal Rust representation:
+This example lets a Rust-owned external value retain a generic Gleam value
+across provider calls. `Box(String)` and `Box(Int)` keep their exact Gleam
+specializations; the provider does not convert them into one universal Rust
+value.
+
+## Read The Example
+
+1. [`project/packages/example_generic_box/src/example_generic_box.gleam`](project/packages/example_generic_box/src/example_generic_box.gleam)
+   declares the generic `Box(item)` API.
+2. [`provider/src/lib.rs`](provider/src/lib.rs) stores, restores, replaces, and
+   maps retained Gleam values.
+3. [`project/src/generic_box_example.gleam`](project/src/generic_box_example.gleam)
+   checks identity, cross-type replacement, equality, and callback mapping.
+
+The Rust payload marks the source value as retained storage:
 
 ```rust
 #[geam::external(
@@ -49,8 +61,9 @@ pub fn contains(boxed: Box(item), expected: item) -> Bool
 pub fn map(boxed: Box(input), mapper: fn(input) -> output) -> Box(output)
 ```
 
-Run it twice to verify old-value preservation, cross-type replacement,
-source-semantic equality, callback mapping, and fresh standalone execution:
+## Run
+
+Run it twice to verify fresh standalone execution as well as retained values:
 
 ```sh
 cd examples/provider/generic_box/project
@@ -60,8 +73,9 @@ geam run
 geam run
 ```
 
-A successful run produces no application output. Read
-[`project/packages/example_generic_box/src/example_generic_box.gleam`](project/packages/example_generic_box/src/example_generic_box.gleam),
-[`provider/src/lib.rs`](provider/src/lib.rs), and
-[`project/src/generic_box_example.gleam`](project/src/generic_box_example.gleam)
-together.
+Each run checks that the original box still contains `"alpha"`, a replacement
+can change its item type to `Int`, a Gleam callback maps that value, and equal
+source values compare equal. Both runs are silent when all assertions pass.
+
+Continue with [text pattern](../text_pattern/README.md) to see a Hex package and
+crates.io provider prepared as a separately published pair.

--- a/examples/provider/request_ids/README.md
+++ b/examples/provider/request_ids/README.md
@@ -1,8 +1,20 @@
-# Request IDs Provider Example
+# Host Provider: Request IDs
 
-This example adds process-local state without configuration. Omitting an
-initializer makes Geam construct `RunState::default()` for every execution.
-The Rust signatures distinguish mutation from observation:
+This example adds process-local state without configuration. The provider owns
+one request counter for the duration of a run, while the Gleam API remains two
+argument-free functions. Omitting an initializer makes Geam construct
+`RunState::default()` for every execution.
+
+## Read The Example
+
+1. [`project/packages/example_request_ids/src/example_request_ids.gleam`](project/packages/example_request_ids/src/example_request_ids.gleam)
+   declares the small source API.
+2. [`provider/src/lib.rs`](provider/src/lib.rs) owns the counter and distinguishes
+   mutable from read-only calls.
+3. [`project/src/request_ids_example.gleam`](project/src/request_ids_example.gleam)
+   checks the counter before and after issuing two IDs.
+
+The Rust signatures make mutation and observation explicit:
 
 ```rust
 #[geam::function]
@@ -19,8 +31,10 @@ pub fn next() -> String
 pub fn issued() -> Int
 ```
 
-Run the example twice to see that each standalone execution starts with an
-independent default state:
+## Run
+
+Run the example twice to see that each standalone execution starts with fresh
+default state:
 
 ```sh
 cd examples/provider/request_ids/project
@@ -30,9 +44,9 @@ geam run
 geam run
 ```
 
-Each run checks the initial count, two generated IDs, and the read-only count
-after each mutation. A successful run produces no application output.
+Each run checks `issued() == 0`, then receives `"request-1"` and `"request-2"`
+while observing the count after each mutation. Both runs are silent when every
+assertion passes, showing that state is not shared between executions.
 
-Read [`project/packages/example_request_ids/src/example_request_ids.gleam`](project/packages/example_request_ids/src/example_request_ids.gleam),
-[`provider/src/lib.rs`](provider/src/lib.rs), and
-[`project/src/request_ids_example.gleam`](project/src/request_ids_example.gleam) together.
+Continue with [feature flags](../feature_flags/README.md) to initialize provider
+state from application-supplied configuration.

--- a/examples/provider/run_metrics/README.md
+++ b/examples/provider/run_metrics/README.md
@@ -1,7 +1,20 @@
-# Run Metrics Provider Example
+# Host Provider: Run Metrics
 
-This example pairs one constructorless Gleam type with a macro-authored Rust
-payload:
+The tag set example derives ordinary source behavior from its Rust payload.
+This example takes control of that boundary: a provider defines how a
+Rust-owned `Metrics` value compares, hashes, and appears when inspected from
+Gleam.
+
+## Read The Example
+
+1. [`project/packages/example_run_metrics/src/example_run_metrics.gleam`](project/packages/example_run_metrics/src/example_run_metrics.gleam)
+   declares the constructorless type and source-visible operations.
+2. [`provider/src/lib.rs`](provider/src/lib.rs) defines the payload, persistent
+   update, and custom external behavior.
+3. [`project/src/run_metrics_example.gleam`](project/src/run_metrics_example.gleam)
+   checks old values, aggregate results, and equality.
+
+The Gleam API is:
 
 ```gleam
 pub type Metrics
@@ -17,13 +30,7 @@ opaque payload, and `record` clones that payload before returning an updated
 version. Earlier values remain readable and independently constructed values
 with the same entries compare equal in Gleam source.
 
-```text
-project/
-  packages/example_run_metrics/  ordinary local Gleam package
-provider/                          geam-example-run-metrics crate
-```
-
-## Run The Example
+## Run
 
 With `geam` available on `PATH`, select the local provider and run the project:
 
@@ -36,22 +43,10 @@ geam run
 
 No provider configuration file is needed, so the component omits both state and
 initialization. All metrics data lives in the source-visible `Metrics` values.
-The entrypoint checks empty, one-sample, multi-sample, missing-key, old-value
-preservation, and equality behavior. A successful run produces no application output.
+The entrypoint checks counts and totals for empty, one-sample, multi-sample,
+and missing-key cases. It also checks that an update preserves the old value
+and that independently built metrics with the same entries compare equal. A
+successful run is silent because all assertions pass.
 
-The tracked `.cargo/config.toml` files only redirect the unreleased Geam
-authoring API to this repository checkout. They are development wiring for this
-example, not consumer metadata.
-
-## What To Read
-
-- [`project/packages/example_run_metrics/src/example_run_metrics.gleam`](project/packages/example_run_metrics/src/example_run_metrics.gleam)
-  is the complete source-visible API.
-- [`provider/src/lib.rs`](provider/src/lib.rs) is the matching Rust payload and
-  component.
-- [`project/src/run_metrics_example.gleam`](project/src/run_metrics_example.gleam)
-  exercises every function through the standalone runner.
-
-Together they show generated external schema and storage ownership, mixed
-external/scalar signatures, persistent updates, source equality, and canonical
-inspection without low-level host registration boilerplate.
+Continue with [call tracing](../call_tracing/README.md) when provider code needs
+to invoke a typed Gleam callback.

--- a/examples/provider/tag_set/README.md
+++ b/examples/provider/tag_set/README.md
@@ -1,8 +1,18 @@
-# Tag Set Provider Example
+# Host Provider: Tag Set
 
-This is the smallest external-value provider. It has no process-local state and
-accepts no configuration. `#[geam::external]` generates ordinary source
-equality, hashing, and opaque `TagSet(<opaque>)` inspection from the Rust value.
+This is the first example where a Gleam value carries data owned by Rust. Gleam
+sees a constructorless `TagSet`; the provider stores its `BTreeSet` payload and
+returns a new persistent value from each update. No process state or runtime
+configuration is involved.
+
+## Read The Example
+
+1. [`project/packages/example_tag_set/src/example_tag_set.gleam`](project/packages/example_tag_set/src/example_tag_set.gleam)
+   declares the constructorless type and its public operations.
+2. [`provider/src/lib.rs`](provider/src/lib.rs) defines the Rust payload and
+   matching functions.
+3. [`project/src/tag_set_example.gleam`](project/src/tag_set_example.gleam)
+   checks persistence, membership, size, and source equality.
 
 The complete Gleam API is:
 
@@ -15,8 +25,8 @@ pub fn contains(tags: TagSet, tag: String) -> Bool
 pub fn size(tags: TagSet) -> Int
 ```
 
-The matching Rust declarations use only the default provider and external
-semantics:
+`#[geam::external]` generates source equality, hashing, and opaque
+`TagSet(<opaque>)` inspection from the Rust value:
 
 ```rust
 #[geam::provider(package = "example_tag_set", modules = [tag_set])]
@@ -29,6 +39,8 @@ struct TagSet {
 }
 ```
 
+## Run
+
 Run it through the generated standalone runner:
 
 ```sh
@@ -38,10 +50,10 @@ geam prepare
 geam run
 ```
 
-A successful run produces no application output. The entrypoint executes every public
-function and checks persistent old values, duplicate insertion, membership,
-size, and equality between independently constructed values.
+The entrypoint checks that inserting `"rust"` leaves the empty value unchanged,
+duplicate insertion keeps the size stable, membership works, and independently
+constructed sets compare equal. A successful run is silent because all
+assertions pass.
 
-Read [`project/packages/example_tag_set/src/example_tag_set.gleam`](project/packages/example_tag_set/src/example_tag_set.gleam),
-[`provider/src/lib.rs`](provider/src/lib.rs), and
-[`project/src/tag_set_example.gleam`](project/src/tag_set_example.gleam) together.
+Continue with [request IDs](../request_ids/README.md) to move mutable data out
+of source values and into state owned by one execution.

--- a/examples/provider/text_pattern/README.md
+++ b/examples/provider/text_pattern/README.md
@@ -92,4 +92,4 @@ for the boundary shared by the public API.
 
 The [provider authoring guide](../../../docs/host-providers.md) covers the API
 from the first function through packaging. The [examples index](../README.md)
-offers smaller examples for each individual capability combined here.
+offers smaller examples for each provider feature combined here.

--- a/examples/provider/text_pattern/README.md
+++ b/examples/provider/text_pattern/README.md
@@ -1,14 +1,31 @@
-# Text Pattern Provider Example
+# Host Provider: Text Pattern
 
-This example pairs a Gleam package published on Hex with a Rust provider
-published on crates.io for [Geam](https://github.com/panarch/geam). The Gleam
-package includes an Erlang `re` implementation. The Rust crate implements the
-same API with `regex` through Geam's public provider authoring macros.
-The release workflow keeps all three at the same version.
+This final example turns the side-by-side authoring layout into two separately
+published packages. Applications add `example_text_pattern` from Hex and keep
+calling its Gleam API. Geam hosts select `geam-example-text-pattern` from
+crates.io to implement that API with Rust's `regex` crate.
 
-See the [Gleam package README](project/packages/example_text_pattern/README.md)
-for installation and API usage, and the [provider README](provider/README.md)
-for the matching Rust implementation and authoring macros.
+The Hex package also ships an Erlang `re` implementation, so the same public
+Gleam modules can run on Erlang without Geam. This repository releases the
+example package and provider at the same version, although provider metadata is
+what declares their compatibility.
+
+## Read The Pair
+
+1. [`project/packages/example_text_pattern/src/example_text_pattern.gleam`](project/packages/example_text_pattern/src/example_text_pattern.gleam)
+   declares the constructorless `Pattern`, `CompileError`, and public API.
+2. [`project/packages/example_text_pattern/src/example_text_pattern_ffi.erl`](project/packages/example_text_pattern/src/example_text_pattern_ffi.erl)
+   implements that API for Erlang.
+3. [`provider/src/lib.rs`](provider/src/lib.rs) implements the same Gleam shapes
+   for Geam with `#[geam::external]`, `#[geam::custom]`, and
+   `#[geam::function]`.
+4. [`project/src/text_pattern_example.gleam`](project/src/text_pattern_example.gleam)
+   runs the shared behavior against either implementation.
+
+The [Gleam package README](project/packages/example_text_pattern/README.md)
+documents its public API. The [provider crate README](provider/README.md)
+explains the Rust implementation and why this advanced external value uses
+custom behavior.
 
 ```text
 project/
@@ -20,42 +37,38 @@ provider/                          geam-example-text-pattern crate
 
 ### Erlang
 
-With Gleam and Erlang/OTP installed, the example runs without Geam or Rust:
+With Gleam and Erlang/OTP installed, run from the repository root without Geam
+or Rust:
 
 ```sh
-git clone https://github.com/panarch/geam.git
-cd geam/examples/provider/text_pattern/project
+cd examples/provider/text_pattern/project
 gleam run --target erlang
 ```
 
 ### Geam
 
-With Gleam, Rust, and Cargo installed, start from the repository root to install
-Geam, select the local provider, and run the same project:
+With Gleam, Rust, and Geam installed, return to the repository root, select the
+local provider, and run the same project:
 
 ```sh
-cargo install --path . --locked
 cd examples/provider/text_pattern/project
 geam provider add --path ../provider
 geam prepare
 geam run
 ```
 
-No provider configuration is required. Both runtimes execute
+No provider configuration is required. Both commands execute
 [`text_pattern_example.gleam`](project/src/text_pattern_example.gleam), checking
 compilation, matching, literal replacement, Unicode, empty results, and invalid
-patterns. A successful run prints no application output. Running the command
-again repeats the same checks.
+patterns. A successful run is silent because all assertions pass.
 
 This checkout uses the Gleam package as a local path dependency. Provider
 selection comes from the Rust crate's Cargo metadata; the Gleam package needs no
 Geam-specific metadata. The provider is not a Geam built-in.
 
-This checkout workflow uses an explicit path selection so changes to the
-provider can be tested without publishing it. The local
-[Cargo patch](.cargo/config.toml) selects the same Geam checkout for provider
-and runner builds. See the [standalone guide](../../../docs/standalone.md) for
-provider selection and managed project files.
+This checkout uses an explicit path selection so provider changes can be tested
+before publication. See the [standalone guide](../../../docs/standalone.md) for
+registry selection and managed project files.
 
 ## Runtime-Specific Examples
 
@@ -77,19 +90,6 @@ The package keeps the engines' native syntax instead of translating between
 them. See its [runtime semantics](project/packages/example_text_pattern/README.md#runtime-semantics)
 for the boundary shared by the public API.
 
-## Read the Implementation
-
-Read the matching declarations together:
-
-- [`project/packages/example_text_pattern/src/example_text_pattern.gleam`](project/packages/example_text_pattern/src/example_text_pattern.gleam)
-  declares the constructorless `Pattern`, `CompileError`, and public functions;
-- [`project/packages/example_text_pattern/src/example_text_pattern_ffi.erl`](project/packages/example_text_pattern/src/example_text_pattern_ffi.erl)
-  supplies the native Erlang implementation shipped in the Hex package;
-- [`provider/src/lib.rs`](provider/src/lib.rs) implements the same shapes with
-  `#[geam::external]`, `#[geam::custom]`, and `#[geam::function]`; and
-- [`provider/README.md`](provider/README.md) explains why this advanced example
-  uses manual external semantics while ordinary registration remains generated.
-
 The [provider authoring guide](../../../docs/host-providers.md) covers the API
-contracts. The [examples index](../README.md) offers smaller examples of the
-individual authoring patterns used here.
+from the first function through packaging. The [examples index](../README.md)
+offers smaller examples for each individual capability combined here.

--- a/examples/provider/text_pattern/project/packages/example_text_pattern/README.md
+++ b/examples/provider/text_pattern/project/packages/example_text_pattern/README.md
@@ -61,6 +61,11 @@ native Rust code. Geam records the selected dependency and Cargo lock, then
 builds and checks the runner. No explicit `geam provider add` or provider
 configuration is needed for this workflow.
 
+`geam-example-text-pattern` uses the exact crates.io discovery-name form derived
+from `example_text_pattern`. Provider authors can read
+[provider names for automatic discovery](https://github.com/panarch/geam/blob/main/docs/host-providers.md#provider-names-for-automatic-discovery)
+for the complete rule, including suffixed provider names.
+
 Geam uses the Rust provider, not the packaged Erlang implementation. See the
 [standalone guide](https://github.com/panarch/geam/blob/main/docs/standalone.md)
 for provider approval, managed files, and entry module selection.

--- a/examples/provider/text_pattern/provider/README.md
+++ b/examples/provider/text_pattern/provider/README.md
@@ -59,10 +59,13 @@ matches the [Gleam declarations](https://github.com/panarch/geam/blob/main/examp
 - ordinary Rust `Result<Pattern, CompileError>` maps to Gleam `Result`; and
 - `Vec<EcoString>` constructs the returned Gleam `List(String)` once.
 
-The crate's Cargo metadata identifies the target Gleam package and version for
-Geam's provider discovery. This release-coupled reference provider pins the
-same version published for Geam and the Hex package. The Gleam package itself
-carries no Geam-specific metadata.
+The Gleam package name `example_text_pattern` maps to this crate's exact
+discovery-name form, `geam-example-text-pattern`. That name lets
+`geam prepare`, `geam run`, and `geam embedding sync` find the crate on
+crates.io. It does not make the crate official or trusted. Cargo metadata then
+identifies the exact target Gleam package and compatible version range. This
+release-coupled reference provider pins the same version published for Geam and
+the Hex package. The Gleam package itself carries no Geam-specific metadata.
 
 See the [provider authoring guide](https://github.com/panarch/geam/blob/main/docs/host-providers.md)
 for the API contracts, or the [other provider examples](https://github.com/panarch/geam/tree/main/examples/provider)

--- a/examples/provider/text_tools/README.md
+++ b/examples/provider/text_tools/README.md
@@ -1,10 +1,20 @@
-# Text Tools Provider Example
+# Host Provider: Text Tools
 
-This is the smallest macro-authored provider example. It has no state,
-configuration, or external values. One Rust provider crate implements three
-ordinary Gleam modules using scalar arguments and return values only.
+This is the smallest complete provider. A Gleam package declares six text
+functions, and one companion Rust crate implements them for Geam. It uses only
+scalar arguments and returns, with no provider state, configuration, or opaque
+external values.
 
-The complete Gleam API is:
+## Read The Example
+
+1. [`project/packages/example_text_tools/src`](project/packages/example_text_tools/src)
+   contains the public Gleam API across three modules.
+2. [`provider/src/lib.rs`](provider/src/lib.rs) implements the same package,
+   module paths, functions, and signatures in Rust.
+3. [`project/src/text_tools_example.gleam`](project/src/text_tools_example.gleam)
+   imports the Gleam modules and checks every call through the provider.
+
+The package API is ordinary Gleam:
 
 ```gleam
 // example_text_tools
@@ -20,8 +30,8 @@ pub fn starts_with(value: String, prefix: String) -> Bool
 pub fn ends_with(value: String, suffix: String) -> Bool
 ```
 
-The provider lists Rust module identifiers in component order, while each
-module declares its exact Gleam module path:
+The provider declares the package once, lists its Rust modules, and gives each
+module the exact Gleam path it implements:
 
 ```rust
 #[geam::provider(
@@ -40,7 +50,9 @@ mod casing { /* ... */ }
 mod checks { /* ... */ }
 ```
 
-Run it through the generated standalone runner:
+## Run
+
+With Gleam, Rust, and Geam installed, run from the repository root:
 
 ```sh
 cd examples/provider/text_tools/project
@@ -49,11 +61,9 @@ geam prepare
 geam run
 ```
 
-A successful run produces no application output. The entrypoint imports all three modules
-and executes every public function.
+The entrypoint checks results including `upper("Geam") == "GEAM"`,
+`surround("ready", "[", "]") == "[ready]"`, and both Boolean predicates. A
+successful run is silent because all assertions pass.
 
-Read the three files under
-[`project/packages/example_text_tools/src`](project/packages/example_text_tools/src),
-[`provider/src/lib.rs`](provider/src/lib.rs), and
-[`project/src/text_tools_example.gleam`](project/src/text_tools_example.gleam)
-together.
+Continue with [value types](../value_types/README.md) to map Gleam scalars,
+tuples, Lists, custom types, Result, and Option to provider signatures.

--- a/examples/provider/value_types/README.md
+++ b/examples/provider/value_types/README.md
@@ -1,9 +1,17 @@
-# Value Types Provider Example
+# Host Provider: Value Types
 
-This example shows how Gleam values map to Rust types in provider functions.
-Separate modules cover scalars, tuples, Lists, custom values, Result, and
-Option, so you can open the mapping you need. The later provider examples add
-state, configuration, and external values.
+This example keeps the provider stateless and expands the first example's
+scalar signatures into the ordinary values most APIs need: tuples, Lists,
+custom types, Result, and Option.
+
+## Read The Example
+
+1. [`project/packages/example_value_types/src/example_value_types`](project/packages/example_value_types/src/example_value_types)
+   separates the Gleam API by value family.
+2. [`provider/src/lib.rs`](provider/src/lib.rs) shows the matching Rust input
+   and output types in one provider.
+3. [`project/src/value_types_example.gleam`](project/src/value_types_example.gleam)
+   constructs each source value and checks the provider result.
 
 ## Scalars
 
@@ -157,6 +165,8 @@ Nested custom values use their generated input type, and a source `List` field
 is a lazy `List` view in `JobInput`; the output enum uses `Vec` only when
 constructing a new source List.
 
+## Run
+
 Run all five modules through the generated standalone runner:
 
 ```sh
@@ -166,18 +176,10 @@ geam prepare
 geam run
 ```
 
-A successful run produces no application output. The entrypoint executes every public
-function and checks all scalar mappings, one-, two-, three-element and nested
-tuples, empty, indexed, pass-through, reversed and tuple-item Lists, unit,
-tuple, named, nested and List-bearing custom constructors, plus source Result
-and Option values.
+The entrypoint checks every public function, including `add(20, 22) == 42`,
+nested tuple reassociation, lazy List pass-through and traversal, custom
+constructors, and successful and failed Result and Option values. A successful
+run is silent because all assertions pass.
 
-Read
-[`project/packages/example_value_types/src/example_value_types/scalars.gleam`](project/packages/example_value_types/src/example_value_types/scalars.gleam),
-[`project/packages/example_value_types/src/example_value_types/tuples.gleam`](project/packages/example_value_types/src/example_value_types/tuples.gleam),
-[`project/packages/example_value_types/src/example_value_types/lists.gleam`](project/packages/example_value_types/src/example_value_types/lists.gleam),
-[`project/packages/example_value_types/src/example_value_types/customs.gleam`](project/packages/example_value_types/src/example_value_types/customs.gleam),
-[`project/packages/example_value_types/src/example_value_types/results.gleam`](project/packages/example_value_types/src/example_value_types/results.gleam),
-[`provider/src/lib.rs`](provider/src/lib.rs), and
-[`project/src/value_types_example.gleam`](project/src/value_types_example.gleam)
-together.
+Continue with [tag set](../tag_set/README.md) when a Gleam value should carry an
+opaque payload owned by Rust.

--- a/zensical.toml
+++ b/zensical.toml
@@ -18,7 +18,7 @@ nav = [
   { "Guides" = [
     { "Run a Gleam project" = "standalone.md" },
     { "Embed Gleam in Rust" = "embedding.md" },
-    { "Author a host provider" = "host-providers.md" },
+    { "Add Rust to a Gleam package" = "host-providers.md" },
   ] },
   { "Reference" = [
     "reference/README.md",


### PR DESCRIPTION
## Summary

- introduce host providers as companion Rust crates with a distinct role from their Gleam packages
- align provider terminology across the README, user guides, and documentation navigation
- turn the provider examples into an ordered path with concrete results and links between stages

## Verification

- Checked local Markdown link targets across the changed guides and provider example READMEs.
