### PR TITLE
Clarify Geam's Gleam integration boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ the natural choice when they fit how your application runs and deploys. Choose
 Geam when Rust needs to host the application, provide native capabilities, or
 call Gleam through generated bindings.
 
-Geam uses Gleam's parser and type analysis to build executable plans for its
-Rust runtime. Generated Rust provides host integration: a managed standalone
-runner or typed embedding bindings.
+Geam uses the parser and type analysis from the supported Gleam release without
+modifying their implementation, then builds executable plans for its Rust
+runtime. Generated Rust provides host integration: a managed standalone runner
+or typed embedding bindings.
 
 A Gleam package keeps its Hex identity, source, and existing target
 implementations when it gains a Geam provider. The companion Rust crate adds a
@@ -173,7 +174,7 @@ Geam implementation; it does not replace or translate the Gleam package.
 
 Geam is actively evolving toward a stable `1.0` API, so public APIs may still
 change. Geam currently supports everyday Gleam data, functions, imports, custom
-types, pattern matching, generics, official package integrations, native host
+types, pattern matching, generics, verified package integrations, native host
 providers, and nested ordinary data passed between Gleam and Rust.
 
 See [compatibility](docs/reference/compatibility.md) for the verified Gleam and

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -28,7 +28,7 @@ GitHub Actions.
 ## Upstream And Releases
 
 - [Upstream Gleam](upstream-gleam.md) records the exact compiler mirror,
-  official package baselines, compatibility evidence, and manual sync policy.
+  upstream package baselines, compatibility evidence, and manual sync policy.
 - [Publishing](publishing.md) documents release preparation, artifact ownership,
   recovery operations, authentication, and GitHub Release creation.
 - [Writing release notes](release-notes.md) defines the user-facing release-note

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -88,7 +88,7 @@ the frontend owner tests. These tests construct Hex, Git, and Local package
 layouts without network access or an installed Gleam CLI, keeping loader owner
 coverage independent of external package acquisition.
 
-The tracked `builtins/stdlib/tests/fixtures/project` project locks official
+The tracked `builtins/stdlib/tests/fixtures/project` project locks upstream
 `gleam_stdlib` `v1.0.3` but does not track downloaded package source. The
 `geam-stdlib` integration target downloads that exact source before executing
 its package-local compatibility suite.
@@ -108,7 +108,7 @@ integration suite does not replace hermetic synthetic owner coverage for the
 loader or providers.
 
 The tracked `tests/fixtures/projects/gleam_http` project independently locks
-official `gleam_http` `v4.3.0` and `gleam_stdlib` `v1.0.3`. It likewise keeps
+upstream `gleam_http` `v4.3.0` and `gleam_stdlib` `v1.0.3`. It likewise keeps
 downloaded package source out of Git and downloads the exact locked source
 automatically before the integration target runs.
 
@@ -119,7 +119,7 @@ It fixes the public surface of all five package modules and executes every
 public function.
 
 The tracked `builtins/json/tests/fixtures/project` project independently locks
-official `gleam_json` `v3.1.0` and `gleam_stdlib` `v1.0.3`. The `geam-json`
+upstream `gleam_json` `v3.1.0` and `gleam_stdlib` `v1.0.3`. The `geam-json`
 integration target downloads its exact locked source before executing the
 package-local compatibility suite.
 
@@ -127,7 +127,7 @@ This target explicitly composes the stdlib and JSON provider bundles, fixes the
 complete public `gleam/json` surface, and executes every public function.
 
 The tracked `builtins/time/tests/fixtures/project` project independently locks
-official `gleam_time` `v1.8.0` and `gleam_stdlib` `v1.0.3`. The `geam-time`
+upstream `gleam_time` `v1.8.0` and `gleam_stdlib` `v1.0.3`. The `geam-time`
 integration target downloads its exact locked source before executing the
 package-local compatibility suite.
 
@@ -252,7 +252,7 @@ value and ownership contracts remain in core tests.
 The tracked `cli/tests/fixtures/standalone_cli` fixture verifies the complete CLI
 assembly boundary. Its Gleam project combines a Pure Gleam path package,
 version-locked stdlib, JSON, and Time dependencies, and two provider-backed path
