### PR TITLE
Pass secrets to reference release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -179,6 +179,7 @@ jobs:
       operation: ${{ inputs.operation == 'Create GitHub Release' && 'Verify published example' || 'Publish reference example' }}
       commit: ${{ inputs.commit }}
       dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary

- inherit secrets when the release workflow calls reference example publishing
- restore `HEXPM_API_KEY` availability on the automatic release path

## Context

The 0.2.3 release reached the reusable reference workflow with its `crates-io`
environment attached, but GitHub resolved the environment secret as empty.
Direct dispatch remains unaffected; secret inheritance covers the reusable call.

The secret value cannot be exercised by a dry run, so the next automatic publish
is the end-to-end verification of this GitHub Actions boundary.