-packages. Official package source is downloaded outside Git, while the local
+packages. Upstream package source is downloaded outside Git, while the local
 packages remain visible test-owned fixtures. The independent Rust providers
 exercise state, callbacks, external storage, and a compound return through the
 generated static profile. A standalone orchestration test feeds packaged

--- a/docs/development/upstream-gleam.md
+++ b/docs/development/upstream-gleam.md
@@ -1,9 +1,19 @@
 # Upstream Gleam Compiler Boundary
 
-Geam does not own a separate source language front-end. It relies on Gleam's
-published compiler front-end, then starts Geam-specific work at the typed AST
-boundary. This document records the upstream baseline, what is used directly,
-and where Geam's runtime-specific boundary begins.
+Geam does not implement a separate source-language front end. It packages
+compiler components from the matching Gleam release and starts Geam-specific
+work at the typed AST boundary. It does not change the parser, type checker, or
+language behavior. Differences are limited to Cargo packaging metadata and
+generated version identification required to publish the components as crates.
+This keeps source handling aligned with the recorded Gleam release and avoids
+maintaining a separate front end.
+
+The Gleam project does not publish or support these compiler components as a
+Rust library. Geam packages the matching source for this integration and is
+responsible for keeping it compatible with each supported Gleam release.
+
+This document records the upstream baseline, what Geam uses directly, and where
+Geam's runtime-specific boundary begins.
 
 For the concise user-facing support matrix, see
 [compatibility](../reference/compatibility.md). This document retains the exact
@@ -29,13 +39,16 @@ The release, commit, and publication date above refer to the
 (UTC), not the compiler crate's publication date.
 
 The `geam-gleam-core` package and its compiler-component dependencies are
-published from the release-tracking `panarch/gleam` mirror. Its
+published from the Geam-maintained, release-tracking `panarch/gleam` packaging
+fork. Its
 [packaging release](https://github.com/panarch/gleam/releases/tag/geam-v1.18.1-geam.2)
 records the same upstream commit. Geam pins that package exactly; the `geam.2`
 suffix is a mirror packaging revision, not a different Gleam release or Geam's
-own lockstep version.
+own lockstep version. Apart from distribution metadata and generated version
+identification, the compiler implementation source matches that upstream
+commit.
 
-The official standard library has an independent baseline:
+The upstream standard library has an independent baseline:
 
 ```text
 Repository: https://github.com/gleam-lang/stdlib
@@ -45,7 +58,7 @@ Release:     v1.0.3
 
 Geam does not bundle or patch that source. A dedicated integration test uses
 Gleam CLI `v1.18.1` to download the locked package, then executes selected
-official modules through Geam's resolved-project pipelines. Provider-free
+upstream modules through Geam's resolved-project pipelines. Provider-free
 modules use the plain pipeline, while modules whose selected closure contains
 externals use the hosted pipeline with the explicit Rust provider bundle. Each
 tracked module locks its public names, argument labels, and signatures while
@@ -104,8 +117,8 @@ compiler-core/src/ast/untyped.rs
 compiler-core/src/ast/typed.rs
 ```
 
-The boundary wrapper also uses Gleam support APIs required to run analyse in the
-same shape as Gleam itself:
+The boundary wrapper also uses internal compiler modules required to run
+analysis in the same shape as the pinned compiler release:
 
 ```text
 compiler-core/src/build.rs
@@ -238,7 +251,7 @@ not add a general mutable external-value model or cyclic runtime graph support.
 ### Gleam Stdlib v1.0.3 Compatibility
 
 Checked modules have exact public-surface coverage and execute unchanged
-official source through the upstream integration suite. An unchecked module is
+upstream package source through the integration suite. An unchecked module is
 not necessarily rejected; it has not yet been verified end to end.
 Geam currently verifies all 19 public modules in this baseline.
 
@@ -281,7 +294,7 @@ collision bucket. Dynamic values retain their exact specialized shape for
 typed Decode operations. StringTree uses persistent acyclic structure, and
 BitArray values preserve logical bit ranges over shared immutable backing.
 Random operations use caller-owned `GleamStdlibRunState`; there is no hidden
-seed or global random state. Official IO operations emit owned stdout and
+seed or global random state. Upstream IO operations emit owned stdout and
 stderr events through the `IoSink` projected by `GleamStdlibHostProfile`. The
 default run state collects those events, and project loading does not select a
 terminal destination.
@@ -297,8 +310,9 @@ The HTTP compatibility suite tracks all five unchanged package modules:
 - [x] `gleam/http/service`
 
 The package declares no external functions or external types, so Geam adds no
-HTTP provider. Its 44 public functions execute through official source, while
-the suite separately fixes 9 public custom types and 3 public type aliases.
+HTTP provider. Its 44 public functions execute through unchanged upstream
+source, while the suite separately fixes 9 public custom types and 3 public
+type aliases.
 The deprecated service aliases and functions remain part of the `v4.3.0`
 compatibility surface.
 
@@ -324,7 +338,7 @@ consumes bytes iteratively and constructs exact Dynamic scalar, List, and Dict
 values directly rather than a generic JSON AST. Nested values are assembled
 child-first to keep the external graph acyclic. JSON objects become
 Dynamic-keyed dictionaries whose keys are Dynamic String values, matching the
-official Decode ABI; duplicate encoded object fields remain ordered, while
+upstream Decode ABI; duplicate encoded object fields remain ordered, while
 decoded dictionaries preserve the first key occurrence.
 
 ### Gleam Time v1.8.0 Compatibility
@@ -338,7 +352,7 @@ The Time compatibility suite tracks all three unchanged package modules:
 The explicit package provider binds only
 `calendar.local_time_offset_seconds` and `timestamp.get_system_time`. All 34
 public functions, 6 public types, and the `utc_offset` and `unix_epoch`
-constants are exercised through official source. Duration arithmetic,
+constants are exercised through unchanged upstream source. Duration arithmetic,
 calendar conversion, RFC3339 parsing, and formatting remain Pure Gleam.
 
 `GleamTimeRunState` owns the stdlib state and a caller-selected `TimeSource`.
@@ -414,7 +428,7 @@ state remains owned by the caller and is borrowed only for
 The caller supplies the `EchoSink` used by `run_main`. Each emitted
 `EchoOutput` owns its materialized value, optional message, and compact source
 location; Geam does not select an output destination for the host.
-The official `gleam/io` provider uses a separate caller-owned `IoSink` for
+Geam's `gleam/io` provider uses a separate caller-owned `IoSink` for
 stdout and stderr text events. Echo and stdlib IO do not share a hidden queue.
 
 ## Intentionally Out Of Scope
@@ -432,15 +446,15 @@ milestone:
 
 ## Current Source Boundary
 
-Source acceptance follows Gleam `v1.18.1` parser and analyse rules. Geam's
-smaller execution profile is enforced by typed-AST planning, not by forking
-Gleam's parser or type inferencer.
+Source acceptance follows the pinned Gleam `v1.18.1` parser and analysis rules.
+Geam's smaller execution profile is enforced by typed-AST planning. Geam does
+not add language behavior changes to the packaged parser or type inferencer.
 
 ## Sync Policy
 
 This document is maintained manually when the upstream baseline or mirror
 packaging revision changes. Geam release-version automation must not update
-compiler or official package baselines.
+compiler or upstream package baselines.
 
 The [Workspace workflow](../../.github/workflows/workspace.yml) checks the `Cargo:`
 line against the compiler version resolved by `cargo metadata --locked`. This

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -198,8 +198,8 @@ cd ..
 geam embedding sync
 ```
 
-Sync enables only the built-in Geam support used by imported Gleam code.
-Official stdlib, JSON, and Time integrations are added explicitly; unused Gleam
+Sync enables only the built-in Geam support used by imported Gleam code. Geam's
+stdlib, JSON, and Time integrations are added explicitly; unused Gleam
 dependencies do not add Rust components.
 
 Most packages need nothing else. If an imported package has native functions

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,9 @@ call Gleam through generated bindings.
 
 ## How the pieces fit
 
-Geam starts after Gleam has parsed and analysed the selected source graph:
+Geam uses the parser and type analysis from the supported Gleam release without
+modifying their implementation. Geam-specific planning begins from the
+resulting typed program:
 
 ```text
 resolved Gleam sources

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,8 +1,9 @@
 # Architecture
 
 Geam exists to run typed Gleam modules where Rust owns the execution
-environment. It preserves Gleam as the source language and compiler front-end,
-then introduces a Rust-owned planner, runtime, and host-capability boundary.
+environment. Gleam remains the source language; Geam uses the parser and type
+checker from the supported Gleam release, then applies a Rust-owned planner,
+runtime, and host-capability boundary.
 
 This lets a Gleam application use native Rust providers without maintaining a
 Rust runner, and lets a Rust application call supported public Gleam functions
@@ -10,7 +11,7 @@ through generated typed bindings.
 
 ## Source And Runtime Ownership
 
-Gleam continues to own:
+The Gleam language and package ecosystem define:
 
 - source syntax, parsing, and type inference;
 - package names, imports, and dependency resolution;
@@ -35,14 +36,18 @@ resolved Gleam project or in-memory package sources
 -> Rust-owned runtime values and effects
 ```
 
-Geam does not define another parser, source AST, package manager, or official
-Gleam target. It relies on a pinned published Gleam compiler front-end and
-starts Geam-specific work at the typed-program boundary.
+Geam reuses Gleam's source-language front end rather than implementing a
+separate parser, source AST, or package manager. Its parser and type checker come
+from the supported Gleam release without modifications to their implementation.
+Geam-specific work starts at the typed-program boundary. Packaging differences
+are limited to distribution metadata and generated version identification,
+while Geam owns planning and execution.
 
 ## Planning Before Execution
 
-The frontend parses and analyses the complete selected module graph. Geam then
-validates that graph while constructing an inspectable `ModulePlan`.
+The compiler integration parses and analyses the complete selected module
+graph. Geam then validates that graph while constructing an inspectable
+`ModulePlan`.
 Unsupported execution semantics are rejected at this boundary, including in
 supplied dependency definitions, rather than becoming conditional runtime
 errors.
@@ -115,10 +120,11 @@ runtime ownership do not change.
 
 ## Effects Stay Caller-Owned
 
-Language Echo uses a caller-supplied `EchoSink`. Official `gleam/io` functions
-use a separate caller-supplied `IoSink`. Entropy, wall-clock access, provider
-configuration, and mutable state are similarly constructed by the runner or
-embedding application rather than read from process-global defaults.
+Language Echo uses a caller-supplied `EchoSink`. The upstream `gleam/io`
+functions use a separate caller-supplied `IoSink` when run through Geam.
+Entropy, wall-clock access, provider configuration, and mutable state are
+similarly constructed by the runner or embedding application rather than read
+from process-global defaults.
 
 This separation makes effects visible at assembly time and keeps execution
 plans independent from credentials, output destinations, and mutable process

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,9 +1,9 @@
 # Compatibility
 
-Geam uses Gleam's published compiler front-end but implements a separate,
-smaller execution profile in Rust. Source acceptance follows Gleam parsing and
-type analysis; executable compatibility is decided while Geam plans the typed
-module graph.
+Geam uses the parser and type checker from the supported Gleam release without
+changing their language behavior, then implements a separate, smaller execution
+profile in Rust. Source acceptance follows that compiler behavior; executable
+compatibility is decided while Geam plans the typed module graph.
 
 Packages and modules beyond the verified list may also work. End-to-end
 compatibility is established when their source and required providers pass the
@@ -21,9 +21,9 @@ integration path described here.
 | `gleam_json` | `v3.1.0` |
 | `gleam_time` | `v1.8.0` |
 
-Geam pins its compiler crate exactly and updates the baseline deliberately. It
-does not follow Gleam `main` or silently reinterpret a project with another
-compiler release.
+`geam-gleam-core` packages the matching compiler source for this integration.
+Geam pins it exactly and updates the baseline deliberately. It does not follow
+Gleam `main` or silently reinterpret a project with another compiler release.
 
 ## Source Profile
 
@@ -68,7 +68,7 @@ for the exact recursive type map.
 ### Gleam Standard Library
 
 Geam verifies all 19 public modules in `gleam_stdlib v1.0.3` against unchanged
-official source:
+upstream package source:
 
 ```text
 gleam/bit_array        gleam/bool          gleam/bytes_tree
@@ -99,7 +99,7 @@ service runtime.
 
 Geam verifies unchanged `gleam_json v3.1.0` through a separate explicit JSON
 provider and the stdlib provider. It covers JSON construction, encoding,
-parsing, `Dynamic` conversion, and official decode behavior without introducing
+parsing, `Dynamic` conversion, and upstream decode behavior without introducing
 a generic JSON runtime value.
 
 The Erlang implementation path is selected. A JavaScript-only external does not
@@ -108,9 +108,9 @@ become a Rust callback merely because it is present in the package.
 ### Gleam Time
 
 Geam verifies all three `gleam_time v1.8.0` modules. Duration arithmetic,
-calendar conversion, and RFC3339 behavior remain in official Gleam source. The
-Time provider supplies only wall-clock time and the current local UTC offset
-through caller-owned state.
+calendar conversion, and RFC3339 behavior remain in unchanged upstream package
+source. The Time provider supplies only wall-clock time and the current local
+UTC offset through caller-owned state.
 
 This integration does not provide timezone history, a monotonic clock, timers,
 sleep, or an implicit system-clock fallback after provider failure.

--- a/docs/reference/embedding-boundary.md
+++ b/docs/reference/embedding-boundary.md
@@ -239,9 +239,9 @@ supported types.
 ## Echo And IO
 
 Provider-free calls receive a caller-owned Echo sink. Hosted calls receive both
-the generated mutable state and Echo sink. Official `gleam/io` writes through
-the stdlib state selected by the application; it does not share a hidden queue
-with Echo.
+the generated mutable state and Echo sink. The upstream `gleam/io` functions
+write through the stdlib state selected by the application when run through
+Geam; they do not share a hidden queue with Echo.
 
 The application decides whether collected output is written to a terminal,
 captured for tests, forwarded elsewhere, or ignored.

--- a/docs/reference/runtime-semantics.md
+++ b/docs/reference/runtime-semantics.md
@@ -263,10 +263,10 @@ retained graph remains acyclic. Geam does not enforce a consumed-token state at
 runtime and does not provide general mutable external references or cycle
 collection.
 
-The explicit official `gleam/dict` provider is one concrete use of this model.
+Geam's explicit `gleam/dict` provider is one concrete use of this model.
 It selects persistent buckets by Gleam source hash and resolves every collision
 with source equality. `Dict` and private `TransientDict` remain nominally
-distinct immutable payload versions, official Gleam fallback bodies remain the
+distinct immutable payload versions, upstream Gleam fallback bodies remain the
 source owner of their operations, and dictionary iteration order is not a
 runtime contract. Canonical inspection sorts rendered entries only to make
 escaped values deterministic to read; that display order does not define
@@ -366,10 +366,11 @@ metadata is a separate design concern.
 
 ## Standard-Library IO
 
-Official `gleam/io` functions emit through the `IoSink` projected by the
-caller's `GleamStdlibHostProfile`. Each owned `IoOutput` records either stdout
-or stderr and one exact text chunk. `print` operations preserve their input;
-`println` operations append exactly one newline before emitting. All four
+The upstream `gleam/io` functions emit through the `IoSink` projected by the
+caller's `GleamStdlibHostProfile` when run through Geam. Each owned `IoOutput`
+records either stdout or stderr and one exact text chunk. `print` operations
+preserve their input; `println` operations append exactly one newline before
+emitting. All four
 operations emit before returning `Nil`, so output remains caller-owned if a
 later source expression panics.
 


### PR DESCRIPTION
## Summary

- explain how Geam uses the parser and type checker from the supported Gleam release
- document the typed AST handoff and packaging-only adaptations
- replace ambiguous `official` wording with precise upstream or Geam ownership
